### PR TITLE
feat: ingest GitHub-native PR/issue attachments into the workspace

### DIFF
--- a/.changeset/uploads-ingest-cli.md
+++ b/.changeset/uploads-ingest-cli.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Add `uploads ingest` to mirror GitHub-native PR/issue attachments into the workspace.

--- a/apps/api/migrations/20260811120000_github_ingested_assets.sql
+++ b/apps/api/migrations/20260811120000_github_ingested_assets.sql
@@ -1,0 +1,16 @@
+-- Ledger of GitHub-native user-attachments mirrored into workspaces
+-- (spec docs/superpowers/specs/2026-08-11-github-attachment-ingestion-design.md).
+-- One row per (repo, asset); detached_at NULL == currently referenced.
+CREATE TABLE github_ingested_assets (
+  repo        TEXT NOT NULL,
+  asset_id    TEXT NOT NULL,
+  workspace   TEXT NOT NULL,
+  object_key  TEXT NOT NULL,
+  kind        TEXT NOT NULL,
+  num         INTEGER NOT NULL,
+  source      TEXT NOT NULL,
+  created_at  TEXT NOT NULL,
+  detached_at TEXT,
+  PRIMARY KEY (repo, asset_id)
+);
+CREATE INDEX github_ingested_assets_source_idx ON github_ingested_assets (repo, source);

--- a/apps/api/src/adoption.ts
+++ b/apps/api/src/adoption.ts
@@ -32,7 +32,7 @@ export type AdoptionMetric = (typeof ADOPTION_METRICS)[number];
  * CLI request from any other API request server-side, so finer-grained client
  * identity comes from the provenance bag's `client` value instead.
  */
-export type UploadSurface = "api" | "mcp" | "promote";
+export type UploadSurface = "api" | "mcp" | "promote" | "github";
 
 /**
  * Analytics Engine dimensions. Never written to D1 — see the module docs.

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -399,6 +399,28 @@ export async function addMissingFileMetadata(
   return next;
 }
 
+/**
+ * Targeted single-key value update. Exists because `replaceFileMetadata` is
+ * delete-then-insert over the whole key set and would wipe server-owned
+ * `video.*` rows — never use replace to flip one flag. Used by the GitHub
+ * attachment ingest reconciler to stamp `gh.detached` without disturbing any
+ * other row. No-op (no row created) if the key isn't already present.
+ */
+export async function updateFileMetadataValue(
+  db: D1Database,
+  workspace: string,
+  objectKey: string,
+  metaKey: string,
+  value: string,
+): Promise<void> {
+  await db
+    .prepare(
+      "UPDATE file_metadata SET meta_value = ?, updated_at = ? WHERE workspace = ? AND object_key = ? AND meta_key = ?",
+    )
+    .bind(value, new Date().toISOString(), workspace, objectKey, metaKey)
+    .run();
+}
+
 /** Deletes all metadata rows for an object (e.g. on object delete). */
 export async function deleteFileMetadata(
   db: D1Database,

--- a/apps/api/src/github-attachment-extract.test.ts
+++ b/apps/api/src/github-attachment-extract.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  attachmentKeyBasename,
+  extractUserAttachments,
+  hasUserAttachmentUrl,
+} from "./github-attachment-extract";
+
+describe("extractUserAttachments", () => {
+  it("finds bare, markdown-image, html img and video forms", () => {
+    const text = [
+      "intro https://github.com/user-attachments/assets/0a1b2c3d-1111-2222-3333-444455556666",
+      "![shot](https://github.com/user-attachments/assets/9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff)",
+      '<img src="https://github.com/user-attachments/assets/12345678-0000-0000-0000-000000000000" width="400">',
+      '<video src="https://github.com/user-attachments/assets/87654321-0000-0000-0000-000000000000"></video>',
+      "[log](https://github.com/user-attachments/files/1234/build-log.txt)",
+    ].join("\n");
+    const ids = extractUserAttachments(text).map((a) => a.id);
+    expect(ids).toEqual([
+      "assets/0a1b2c3d-1111-2222-3333-444455556666",
+      "assets/9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff",
+      "assets/12345678-0000-0000-0000-000000000000",
+      "assets/87654321-0000-0000-0000-000000000000",
+      "files/1234/build-log.txt",
+    ]);
+  });
+
+  it("dedupes repeated references and ignores other github urls", () => {
+    const u = "https://github.com/user-attachments/assets/0a1b2c3d-1111-2222-3333-444455556666";
+    const text = `${u} and again ![x](${u}) plus https://github.com/acme/app/pull/7`;
+    expect(extractUserAttachments(text)).toHaveLength(1);
+    expect(extractUserAttachments("plain text")).toEqual([]);
+  });
+
+  it("strips trailing markdown/html delimiters from captured urls", () => {
+    const text =
+      "(see https://github.com/user-attachments/assets/0a1b2c3d-1111-2222-3333-444455556666)";
+    expect(extractUserAttachments(text)[0]?.id).toBe("assets/0a1b2c3d-1111-2222-3333-444455556666");
+  });
+});
+
+describe("hasUserAttachmentUrl", () => {
+  it("is a cheap substring gate", () => {
+    expect(hasUserAttachmentUrl("x https://github.com/user-attachments/assets/a1b2 y")).toBe(true);
+    expect(hasUserAttachmentUrl("no attachments here")).toBe(false);
+  });
+});
+
+describe("attachmentKeyBasename", () => {
+  it("flattens ids into safe key basenames", () => {
+    expect(attachmentKeyBasename("assets/0a1b-2c3d")).toBe("0a1b-2c3d");
+    expect(attachmentKeyBasename("files/9/My Shot (final).png")).toBe("9-my-shot-final.png");
+  });
+});

--- a/apps/api/src/github-attachment-extract.ts
+++ b/apps/api/src/github-attachment-extract.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure extraction of github.com/user-attachments references from PR/issue
+ * markdown. The asset id (path after /user-attachments/) is the stable
+ * identity the ingest ledger keys on — GitHub keeps it constant across
+ * renders/edits. No I/O; safe to call from extractWebhookEvent.
+ */
+const ATTACHMENT_RE =
+  /https:\/\/github\.com\/user-attachments\/(assets\/[0-9a-fA-F-]{8,}|files\/\d+\/[^\s)"'<>\]]+)/g;
+
+export interface ExtractedAttachment {
+  id: string;
+  url: string;
+}
+
+export function extractUserAttachments(text: string): ExtractedAttachment[] {
+  const seen = new Set<string>();
+  const out: ExtractedAttachment[] = [];
+  for (const m of text.matchAll(ATTACHMENT_RE)) {
+    const id = m[1].replace(/[.,;:]+$/, ""); // trailing prose punctuation
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, url: `https://github.com/user-attachments/${id}` });
+  }
+  return out;
+}
+
+export function hasUserAttachmentUrl(text: string): boolean {
+  return text.includes("github.com/user-attachments/");
+}
+
+export function attachmentKeyBasename(id: string): string {
+  const flat = id.replace(/^(assets|files)\//, "").replace(/\//g, "-");
+  return flat
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/-+\./g, ".") // "final-.png" -> "final.png"
+    .replace(/^[-.]+|-+$/g, "");
+}

--- a/apps/api/src/github-comment-render.ts
+++ b/apps/api/src/github-comment-render.ts
@@ -15,7 +15,11 @@ export interface GhTarget {
   num: number;
 }
 
-function sanitizeKeySegment(s: string): string {
+/** Non-safe chars → `-` for a single R2 key segment (owner/name/branch/…).
+ * Exported for reuse by other GitHub-key builders (github-ingest.ts) that
+ * need the identical sanitization rule — github-promote.ts keeps its own
+ * byte-identical private copy rather than importing this one. */
+export function sanitizeKeySegment(s: string): string {
   return s.replace(/[^A-Za-z0-9._-]/g, "-");
 }
 

--- a/apps/api/src/github-ingest-ledger.ts
+++ b/apps/api/src/github-ingest-ledger.ts
@@ -1,0 +1,154 @@
+/**
+ * Ledger of GitHub-native user-attachments mirrored into workspaces
+ * (`github_ingested_assets` D1 table), the idempotency backbone for the
+ * ingest reconcile loop (see docs/superpowers/specs/2026-08-11-github-
+ * attachment-ingestion-design.md). One row per (repo, asset id);
+ * `detachedAt` NULL means the asset is currently referenced by `source` in
+ * the PR/issue body or comment it was recorded against. When a subsequent
+ * scan no longer finds the asset referenced, the reconciler sets
+ * `detachedAt`; if it later reappears, `detachedAt` is cleared back to null
+ * rather than inserting a duplicate row.
+ *
+ * This module is called from inside the queue consumer, where a D1 failure
+ * must surface as a thrown error so the queue retries the delivery — unlike
+ * github-repo-links.ts's `findRepoLink`/`recordRepoLink`, nothing here
+ * swallows errors.
+ */
+
+export interface IngestLedgerRow {
+  repo: string; // lowercase owner/name
+  assetId: string; // path after /user-attachments/, e.g. "assets/<uuid>" or "files/123/shot.png"
+  workspace: string;
+  objectKey: string;
+  kind: "pull" | "issues";
+  num: number;
+  source: string; // "body" | "comment:<id>"
+  createdAt: string; // ISO
+  detachedAt: string | null;
+}
+
+interface IngestLedgerDbRow {
+  repo: string;
+  asset_id: string;
+  workspace: string;
+  object_key: string;
+  kind: "pull" | "issues";
+  num: number;
+  source: string;
+  created_at: string;
+  detached_at: string | null;
+}
+
+function normalizeRepo(repo: string): string {
+  return repo.toLowerCase();
+}
+
+function fromRow(row: IngestLedgerDbRow): IngestLedgerRow {
+  return {
+    repo: row.repo,
+    assetId: row.asset_id,
+    workspace: row.workspace,
+    objectKey: row.object_key,
+    kind: row.kind,
+    num: row.num,
+    source: row.source,
+    createdAt: row.created_at,
+    detachedAt: row.detached_at,
+  };
+}
+
+/**
+ * Records a newly-discovered ingested asset. `INSERT OR IGNORE` on the
+ * (repo, asset_id) primary key: a duplicate record (the same asset seen
+ * again on a later scan) is a silent no-op rather than an overwrite —
+ * `setLedgerDetached`/`setLedgerSource` are the explicit ways to update an
+ * existing row.
+ */
+export async function recordIngestedAsset(
+  db: D1Database,
+  row: Omit<IngestLedgerRow, "detachedAt">,
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO github_ingested_assets
+         (repo, asset_id, workspace, object_key, kind, num, source, created_at, detached_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+    )
+    .bind(
+      normalizeRepo(row.repo),
+      row.assetId,
+      row.workspace,
+      row.objectKey,
+      row.kind,
+      row.num,
+      row.source,
+      row.createdAt,
+    )
+    .run();
+}
+
+/** The ledger row for a single (repo, asset id), or null if never recorded. */
+export async function ledgerRow(
+  db: D1Database,
+  repo: string,
+  assetId: string,
+): Promise<IngestLedgerRow | null> {
+  const row = await db
+    .prepare(
+      `SELECT repo, asset_id, workspace, object_key, kind, num, source, created_at, detached_at
+       FROM github_ingested_assets WHERE repo = ? AND asset_id = ?`,
+    )
+    .bind(normalizeRepo(repo), assetId)
+    .first<IngestLedgerDbRow>();
+  return row ? fromRow(row) : null;
+}
+
+/** All ledger rows for `repo` currently attributed to `source` ("body" or "comment:<id>"). */
+export async function ledgerRowsForSource(
+  db: D1Database,
+  repo: string,
+  source: string,
+): Promise<IngestLedgerRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT repo, asset_id, workspace, object_key, kind, num, source, created_at, detached_at
+       FROM github_ingested_assets WHERE repo = ? AND source = ?`,
+    )
+    .bind(normalizeRepo(repo), source)
+    .all<IngestLedgerDbRow>();
+  return (results ?? []).map(fromRow);
+}
+
+/**
+ * Flips `detachedAt` for a ledger row — set to a timestamp when the
+ * reconciler no longer finds the asset referenced, or back to null when it
+ * reappears.
+ */
+export async function setLedgerDetached(
+  db: D1Database,
+  repo: string,
+  assetId: string,
+  detachedAt: string | null,
+): Promise<void> {
+  await db
+    .prepare(`UPDATE github_ingested_assets SET detached_at = ? WHERE repo = ? AND asset_id = ?`)
+    .bind(detachedAt, normalizeRepo(repo), assetId)
+    .run();
+}
+
+/**
+ * Moves an already-recorded asset between sources (e.g. a comment gets
+ * edited and the asset now lives under a different comment id, or moves
+ * from a comment into the body).
+ */
+export async function setLedgerSource(
+  db: D1Database,
+  repo: string,
+  assetId: string,
+  source: string,
+): Promise<void> {
+  await db
+    .prepare(`UPDATE github_ingested_assets SET source = ? WHERE repo = ? AND asset_id = ?`)
+    .bind(source, normalizeRepo(repo), assetId)
+    .run();
+}

--- a/apps/api/src/github-ingest.test.ts
+++ b/apps/api/src/github-ingest.test.ts
@@ -24,6 +24,7 @@ import { recordRepoLink } from "./github-repo-links";
 import type { WorkspaceRecord } from "./workspace";
 import { FakeKv } from "../test/fake-kv";
 import { GITHUB_APP_CFG_ENV } from "../test/github-app-env";
+import { fakeFetch, pngRoute, withGlobalFetch } from "../test/helpers/github-fetch-fakes";
 import { UsageFakeD1 } from "../test/usage-fake-d1";
 
 const REPO = "acme/app";
@@ -56,20 +57,6 @@ function withRegistry(env: Env, record: WorkspaceRecord): Env {
   return { ...env, REGISTRY: registry } as unknown as Env;
 }
 
-/** Matches routes by substring against the requested URL, like repo-comment-config.test.ts's fakeFetch. */
-function fakeFetch(routes: Record<string, (init: RequestInit) => Response | Promise<Response>>) {
-  return (async (url: string, init: RequestInit = {}) => {
-    for (const [pattern, handler] of Object.entries(routes)) {
-      if (String(url).includes(pattern)) return handler(init);
-    }
-    return new Response("not found", { status: 404 });
-  }) as unknown as typeof fetch;
-}
-
-function pngRoute(): Response {
-  return new Response(PNG, { status: 200, headers: { "content-type": "image/png" } });
-}
-
 function spyPut() {
   const calls: Array<{
     key: string;
@@ -100,20 +87,10 @@ function spyPut() {
   return { putImpl: putImpl as unknown as typeof import("./files-core").putObject, calls };
 }
 
-async function withGlobalFetch<T>(impl: typeof fetch, fn: () => Promise<T>): Promise<T> {
-  const real = globalThis.fetch;
-  globalThis.fetch = impl;
-  try {
-    return await fn();
-  } finally {
-    globalThis.fetch = real;
-  }
-}
-
 describe("reconcileIngestSource", () => {
   it("new asset in body: put + ledger row + metadata stamped", async () => {
     const { env } = baseEnv();
-    const fetchImpl = fakeFetch({ [ASSET_ID]: pngRoute });
+    const fetchImpl = fakeFetch({ [ASSET_ID]: pngRoute(PNG) });
     const { putImpl, calls } = spyPut();
     const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
 
@@ -158,7 +135,7 @@ describe("reconcileIngestSource", () => {
       source: "body",
       createdAt: new Date().toISOString(),
     });
-    const fetchImpl = vi.fn(fakeFetch({ [ASSET_ID]: pngRoute }));
+    const fetchImpl = vi.fn(fakeFetch({ [ASSET_ID]: pngRoute(PNG) }));
     const { putImpl, calls } = spyPut();
 
     const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, "octocat", {
@@ -278,6 +255,78 @@ describe("reconcileIngestSource", () => {
     expect(await ledgerRow(env.DB, REPO, ASSET_ID)).toBeNull();
   });
 
+  it("media gate derives from the shared upload allowlist: AVIF (in guards.ts's allowlist) is accepted", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    // ftyp box (offset 4) with major brand "avif" — the exact bytes
+    // guards.ts's detectContentType sniffs as image/avif.
+    const AVIF = new Uint8Array([
+      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66,
+    ]);
+    const fetchImpl = fakeFetch({
+      [ASSET_ID]: () =>
+        new Response(AVIF, { status: 200, headers: { "content-type": "image/avif" } }),
+    });
+    const { putImpl, calls } = spyPut();
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, {
+      fetchImpl,
+      putImpl,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.key).toBe(`gh/acme-app/pull-7/${attachmentKeyBasename(ASSET_ID)}.avif`);
+    expect(summary.skipped).toEqual([]);
+  });
+
+  it("media gate follows a workspace's own restricted allowlist: webm passes when it's in policy.allowed", async () => {
+    const { env } = baseEnv();
+    const webmWs = { allowedContentTypes: ["video/webm"] } as WorkspaceRecord;
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    // EBML header — the bytes detectContentType sniffs as video/webm.
+    const WEBM = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 1, 2, 3, 4]);
+    const fetchImpl = fakeFetch({
+      [ASSET_ID]: () =>
+        new Response(WEBM, { status: 200, headers: { "content-type": "video/webm" } }),
+    });
+    const { putImpl, calls } = spyPut();
+
+    const summary = await reconcileIngestSource(env, webmWs, WS, ref, `see ${ASSET_URL}`, null, {
+      fetchImpl,
+      putImpl,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.key).toBe(`gh/acme-app/pull-7/${attachmentKeyBasename(ASSET_ID)}.webm`);
+    expect(summary.skipped).toEqual([]);
+  });
+
+  it("media gate follows a workspace's own restricted allowlist: a type outside it (PNG) is skipped even though the default allowlist accepts it", async () => {
+    const { env } = baseEnv();
+    // Restricted to webm only — proves the gate reads `policy.allowed`
+    // rather than a fixed table that would accept PNG regardless.
+    const webmOnlyWs = { allowedContentTypes: ["video/webm"] } as WorkspaceRecord;
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    const fetchImpl = fakeFetch({ [ASSET_ID]: pngRoute(PNG) });
+    const { putImpl, calls } = spyPut();
+
+    const summary = await reconcileIngestSource(
+      env,
+      webmOnlyWs,
+      WS,
+      ref,
+      `see ${ASSET_URL}`,
+      null,
+      {
+        fetchImpl,
+        putImpl,
+      },
+    );
+
+    expect(calls).toHaveLength(0);
+    expect(summary.skipped).toEqual([{ url: ASSET_URL, reason: "unsupported_media_type" }]);
+  });
+
   it("guard skip: asset 404 is a permanent skip", async () => {
     const { env } = baseEnv();
     const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
@@ -295,7 +344,7 @@ describe("reconcileIngestSource", () => {
     const { env } = baseEnv();
     const smallWs = { maxUploadBytes: 4 } as WorkspaceRecord;
     const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
-    const fetchImpl = fakeFetch({ [ASSET_ID]: pngRoute });
+    const fetchImpl = fakeFetch({ [ASSET_ID]: pngRoute(PNG) });
     const { putImpl, calls } = spyPut();
 
     const summary = await reconcileIngestSource(env, smallWs, WS, ref, `see ${ASSET_URL}`, null, {
@@ -311,7 +360,7 @@ describe("reconcileIngestSource", () => {
   it("budget-code putImpl error is a skip; a plain error rethrows", async () => {
     const { env } = baseEnv();
     const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
-    const fetchImpl = fakeFetch({ [ASSET_ID]: pngRoute });
+    const fetchImpl = fakeFetch({ [ASSET_ID]: pngRoute(PNG) });
 
     const budgetPut = vi.fn(async () => {
       throw new InsufficientStorageError("storage quota exceeded", {
@@ -518,7 +567,7 @@ describe("ingestForWebhook", () => {
         new Response(JSON.stringify({ body: `see ${ASSET_URL}`, user: { login: "octocat" } }), {
           status: 200,
         }),
-      [ASSET_ID]: pngRoute,
+      [ASSET_ID]: pngRoute(PNG),
     });
     const { putImpl, calls } = spyPut();
     const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
@@ -596,7 +645,7 @@ describe("reconcileIngestTarget", () => {
       if (u.includes("/repos/acme/app/issues/7")) {
         return new Response(JSON.stringify({ body: "", user: { login: "bob" } }), { status: 200 });
       }
-      if (u.includes(otherAssetId)) return pngRoute();
+      if (u.includes(otherAssetId)) return pngRoute(PNG)();
       void init;
       return new Response("nf", { status: 404 });
     }) as unknown as typeof fetch;
@@ -654,7 +703,7 @@ describe("reconcileIngestTarget", () => {
       if (u.includes("/repos/acme/app/issues/7")) {
         return new Response(JSON.stringify({ body: "", user: { login: "bob" } }), { status: 200 });
       }
-      if (u.includes(otherAssetId)) return pngRoute();
+      if (u.includes(otherAssetId)) return pngRoute(PNG)();
       return new Response("nf", { status: 404 });
     }) as unknown as typeof fetch;
     const { putImpl, calls } = spyPut();

--- a/apps/api/src/github-ingest.test.ts
+++ b/apps/api/src/github-ingest.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Task 4 of the GitHub attachment ingestion feature (spec
+ * docs/superpowers/specs/2026-08-11-github-attachment-ingestion-design.md):
+ * the reconcile core + fetch/store pipeline. `reconcileIngestSource` is
+ * exercised directly via the `IngestDeps` seams (no module mocking needed);
+ * `ingestForWebhook` additionally exercises `resolveRepoCommentOptions`
+ * (repo-comment-config.ts), which is not fetch-seamed, so those tests swap
+ * `globalThis.fetch` for the duration of the call (repo-comment-config.test.ts
+ * style) in addition to passing the same fake as `deps.fetchImpl`.
+ */
+import { InsufficientStorageError } from "@uploads/errors";
+import { describe, expect, it, vi } from "vitest";
+import { attachmentKeyBasename } from "./github-attachment-extract";
+import {
+  ingestForWebhook,
+  reconcileIngestSource,
+  reconcileIngestTarget,
+  type IngestSourceRef,
+} from "./github-ingest";
+import { ledgerRow, ledgerRowsForSource, recordIngestedAsset } from "./github-ingest-ledger";
+import { setLedgerDetached } from "./github-ingest-ledger";
+import { getFileMetadata, replaceFileMetadata } from "./file-metadata";
+import { recordRepoLink } from "./github-repo-links";
+import type { WorkspaceRecord } from "./workspace";
+import { FakeKv } from "../test/fake-kv";
+import { GITHUB_APP_CFG_ENV } from "../test/github-app-env";
+import { UsageFakeD1 } from "../test/usage-fake-d1";
+
+const REPO = "acme/app";
+const WS = "acme";
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+const ASSET_ID = "assets/11111111-1111-1111-1111-111111111111";
+const ASSET_URL = `https://github.com/user-attachments/${ASSET_ID}`;
+const KEY = `gh/acme-app/pull-7/${attachmentKeyBasename(ASSET_ID)}.png`;
+
+const ws = {} as WorkspaceRecord;
+
+function baseEnv(): { env: Env; db: UsageFakeD1; kv: FakeKv } {
+  const db = new UsageFakeD1();
+  const kv = new FakeKv();
+  kv.store.set("ghinst:acme/app", { value: "42" });
+  kv.store.set("ghtok:42", { value: "ghs_test" });
+  const env = {
+    DB: db,
+    GITHUB_CACHE: kv,
+    ...GITHUB_APP_CFG_ENV,
+  } as unknown as Env;
+  return { env, db, kv };
+}
+
+function withRegistry(env: Env, record: WorkspaceRecord): Env {
+  const registry = {
+    get: (async (key: string) =>
+      key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+  };
+  return { ...env, REGISTRY: registry } as unknown as Env;
+}
+
+/** Matches routes by substring against the requested URL, like repo-comment-config.test.ts's fakeFetch. */
+function fakeFetch(routes: Record<string, (init: RequestInit) => Response | Promise<Response>>) {
+  return (async (url: string, init: RequestInit = {}) => {
+    for (const [pattern, handler] of Object.entries(routes)) {
+      if (String(url).includes(pattern)) return handler(init);
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+function pngRoute(): Response {
+  return new Response(PNG, { status: 200, headers: { "content-type": "image/png" } });
+}
+
+function spyPut() {
+  const calls: Array<{
+    key: string;
+    bytes: Uint8Array;
+    workspaceName: string;
+    opts?: Record<string, unknown>;
+  }> = [];
+  const putImpl = vi.fn(
+    async (
+      _env: Env,
+      _ws: WorkspaceRecord,
+      key: string,
+      bytes: Uint8Array,
+      workspaceName: string,
+      opts?: Record<string, unknown>,
+    ) => {
+      calls.push({ key, bytes, workspaceName, opts });
+      return {
+        key,
+        size: bytes.length,
+        contentType: "image/png",
+        replaced: false,
+        url: null,
+        embedUrl: null,
+      };
+    },
+  );
+  return { putImpl: putImpl as unknown as typeof import("./files-core").putObject, calls };
+}
+
+async function withGlobalFetch<T>(impl: typeof fetch, fn: () => Promise<T>): Promise<T> {
+  const real = globalThis.fetch;
+  globalThis.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = real;
+  }
+}
+
+describe("reconcileIngestSource", () => {
+  it("new asset in body: put + ledger row + metadata stamped", async () => {
+    const { env } = baseEnv();
+    const fetchImpl = fakeFetch({ [ASSET_ID]: pngRoute });
+    const { putImpl, calls } = spyPut();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, "octocat", {
+      fetchImpl,
+      putImpl,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.key).toBe(KEY);
+    expect(calls[0]!.workspaceName).toBe(WS);
+    expect(calls[0]!.opts?.metadata).toEqual({
+      "gh.repo": "acme/app",
+      "gh.kind": "pull",
+      "gh.number": "7",
+      "gh.origin": "github",
+      "gh.author": "octocat",
+      "gh.detached": "false",
+      "gh.source": "body",
+    });
+    expect(calls[0]!.opts?.surface).toBe("github");
+    expect(calls[0]!.opts?.replace).toBe(true);
+
+    expect(summary).toEqual({ ingested: [KEY], reattached: [], detached: [], skipped: [] });
+
+    const row = await ledgerRow(env.DB, REPO, ASSET_ID);
+    expect(row).not.toBeNull();
+    expect(row?.detachedAt).toBeNull();
+    expect(row?.objectKey).toBe(KEY);
+  });
+
+  it("already-ledgered asset: no re-fetch, no put", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    await recordIngestedAsset(env.DB, {
+      repo: REPO,
+      assetId: ASSET_ID,
+      workspace: WS,
+      objectKey: KEY,
+      kind: "pull",
+      num: 7,
+      source: "body",
+      createdAt: new Date().toISOString(),
+    });
+    const fetchImpl = vi.fn(fakeFetch({ [ASSET_ID]: pngRoute }));
+    const { putImpl, calls } = spyPut();
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, "octocat", {
+      fetchImpl,
+      putImpl,
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(summary).toEqual({ ingested: [], reattached: [], detached: [], skipped: [] });
+  });
+
+  it("removed from text: detaches the ledger row and flips gh.detached", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    await recordIngestedAsset(env.DB, {
+      repo: REPO,
+      assetId: ASSET_ID,
+      workspace: WS,
+      objectKey: KEY,
+      kind: "pull",
+      num: 7,
+      source: "body",
+      createdAt: new Date().toISOString(),
+    });
+    await replaceFileMetadata(env.DB, WS, KEY, { "gh.detached": "false" });
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, "no attachment here", null, {});
+
+    expect(summary).toEqual({ ingested: [], reattached: [], detached: [KEY], skipped: [] });
+    const row = await ledgerRow(env.DB, REPO, ASSET_ID);
+    expect(row?.detachedAt).not.toBeNull();
+    const meta = await getFileMetadata(env.DB, WS, KEY);
+    expect(meta["gh.detached"]).toBe("true");
+  });
+
+  it("re-added after detach: reattaches without re-fetching or re-putting", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    await recordIngestedAsset(env.DB, {
+      repo: REPO,
+      assetId: ASSET_ID,
+      workspace: WS,
+      objectKey: KEY,
+      kind: "pull",
+      num: 7,
+      source: "body",
+      createdAt: new Date().toISOString(),
+    });
+    await setLedgerDetached(env.DB, REPO, ASSET_ID, new Date().toISOString());
+    await replaceFileMetadata(env.DB, WS, KEY, { "gh.detached": "true" });
+    const { putImpl, calls } = spyPut();
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, "octocat", {
+      putImpl,
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(summary).toEqual({ ingested: [], reattached: [KEY], detached: [], skipped: [] });
+    const row = await ledgerRow(env.DB, REPO, ASSET_ID);
+    expect(row?.detachedAt).toBeNull();
+    const meta = await getFileMetadata(env.DB, WS, KEY);
+    expect(meta["gh.detached"]).toBe("false");
+  });
+
+  it("text: null (comment deleted) detaches only that source's rows", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "issues", num: 3, source: "comment:9" };
+    const key1 = "gh/acme-app/issues-3/asset-one.png";
+    const key2 = "gh/acme-app/issues-3/asset-two.png";
+    await recordIngestedAsset(env.DB, {
+      repo: REPO,
+      assetId: "assets/one",
+      workspace: WS,
+      objectKey: key1,
+      kind: "issues",
+      num: 3,
+      source: "comment:9",
+      createdAt: new Date().toISOString(),
+    });
+    await recordIngestedAsset(env.DB, {
+      repo: REPO,
+      assetId: "assets/two",
+      workspace: WS,
+      objectKey: key2,
+      kind: "issues",
+      num: 3,
+      source: "body",
+      createdAt: new Date().toISOString(),
+    });
+    await replaceFileMetadata(env.DB, WS, key1, { "gh.detached": "false" });
+    await replaceFileMetadata(env.DB, WS, key2, { "gh.detached": "false" });
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, null, null, {});
+
+    expect(summary.detached).toEqual([key1]);
+    expect((await ledgerRow(env.DB, REPO, "assets/one"))?.detachedAt).not.toBeNull();
+    expect((await ledgerRow(env.DB, REPO, "assets/two"))?.detachedAt).toBeNull();
+  });
+
+  it("guard skip: unsupported media type is a permanent skip (no put, no ledger row, no throw)", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    const fetchImpl = fakeFetch({
+      [ASSET_ID]: () =>
+        new Response("<html></html>", { status: 200, headers: { "content-type": "text/html" } }),
+    });
+    const { putImpl, calls } = spyPut();
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, {
+      fetchImpl,
+      putImpl,
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(summary.skipped).toEqual([{ url: ASSET_URL, reason: "unsupported_media_type" }]);
+    expect(await ledgerRow(env.DB, REPO, ASSET_ID)).toBeNull();
+  });
+
+  it("guard skip: asset 404 is a permanent skip", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    const fetchImpl = fakeFetch({ [ASSET_ID]: () => new Response("nf", { status: 404 }) });
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, {
+      fetchImpl,
+    });
+
+    expect(summary.skipped).toEqual([{ url: ASSET_URL, reason: "asset_not_found" }]);
+    expect(await ledgerRow(env.DB, REPO, ASSET_ID)).toBeNull();
+  });
+
+  it("oversize asset: too_large skip, no put", async () => {
+    const { env } = baseEnv();
+    const smallWs = { maxUploadBytes: 4 } as WorkspaceRecord;
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    const fetchImpl = fakeFetch({ [ASSET_ID]: pngRoute });
+    const { putImpl, calls } = spyPut();
+
+    const summary = await reconcileIngestSource(env, smallWs, WS, ref, `see ${ASSET_URL}`, null, {
+      fetchImpl,
+      putImpl,
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(summary.skipped).toEqual([{ url: ASSET_URL, reason: "too_large" }]);
+  });
+
+  it("budget-code putImpl error is a skip; a plain error rethrows", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    const fetchImpl = fakeFetch({ [ASSET_ID]: pngRoute });
+
+    const budgetPut = vi.fn(async () => {
+      throw new InsufficientStorageError("storage quota exceeded", {
+        code: "storage_quota_exceeded",
+      });
+    }) as unknown as typeof import("./files-core").putObject;
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, {
+      fetchImpl,
+      putImpl: budgetPut,
+    });
+    expect(summary.skipped).toEqual([{ url: ASSET_URL, reason: "storage_quota_exceeded" }]);
+    expect(await ledgerRow(env.DB, REPO, ASSET_ID)).toBeNull();
+
+    const boomPut = vi.fn(async () => {
+      throw new Error("boom");
+    }) as unknown as typeof import("./files-core").putObject;
+    await expect(
+      reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, {
+        fetchImpl,
+        putImpl: boomPut,
+      }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("transient asset fetch (503) throws instead of skipping", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    const fetchImpl = fakeFetch({ [ASSET_ID]: () => new Response("err", { status: 503 }) });
+
+    await expect(
+      reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, { fetchImpl }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("ingestForWebhook", () => {
+  it("no repo link: resolves, no fetches", async () => {
+    const { env: base } = baseEnv();
+    const env = withRegistry(base, { provider: "r2", bucket: "b" } as WorkspaceRecord);
+    const fetchImpl = vi.fn(fakeFetch({}));
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+
+    await expect(ingestForWebhook(env, ref, { fetchImpl })).resolves.toBeUndefined();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("link + workspace but knob false: resolves without fetching the issue body or asset", async () => {
+    const { env: base } = baseEnv();
+    const env = withRegistry(base, { provider: "r2", bucket: "b" } as WorkspaceRecord);
+    await recordRepoLink(env.DB, REPO, WS, "test");
+    const calls: string[] = [];
+    const impl = ((url: string, init: RequestInit = {}) => {
+      calls.push(String(url));
+      return fakeFetch({ "/contents/": () => new Response("nf", { status: 404 }) })(url, init);
+    }) as unknown as typeof fetch;
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+
+    await withGlobalFetch(impl, () => ingestForWebhook(env, ref, { fetchImpl: impl }));
+
+    expect(calls.some((u) => u.includes("/issues/7") || u.includes(ASSET_ID))).toBe(false);
+  });
+
+  it("knob true: fetches the issue body, puts, ledgers", async () => {
+    const { env: base } = baseEnv();
+    const env = withRegistry(base, {
+      provider: "r2",
+      bucket: "b",
+      githubIngestAttachments: true,
+    } as WorkspaceRecord);
+    await recordRepoLink(env.DB, REPO, WS, "test");
+    const impl = fakeFetch({
+      "/contents/": () => new Response("nf", { status: 404 }),
+      "/repos/acme/app/issues/7": () =>
+        new Response(JSON.stringify({ body: `see ${ASSET_URL}`, user: { login: "octocat" } }), {
+          status: 200,
+        }),
+      [ASSET_ID]: pngRoute,
+    });
+    const { putImpl, calls } = spyPut();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+
+    await withGlobalFetch(impl, () => ingestForWebhook(env, ref, { fetchImpl: impl, putImpl }));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.key).toBe(KEY);
+    const row = await ledgerRow(env.DB, REPO, ASSET_ID);
+    expect(row).not.toBeNull();
+  });
+
+  it("comment source 404: reconciles with text null (detach-all), not a throw", async () => {
+    const { env: base } = baseEnv();
+    const env = withRegistry(base, {
+      provider: "r2",
+      bucket: "b",
+      githubIngestAttachments: true,
+    } as WorkspaceRecord);
+    await recordRepoLink(env.DB, REPO, WS, "test");
+    const key = "gh/acme-app/issues-3/asset-one.png";
+    await recordIngestedAsset(env.DB, {
+      repo: REPO,
+      assetId: "assets/one",
+      workspace: WS,
+      objectKey: key,
+      kind: "issues",
+      num: 3,
+      source: "comment:44",
+      createdAt: new Date().toISOString(),
+    });
+    await replaceFileMetadata(env.DB, WS, key, { "gh.detached": "false" });
+
+    const impl = fakeFetch({
+      "/contents/": () => new Response("nf", { status: 404 }),
+      "/issues/comments/44": () => new Response("nf", { status: 404 }),
+    });
+    const ref: IngestSourceRef = { repo: REPO, kind: "issues", num: 3, source: "comment:44" };
+
+    await withGlobalFetch(impl, () =>
+      expect(ingestForWebhook(env, ref, { fetchImpl: impl })).resolves.toBeUndefined(),
+    );
+
+    const row = await ledgerRow(env.DB, REPO, "assets/one");
+    expect(row?.detachedAt).not.toBeNull();
+  });
+});
+
+describe("reconcileIngestTarget", () => {
+  it("walks the body and every paginated comment page, merging summaries", async () => {
+    const { env } = baseEnv();
+    const otherAssetId = "assets/22222222-2222-2222-2222-222222222222";
+    const otherAssetUrl = `https://github.com/user-attachments/${otherAssetId}`;
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      id: 300 + i,
+      body: "no attachment here",
+      user: { login: "bob" },
+    }));
+    const page2 = [{ id: 200, body: `see ${otherAssetUrl}`, user: { login: "eve" } }];
+    const commentCalls: string[] = [];
+    const impl = (async (url: string, init: RequestInit = {}) => {
+      const u = String(url);
+      if (u.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (u.includes("/installation")) {
+        return new Response(JSON.stringify({ id: 42 }), { status: 200 });
+      }
+      if (u.includes("/issues/7/comments")) {
+        commentCalls.push(u);
+        if (u.includes("&page=1")) return new Response(JSON.stringify(page1), { status: 200 });
+        if (u.includes("&page=2")) return new Response(JSON.stringify(page2), { status: 200 });
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (u.includes("/repos/acme/app/issues/7")) {
+        return new Response(JSON.stringify({ body: "", user: { login: "bob" } }), { status: 200 });
+      }
+      if (u.includes(otherAssetId)) return pngRoute();
+      void init;
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const { putImpl, calls } = spyPut();
+
+    const summary = await reconcileIngestTarget(
+      env,
+      ws,
+      WS,
+      { repo: REPO, kind: "pull", num: 7 },
+      { fetchImpl: impl, putImpl },
+    );
+
+    expect(commentCalls.filter((u) => u.includes("&page=1"))).toHaveLength(1);
+    expect(commentCalls.filter((u) => u.includes("&page=2"))).toHaveLength(1);
+    expect(commentCalls.filter((u) => u.includes("&page=3"))).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    expect(summary.ingested).toHaveLength(1);
+    const rows = await ledgerRowsForSource(env.DB, REPO, "comment:200");
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/apps/api/src/github-ingest.test.ts
+++ b/apps/api/src/github-ingest.test.ts
@@ -305,6 +305,7 @@ describe("reconcileIngestSource", () => {
 
     expect(calls).toHaveLength(0);
     expect(summary.skipped).toEqual([{ url: ASSET_URL, reason: "too_large" }]);
+    expect(await ledgerRow(env.DB, REPO, ASSET_ID)).toBeNull();
   });
 
   it("budget-code putImpl error is a skip; a plain error rethrows", async () => {
@@ -487,5 +488,112 @@ describe("reconcileIngestTarget", () => {
     expect(summary.ingested).toHaveLength(1);
     const rows = await ledgerRowsForSource(env.DB, REPO, "comment:200");
     expect(rows).toHaveLength(1);
+  });
+
+  it("logs a structured truncation notice when all 3 comment pages come back full, and still reconciles them", async () => {
+    const { env } = baseEnv();
+    const otherAssetId = "assets/33333333-3333-3333-3333-333333333333";
+    const otherAssetUrl = `https://github.com/user-attachments/${otherAssetId}`;
+    const pageOf = (start: number, withAttachmentOnLast: boolean) =>
+      Array.from({ length: 100 }, (_, i) => {
+        const isLast = withAttachmentOnLast && i === 99;
+        return {
+          id: start + i,
+          body: isLast ? `see ${otherAssetUrl}` : "no attachment here",
+          user: { login: "bob" },
+        };
+      });
+    const page1 = pageOf(1000, false);
+    const page2 = pageOf(2000, false);
+    const page3 = pageOf(3000, true); // last comment on page 3 carries the attachment
+    const commentCalls: string[] = [];
+    const impl = (async (url: string) => {
+      const u = String(url);
+      if (u.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (u.includes("/installation")) {
+        return new Response(JSON.stringify({ id: 42 }), { status: 200 });
+      }
+      if (u.includes("/issues/7/comments")) {
+        commentCalls.push(u);
+        if (u.includes("&page=1")) return new Response(JSON.stringify(page1), { status: 200 });
+        if (u.includes("&page=2")) return new Response(JSON.stringify(page2), { status: 200 });
+        if (u.includes("&page=3")) return new Response(JSON.stringify(page3), { status: 200 });
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (u.includes("/repos/acme/app/issues/7")) {
+        return new Response(JSON.stringify({ body: "", user: { login: "bob" } }), { status: 200 });
+      }
+      if (u.includes(otherAssetId)) return pngRoute();
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const { putImpl, calls } = spyPut();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const summary = await reconcileIngestTarget(
+        env,
+        ws,
+        WS,
+        { repo: REPO, kind: "pull", num: 7 },
+        { fetchImpl: impl, putImpl },
+      );
+
+      expect(commentCalls.filter((u) => u.includes("&page=1"))).toHaveLength(1);
+      expect(commentCalls.filter((u) => u.includes("&page=2"))).toHaveLength(1);
+      expect(commentCalls.filter((u) => u.includes("&page=3"))).toHaveLength(1);
+      expect(commentCalls.filter((u) => u.includes("&page=4"))).toHaveLength(0);
+      // The reconciler still processed every comment it fetched, including
+      // page 3's — the truncation is "we stopped requesting more pages",
+      // not "we dropped what we already have".
+      expect(calls).toHaveLength(1);
+      expect(summary.ingested).toHaveLength(1);
+      const rows = await ledgerRowsForSource(env.DB, REPO, `comment:${3000 + 99}`);
+      expect(rows).toHaveLength(1);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        JSON.stringify({
+          message: "github ingest comment scan truncated",
+          repo: REPO,
+          num: 7,
+        }),
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("throws github_app_not_installed instead of an empty summary when the app isn't configured", async () => {
+    const db = new UsageFakeD1();
+    const kv = new FakeKv(); // no ghinst:/ghtok: cache entries seeded
+    const env = {
+      DB: db,
+      GITHUB_CACHE: kv,
+      // Deliberately omit GITHUB_APP_CFG_ENV so githubAppConfig(env) returns null.
+    } as unknown as Env;
+
+    await expect(
+      reconcileIngestTarget(env, ws, WS, { repo: REPO, kind: "pull", num: 7 }, {}),
+    ).rejects.toMatchObject({ code: "github_app_not_installed" });
+  });
+
+  it("throws github_app_not_installed when the app is configured but not installed on the repo", async () => {
+    const { env } = baseEnv();
+    const impl = fakeFetch({
+      "/installation": () => new Response("nf", { status: 404 }),
+    });
+    // Bypass the KV-cached installation id from baseEnv() so installationForRepo actually misses.
+    const freshEnv = { ...env, GITHUB_CACHE: new FakeKv() } as unknown as Env;
+
+    await expect(
+      reconcileIngestTarget(
+        freshEnv,
+        ws,
+        WS,
+        { repo: REPO, kind: "pull", num: 7 },
+        { fetchImpl: impl },
+      ),
+    ).rejects.toMatchObject({ code: "github_app_not_installed" });
   });
 });

--- a/apps/api/src/github-ingest.test.ts
+++ b/apps/api/src/github-ingest.test.ts
@@ -8,7 +8,7 @@
  * `globalThis.fetch` for the duration of the call (repo-comment-config.test.ts
  * style) in addition to passing the same fake as `deps.fetchImpl`.
  */
-import { InsufficientStorageError } from "@uploads/errors";
+import { InsufficientStorageError, RateLimitedError } from "@uploads/errors";
 import { describe, expect, it, vi } from "vitest";
 import { attachmentKeyBasename } from "./github-attachment-extract";
 import {
@@ -373,6 +373,20 @@ describe("reconcileIngestSource", () => {
       putImpl: budgetPut,
     });
     expect(summary.skipped).toEqual([{ url: ASSET_URL, reason: "storage_quota_exceeded" }]);
+    expect(await ledgerRow(env.DB, REPO, ASSET_ID)).toBeNull();
+
+    // upload_budget_exceeded is typed rate_limited (normally retryable) but
+    // budget windows outlast queue retries — the carve-out keeps it a skip.
+    const uploadBudgetPut = vi.fn(async () => {
+      throw new RateLimitedError("upload budget exceeded", {
+        code: "upload_budget_exceeded",
+      });
+    }) as unknown as typeof import("./files-core").putObject;
+    const budgetSummary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, {
+      fetchImpl,
+      putImpl: uploadBudgetPut,
+    });
+    expect(budgetSummary.skipped).toEqual([{ url: ASSET_URL, reason: "upload_budget_exceeded" }]);
     expect(await ledgerRow(env.DB, REPO, ASSET_ID)).toBeNull();
 
     const boomPut = vi.fn(async () => {

--- a/apps/api/src/github-ingest.test.ts
+++ b/apps/api/src/github-ingest.test.ts
@@ -346,6 +346,135 @@ describe("reconcileIngestSource", () => {
       reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, { fetchImpl }),
     ).rejects.toThrow();
   });
+
+  /**
+   * Wraps `env.DB` so the FIRST `.run()` on a statement whose normalized SQL
+   * contains `sqlSubstring` throws, then behaves normally forever after —
+   * simulating a transient D1 failure on exactly one write (e.g. the ledger
+   * UPDATE) without disturbing any other statement. Used by the retry-safety
+   * regression tests below: metadata-first ordering means a ledger-write
+   * failure must leave the ledger guard seeing pre-write state, so a second
+   * reconcile call redoes (idempotently) both writes and reaches a fully
+   * consistent end state.
+   */
+  function failOnceOn(db: Env["DB"], sqlSubstring: string): Env["DB"] {
+    let armed = true;
+    const originalPrepare = db.prepare.bind(db);
+    return {
+      ...db,
+      prepare: (sql: string) => {
+        const stmt = originalPrepare(sql);
+        if (!sql.replace(/\s+/g, " ").includes(sqlSubstring)) return stmt;
+        return {
+          ...stmt,
+          bind: (...args: unknown[]) => {
+            const bound = stmt.bind(...args);
+            return {
+              ...bound,
+              run: async () => {
+                if (armed) {
+                  armed = false;
+                  throw new Error("transient D1 failure");
+                }
+                return bound.run();
+              },
+            };
+          },
+        };
+      },
+    } as unknown as Env["DB"];
+  }
+
+  it("retry-safe reattach: ledger write fails first, retry reaches consistent state", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    await recordIngestedAsset(env.DB, {
+      repo: REPO,
+      assetId: ASSET_ID,
+      workspace: WS,
+      objectKey: KEY,
+      kind: "pull",
+      num: 7,
+      source: "body",
+      createdAt: new Date().toISOString(),
+    });
+    await setLedgerDetached(env.DB, REPO, ASSET_ID, new Date().toISOString());
+    await replaceFileMetadata(env.DB, WS, KEY, { "gh.detached": "true" });
+
+    const flakyDb = failOnceOn(env.DB, "UPDATE github_ingested_assets SET detached_at");
+    const flakyEnv = { ...env, DB: flakyDb } as unknown as Env;
+
+    await expect(
+      reconcileIngestSource(flakyEnv, ws, WS, ref, `see ${ASSET_URL}`, "octocat", {}),
+    ).rejects.toThrow("transient D1 failure");
+
+    // Metadata-first: the metadata write landed even though the call
+    // rejected, but the ledger row is still marked detached — the guard
+    // will see stale state and redo both writes on retry.
+    expect((await getFileMetadata(env.DB, WS, KEY))["gh.detached"]).toBe("false");
+    expect((await ledgerRow(env.DB, REPO, ASSET_ID))?.detachedAt).not.toBeNull();
+
+    const summary = await reconcileIngestSource(
+      flakyEnv,
+      ws,
+      WS,
+      ref,
+      `see ${ASSET_URL}`,
+      "octocat",
+      {},
+    );
+
+    expect(summary).toEqual({ ingested: [], reattached: [KEY], detached: [], skipped: [] });
+    const row = await ledgerRow(env.DB, REPO, ASSET_ID);
+    expect(row?.detachedAt).toBeNull();
+    const meta = await getFileMetadata(env.DB, WS, KEY);
+    expect(meta["gh.detached"]).toBe("false");
+  });
+
+  it("retry-safe detach: ledger write fails first, retry reaches consistent state", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    await recordIngestedAsset(env.DB, {
+      repo: REPO,
+      assetId: ASSET_ID,
+      workspace: WS,
+      objectKey: KEY,
+      kind: "pull",
+      num: 7,
+      source: "body",
+      createdAt: new Date().toISOString(),
+    });
+    await replaceFileMetadata(env.DB, WS, KEY, { "gh.detached": "false" });
+
+    const flakyDb = failOnceOn(env.DB, "UPDATE github_ingested_assets SET detached_at");
+    const flakyEnv = { ...env, DB: flakyDb } as unknown as Env;
+
+    await expect(
+      reconcileIngestSource(flakyEnv, ws, WS, ref, "no attachment here", null, {}),
+    ).rejects.toThrow("transient D1 failure");
+
+    // Metadata-first: the metadata write landed even though the call
+    // rejected, but the ledger row is still attached — the guard will see
+    // stale state and redo both writes on retry.
+    expect((await getFileMetadata(env.DB, WS, KEY))["gh.detached"]).toBe("true");
+    expect((await ledgerRow(env.DB, REPO, ASSET_ID))?.detachedAt).toBeNull();
+
+    const summary = await reconcileIngestSource(
+      flakyEnv,
+      ws,
+      WS,
+      ref,
+      "no attachment here",
+      null,
+      {},
+    );
+
+    expect(summary).toEqual({ ingested: [], reattached: [], detached: [KEY], skipped: [] });
+    const row = await ledgerRow(env.DB, REPO, ASSET_ID);
+    expect(row?.detachedAt).not.toBeNull();
+    const meta = await getFileMetadata(env.DB, WS, KEY);
+    expect(meta["gh.detached"]).toBe("true");
+  });
 });
 
 describe("ingestForWebhook", () => {

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -210,8 +210,13 @@ async function fetchAndStore(
     // request later can't succeed, so it's a permanent skip like the other
     // guard checks above. An AppError with a retryable type (rate_limited,
     // unavailable) or any non-AppError failure rethrows, so the queue's own
-    // retry/backoff handles it instead.
-    if (err instanceof AppError && !isRetryableType(err.type)) {
+    // retry/backoff handles it instead. One carve-out: upload_budget_exceeded
+    // is typed rate_limited, but its budget window outlasts any queue retry
+    // horizon — the spec calls it a permanent skip, not a retry.
+    if (
+      err instanceof AppError &&
+      (!isRetryableType(err.type) || err.code === "upload_budget_exceeded")
+    ) {
       return { kind: "skip", reason: err.code ?? err.type };
     }
     throw err;

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -23,6 +23,7 @@
  * queue's own retry/backoff handles them.
  */
 
+import { NotFoundError } from "@uploads/errors";
 import { attachmentKeyBasename, extractUserAttachments } from "./github-attachment-extract";
 import {
   githubAppConfig,
@@ -315,6 +316,15 @@ export async function ingestForWebhook(
  * comment (paginated, 100/page, up to 3 pages — a repo with a genuinely
  * longer thread logs a structured truncation notice rather than silently
  * capping). Returns the merged summary across body + all comments.
+ *
+ * Unlike `ingestForWebhook` (which degrades to a silent no-op when the repo
+ * isn't linked or the knob is off — routine, expected states for most repos)
+ * a missing/uninstalled GitHub App here is surfaced as a thrown
+ * `NotFoundError` (`code: "github_app_not_installed"`): this entry point is
+ * driven by an explicit user/admin action whose result is shown back to
+ * them, so an empty summary would be indistinguishable from "nothing to
+ * ingest" when the real story is "ingestion can't run at all". Token-mint
+ * failure still throws a plain (transient) `Error`, unchanged.
  */
 export async function reconcileIngestTarget(
   env: Env,
@@ -327,9 +337,16 @@ export async function reconcileIngestTarget(
   const merged = emptySummary();
 
   const cfg = githubAppConfig(env);
-  if (!cfg) return merged;
+  if (!cfg) {
+    throw new NotFoundError("github app not configured", { code: "github_app_not_installed" });
+  }
   const installationId = await installationForRepo(env, cfg, target.repo, fetchImpl);
-  if (installationId === null) return merged;
+  if (installationId === null) {
+    throw new NotFoundError("github app not installed on repo", {
+      code: "github_app_not_installed",
+      details: { repo: target.repo },
+    });
+  }
   const token = await installationToken(env, cfg, installationId, fetchImpl);
   if (!token) throw new Error("github installation token mint failed");
 

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -1,0 +1,414 @@
+/**
+ * GitHub attachment ingest reconcile core (Task 4, spec
+ * docs/superpowers/specs/2026-08-11-github-attachment-ingestion-design.md):
+ * mirrors `github.com/user-attachments/...` URLs referenced from a PR/issue
+ * body or comment into workspace-owned storage, so they survive independent
+ * of GitHub's own attachment lifecycle and carry the same queryable
+ * `gh.*` metadata as every other managed GitHub upload.
+ *
+ * The ledger (`github-ingest-ledger.ts`) is the idempotency backbone: a
+ * `(repo, assetId)` row records that an asset has already been fetched and
+ * stored (`objectKey`), independent of which PR/issue/comment it currently
+ * lives under. Reconciling a source diffs "assets currently referenced in
+ * this text" against "ledger rows currently attributed to this source":
+ * newly-referenced assets not yet ledgered are fetched and stored; ledgered
+ * assets no longer referenced are marked `detached` (their `gh.detached`
+ * metadata flips to "true", never deleted — the object stays addressable);
+ * a detached asset that reappears is reattached without a re-fetch.
+ *
+ * Guard failures (non-media, oversize, over budget, asset 404/403/410) are
+ * PERMANENT skips: recorded in the summary, never ledgered, never thrown —
+ * a queue consumer must not retry a payload that will never succeed. Network
+ * failures, GitHub 5xx, and installation-token mint failures throw, so the
+ * queue's own retry/backoff handles them.
+ */
+
+import { attachmentKeyBasename, extractUserAttachments } from "./github-attachment-extract";
+import {
+  githubAppConfig,
+  githubFetch,
+  githubHeaders,
+  installationForRepo,
+  installationToken,
+} from "./github-app";
+import {
+  ledgerRow,
+  ledgerRowsForSource,
+  recordIngestedAsset,
+  setLedgerDetached,
+  setLedgerSource,
+} from "./github-ingest-ledger";
+import { updateFileMetadataValue } from "./file-metadata";
+import { detectContentType, maxBytesForContentType, resolveUploadPolicy } from "./guards";
+import { putObject } from "./files-core";
+import { findRepoLinkStrict } from "./github-repo-links";
+import { resolveRepoCommentOptions } from "./repo-comment-config";
+import { loadWorkspaceRecord, type WorkspaceRecord } from "./workspace";
+
+export interface IngestSourceRef {
+  repo: string;
+  kind: "pull" | "issues";
+  num: number;
+  /** "body" or "comment:<id>" — the ledger's `source` column. */
+  source: string;
+}
+
+export interface IngestSummary {
+  /** Object keys newly written this pass. */
+  ingested: string[];
+  /** Object keys whose ledger row (and gh.detached metadata) un-detached. */
+  reattached: string[];
+  /** Object keys whose ledger row (and gh.detached metadata) detached. */
+  detached: string[];
+  /** Permanent guard failures — never ledgered, never retried. */
+  skipped: { url: string; reason: string }[];
+}
+
+export interface IngestDeps {
+  fetchImpl?: typeof fetch;
+  putImpl?: typeof putObject;
+  now?: () => Date;
+}
+
+function emptySummary(): IngestSummary {
+  return { ingested: [], reattached: [], detached: [], skipped: [] };
+}
+
+function mergeSummary(into: IngestSummary, from: IngestSummary): void {
+  into.ingested.push(...from.ingested);
+  into.reattached.push(...from.reattached);
+  into.detached.push(...from.detached);
+  into.skipped.push(...from.skipped);
+}
+
+/**
+ * putObject-thrown errors carrying one of these codes are guard failures the
+ * upload path already classified as permanent — the ingest pipeline treats
+ * them the same way (skip, don't ledger, don't retry) rather than duplicating
+ * their thresholds.
+ */
+const SKIP_CODES = new Set([
+  "storage_quota_exceeded",
+  "upload_budget_exceeded",
+  "unsupported_media_type",
+  "file_metadata_limit_exceeded",
+  "empty_body",
+]);
+
+const EXT_BY_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+};
+
+function ingestKey(ref: IngestSourceRef, assetId: string, ext: string): string {
+  const repoSeg = ref.repo.toLowerCase().replace("/", "-");
+  return `gh/${repoSeg}/${ref.kind}-${ref.num}/${attachmentKeyBasename(assetId)}.${ext}`;
+}
+
+function ingestMetadata(ref: IngestSourceRef, author: string | null): Record<string, string> {
+  return {
+    "gh.repo": ref.repo.toLowerCase(),
+    "gh.kind": ref.kind,
+    "gh.number": String(ref.num),
+    "gh.origin": "github",
+    ...(author ? { "gh.author": author } : {}),
+    "gh.detached": "false",
+    "gh.source": ref.source,
+  };
+}
+
+type FetchAndStoreResult = { kind: "ok"; key: string } | { kind: "skip"; reason: string };
+
+/**
+ * Mints an installation token, fetches one asset's bytes, sniffs/guards
+ * them, and puts the object. Guard failures return a `skip` result; a failed
+ * token mint or a non-guard fetch/put failure throws (transient — see the
+ * module doc-comment).
+ */
+async function fetchAndStore(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  ref: IngestSourceRef,
+  attachment: { id: string; url: string },
+  author: string | null,
+  deps: IngestDeps,
+): Promise<FetchAndStoreResult> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const putImpl = deps.putImpl ?? putObject;
+  const now = deps.now ?? (() => new Date());
+
+  const cfg = githubAppConfig(env);
+  if (!cfg) return { kind: "skip", reason: "app_not_configured" };
+  const installationId = await installationForRepo(env, cfg, ref.repo, fetchImpl);
+  if (installationId === null) return { kind: "skip", reason: "app_not_installed" };
+  const token = await installationToken(env, cfg, installationId, fetchImpl);
+  if (!token) throw new Error("github installation token mint failed");
+
+  const res = await githubFetch(fetchImpl, attachment.url, {
+    headers: { authorization: `Bearer ${token}`, "user-agent": "uploads.sh" },
+  });
+  if (res.status === 404 || res.status === 403 || res.status === 410) {
+    return { kind: "skip", reason: "asset_not_found" };
+  }
+  if (!res.ok) {
+    throw new Error(`github asset fetch failed: ${res.status}`);
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+
+  const sniffed = detectContentType(bytes);
+  if (!sniffed || !(sniffed in EXT_BY_TYPE)) {
+    return { kind: "skip", reason: "unsupported_media_type" };
+  }
+
+  const policy = resolveUploadPolicy(ws);
+  if (bytes.length > maxBytesForContentType(policy, sniffed)) {
+    return { kind: "skip", reason: "too_large" };
+  }
+
+  const key = ingestKey(ref, attachment.id, EXT_BY_TYPE[sniffed]!);
+  try {
+    await putImpl(env, ws, key, bytes, workspaceName, {
+      metadata: ingestMetadata(ref, author),
+      replace: true,
+      surface: "github",
+    });
+  } catch (err) {
+    const code = (err as { code?: unknown })?.code;
+    if (typeof code === "string" && SKIP_CODES.has(code)) {
+      return { kind: "skip", reason: code };
+    }
+    throw err;
+  }
+
+  await recordIngestedAsset(env.DB, {
+    repo: ref.repo,
+    assetId: attachment.id,
+    workspace: workspaceName,
+    objectKey: key,
+    kind: ref.kind,
+    num: ref.num,
+    source: ref.source,
+    createdAt: now().toISOString(),
+  });
+
+  return { kind: "ok", key };
+}
+
+/**
+ * Reconciles ONE source (a body or one comment) against `text`. `text: null`
+ * means the source is gone (comment deleted) — every non-detached ledger row
+ * currently attributed to `ref.source` is detached, nothing is fetched.
+ */
+export async function reconcileIngestSource(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  ref: IngestSourceRef,
+  text: string | null,
+  author: string | null,
+  deps: IngestDeps = {},
+): Promise<IngestSummary> {
+  const db = env.DB;
+  const summary = emptySummary();
+  const found = text === null ? [] : extractUserAttachments(text);
+  const foundIds = new Set(found.map((a) => a.id));
+
+  for (const attachment of found) {
+    const row = await ledgerRow(db, ref.repo, attachment.id);
+    if (row) {
+      if (row.detachedAt === null) {
+        // Already attached under this exact source — nothing to do. If the
+        // image moved between sources (e.g. an edit relocated it from the
+        // body into a comment), the ledger's source pointer follows.
+        if (row.source !== ref.source) {
+          await setLedgerSource(db, ref.repo, attachment.id, ref.source);
+        }
+        continue;
+      }
+      // Previously detached, now referenced again — reattach without a
+      // re-fetch; the object is still in storage.
+      await setLedgerDetached(db, ref.repo, attachment.id, null);
+      await updateFileMetadataValue(db, row.workspace, row.objectKey, "gh.detached", "false");
+      summary.reattached.push(row.objectKey);
+      continue;
+    }
+
+    const result = await fetchAndStore(env, ws, workspaceName, ref, attachment, author, deps);
+    if (result.kind === "skip") {
+      summary.skipped.push({ url: attachment.url, reason: result.reason });
+      continue;
+    }
+    summary.ingested.push(result.key);
+  }
+
+  const now = deps.now ?? (() => new Date());
+  const existing = await ledgerRowsForSource(db, ref.repo, ref.source);
+  for (const row of existing) {
+    if (row.detachedAt !== null) continue;
+    if (foundIds.has(row.assetId)) continue;
+    await setLedgerDetached(db, ref.repo, row.assetId, now().toISOString());
+    await updateFileMetadataValue(db, row.workspace, row.objectKey, "gh.detached", "true");
+    summary.detached.push(row.objectKey);
+  }
+
+  return summary;
+}
+
+/** GET the current body/comment text + author from GitHub, or `text: null` on 404. */
+async function fetchSourceText(
+  fetchImpl: typeof fetch,
+  token: string,
+  ref: IngestSourceRef,
+): Promise<{ text: string | null; author: string | null }> {
+  const url =
+    ref.source === "body"
+      ? `https://api.github.com/repos/${ref.repo}/issues/${ref.num}`
+      : `https://api.github.com/repos/${ref.repo}/issues/comments/${ref.source.slice("comment:".length)}`;
+  const res = await githubFetch(fetchImpl, url, { headers: githubHeaders(token) });
+  if (res.status === 404) return { text: null, author: null };
+  if (!res.ok) throw new Error(`github source fetch failed: ${res.status}`);
+  const body = (await res.json()) as { body?: string | null; user?: { login?: string } };
+  return { text: body.body ?? null, author: body.user?.login ?? null };
+}
+
+/**
+ * Webhook entry point: resolves the repo→workspace link, the per-repo/per-
+ * workspace knob (`resolveRepoCommentOptions`'s `ingestGithubAttachments`),
+ * fetches the current text for `ref`, and reconciles it. No-ops (resolves,
+ * no GitHub calls) when the repo isn't linked, the workspace can't be
+ * loaded, or the knob is off. Throws on transient failure (D1 outage via
+ * `findRepoLinkStrict`, installation-token mint failure, non-404 GitHub
+ * error) so the caller's queue retries the delivery.
+ */
+export async function ingestForWebhook(
+  env: Env,
+  ref: IngestSourceRef,
+  deps: IngestDeps = {},
+): Promise<void> {
+  const link = await findRepoLinkStrict(env.DB, ref.repo);
+  if (!link) return;
+  const ws = await loadWorkspaceRecord(env, link.workspaceName);
+  if (!ws) return;
+
+  const { options } = await resolveRepoCommentOptions(env, ws, ref.repo);
+  if (!options.ingestGithubAttachments) return;
+
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const cfg = githubAppConfig(env);
+  if (!cfg) return;
+  const installationId = await installationForRepo(env, cfg, ref.repo, fetchImpl);
+  if (installationId === null) return;
+  const token = await installationToken(env, cfg, installationId, fetchImpl);
+  if (!token) throw new Error("github installation token mint failed");
+
+  const { text, author } = await fetchSourceText(fetchImpl, token, ref);
+  await reconcileIngestSource(env, ws, link.workspaceName, ref, text, author, deps);
+}
+
+/**
+ * Manual/backfill entry point: reconciles the target's body plus every issue
+ * comment (paginated, 100/page, up to 3 pages — a repo with a genuinely
+ * longer thread logs a structured truncation notice rather than silently
+ * capping). Returns the merged summary across body + all comments.
+ */
+export async function reconcileIngestTarget(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  target: { repo: string; kind: "pull" | "issues"; num: number },
+  deps: IngestDeps = {},
+): Promise<IngestSummary> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const merged = emptySummary();
+
+  const cfg = githubAppConfig(env);
+  if (!cfg) return merged;
+  const installationId = await installationForRepo(env, cfg, target.repo, fetchImpl);
+  if (installationId === null) return merged;
+  const token = await installationToken(env, cfg, installationId, fetchImpl);
+  if (!token) throw new Error("github installation token mint failed");
+
+  const bodyRes = await githubFetch(
+    fetchImpl,
+    `https://api.github.com/repos/${target.repo}/issues/${target.num}`,
+    { headers: githubHeaders(token) },
+  );
+  if (!bodyRes.ok) throw new Error(`github source fetch failed: ${bodyRes.status}`);
+  const bodyJson = (await bodyRes.json()) as { body?: string | null; user?: { login?: string } };
+  const bodyRef: IngestSourceRef = {
+    repo: target.repo,
+    kind: target.kind,
+    num: target.num,
+    source: "body",
+  };
+  mergeSummary(
+    merged,
+    await reconcileIngestSource(
+      env,
+      ws,
+      workspaceName,
+      bodyRef,
+      bodyJson.body ?? null,
+      bodyJson.user?.login ?? null,
+      deps,
+    ),
+  );
+
+  const PER_PAGE = 100;
+  const MAX_PAGES = 3;
+  let sawFullFinalPage = false;
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const res = await githubFetch(
+      fetchImpl,
+      `https://api.github.com/repos/${target.repo}/issues/${target.num}/comments?per_page=${PER_PAGE}&page=${page}`,
+      { headers: githubHeaders(token) },
+    );
+    if (!res.ok) throw new Error(`github comments fetch failed: ${res.status}`);
+    const comments = (await res.json()) as Array<{
+      id: number;
+      body?: string | null;
+      user?: { login?: string };
+    }>;
+
+    for (const comment of comments) {
+      const commentRef: IngestSourceRef = {
+        repo: target.repo,
+        kind: target.kind,
+        num: target.num,
+        source: `comment:${comment.id}`,
+      };
+      mergeSummary(
+        merged,
+        await reconcileIngestSource(
+          env,
+          ws,
+          workspaceName,
+          commentRef,
+          comment.body ?? null,
+          comment.user?.login ?? null,
+          deps,
+        ),
+      );
+    }
+
+    if (comments.length < PER_PAGE) break;
+    if (page === MAX_PAGES) sawFullFinalPage = true;
+  }
+
+  if (sawFullFinalPage) {
+    console.log(
+      JSON.stringify({
+        message: "github ingest comment scan truncated",
+        repo: target.repo,
+        num: target.num,
+      }),
+    );
+  }
+
+  return merged;
+}

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -232,9 +232,16 @@ export async function reconcileIngestSource(
         continue;
       }
       // Previously detached, now referenced again — reattach without a
-      // re-fetch; the object is still in storage.
-      await setLedgerDetached(db, ref.repo, attachment.id, null);
+      // re-fetch; the object is still in storage. Metadata write goes
+      // first: if it lands but the ledger write then fails and the
+      // message retries, the ledger row's `detachedAt !== null` guard
+      // above still holds and both writes redo (the metadata UPDATE is
+      // idempotent). Ledger-first would let a later metadata failure
+      // slip through unseen — the guard would see the already-clean
+      // ledger row and skip the row entirely, leaving `gh.detached`
+      // permanently stale.
       await updateFileMetadataValue(db, row.workspace, row.objectKey, "gh.detached", "false");
+      await setLedgerDetached(db, ref.repo, attachment.id, null);
       summary.reattached.push(row.objectKey);
       continue;
     }
@@ -252,8 +259,12 @@ export async function reconcileIngestSource(
   for (const row of existing) {
     if (row.detachedAt !== null) continue;
     if (foundIds.has(row.assetId)) continue;
-    await setLedgerDetached(db, ref.repo, row.assetId, now().toISOString());
+    // Metadata-first for the same retry-safety reason as the reattach
+    // branch above: the `detachedAt !== null` guard on entry to this loop
+    // only sees stale (pre-write) ledger state on retry if the ledger
+    // write is the one that happens last.
     await updateFileMetadataValue(db, row.workspace, row.objectKey, "gh.detached", "true");
+    await setLedgerDetached(db, ref.repo, row.assetId, now().toISOString());
     summary.detached.push(row.objectKey);
   }
 

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -23,8 +23,9 @@
  * queue's own retry/backoff handles them.
  */
 
-import { NotFoundError } from "@uploads/errors";
+import { AppError, isRetryableType, NotFoundError } from "@uploads/errors";
 import { attachmentKeyBasename, extractUserAttachments } from "./github-attachment-extract";
+import { sanitizeKeySegment } from "./github-comment-render";
 import {
   githubAppConfig,
   githubFetch,
@@ -68,7 +69,14 @@ export interface IngestSummary {
 export interface IngestDeps {
   fetchImpl?: typeof fetch;
   putImpl?: typeof putObject;
-  now?: () => Date;
+  /**
+   * Installation token already minted by the caller (`ingestForWebhook` and
+   * `reconcileIngestTarget` both mint one to fetch the source text before
+   * reconciling) — `fetchAndStore` reuses it instead of minting a fresh
+   * token per attachment. Absent only for a direct `reconcileIngestSource`
+   * call with no pre-minted token, which still self-mints as before.
+   */
+  token?: string;
 }
 
 function emptySummary(): IngestSummary {
@@ -83,37 +91,44 @@ function mergeSummary(into: IngestSummary, from: IngestSummary): void {
 }
 
 /**
- * putObject-thrown errors carrying one of these codes are guard failures the
- * upload path already classified as permanent — the ingest pipeline treats
- * them the same way (skip, don't ledger, don't retry) rather than duplicating
- * their thresholds.
+ * Extensions that don't match their subtype verbatim. Every other content
+ * type accepted by the workspace's upload policy derives its extension from
+ * the subtype (`image/webp` → `webp`, `image/avif` → `avif`, `video/webm` →
+ * `webm`), so this stays a short override list rather than a shadow table of
+ * every allowed type — see the media-gate comment in `fetchAndStore`.
  */
-const SKIP_CODES = new Set([
-  "storage_quota_exceeded",
-  "upload_budget_exceeded",
-  "unsupported_media_type",
-  "file_metadata_limit_exceeded",
-  "empty_body",
-]);
-
-const EXT_BY_TYPE: Record<string, string> = {
-  "image/png": "png",
+const EXT_OVERRIDES: Record<string, string> = {
   "image/jpeg": "jpg",
-  "image/gif": "gif",
-  "image/webp": "webp",
-  "video/mp4": "mp4",
-  "video/webm": "webm",
 };
 
+function extensionForContentType(contentType: string): string {
+  return EXT_OVERRIDES[contentType] ?? contentType.split("/")[1] ?? "bin";
+}
+
+/**
+ * DELIBERATELY a different layout from github-promote.ts's
+ * `gh/<owner>/<name>/pull/<num>/<filename>` attachment prefix: ingested
+ * assets are an INDEX only (queryable via `gh.*` metadata, e.g. the "From
+ * GitHub" rail), not a source of truth for the managed comment — they must
+ * not land under the prefix `gatherCommentBody` lists when rendering it.
+ */
 function ingestKey(ref: IngestSourceRef, assetId: string, ext: string): string {
-  const repoSeg = ref.repo.toLowerCase().replace("/", "-");
+  const [owner, name] = ref.repo.split("/");
+  const repoSeg =
+    `${sanitizeKeySegment(owner ?? "")}-${sanitizeKeySegment(name ?? "")}`.toLowerCase();
   return `gh/${repoSeg}/${ref.kind}-${ref.num}/${attachmentKeyBasename(assetId)}.${ext}`;
 }
 
 function ingestMetadata(ref: IngestSourceRef, author: string | null): Record<string, string> {
   return {
     "gh.repo": ref.repo.toLowerCase(),
-    "gh.kind": ref.kind,
+    // Stored vocabulary is singular ("issue"/"pull"), matching the CLI
+    // (packages/uploads/src/github.ts) and `deriveGithubContext`
+    // (routes/public-files.ts). `ref.kind` itself stays plural ("issues") —
+    // that's the GitHub REST API path segment, also used for the object-key
+    // layout above (`{pull|issues}-{num}`), which is unrelated to this
+    // stored value and unchanged.
+    "gh.kind": ref.kind === "issues" ? "issue" : "pull",
     "gh.number": String(ref.num),
     "gh.origin": "github",
     ...(author ? { "gh.author": author } : {}),
@@ -125,10 +140,10 @@ function ingestMetadata(ref: IngestSourceRef, author: string | null): Record<str
 type FetchAndStoreResult = { kind: "ok"; key: string } | { kind: "skip"; reason: string };
 
 /**
- * Mints an installation token, fetches one asset's bytes, sniffs/guards
- * them, and puts the object. Guard failures return a `skip` result; a failed
- * token mint or a non-guard fetch/put failure throws (transient — see the
- * module doc-comment).
+ * Fetches one asset's bytes (reusing `deps.token` when the caller already
+ * minted one, else self-minting), sniffs/guards them, and puts the object.
+ * Guard failures return a `skip` result; a failed token mint or a non-guard
+ * fetch/put failure throws (transient — see the module doc-comment).
  */
 async function fetchAndStore(
   env: Env,
@@ -141,14 +156,17 @@ async function fetchAndStore(
 ): Promise<FetchAndStoreResult> {
   const fetchImpl = deps.fetchImpl ?? fetch;
   const putImpl = deps.putImpl ?? putObject;
-  const now = deps.now ?? (() => new Date());
 
-  const cfg = githubAppConfig(env);
-  if (!cfg) return { kind: "skip", reason: "app_not_configured" };
-  const installationId = await installationForRepo(env, cfg, ref.repo, fetchImpl);
-  if (installationId === null) return { kind: "skip", reason: "app_not_installed" };
-  const token = await installationToken(env, cfg, installationId, fetchImpl);
-  if (!token) throw new Error("github installation token mint failed");
+  let token = deps.token;
+  if (!token) {
+    const cfg = githubAppConfig(env);
+    if (!cfg) return { kind: "skip", reason: "app_not_configured" };
+    const installationId = await installationForRepo(env, cfg, ref.repo, fetchImpl);
+    if (installationId === null) return { kind: "skip", reason: "app_not_installed" };
+    const minted = await installationToken(env, cfg, installationId, fetchImpl);
+    if (!minted) throw new Error("github installation token mint failed");
+    token = minted;
+  }
 
   const res = await githubFetch(fetchImpl, attachment.url, {
     headers: { authorization: `Bearer ${token}`, "user-agent": "uploads.sh" },
@@ -161,17 +179,23 @@ async function fetchAndStore(
   }
   const bytes = new Uint8Array(await res.arrayBuffer());
 
+  // Media gate: membership in the workspace's own upload allowlist
+  // (`resolveUploadPolicy(ws).allowed`, guards.ts) rather than a shadow
+  // table duplicating it — a type this workspace's direct uploads accept
+  // (e.g. `image/avif`) is accepted here too, with no separate list to keep
+  // in sync. Non-sniffable bytes or a type outside the allowlist is the same
+  // permanent `unsupported_media_type` skip either way.
+  const policy = resolveUploadPolicy(ws);
   const sniffed = detectContentType(bytes);
-  if (!sniffed || !(sniffed in EXT_BY_TYPE)) {
+  if (!sniffed || !policy.allowed.has(sniffed)) {
     return { kind: "skip", reason: "unsupported_media_type" };
   }
 
-  const policy = resolveUploadPolicy(ws);
   if (bytes.length > maxBytesForContentType(policy, sniffed)) {
     return { kind: "skip", reason: "too_large" };
   }
 
-  const key = ingestKey(ref, attachment.id, EXT_BY_TYPE[sniffed]!);
+  const key = ingestKey(ref, attachment.id, extensionForContentType(sniffed));
   try {
     await putImpl(env, ws, key, bytes, workspaceName, {
       metadata: ingestMetadata(ref, author),
@@ -179,9 +203,16 @@ async function fetchAndStore(
       surface: "github",
     });
   } catch (err) {
-    const code = (err as { code?: unknown })?.code;
-    if (typeof code === "string" && SKIP_CODES.has(code)) {
-      return { kind: "skip", reason: code };
+    // Taxonomy-based, not an enumerated code list: putObject's guard
+    // failures (budget, metadata caps, empty body, unsupported type, …) are
+    // all AppError subclasses, and every one of them carries a non-retryable
+    // `type` (@uploads/errors' `isRetryableType`) — retrying the identical
+    // request later can't succeed, so it's a permanent skip like the other
+    // guard checks above. An AppError with a retryable type (rate_limited,
+    // unavailable) or any non-AppError failure rethrows, so the queue's own
+    // retry/backoff handles it instead.
+    if (err instanceof AppError && !isRetryableType(err.type)) {
+      return { kind: "skip", reason: err.code ?? err.type };
     }
     throw err;
   }
@@ -194,7 +225,7 @@ async function fetchAndStore(
     kind: ref.kind,
     num: ref.num,
     source: ref.source,
-    createdAt: now().toISOString(),
+    createdAt: new Date().toISOString(),
   });
 
   return { kind: "ok", key };
@@ -219,8 +250,15 @@ export async function reconcileIngestSource(
   const found = text === null ? [] : extractUserAttachments(text);
   const foundIds = new Set(found.map((a) => a.id));
 
+  // Hoisted out of the loop below and fetched in parallel — one row lookup
+  // per found attachment, independent of the others, rather than serialized
+  // await-per-iteration.
+  const rows = new Map(
+    await Promise.all(found.map(async (a) => [a.id, await ledgerRow(db, ref.repo, a.id)] as const)),
+  );
+
   for (const attachment of found) {
-    const row = await ledgerRow(db, ref.repo, attachment.id);
+    const row = rows.get(attachment.id) ?? null;
     if (row) {
       if (row.detachedAt === null) {
         // Already attached under this exact source — nothing to do. If the
@@ -254,7 +292,6 @@ export async function reconcileIngestSource(
     summary.ingested.push(result.key);
   }
 
-  const now = deps.now ?? (() => new Date());
   const existing = await ledgerRowsForSource(db, ref.repo, ref.source);
   for (const row of existing) {
     if (row.detachedAt !== null) continue;
@@ -264,7 +301,7 @@ export async function reconcileIngestSource(
     // only sees stale (pre-write) ledger state on retry if the ledger
     // write is the one that happens last.
     await updateFileMetadataValue(db, row.workspace, row.objectKey, "gh.detached", "true");
-    await setLedgerDetached(db, ref.repo, row.assetId, now().toISOString());
+    await setLedgerDetached(db, ref.repo, row.assetId, new Date().toISOString());
     summary.detached.push(row.objectKey);
   }
 
@@ -319,7 +356,10 @@ export async function ingestForWebhook(
   if (!token) throw new Error("github installation token mint failed");
 
   const { text, author } = await fetchSourceText(fetchImpl, token, ref);
-  await reconcileIngestSource(env, ws, link.workspaceName, ref, text, author, deps);
+  await reconcileIngestSource(env, ws, link.workspaceName, ref, text, author, {
+    ...deps,
+    token,
+  });
 }
 
 /**
@@ -383,7 +423,7 @@ export async function reconcileIngestTarget(
       bodyRef,
       bodyJson.body ?? null,
       bodyJson.user?.login ?? null,
-      deps,
+      { ...deps, token },
     ),
   );
 
@@ -419,7 +459,7 @@ export async function reconcileIngestTarget(
           commentRef,
           comment.body ?? null,
           comment.user?.login ?? null,
-          deps,
+          { ...deps, token },
         ),
       );
     }

--- a/apps/api/src/github-webhook-queue.test.ts
+++ b/apps/api/src/github-webhook-queue.test.ts
@@ -6,14 +6,17 @@
  * processing semantics themselves are covered by github-webhook.test.ts and
  * the auto-promote/reconcile suites, which exercise the queueless inline path.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { extractWebhookEvent, handleWebhook, type WebhookEvent } from "./github-webhook";
 import {
   GITHUB_WEBHOOK_DLQ,
   GITHUB_WEBHOOK_QUEUE,
   handleGithubWebhookBatch,
 } from "./github-webhook-queue";
+import { ingestForWebhook } from "./github-ingest";
 import { FakeKv } from "../test/fake-kv";
+
+vi.mock("./github-ingest", () => ({ ingestForWebhook: vi.fn() }));
 
 class FakeQueue {
   sent: WebhookEvent[] = [];
@@ -93,6 +96,116 @@ describe("extractWebhookEvent", () => {
     });
     expect(ev).toEqual({ keys: ["ghref:acme/web#7"] });
   });
+
+  const URL = "https://github.com/user-attachments/assets/0a1b2c3d-1111-2222-3333-444455556666";
+
+  it("pull_request opened with attachment url sets ingest", () => {
+    const ev = extractWebhookEvent("pull_request", {
+      action: "opened",
+      repository: { full_name: "acme/app" },
+      pull_request: { number: 7, body: `hello ${URL}` },
+    });
+    expect(ev?.ingest).toEqual({ repo: "acme/app", kind: "pull", num: 7, source: "body" });
+  });
+
+  it("pull_request opened without attachment url sets no ingest", () => {
+    const ev = extractWebhookEvent("pull_request", {
+      action: "opened",
+      repository: { full_name: "acme/app" },
+      pull_request: { number: 7, body: "hi" },
+    });
+    expect(ev?.ingest).toBeUndefined();
+  });
+
+  it("issues edited with a body change always sets ingest (removal case)", () => {
+    const ev = extractWebhookEvent("issues", {
+      action: "edited",
+      changes: { body: { from: "old" } },
+      repository: { full_name: "acme/app" },
+      issue: { number: 3, body: "no urls anymore" },
+    });
+    expect(ev?.ingest).toEqual({ repo: "acme/app", kind: "issues", num: 3, source: "body" });
+  });
+
+  it("issues edited title-only (no changes.body) sets no ingest", () => {
+    const ev = extractWebhookEvent("issues", {
+      action: "edited",
+      changes: { title: { from: "old title" } },
+      repository: { full_name: "acme/app" },
+      issue: { number: 3, body: `still has ${URL}` },
+    });
+    expect(ev?.ingest).toBeUndefined();
+  });
+
+  it("issue_comment created with url sets ingest with comment source", () => {
+    const ev = extractWebhookEvent("issue_comment", {
+      action: "created",
+      repository: { full_name: "acme/app" },
+      issue: { number: 7, pull_request: {} },
+      comment: { id: 44, body: URL, user: { login: "octocat", type: "User" } },
+    });
+    expect(ev?.ingest).toEqual({ repo: "acme/app", kind: "pull", num: 7, source: "comment:44" });
+  });
+
+  it("issue_comment created without url sets no ingest", () => {
+    const ev = extractWebhookEvent("issue_comment", {
+      action: "created",
+      repository: { full_name: "acme/app" },
+      issue: { number: 7, pull_request: {} },
+      comment: { id: 44, body: "plain text", user: { login: "octocat", type: "User" } },
+    });
+    expect(ev).toBeNull();
+  });
+
+  it("issue_comment edited always sets ingest; deleted sets ingest only when the removed body had a url", () => {
+    const edited = extractWebhookEvent("issue_comment", {
+      action: "edited",
+      repository: { full_name: "acme/app" },
+      issue: { number: 7, pull_request: {} },
+      comment: {
+        id: 44,
+        body: "no urls in the new body",
+        user: { login: "octocat", type: "User" },
+      },
+      sender: { login: "octocat", type: "User" },
+    });
+    expect(edited?.ingest).toEqual({
+      repo: "acme/app",
+      kind: "pull",
+      num: 7,
+      source: "comment:44",
+    });
+
+    const editedByBot = extractWebhookEvent("issue_comment", {
+      action: "edited",
+      repository: { full_name: "acme/app" },
+      issue: { number: 7, pull_request: {} },
+      comment: { id: 44, body: "our own write", user: { login: "our-bot", type: "Bot" } },
+      sender: { login: "our-bot", type: "Bot" },
+    });
+    expect(editedByBot?.ingest).toBeUndefined();
+
+    const deletedWithUrl = extractWebhookEvent("issue_comment", {
+      action: "deleted",
+      repository: { full_name: "acme/app" },
+      issue: { number: 7, pull_request: {} },
+      comment: { id: 44, body: URL, user: { login: "octocat", type: "User" } },
+    });
+    expect(deletedWithUrl?.ingest).toEqual({
+      repo: "acme/app",
+      kind: "pull",
+      num: 7,
+      source: "comment:44",
+    });
+
+    const deletedPlainText = extractWebhookEvent("issue_comment", {
+      action: "deleted",
+      repository: { full_name: "acme/app" },
+      issue: { number: 7, pull_request: {} },
+      comment: { id: 44, body: "plain text", user: { login: "octocat", type: "User" } },
+    });
+    expect(deletedPlainText?.ingest).toBeUndefined();
+  });
 });
 
 describe("handleWebhook producer path", () => {
@@ -166,5 +279,24 @@ describe("handleGithubWebhookBatch", () => {
     expect(kv.store.has("ghtok:42")).toBe(true); // untouched — terminal log only.
     expect(m.acked).toBe(true);
     expect(m.retried).toBe(false);
+  });
+
+  it("dispatches ingest events to ingestForWebhook and acks", async () => {
+    vi.mocked(ingestForWebhook).mockResolvedValueOnce(undefined);
+    const ref = { repo: "acme/app", kind: "pull" as const, num: 7, source: "body" };
+    const m = msg({ keys: [], ingest: ref });
+    await handleGithubWebhookBatch(batch(GITHUB_WEBHOOK_QUEUE, [m]), envWith(new FakeKv()));
+    expect(ingestForWebhook).toHaveBeenCalledWith(expect.anything(), ref);
+    expect(m.acked).toBe(true);
+    expect(m.retried).toBe(false);
+  });
+
+  it("retries a message whose ingestForWebhook throws", async () => {
+    vi.mocked(ingestForWebhook).mockRejectedValueOnce(new Error("transient"));
+    const ref = { repo: "acme/app", kind: "pull" as const, num: 7, source: "body" };
+    const m = msg({ keys: [], ingest: ref });
+    await handleGithubWebhookBatch(batch(GITHUB_WEBHOOK_QUEUE, [m]), envWith(new FakeKv()));
+    expect(m.retried).toBe(true);
+    expect(m.acked).toBe(false);
   });
 });

--- a/apps/api/src/github-webhook-queue.ts
+++ b/apps/api/src/github-webhook-queue.ts
@@ -38,6 +38,7 @@ export async function handleGithubWebhookBatch(
           attempts: msg.attempts,
           promote: msg.body?.promote ?? null,
           reconcile: msg.body?.reconcile ?? null,
+          ingest: msg.body?.ingest ?? null,
           error: err instanceof Error ? err.message : String(err),
         }),
       );

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -376,11 +376,11 @@ export function extractWebhookEvent(eventType: string, payload: unknown): Webhoo
       const source = `comment:${commentId}`;
       const body = ip.comment?.body;
       const hasUrl = typeof body === "string" && hasUserAttachmentUrl(body);
-      if (ip.action === "created" && hasUrl) {
-        ev.ingest = { repo, kind, num, source };
-      } else if (ip.action === "edited" && ip.sender?.type !== "Bot") {
-        ev.ingest = { repo, kind, num, source };
-      } else if (ip.action === "deleted" && hasUrl) {
+      const gated =
+        (ip.action === "created" && hasUrl) ||
+        (ip.action === "edited" && ip.sender?.type !== "Bot") ||
+        (ip.action === "deleted" && hasUrl);
+      if (gated) {
         ev.ingest = { repo, kind, num, source };
       }
     }

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -37,10 +37,12 @@
  * degraded rather than dropping deliveries.
  */
 
+import { hasUserAttachmentUrl } from "./github-attachment-extract";
 import { githubAppConfig, installationForRepo } from "./github-app";
 import { commentCacheKey, gatherCommentBody, upsertBotComment } from "./github-comment";
 import { ATTACHMENTS_MARKER } from "./github-comment-render";
 import type { GhTarget } from "./github-comment-render";
+import { ingestForWebhook, type IngestSourceRef } from "./github-ingest";
 import { promoteBranchAttachments } from "./github-promote";
 // Strict lookup on purpose (#287): a D1 outage must THROW so the queue
 // consumer retries the event, not read as "repo not linked" and ack-drop it.
@@ -208,7 +210,7 @@ interface IssueCommentPayload {
   action?: unknown;
   repository?: { full_name?: unknown };
   issue?: { number?: unknown; pull_request?: unknown };
-  comment?: { body?: unknown; user?: { login?: unknown; type?: unknown } };
+  comment?: { id?: unknown; body?: unknown; user?: { login?: unknown; type?: unknown } };
   sender?: { login?: unknown; type?: unknown };
 }
 
@@ -283,6 +285,9 @@ export interface WebhookEvent {
   promote?: { repo: string; num: number; branch: string };
   /** Gated issue_comment edited/deleted → heal the managed comment. */
   reconcile?: { repo: string; num: number; kind: GhTarget["kind"] };
+  /** Opt-in GitHub-native attachment ingest (spec 2026-08-11). Source ref only —
+   * the consumer re-fetches current text, so this stays queue-compact. */
+  ingest?: IngestSourceRef;
 }
 
 /**
@@ -305,10 +310,27 @@ export function extractWebhookEvent(eventType: string, payload: unknown): Webhoo
   } else if (eventType === "issues" || eventType === "pull_request") {
     const fullName = (p.repository as { full_name?: unknown } | undefined)?.full_name;
     const item = (eventType === "issues" ? p.issue : p.pull_request) as
-      | { number?: unknown }
+      | { number?: unknown; body?: unknown }
       | undefined;
     if (typeof fullName === "string" && typeof item?.number === "number") {
       ev.keys.push(`ghref:${fullName.toLowerCase()}#${item.number}`);
+
+      // Ingest gating (spec 2026-08-11): opened → substring-gated on the
+      // body; edited → gated only on the presence of a body *change* (covers
+      // both add and remove — removal leaves no url in the new body, but the
+      // consumer re-fetches and reconciles against the empty case too).
+      // Casing intentionally NOT lowercased here, matching `promote` — the
+      // ledger normalizes internally.
+      const action = p.action;
+      const kind: GhTarget["kind"] = eventType === "pull_request" ? "pull" : "issues";
+      if (action === "opened" && typeof item.body === "string" && hasUserAttachmentUrl(item.body)) {
+        ev.ingest = { repo: fullName, kind, num: item.number, source: "body" };
+      } else if (action === "edited") {
+        const changes = p.changes as { body?: unknown } | undefined;
+        if (changes && "body" in changes) {
+          ev.ingest = { repo: fullName, kind, num: item.number, source: "body" };
+        }
+      }
     }
   }
 
@@ -341,10 +363,31 @@ export function extractWebhookEvent(eventType: string, payload: unknown): Webhoo
     if (isReconcilableCommentEvent(ip) && typeof repo === "string" && typeof num === "number") {
       ev.reconcile = { repo, num, kind: ip.issue?.pull_request ? "pull" : "issues" };
     }
+
+    // Ingest gating (spec 2026-08-11): created/deleted are substring-gated
+    // (a deleted comment's payload carries its pre-deletion body — the
+    // consumer's GET then 404s, detaching everything under that source).
+    // edited always fires unless the sender is a Bot (our own comment write
+    // or another bot's churn) — a removal is invisible in the new body, so
+    // the only reliable signal is "something changed".
+    const commentId = ip.comment?.id;
+    if (typeof repo === "string" && typeof num === "number" && typeof commentId === "number") {
+      const kind: GhTarget["kind"] = ip.issue?.pull_request ? "pull" : "issues";
+      const source = `comment:${commentId}`;
+      const body = ip.comment?.body;
+      const hasUrl = typeof body === "string" && hasUserAttachmentUrl(body);
+      if (ip.action === "created" && hasUrl) {
+        ev.ingest = { repo, kind, num, source };
+      } else if (ip.action === "edited" && ip.sender?.type !== "Bot") {
+        ev.ingest = { repo, kind, num, source };
+      } else if (ip.action === "deleted" && hasUrl) {
+        ev.ingest = { repo, kind, num, source };
+      }
+    }
   }
   // ping and unknown events fall through with no work.
 
-  return ev.keys.length || ev.promote || ev.reconcile ? ev : null;
+  return ev.keys.length || ev.promote || ev.reconcile || ev.ingest ? ev : null;
 }
 
 /**
@@ -363,6 +406,9 @@ export async function processWebhookEvent(env: Env, ev: WebhookEvent): Promise<v
   if (ev.reconcile) {
     await reconcileBotComment(env, ev.reconcile.repo, ev.reconcile.num, ev.reconcile.kind);
   }
+  if (ev.ingest) {
+    await ingestForWebhook(env, ev.ingest);
+  }
 }
 
 /** `processWebhookEvent` with every failure caught and logged — the inline
@@ -376,6 +422,7 @@ async function processInline(env: Env, ev: WebhookEvent): Promise<void> {
         message: "webhook inline processing failed",
         promote: ev.promote ?? null,
         reconcile: ev.reconcile ?? null,
+        ingest: ev.ingest ?? null,
         error: err instanceof Error ? err.message : String(err),
       }),
     );

--- a/apps/api/src/repo-comment-config.test.ts
+++ b/apps/api/src/repo-comment-config.test.ts
@@ -353,6 +353,7 @@ describe("workspaceCommentDefaults", () => {
       githubCommentNote: "hi",
       githubCommentLinkToFilePage: false,
       githubCommentShowMetadata: false,
+      githubIngestAttachments: true,
     } as WorkspaceRecord;
     const defaults = workspaceCommentDefaults(ws);
     expect(defaults).toEqual({
@@ -361,6 +362,7 @@ describe("workspaceCommentDefaults", () => {
       note: "hi",
       linkToFilePage: false,
       showMetadata: false,
+      ingestGithubAttachments: true,
     });
   });
 

--- a/apps/api/src/repo-comment-config.ts
+++ b/apps/api/src/repo-comment-config.ts
@@ -136,6 +136,8 @@ export function workspaceCommentDefaults(ws: WorkspaceRecord): WorkspaceCommentD
   if (ws.githubCommentLinkToFilePage !== undefined)
     defaults.linkToFilePage = ws.githubCommentLinkToFilePage;
   if (ws.githubCommentNote !== undefined) defaults.note = ws.githubCommentNote;
+  if (ws.githubIngestAttachments !== undefined)
+    defaults.ingestGithubAttachments = ws.githubIngestAttachments;
   return defaults;
 }
 

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1990,6 +1990,7 @@ describe("workspace comment-settings routes", () => {
       showMetadata: null,
       linkToFilePage: null,
       note: null,
+      ingestGithubAttachments: null,
     });
   });
 
@@ -2011,6 +2012,7 @@ describe("workspace comment-settings routes", () => {
       showMetadata: null,
       linkToFilePage: null,
       note: "Hi",
+      ingestGithubAttachments: null,
     });
 
     // Re-read via GET, independent of the PATCH response, per the brief.
@@ -2021,6 +2023,7 @@ describe("workspace comment-settings routes", () => {
       showMetadata: null,
       linkToFilePage: null,
       note: "Hi",
+      ingestGithubAttachments: null,
     });
 
     const saved = registry.record<{ version?: number }>("acme");
@@ -2118,6 +2121,7 @@ describe("workspace comment-settings routes", () => {
       showMetadata: false,
       linkToFilePage: false,
       note: null,
+      ingestGithubAttachments: null,
     });
     const saved = registry.record<{
       githubCommentShowMetadata?: unknown;
@@ -2282,6 +2286,7 @@ describe("GET /me/workspaces/:name/comment-preview", () => {
       metaState: true,
       linkToFilePage: true,
       note: null,
+      ingestGithubAttachments: false,
     });
     expect(body.source).toMatchObject({ imageWidth: "auto" });
     expect(typeof body.body).toBe("string");

--- a/apps/api/src/routes/workspace-github.ts
+++ b/apps/api/src/routes/workspace-github.ts
@@ -42,10 +42,12 @@
  * createdAt}`), same "don't forward a shape that isn't a strict superset"
  * rule phase 2 applied to the galleries list alias.
  */
-import { ForbiddenError } from "@uploads/errors";
-import { Hono, type MiddlewareHandler } from "hono";
+import { ForbiddenError, NotFoundError, ValidationError } from "@uploads/errors";
+import { Hono, type Handler, type MiddlewareHandler } from "hono";
 import { dualWorkspaceAuth, requireSessionAdmin, type DualAuthVars } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
+import { reconcileIngestTarget } from "../github-ingest";
+import { deriveRepoBinding, findRepoLink } from "../github-repo-links";
 import { writeRateLimit } from "../guards";
 import { requireScope } from "../workspace";
 import { githubActivityHandler } from "./github-activity";
@@ -58,6 +60,53 @@ import {
 } from "./github-link";
 import { githubHealthHandler } from "./github-health";
 import { githubPromoteHandler } from "./github-promote";
+
+// Same owner/name grammar as routes/github-comment.ts's `REPO_RE` — repeated
+// here rather than imported since that copy is module-private (deliberately
+// not exported to avoid coupling this handler to that route's file).
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+/**
+ * POST /:workspace/github/ingest (Task 6, manual/backfill entry point). Dual-
+ * auth, `files:write`-scoped, rate-limited — unlike `comment`/`promote` this
+ * is NOT token-only, since it doesn't post to GitHub on the caller's behalf.
+ *
+ * Deliberately bypasses the `ingestGithubAttachments` per-repo/per-workspace
+ * knob (`reconcileIngestTarget` doesn't consult it) — an explicit manual
+ * ingest is opt-in by construction, same reasoning as a manual backfill
+ * command ignoring an automation on/off switch.
+ *
+ * `reconcileIngestTarget` throws `NotFoundError` (`code:
+ * "github_app_not_installed"`) when the GitHub App isn't configured or isn't
+ * installed on the repo — that's allowed to propagate here and maps to a 404
+ * via `respondError`.
+ */
+const githubIngestHandler: Handler<DualAuthVars> = async (c) => {
+  const ws = c.get("workspace");
+  const workspaceName = c.get("workspaceName");
+  const body = await c.req.json().catch(() => ({}));
+  const repo = typeof body.repo === "string" ? body.repo : "";
+  const pr = typeof body.pr === "number" ? body.pr : undefined;
+  const issue = typeof body.issue === "number" ? body.issue : undefined;
+  if (!REPO_RE.test(repo) || (pr === undefined) === (issue === undefined)) {
+    throw new ValidationError("repo plus exactly one of pr or issue required", {
+      code: "github_ingest_target",
+    });
+  }
+  const link = await findRepoLink(c.env.DB, repo);
+  if (deriveRepoBinding(link, workspaceName) !== "self") {
+    // 404 (not 403) so an "other"-bound repo can't be told apart from an
+    // unlinked one — never leaks whether/where it's linked (issue #398).
+    throw new NotFoundError("repo is not linked to this workspace", { code: "repo_not_linked" });
+  }
+  const target = {
+    repo,
+    kind: pr !== undefined ? ("pull" as const) : ("issues" as const),
+    num: (pr ?? issue) as number,
+  };
+  const summary = await reconcileIngestTarget(c.env, ws, workspaceName, target);
+  return c.json({ repo: repo.toLowerCase(), kind: target.kind, num: target.num, ...summary });
+};
 
 // Same cross-cast pattern as `routes/workspace-galleries.ts`'s `scoped`:
 // these helpers/handlers are typed against `WorkspaceVars`, a strict subset
@@ -144,6 +193,13 @@ export const workspaceGithub = new Hono<DualAuthVars>()
     scoped("files:read"),
     adminForSession,
     githubActivityHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .post(
+    "/:workspace/github/ingest",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    githubIngestHandler,
   )
   // `.fetch()`-ed directly by nothing today (no old-path alias forwards
   // through this router — see the module docblock's repo-links note), but

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -137,13 +137,14 @@ const COMMENT_IMAGE_WIDTH_MAX = 1000;
 const COMMENT_MAX_INLINE_IMAGES_MIN = 1;
 const COMMENT_MAX_INLINE_IMAGES_MAX = 48;
 
-/** The five workspace-level comment-defaults fields (issue #307). */
+/** The six workspace-level comment-defaults fields (issue #307; ingestGithubAttachments added issue-spec 2026-08-11). */
 const COMMENT_SETTINGS_KEYS = [
   "imageWidth",
   "maxInlineImages",
   "showMetadata",
   "linkToFilePage",
   "note",
+  "ingestGithubAttachments",
 ] as const;
 type CommentSettingsKey = (typeof COMMENT_SETTINGS_KEYS)[number];
 
@@ -154,6 +155,7 @@ const COMMENT_SETTINGS_RECORD_FIELD: Record<CommentSettingsKey, keyof WorkspaceR
   showMetadata: "githubCommentShowMetadata",
   linkToFilePage: "githubCommentLinkToFilePage",
   note: "githubCommentNote",
+  ingestGithubAttachments: "githubIngestAttachments",
 };
 
 type CommentSettingsValue = string | number | boolean;
@@ -240,6 +242,17 @@ function validateCommentSettingsPatch(body: unknown): CommentSettingsPatch {
     patch.linkToFilePage = value;
   }
 
+  if ("ingestGithubAttachments" in record) {
+    const value = record.ingestGithubAttachments;
+    if (value !== null && typeof value !== "boolean") {
+      throw new ValidationError("ingestGithubAttachments must be a boolean or null", {
+        code: "invalid_settings",
+        details: { field: "ingestGithubAttachments" },
+      });
+    }
+    patch.ingestGithubAttachments = value;
+  }
+
   if ("note" in record) {
     const value = record.note;
     if (value === null) {
@@ -272,6 +285,7 @@ function commentSettingsResponse(record: WorkspaceRecord) {
     showMetadata: record.githubCommentShowMetadata ?? null,
     linkToFilePage: record.githubCommentLinkToFilePage ?? null,
     note: record.githubCommentNote ?? null,
+    ingestGithubAttachments: record.githubIngestAttachments ?? null,
   };
 }
 

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -149,6 +149,8 @@ export interface WorkspaceRecord {
   /** Workspace default short markdown note under the comment header.
    * Trimmed, max 500 chars (validated on PATCH). Repo config overrides. */
   githubCommentNote?: string;
+  /** Workspace default for the repo `ingestGithubAttachments` knob (issue-spec 2026-08-11). */
+  githubIngestAttachments?: boolean;
   /**
    * Per-workspace opt-out for video poster generation (issue #299). Default
    * (undefined/true) generates. The surgical kill switch between "all

--- a/apps/api/test/file-metadata.test.ts
+++ b/apps/api/test/file-metadata.test.ts
@@ -7,8 +7,10 @@ import {
   META_MAX_KEYS,
   META_MAX_TOTAL_BYTES,
   META_VALUE_MAX,
+  replaceFileMetadata,
   setFileMetadata,
   setServerFileMetadata,
+  updateFileMetadataValue,
   validateMetadataEntries,
   validateStoredMetadataEntries,
 } from "../src/file-metadata";
@@ -261,6 +263,27 @@ describe("setFileMetadata: post-merge validation must not re-reject stored serve
         "video.poster": "1",
         "video.duration": "14",
         path: "/checkout",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("updateFileMetadataValue", () => {
+  it("flips one key without touching others or server-owned video.* rows", async () => {
+    const sqlite = new SqliteD1(FILE_METADATA_MIGRATION);
+    try {
+      const db = database(sqlite);
+      await replaceFileMetadata(db, "ws", "k.png", { "gh.detached": "false", path: "/x" });
+      await setServerFileMetadata(db, "ws", "k.png", { "video.poster": "1" });
+
+      await updateFileMetadataValue(db, "ws", "k.png", "gh.detached", "true");
+
+      await expect(getFileMetadata(db, "ws", "k.png")).resolves.toEqual({
+        "gh.detached": "true",
+        path: "/x",
+        "video.poster": "1",
       });
     } finally {
       sqlite.close();

--- a/apps/api/test/github-ingest-e2e.test.ts
+++ b/apps/api/test/github-ingest-e2e.test.ts
@@ -1,0 +1,216 @@
+/**
+ * End-to-end smoke test for GitHub attachment ingestion (spec
+ * docs/superpowers/specs/2026-08-11-github-attachment-ingestion-design.md),
+ * task 9. Exercises the REAL chain with no module mocking:
+ *
+ *   handleWebhook (github-webhook.ts)
+ *     → enqueues a compact WebhookEvent onto GITHUB_WEBHOOK_QUEUE
+ *   handleGithubWebhookBatch (github-webhook-queue.ts)
+ *     → processWebhookEvent → ingestForWebhook → reconcileIngestSource
+ *     → the REAL putObject (files-core.ts) writing to a fake R2 bucket
+ *
+ * Harness patterns are copied wholesale from github-ingest.test.ts (fake
+ * GitHub App env/KV, fakeFetch route table, globalThis.fetch swap for
+ * repo-comment-config's un-seamed fetch) and routes-workspace-github.test.ts
+ * (REGISTRY/D1/R2 env shape for exercising real putObject).
+ */
+import { describe, expect, it } from "vitest";
+import { attachmentKeyBasename } from "../src/github-attachment-extract";
+import { findObjectsByMetadata } from "../src/file-metadata";
+import { ledgerRow } from "../src/github-ingest-ledger";
+import { recordRepoLink } from "../src/github-repo-links";
+import { extractWebhookEvent, handleWebhook, type WebhookEvent } from "../src/github-webhook";
+import { GITHUB_WEBHOOK_QUEUE, handleGithubWebhookBatch } from "../src/github-webhook-queue";
+import type { WorkspaceRecord } from "../src/workspace";
+import { FakeKv } from "./fake-kv";
+import { FakeR2Bucket } from "./fake-r2";
+import { GITHUB_APP_CFG_ENV } from "./github-app-env";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+const REPO = "acme/app";
+const WS = "acme";
+const NUM = 7;
+const COMMENT_ID = 555;
+const ASSET_ID = "assets/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const ASSET_URL = `https://github.com/user-attachments/${ASSET_ID}`;
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+const KEY = `gh/acme-app/pull-${NUM}/${attachmentKeyBasename(ASSET_ID)}.png`;
+
+/** A realistic `issue_comment` `created` webhook payload on a PR thread whose
+ * comment body carries a user-attachments asset URL. */
+const issueCommentPayload = {
+  action: "created",
+  repository: { full_name: REPO, id: 123456 },
+  issue: {
+    number: NUM,
+    pull_request: { url: `https://api.github.com/repos/${REPO}/pulls/${NUM}` },
+  },
+  comment: {
+    id: COMMENT_ID,
+    body: `Here's a screenshot of the bug:\n\n${ASSET_URL}`,
+    user: { login: "octocat", type: "User" },
+  },
+  sender: { login: "octocat", type: "User" },
+};
+
+/** Minimal queue producer binding stand-in (github-webhook-queue.test.ts style). */
+class FakeQueue {
+  sent: WebhookEvent[] = [];
+  async send(body: WebhookEvent): Promise<void> {
+    this.sent.push(body);
+  }
+}
+
+interface FakeMessage {
+  body: WebhookEvent;
+  attempts: number;
+  acked: boolean;
+  retried: boolean;
+  ack(): void;
+  retry(): void;
+}
+
+function msg(body: WebhookEvent): FakeMessage {
+  const m: FakeMessage = {
+    body,
+    attempts: 1,
+    acked: false,
+    retried: false,
+    ack() {
+      m.acked = true;
+    },
+    retry() {
+      m.retried = true;
+    },
+  };
+  return m;
+}
+
+function batch(messages: FakeMessage[]): MessageBatch<WebhookEvent> {
+  return { queue: GITHUB_WEBHOOK_QUEUE, messages } as unknown as MessageBatch<WebhookEvent>;
+}
+
+/** Matches routes by substring against the requested URL (repo-comment-config.test.ts style). */
+function fakeFetch(routes: Record<string, (init: RequestInit) => Response | Promise<Response>>) {
+  return (async (url: string, init: RequestInit = {}) => {
+    for (const [pattern, handler] of Object.entries(routes)) {
+      if (String(url).includes(pattern)) return handler(init);
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+function pngRoute(): Response {
+  return new Response(PNG, { status: 200, headers: { "content-type": "image/png" } });
+}
+
+async function withGlobalFetch<T>(impl: typeof fetch, fn: () => Promise<T>): Promise<T> {
+  const real = globalThis.fetch;
+  globalThis.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = real;
+  }
+}
+
+describe("github ingest end-to-end (webhook → queue → real putObject)", () => {
+  it("issue_comment created enqueues a compact ingest event with the expected shape", async () => {
+    const kv = new FakeKv();
+    const queue = new FakeQueue();
+    const env = { GITHUB_CACHE: kv, GITHUB_WEBHOOK_QUEUE: queue } as unknown as Env;
+
+    await handleWebhook(env, "issue_comment", issueCommentPayload);
+
+    expect(queue.sent).toHaveLength(1);
+    expect(queue.sent[0]!.ingest).toEqual({
+      repo: REPO,
+      kind: "pull",
+      num: NUM,
+      source: `comment:${COMMENT_ID}`,
+    });
+  });
+
+  it("feeds the enqueued message through the real queue consumer: acks, writes the real object, stamps metadata + ledger", async () => {
+    // 1. Produce the compact event exactly as the webhook route would.
+    const ev = extractWebhookEvent("issue_comment", issueCommentPayload);
+    expect(ev?.ingest).toEqual({
+      repo: REPO,
+      kind: "pull",
+      num: NUM,
+      source: `comment:${COMMENT_ID}`,
+    });
+
+    // 2. Build a real-module processing env: D1 fakes, GITHUB_CACHE KV, a
+    // REGISTRY-backed workspace with the opt-in knob on, and a real R2 fake
+    // so the real putObject writes somewhere. No GITHUB_WEBHOOK_QUEUE
+    // binding — its absence is what makes handleGithubWebhookBatch's
+    // per-message processing run for real.
+    const db = new UsageFakeD1();
+    const githubCache = new FakeKv();
+    githubCache.store.set("ghinst:acme/app", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "ghs_test" });
+
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "b",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      githubIngestAttachments: true,
+    };
+    const registry = {
+      get: (async (key: string) =>
+        key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+    };
+
+    const env = {
+      DB: db,
+      GITHUB_CACHE: githubCache,
+      REGISTRY: registry,
+      UPLOADS_DEFAULT: new FakeR2Bucket(),
+      ...GITHUB_APP_CFG_ENV,
+    } as unknown as Env;
+
+    await recordRepoLink(env.DB, REPO, WS, "test");
+
+    // 3. Fake every GitHub API call the chain makes: repo-comment-config's
+    // un-seamed contents lookup (404 → no repo config, workspace default
+    // wins), the comment GET (returns the same body), and the asset URL
+    // itself (PNG bytes).
+    const fetchImpl = fakeFetch({
+      "/contents/": () => new Response("nf", { status: 404 }),
+      [`/issues/comments/${COMMENT_ID}`]: () =>
+        new Response(
+          JSON.stringify({ body: issueCommentPayload.comment.body, user: { login: "octocat" } }),
+          { status: 200 },
+        ),
+      [ASSET_ID]: pngRoute,
+    });
+
+    const message = msg(ev!);
+    await withGlobalFetch(fetchImpl, () => handleGithubWebhookBatch(batch([message]), env));
+
+    // Message acked (not retried).
+    expect(message.acked).toBe(true);
+    expect(message.retried).toBe(false);
+
+    // Object exists in the fake R2 under the expected key.
+    const bucket = env.UPLOADS_DEFAULT as unknown as FakeR2Bucket;
+    const stored = bucket.store.get(`acme/${KEY}`) ?? bucket.store.get(KEY);
+    expect(stored).toBeDefined();
+
+    // findObjectsByMetadata returns exactly that key.
+    const found = await findObjectsByMetadata(env.DB, WS, {
+      "gh.origin": "github",
+      "gh.detached": "false",
+    });
+    expect(found.map((f) => f.key)).toEqual([KEY]);
+
+    // Ledger row exists and is not detached.
+    const row = await ledgerRow(env.DB, REPO, ASSET_ID);
+    expect(row).not.toBeNull();
+    expect(row?.detachedAt).toBeNull();
+    expect(row?.objectKey).toBe(KEY);
+  });
+});

--- a/apps/api/test/github-ingest-e2e.test.ts
+++ b/apps/api/test/github-ingest-e2e.test.ts
@@ -25,6 +25,7 @@ import type { WorkspaceRecord } from "../src/workspace";
 import { FakeKv } from "./fake-kv";
 import { FakeR2Bucket } from "./fake-r2";
 import { GITHUB_APP_CFG_ENV } from "./github-app-env";
+import { fakeFetch, pngRoute, withGlobalFetch } from "./helpers/github-fetch-fakes";
 import { UsageFakeD1 } from "./usage-fake-d1";
 
 const REPO = "acme/app";
@@ -88,30 +89,6 @@ function msg(body: WebhookEvent): FakeMessage {
 
 function batch(messages: FakeMessage[]): MessageBatch<WebhookEvent> {
   return { queue: GITHUB_WEBHOOK_QUEUE, messages } as unknown as MessageBatch<WebhookEvent>;
-}
-
-/** Matches routes by substring against the requested URL (repo-comment-config.test.ts style). */
-function fakeFetch(routes: Record<string, (init: RequestInit) => Response | Promise<Response>>) {
-  return (async (url: string, init: RequestInit = {}) => {
-    for (const [pattern, handler] of Object.entries(routes)) {
-      if (String(url).includes(pattern)) return handler(init);
-    }
-    return new Response("not found", { status: 404 });
-  }) as unknown as typeof fetch;
-}
-
-function pngRoute(): Response {
-  return new Response(PNG, { status: 200, headers: { "content-type": "image/png" } });
-}
-
-async function withGlobalFetch<T>(impl: typeof fetch, fn: () => Promise<T>): Promise<T> {
-  const real = globalThis.fetch;
-  globalThis.fetch = impl;
-  try {
-    return await fn();
-  } finally {
-    globalThis.fetch = real;
-  }
 }
 
 describe("github ingest end-to-end (webhook → queue → real putObject)", () => {
@@ -185,7 +162,7 @@ describe("github ingest end-to-end (webhook → queue → real putObject)", () =
           JSON.stringify({ body: issueCommentPayload.comment.body, user: { login: "octocat" } }),
           { status: 200 },
         ),
-      [ASSET_ID]: pngRoute,
+      [ASSET_ID]: pngRoute(PNG),
     });
 
     const message = msg(ev!);

--- a/apps/api/test/github-ingest-ledger-sqlite.test.ts
+++ b/apps/api/test/github-ingest-ledger-sqlite.test.ts
@@ -1,0 +1,73 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import {
+  ledgerRow,
+  ledgerRowsForSource,
+  recordIngestedAsset,
+  setLedgerDetached,
+  setLedgerSource,
+} from "../src/github-ingest-ledger";
+import { database, SqliteD1 } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = ["migrations/20260811120000_github_ingested_assets.sql"];
+
+const row = (over: Partial<Parameters<typeof recordIngestedAsset>[1]> = {}) => ({
+  repo: "acme/app",
+  assetId: "assets/aaaa-bbbb",
+  workspace: "acme",
+  objectKey: "gh/acme-app/pull-7/aaaa-bbbb.png",
+  kind: "pull" as const,
+  num: 7,
+  source: "body",
+  createdAt: "2026-08-11T00:00:00.000Z",
+  ...over,
+});
+
+describe("github ingest ledger", () => {
+  it("records, reads back, and scopes by source", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordIngestedAsset(db, row());
+      await recordIngestedAsset(db, row({ assetId: "files/9/x.png", source: "comment:44" }));
+      expect((await ledgerRow(db, "acme/app", "assets/aaaa-bbbb"))?.objectKey).toBe(
+        "gh/acme-app/pull-7/aaaa-bbbb.png",
+      );
+      expect(await ledgerRowsForSource(db, "acme/app", "body")).toHaveLength(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("detach and re-attach flip detached_at; duplicate record is ignored", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordIngestedAsset(db, row());
+      await recordIngestedAsset(db, row({ objectKey: "gh/other.png" })); // INSERT OR IGNORE
+      expect((await ledgerRow(db, "acme/app", "assets/aaaa-bbbb"))?.objectKey).toBe(
+        "gh/acme-app/pull-7/aaaa-bbbb.png",
+      );
+      await setLedgerDetached(db, "acme/app", "assets/aaaa-bbbb", "2026-08-12T00:00:00.000Z");
+      expect((await ledgerRow(db, "acme/app", "assets/aaaa-bbbb"))?.detachedAt).not.toBeNull();
+      await setLedgerDetached(db, "acme/app", "assets/aaaa-bbbb", null);
+      expect((await ledgerRow(db, "acme/app", "assets/aaaa-bbbb"))?.detachedAt).toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("setLedgerSource moves an asset between sources", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordIngestedAsset(db, row());
+      await setLedgerSource(db, "acme/app", "assets/aaaa-bbbb", "comment:44");
+      expect(await ledgerRowsForSource(db, "acme/app", "body")).toHaveLength(0);
+      expect(await ledgerRowsForSource(db, "acme/app", "comment:44")).toHaveLength(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/helpers/fake-file-metadata-table.ts
+++ b/apps/api/test/helpers/fake-file-metadata-table.ts
@@ -69,6 +69,23 @@ export class FileMetadataTable {
       this.metadata.delete(this.scopeKey(workspace, objectKey));
       return { success: true, meta: { changes: 1 }, results: [] };
     }
+    if (normalizedSql.startsWith("UPDATE file_metadata SET meta_value = ?")) {
+      // updateFileMetadataValue: targeted single-key flip (e.g. gh.detached),
+      // no-op if the key isn't already present.
+      const [value, , workspace, objectKey, metaKey] = args as [
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
+      const map = this.metadata.get(this.scopeKey(workspace, objectKey));
+      if (!map || !map.has(metaKey)) {
+        return { success: true, meta: { changes: 0 }, results: [] };
+      }
+      map.set(metaKey, value);
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
     return undefined;
   }
 

--- a/apps/api/test/helpers/fake-ingest-ledger-table.ts
+++ b/apps/api/test/helpers/fake-ingest-ledger-table.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared in-memory `github_ingested_assets` table backing for route/queue
+ * tests (usage-fake-d1.ts) — mirrors the real D1 semantics (INSERT OR
+ * IGNORE keyed on (repo, asset_id); UPDATE for detach/source) without a
+ * full sqlite-backed D1. See github-ingest-ledger-sqlite.test.ts for the
+ * real-SQL-semantics coverage.
+ */
+
+export interface IngestLedgerDbRow {
+  repo: string;
+  asset_id: string;
+  workspace: string;
+  object_key: string;
+  kind: "pull" | "issues";
+  num: number;
+  source: string;
+  created_at: string;
+  detached_at: string | null;
+}
+
+export interface FakeRunResult {
+  success: true;
+  meta: { changes: number };
+  results: [];
+}
+
+export interface FakeAllResult<T> {
+  success: true;
+  results: T[];
+  meta: Record<string, unknown>;
+}
+
+function key(repo: string, assetId: string): string {
+  return `${repo}::${assetId}`;
+}
+
+export class IngestLedgerTable {
+  readonly rows = new Map<string, IngestLedgerDbRow>();
+
+  tryRun(normalizedSql: string, args: unknown[]): FakeRunResult | undefined {
+    if (normalizedSql.startsWith("INSERT OR IGNORE INTO github_ingested_assets")) {
+      const [repo, assetId, workspace, objectKey, kind, num, source, createdAt] = args as [
+        string,
+        string,
+        string,
+        string,
+        "pull" | "issues",
+        number,
+        string,
+        string,
+      ];
+      const k = key(repo, assetId);
+      if (this.rows.has(k)) return { success: true, meta: { changes: 0 }, results: [] };
+      this.rows.set(k, {
+        repo,
+        asset_id: assetId,
+        workspace,
+        object_key: objectKey,
+        kind,
+        num,
+        source,
+        created_at: createdAt,
+        detached_at: null,
+      });
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    if (
+      normalizedSql.startsWith("UPDATE github_ingested_assets SET detached_at = ?") &&
+      normalizedSql.includes("WHERE repo = ? AND asset_id = ?")
+    ) {
+      const [detachedAt, repo, assetId] = args as [string | null, string, string];
+      const row = this.rows.get(key(repo, assetId));
+      if (!row) return { success: true, meta: { changes: 0 }, results: [] };
+      row.detached_at = detachedAt;
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    if (
+      normalizedSql.startsWith("UPDATE github_ingested_assets SET source = ?") &&
+      normalizedSql.includes("WHERE repo = ? AND asset_id = ?")
+    ) {
+      const [source, repo, assetId] = args as [string, string, string];
+      const row = this.rows.get(key(repo, assetId));
+      if (!row) return { success: true, meta: { changes: 0 }, results: [] };
+      row.source = source;
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    return undefined;
+  }
+
+  tryFirst<T>(normalizedSql: string, args: unknown[]): T | null | undefined {
+    if (normalizedSql.includes("FROM github_ingested_assets WHERE repo = ? AND asset_id = ?")) {
+      const [repo, assetId] = args as [string, string];
+      return (this.rows.get(key(repo, assetId)) as T) ?? null;
+    }
+    return undefined;
+  }
+
+  tryAll<T>(normalizedSql: string, args: unknown[]): FakeAllResult<T> | undefined {
+    if (normalizedSql.includes("FROM github_ingested_assets WHERE repo = ? AND source = ?")) {
+      const [repo, source] = args as [string, string];
+      const results = [...this.rows.values()].filter(
+        (row) => row.repo === repo && row.source === source,
+      );
+      return { success: true, results: results as T[], meta: {} };
+    }
+    return undefined;
+  }
+}

--- a/apps/api/test/helpers/github-fetch-fakes.ts
+++ b/apps/api/test/helpers/github-fetch-fakes.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared fetch fakes for the GitHub ingest test suites (github-ingest.test.ts,
+ * github-ingest-e2e.test.ts, routes-workspace-github.test.ts). Previously
+ * copy-pasted across all three call sites; extracted here so there's one
+ * definition to keep in sync.
+ */
+
+/** Matches routes by substring against the requested URL, like repo-comment-config.test.ts's fakeFetch. */
+export function fakeFetch(
+  routes: Record<string, (init: RequestInit) => Response | Promise<Response>>,
+) {
+  return (async (url: string, init: RequestInit = {}) => {
+    for (const [pattern, handler] of Object.entries(routes)) {
+      if (String(url).includes(pattern)) return handler(init);
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+/** A 200 PNG response, for routing an asset-URL fetch in `fakeFetch`'s route table. */
+export function pngRoute(png: Uint8Array): () => Response {
+  return () => new Response(png, { status: 200, headers: { "content-type": "image/png" } });
+}
+
+/** Swaps `globalThis.fetch` for the duration of `fn` — needed for call sites
+ * (repo-comment-config's un-seamed lookup) that aren't reachable via a
+ * `fetchImpl` seam. */
+export async function withGlobalFetch<T>(impl: typeof fetch, fn: () => Promise<T>): Promise<T> {
+  const real = globalThis.fetch;
+  globalThis.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = real;
+  }
+}

--- a/apps/api/test/routes-workspace-github.test.ts
+++ b/apps/api/test/routes-workspace-github.test.ts
@@ -17,6 +17,7 @@ import { FakeKv } from "./fake-kv";
 import { FakeR2Bucket } from "./fake-r2";
 import { GITHUB_APP_CFG_ENV } from "./github-app-env";
 import { withMintingUserToken } from "./helpers/fake-minting-user-token";
+import { withGlobalFetch } from "./helpers/github-fetch-fakes";
 import { UsageFakeD1 } from "./usage-fake-d1";
 
 const WS = "acme";
@@ -524,16 +525,6 @@ describe("POST /v1/workspaces/:workspace/github/ingest (manual, dual-auth)", () 
       }
       return new Response("not found", { status: 404 });
     }) as unknown as typeof fetch;
-  }
-
-  async function withGlobalFetch<T>(impl: typeof fetch, fn: () => Promise<T>): Promise<T> {
-    const real = globalThis.fetch;
-    globalThis.fetch = impl;
-    try {
-      return await fn();
-    } finally {
-      globalThis.fetch = real;
-    }
   }
 
   it("token auth + linked repo + one asset in body: 200 with ingested length 1", async () => {

--- a/apps/api/test/routes-workspace-github.test.ts
+++ b/apps/api/test/routes-workspace-github.test.ts
@@ -9,6 +9,8 @@
  * posture on link/repo-link/health/activity, and untouched old-path behavior.
  */
 import { beforeAll, describe, expect, it } from "vitest";
+import { attachmentKeyBasename } from "../src/github-attachment-extract";
+import { recordRepoLink } from "../src/github-repo-links";
 import { app } from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
 import { FakeKv } from "./fake-kv";
@@ -493,6 +495,226 @@ describe("GET /v1/workspaces/:workspace/github/activity (dual-auth, session-admi
       env,
     );
     expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /v1/workspaces/:workspace/github/ingest (manual, dual-auth)", () => {
+  const REPO = "acme/web";
+  const ASSET_ID = "assets/11111111-1111-1111-1111-111111111111";
+  const ASSET_URL = `https://github.com/user-attachments/${ASSET_ID}`;
+  const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+  const KEY = `gh/acme-web/pull-5/${attachmentKeyBasename(ASSET_ID)}.png`;
+
+  function seedInstallation(githubCache: FakeKv) {
+    githubCache.store.set(`ghinst:${REPO}`, { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "ghs_test" });
+  }
+
+  function fakeGithubFetch(bodyText: string) {
+    return (async (url: string) => {
+      const u = String(url);
+      if (u.includes(`/repos/${REPO}/issues/5/comments`)) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (u.includes(`/repos/${REPO}/issues/5`)) {
+        return Response.json({ body: bodyText, user: { login: "octocat" } });
+      }
+      if (u.includes(ASSET_ID)) {
+        return new Response(PNG, { status: 200, headers: { "content-type": "image/png" } });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+  }
+
+  async function withGlobalFetch<T>(impl: typeof fetch, fn: () => Promise<T>): Promise<T> {
+    const real = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      return await fn();
+    } finally {
+      globalThis.fetch = real;
+    }
+  }
+
+  it("token auth + linked repo + one asset in body: 200 with ingested length 1", async () => {
+    const { env, db, githubCache } = await makeEnv();
+    await recordRepoLink(db as unknown as D1Database, REPO, WS, "test");
+    seedInstallation(githubCache);
+
+    const res = await withGlobalFetch(fakeGithubFetch(`see ${ASSET_URL}`), async () =>
+      app.request(
+        "/v1/workspaces/acme/github/ingest",
+        {
+          method: "POST",
+          headers: { ...bearer(), "content-type": "application/json" },
+          body: JSON.stringify({ repo: REPO, pr: 5 }),
+        },
+        env,
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      repo: string;
+      kind: string;
+      num: number;
+      ingested: string[];
+      reattached: string[];
+      detached: string[];
+      skipped: unknown[];
+    };
+    expect(body).toEqual({
+      repo: REPO,
+      kind: "pull",
+      num: 5,
+      ingested: [KEY],
+      reattached: [],
+      detached: [],
+      skipped: [],
+    });
+  });
+
+  it("both pr and issue set: 400 ValidationError code github_ingest_target", async () => {
+    const { env, db } = await makeEnv();
+    await recordRepoLink(db as unknown as D1Database, REPO, WS, "test");
+    const res = await app.request(
+      "/v1/workspaces/acme/github/ingest",
+      {
+        method: "POST",
+        headers: { ...bearer(), "content-type": "application/json" },
+        body: JSON.stringify({ repo: REPO, pr: 5, issue: 6 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const errBody = (await res.json()) as { error?: { code?: string } };
+    expect(errBody.error?.code).toBe("github_ingest_target");
+  });
+
+  it("neither pr nor issue set: 400 ValidationError code github_ingest_target", async () => {
+    const { env, db } = await makeEnv();
+    await recordRepoLink(db as unknown as D1Database, REPO, WS, "test");
+    const res = await app.request(
+      "/v1/workspaces/acme/github/ingest",
+      {
+        method: "POST",
+        headers: { ...bearer(), "content-type": "application/json" },
+        body: JSON.stringify({ repo: REPO }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const errBody = (await res.json()) as { error?: { code?: string } };
+    expect(errBody.error?.code).toBe("github_ingest_target");
+  });
+
+  it("repo not linked to any workspace: 404 repo_not_linked", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/github/ingest",
+      {
+        method: "POST",
+        headers: { ...bearer(), "content-type": "application/json" },
+        body: JSON.stringify({ repo: REPO, pr: 5 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    const errBody = (await res.json()) as { error?: { code?: string } };
+    expect(errBody.error?.code).toBe("repo_not_linked");
+  });
+
+  it("repo linked to a different workspace: 404 repo_not_linked, does not leak the owning workspace", async () => {
+    const { env, db } = await makeEnv();
+    await recordRepoLink(db as unknown as D1Database, REPO, "someone-else", "test");
+    const res = await app.request(
+      "/v1/workspaces/acme/github/ingest",
+      {
+        method: "POST",
+        headers: { ...bearer(), "content-type": "application/json" },
+        body: JSON.stringify({ repo: REPO, pr: 5 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    const bodyText = await res.text();
+    expect(bodyText).not.toContain("someone-else");
+    const errBody = JSON.parse(bodyText) as { error?: { code?: string } };
+    expect(errBody.error?.code).toBe("repo_not_linked");
+  });
+
+  it("works with the ingest knob off (manual bypasses it)", async () => {
+    // makeEnv()'s workspace record never sets `githubIngestAttachments`, so
+    // this exercises the same knob-less record the webhook path would
+    // silently no-op on — the manual endpoint must still ingest.
+    const { env, db, githubCache } = await makeEnv();
+    await recordRepoLink(db as unknown as D1Database, REPO, WS, "test");
+    seedInstallation(githubCache);
+
+    const res = await withGlobalFetch(fakeGithubFetch(`see ${ASSET_URL}`), async () =>
+      app.request(
+        "/v1/workspaces/acme/github/ingest",
+        {
+          method: "POST",
+          headers: { ...bearer(), "content-type": "application/json" },
+          body: JSON.stringify({ repo: REPO, issue: 5 }),
+        },
+        env,
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { kind: string; ingested: string[] };
+    expect(body.kind).toBe("issues");
+    expect(body.ingested).toEqual([`gh/acme-web/issues-5/${attachmentKeyBasename(ASSET_ID)}.png`]);
+  });
+
+  it("github app not configured/installed propagates as 404 github_app_not_installed", async () => {
+    const { env, db, githubCache } = await makeEnv();
+    await recordRepoLink(db as unknown as D1Database, REPO, WS, "test");
+    // Deliberately don't seed ghinst:/ghtok: — installationForRepo misses.
+    void githubCache;
+    const res = await withGlobalFetch(
+      (async (url: string) =>
+        String(url).includes("/installation")
+          ? new Response("nf", { status: 404 })
+          : new Response("nf", { status: 404 })) as unknown as typeof fetch,
+      async () =>
+        app.request(
+          "/v1/workspaces/acme/github/ingest",
+          {
+            method: "POST",
+            headers: { ...bearer(), "content-type": "application/json" },
+            body: JSON.stringify({ repo: REPO, pr: 5 }),
+          },
+          env,
+        ),
+    );
+    expect(res.status).toBe(404);
+    const errBody = (await res.json()) as { error?: { code?: string } };
+    expect(errBody.error?.code).toBe("github_app_not_installed");
+  });
+
+  it("session (cookie) auth also reaches the handler", async () => {
+    const { env, db, githubCache } = await makeEnv();
+    await recordRepoLink(db as unknown as D1Database, REPO, WS, "test");
+    seedInstallation(githubCache);
+
+    const res = await withGlobalFetch(fakeGithubFetch(`see ${ASSET_URL}`), async () =>
+      app.request(
+        "/v1/workspaces/acme/github/ingest",
+        {
+          method: "POST",
+          headers: { ...sessionCookie, "content-type": "application/json" },
+          body: JSON.stringify({ repo: REPO, pr: 5 }),
+        },
+        env,
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ingested: string[] };
+    expect(body.ingested).toEqual([KEY]);
   });
 });
 

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -196,6 +196,7 @@ describe("GET/PATCH /v1/workspaces/:workspace/comment-settings", () => {
       showMetadata: null,
       linkToFilePage: null,
       note: null,
+      ingestGithubAttachments: null,
     });
   });
 
@@ -276,6 +277,38 @@ describe("GET/PATCH /v1/workspaces/:workspace/comment-settings", () => {
         method: "PATCH",
         headers: { ...sessionHeaders, "content-type": "application/json" },
         body: JSON.stringify({ imageWidth: 1 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH round-trips ingestGithubAttachments for an owner session", async () => {
+    const { env, registry } = makeEnv({ role: "owner" });
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ ingestGithubAttachments: true }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ingestGithubAttachments: true });
+    expect(
+      registry.record<{ githubIngestAttachments?: boolean }>("acme")?.githubIngestAttachments,
+    ).toBe(true);
+  });
+
+  it("PATCH rejects a non-boolean ingestGithubAttachments with 400", async () => {
+    const { env } = makeEnv({ role: "admin" });
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ ingestGithubAttachments: "yes" }),
       },
       env,
     );

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -5,6 +5,7 @@
 
 import { DeleteUsageClaimsTable } from "./helpers/fake-delete-usage-claims-table";
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
+import { IngestLedgerTable } from "./helpers/fake-ingest-ledger-table";
 import { PrActivityTable } from "./helpers/fake-pr-activity-table";
 import { RepoLinksTable } from "./helpers/fake-repo-links-table";
 
@@ -43,6 +44,12 @@ export class UsageFakeD1 {
   get prActivity() {
     return this.prActivityTable.rows;
   }
+  // Backs `github_ingested_assets` — the ingest ledger's idempotency
+  // backbone (Task 2 of the GitHub attachment ingestion feature).
+  private ingestLedgerTable = new IngestLedgerTable();
+  get ingestLedger() {
+    return this.ingestLedgerTable.rows;
+  }
 
   prepare = (sql: string) => {
     const normalized = sql.replace(/\s+/g, " ").trim();
@@ -60,6 +67,8 @@ export class UsageFakeD1 {
         }
         const linkResult = this.repoLinksTable.tryFirst(normalized, values);
         if (linkResult !== undefined) return linkResult;
+        const ledgerFirstResult = this.ingestLedgerTable.tryFirst(normalized, values);
+        if (ledgerFirstResult !== undefined) return ledgerFirstResult;
         throw new Error(`unsupported first: ${normalized}`);
       },
       all: async <T>() => {
@@ -69,6 +78,8 @@ export class UsageFakeD1 {
         if (linkResult) return linkResult;
         const activityResult = this.prActivityTable.tryAll<T>(normalized, values);
         if (activityResult) return activityResult;
+        const ledgerAllResult = this.ingestLedgerTable.tryAll<T>(normalized, values);
+        if (ledgerAllResult) return ledgerAllResult;
         // Galleries aren't modeled by this fake (route/gallery-specific tests
         // bring their own D1 stand-in) — an empty page is a safe, honest
         // default for callers (e.g. the webhook auto-promote gather) that
@@ -85,6 +96,8 @@ export class UsageFakeD1 {
         if (linkResult) return linkResult;
         const activityResult = this.prActivityTable.tryRun(normalized, values);
         if (activityResult) return activityResult;
+        const ledgerRunResult = this.ingestLedgerTable.tryRun(normalized, values);
+        if (ledgerRunResult) return ledgerRunResult;
         const claimResult = this.deleteUsageClaimsTable.tryRun(normalized, values);
         if (claimResult) return claimResult;
         if (normalized.startsWith("INSERT OR IGNORE INTO workspace_usage")) {

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -106,6 +106,16 @@ function extLabel(key: string): string {
   return match ? match[1].toLowerCase() : "file";
 }
 
+/** "PR #7" / "Issue #3", plus the author when present. */
+function ghLabel(item: SearchFileItem): string {
+  const kind = item.metadata["gh.kind"];
+  const number = item.metadata["gh.number"];
+  const kindLabel = kind === "pull" ? "PR" : kind === "issues" ? "Issue" : kind;
+  const base = kindLabel && number ? `${kindLabel} #${number}` : kindLabel || number || "GitHub";
+  const author = item.metadata["gh.author"];
+  return author ? `${base} · ${author}` : base;
+}
+
 // ── Thumb tile ─────────────────────────────────────────────────────────
 
 function ShotThumb({
@@ -183,6 +193,7 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
   );
   const [drill, setDrill] = useState<DrillState>({ status: "idle" });
   const [drillRetryNonce, setDrillRetryNonce] = useState(0);
+  const [ghState, setGhState] = useState<DrillState>({ status: "loading" });
 
   // Workspace-level facts (hasPublicUrl), gated behind session resolution —
   // same pattern as WorkspaceFileTable.
@@ -218,6 +229,29 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
       cancelled = true;
     };
   }, [apiOrigin, workspace, overviewRetryNonce]);
+
+  // GitHub-mirrored screenshots ("From GitHub" section), fetched in parallel
+  // with the by-path overview. A failure here must never block or break the
+  // by-path view — it just renders nothing.
+  useEffect(() => {
+    let cancelled = false;
+    onSession(() => {
+      void searchWorkspaceFiles(apiOrigin, workspace, [
+        { key: "gh.origin", value: "github" },
+        { key: "gh.detached", value: "false" },
+      ]).then((result) => {
+        if (cancelled) return;
+        setGhState(
+          result.kind === "ok"
+            ? { status: "ready", items: result.items, truncated: result.truncated }
+            : { status: "error" },
+        );
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiOrigin, workspace]);
 
   // Drill-in fetch — URL-synced so a reload or shared link lands on the
   // same path. Clearing drillPath ("") goes back to the overview without a
@@ -360,6 +394,37 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
       {overview.truncated && (
         <p className="wft-end">Showing the most active paths — narrow with a specific path.</p>
       )}
+      {ghState.status === "ready" && ghState.items.length > 0 && (
+        <GitHubSection items={ghState.items} onOpen={open} />
+      )}
+    </div>
+  );
+}
+
+function GitHubSection({
+  items,
+  onOpen,
+}: {
+  items: SearchFileItem[];
+  onOpen: (file: SearchFileItem) => void;
+}) {
+  return (
+    <div className="wsp-group">
+      <div className="wsp-group__head">
+        <span className="wsp-group__path">From GitHub</span>
+        <span className="wsp-group__meta">
+          {items.length} {items.length === 1 ? "file" : "files"}
+        </span>
+      </div>
+      <div className="wsp-strip">
+        {items.map((item) => (
+          <ShotThumb
+            key={item.key}
+            item={{ ...item, state: ghLabel(item) }}
+            onOpen={() => onOpen(item)}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -110,7 +110,10 @@ function extLabel(key: string): string {
 function ghLabel(item: SearchFileItem): string {
   const kind = item.metadata["gh.kind"];
   const number = item.metadata["gh.number"];
-  const kindLabel = kind === "pull" ? "PR" : kind === "issues" ? "Issue" : kind;
+  // Stored vocabulary is singular ("issue"), matching the CLI and
+  // deriveGithubContext (routes/public-files.ts) — "issues" is kept too for
+  // robustness against any pre-migration row still carrying the old value.
+  const kindLabel = kind === "pull" ? "PR" : kind === "issue" || kind === "issues" ? "Issue" : kind;
   const numberLabel = number ? `#${number}` : "";
   const base = [kindLabel, numberLabel].filter(Boolean).join(" ") || "GitHub";
   const author = item.metadata["gh.author"];

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -111,7 +111,8 @@ function ghLabel(item: SearchFileItem): string {
   const kind = item.metadata["gh.kind"];
   const number = item.metadata["gh.number"];
   const kindLabel = kind === "pull" ? "PR" : kind === "issues" ? "Issue" : kind;
-  const base = kindLabel && number ? `${kindLabel} #${number}` : kindLabel || number || "GitHub";
+  const numberLabel = number ? `#${number}` : "";
+  const base = [kindLabel, numberLabel].filter(Boolean).join(" ") || "GitHub";
   const author = item.metadata["gh.author"];
   return author ? `${base} · ${author}` : base;
 }
@@ -372,31 +373,35 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
     );
   }
 
-  // Overview: empty state when no path-tagged screenshots exist at all.
-  if (overview.groups.length === 0) {
-    return (
-      <div className="ws-empty-state">
-        <p className="ws-empty-state__title">No screenshots with a path yet</p>
-        <p className="ws-empty-state__body">
-          <code>uploads screenshot</code> records the page it captured automatically, and any upload
-          can pass <code>--meta path=/settings</code> to group here. See{" "}
-          <a href="/docs">the docs</a> for details.
-        </p>
-      </div>
-    );
-  }
+  // Overview: by-path groups, or the empty state when no path-tagged
+  // screenshots exist at all — either way, the GitHub section (when
+  // non-empty) still renders below it, since GitHub-ingested files carry no
+  // `path` metadata and would otherwise never surface in a GitHub-only
+  // workspace.
+  const showGh = ghState.status === "ready" && ghState.items.length > 0;
 
   return (
     <div className="wsp">
-      {overview.groups.map((group) => (
-        <PathGroupSection key={group.path} group={group} onDrill={setDrillPath} onOpen={open} />
-      ))}
-      {overview.truncated && (
-        <p className="wft-end">Showing the most active paths — narrow with a specific path.</p>
+      {overview.groups.length === 0 ? (
+        <div className="ws-empty-state">
+          <p className="ws-empty-state__title">No screenshots with a path yet</p>
+          <p className="ws-empty-state__body">
+            <code>uploads screenshot</code> records the page it captured automatically, and any
+            upload can pass <code>--meta path=/settings</code> to group here. See{" "}
+            <a href="/docs">the docs</a> for details.
+          </p>
+        </div>
+      ) : (
+        <>
+          {overview.groups.map((group) => (
+            <PathGroupSection key={group.path} group={group} onDrill={setDrillPath} onOpen={open} />
+          ))}
+          {overview.truncated && (
+            <p className="wft-end">Showing the most active paths — narrow with a specific path.</p>
+          )}
+        </>
       )}
-      {ghState.status === "ready" && ghState.items.length > 0 && (
-        <GitHubSection items={ghState.items} onOpen={open} />
-      )}
+      {showGh && <GitHubSection items={ghState.items} onOpen={open} />}
     </div>
   );
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -75,27 +75,28 @@ command to run by hand, rather than overwriting your build.
 
 ## Command overview
 
-| Command                  | What it does                                                            |
-| ------------------------ | ----------------------------------------------------------------------- |
-| `attach <file…>`         | Attach media to the current PR (stable URLs + comment)                  |
-| `put <file>`             | Upload one file → public URL + GitHub markdown                          |
-| `screenshot <url\|html>` | Capture a page (or local HTML) and host it in one step                  |
-| `annotate <image>`       | Bake boxes, arrows, labels, strokes, and redactions onto an image       |
-| `comment`                | Create/update a PR/issue attachments comment (via `gh`)                 |
-| `list` / `find k=v`      | List objects, optionally filtered by queryable metadata                 |
-| `meta get` / `meta set`  | Read or merge-set an object's queryable metadata                        |
-| `gallery …`              | Create and organize public media galleries                              |
-| `delete <key>`           | Delete an object                                                        |
-| `usage`                  | Workspace storage / upload counters                                     |
-| `install`                | Skills + remote MCP + hooks (Grok/Cursor); see plugins for Claude/Codex |
-| `hook`                   | Agent harness handlers (e.g. pre-PR screenshot reminder)                |
-| `update`                 | Update the CLI, then refresh skills / MCP / hooks                       |
-| `login` / `logout`       | Sign in (browser or enrollment code) / clear saved token                |
-| `whoami` (`status`)      | Show the active workspace and token                                     |
-| `invite`                 | Invite a teammate to a workspace (workspace admin)                      |
-| `doctor` / `health`      | Health + auth + workspace checks / API liveness                         |
-| `setup` / `config`       | Inspect and configure CLI settings                                      |
-| `mcp`                    | Serve MCP over stdio, both spec eras (tools mirror the CLI)             |
+| Command                  | What it does                                                                  |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| `attach <file…>`         | Attach media to the current PR (stable URLs + comment)                        |
+| `put <file>`             | Upload one file → public URL + GitHub markdown                                |
+| `screenshot <url\|html>` | Capture a page (or local HTML) and host it in one step                        |
+| `annotate <image>`       | Bake boxes, arrows, labels, strokes, and redactions onto an image             |
+| `comment`                | Create/update a PR/issue attachments comment (via `gh`)                       |
+| `ingest`                 | Mirror `github.com/user-attachments` media from a PR/issue into the workspace |
+| `list` / `find k=v`      | List objects, optionally filtered by queryable metadata                       |
+| `meta get` / `meta set`  | Read or merge-set an object's queryable metadata                              |
+| `gallery …`              | Create and organize public media galleries                                    |
+| `delete <key>`           | Delete an object                                                              |
+| `usage`                  | Workspace storage / upload counters                                           |
+| `install`                | Skills + remote MCP + hooks (Grok/Cursor); see plugins for Claude/Codex       |
+| `hook`                   | Agent harness handlers (e.g. pre-PR screenshot reminder)                      |
+| `update`                 | Update the CLI, then refresh skills / MCP / hooks                             |
+| `login` / `logout`       | Sign in (browser or enrollment code) / clear saved token                      |
+| `whoami` (`status`)      | Show the active workspace and token                                           |
+| `invite`                 | Invite a teammate to a workspace (workspace admin)                            |
+| `doctor` / `health`      | Health + auth + workspace checks / API liveness                               |
+| `setup` / `config`       | Inspect and configure CLI settings                                            |
+| `mcp`                    | Serve MCP over stdio, both spec eras (tools mirror the CLI)                   |
 
 Run `uploads <command> --help` for a command's flags.
 
@@ -175,6 +176,22 @@ exists` without writing.
 > (`gh/myorg/myapp/pull/123/after.png`), so generic names are easier to guess
 > than hashed keys. Treat uploads as public; don't host secrets or sensitive UI.
 > Tighter access controls for private repos are planned — see [roadmap](roadmap.md).
+
+**Mirroring GitHub-native attachments** (`uploads ingest`) handles the other
+direction: images someone dropped straight into a PR/issue via
+`github.com/user-attachments/…`, which only exist behind GitHub's own
+authenticated hosting. `uploads ingest --pr <n>` (or `--issue <n>`) scans the
+description and comments, mirrors any new ones into the workspace (indexed,
+not added to the managed comment), and detaches ones no longer referenced:
+
+```bash
+uploads ingest --pr 123
+uploads ingest --issue 45 --repo myorg/myapp
+```
+
+This is the manual/backfill entry point. The `.uploads.yml` `ingestGithubAttachments`
+knob gates the automatic webhook path only — it has no effect on running
+`ingest` directly.
 
 ## Annotating screenshots
 

--- a/docs/superpowers/plans/2026-08-11-github-attachment-ingestion.md
+++ b/docs/superpowers/plans/2026-08-11-github-attachment-ingestion.md
@@ -1,0 +1,1040 @@
+# GitHub-Native Attachment Ingestion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-github-attachment-ingestion-design.md`
+
+**Goal:** Mirror `github.com/user-attachments` assets from PR/issue bodies and comments into the linked workspace so GitHub-native uploads appear in `find_files`, search, and the Screenshots page.
+
+**Architecture:** One reconciliation core (`apps/api/src/github-ingest.ts`) with two triggers: a new `ingest` field on the existing webhook-queue `WebhookEvent` (automatic, gated by a new `ingestGithubAttachments` repo/workspace knob), and a manual `POST /v1/workspaces/:workspace/github/ingest` endpoint (+ `uploads ingest` CLI). A D1 ledger table keyed by (repo, asset id) makes every reconcile idempotent; removal soft-detaches (`gh.detached=true`) and never deletes bytes.
+
+**Tech Stack:** Cloudflare Workers (Hono), D1, R2, Queues; vitest with the repo's fake-D1/fake-R2 harness; the published `uploads` CLI package.
+
+## Global Constraints
+
+- The `.uploads.yml` parser exists in TWO deliberately duplicated copies — `packages/comment-config/src/index.ts` and `packages/uploads/src/comment-config.ts` — kept honest by `test/fixtures/comment-config-golden.json`. Any parser change lands in both copies + the fixture in the same task.
+- Queue messages are compact field-extractions, never raw GitHub payloads (128 KB cap). The ingest message carries a source _reference_; the consumer re-fetches current text.
+- `extractWebhookEvent` is pure (no I/O). All gating that needs DB/KV happens in the consumer.
+- Guard failures (non-media, oversize, over budget, asset 404) are **permanent skips** with a structured log — they must never `throw` into the queue retry path. Network failures / GitHub 5xx **do** throw (retry).
+- Metadata keys must match `META_KEY_RE = /^[a-z][a-z0-9._-]{0,63}$/`, values ≤ 512 bytes, ≤ 24 keys total. New keys: `gh.origin=github`, `gh.author=<login>`, `gh.detached=false|true` (always stamped), `gh.source=body|comment:<id>`. Existing keys reused: `gh.repo`, `gh.kind`, `gh.number`. Never stamp `gh.uploader`/`gh.uploader-id` (server-derived elsewhere).
+- Never call `replaceFileMetadata` to flip one key (delete-then-insert wipes server-owned `video.*` rows). Task 4 adds a targeted single-key update helper.
+- All writes go through `putObject` (files-core) — never bare R2 puts.
+- Object keys live under the managed prefix: `gh/{owner}-{repo}/{pull|issues}-{num}/{assetId}.{ext}` (`isManagedGithubKey` → replace always allowed).
+- D1 migration naming: `YYYYMMDDHHMMSS_snake_case.sql` in `apps/api/migrations/`. Migrations auto-apply on merge to main — no manual wrangler step.
+- CLI changes need a changeset for the published CLI package only (an ignored-package changeset silently blocks all publishes).
+- Commit style: `feat(api): …` / `feat(cli): …` etc., no sensational adjectives.
+- Run tests with `pnpm vitest run <file>` from the repo root (plain vitest, no pool-workers).
+
+---
+
+### Task 1: `ingestGithubAttachments` config knob
+
+**Files:**
+
+- Modify: `packages/comment-config/src/index.ts`
+- Modify: `packages/uploads/src/comment-config.ts` (byte-for-byte same parser edits)
+- Modify: `test/fixtures/comment-config-golden.json`
+- Modify: `apps/api/src/repo-comment-config.ts` (`workspaceCommentDefaults`)
+- Modify: `apps/api/src/workspace.ts` (WorkspaceRecord field `githubIngestAttachments?: boolean`)
+- Modify: `apps/api/src/routes/workspace-settings.ts` (PATCH accepts the new boolean)
+- Test: `packages/comment-config/src/index.test.ts`, `packages/uploads/test/comment-config.test.ts` (golden-fixture driven), plus the workspace-settings route test file that covers other boolean knobs
+
+**Interfaces:**
+
+- Consumes: existing `RepoCommentConfig` / `WorkspaceCommentDefaults` / `ResolvedCommentOptions` / `resolveCommentOptions` / `parseRepoCommentConfig`.
+- Produces: `ResolvedCommentOptions.ingestGithubAttachments: boolean` (default `false`), resolvable repo → workspace → auto. `WorkspaceRecord.githubIngestAttachments?: boolean`. Task 5 reads `options.ingestGithubAttachments` via `resolveRepoCommentOptions(env, ws, repo)`.
+
+- [ ] **Step 1: Add golden-fixture cases (the failing test)**
+
+Append to `parseCases` in `test/fixtures/comment-config-golden.json`:
+
+```json
+{
+  "name": "ingestGithubAttachments true",
+  "text": "ingestGithubAttachments: true\n",
+  "format": "yaml",
+  "expected": { "config": { "ingestGithubAttachments": true }, "warnings": [] }
+},
+{
+  "name": "ingestGithubAttachments non-boolean warns",
+  "text": "ingestGithubAttachments: yes please\n",
+  "format": "yaml",
+  "expected": { "config": null, "warnings": ["ingestGithubAttachments: expected true or false"] }
+}
+```
+
+(Match the exact warning-string style of the existing boolean knobs — read how `linkToFilePage` warns first and copy that phrasing; adjust the fixture to match.)
+
+Append to `resolveCases`:
+
+```json
+{
+  "name": "ingest knob repo over workspace",
+  "repo": { "ingestGithubAttachments": true },
+  "workspace": { "ingestGithubAttachments": false },
+  "expected": {
+    "options": {
+      "imageWidth": "auto",
+      "maxInlineImages": 16,
+      "metaPath": true,
+      "metaState": true,
+      "linkToFilePage": true,
+      "note": null,
+      "ingestGithubAttachments": true
+    },
+    "source": {
+      "imageWidth": "auto",
+      "maxInlineImages": "auto",
+      "metaPath": "auto",
+      "metaState": "auto",
+      "linkToFilePage": "auto",
+      "note": "auto",
+      "ingestGithubAttachments": "repo"
+    }
+  }
+}
+```
+
+Also update every EXISTING `resolveCases` expectation: each gains `"ingestGithubAttachments": false` in `options` and `"ingestGithubAttachments": "auto"` in `source` (the resolver returns every key).
+
+- [ ] **Step 2: Run both golden-driven suites to verify they fail**
+
+Run: `pnpm vitest run packages/comment-config/src/index.test.ts packages/uploads/test/comment-config.test.ts`
+Expected: FAIL (unknown key warning / missing field in resolved options).
+
+- [ ] **Step 3: Implement the knob in the canonical parser**
+
+In `packages/comment-config/src/index.ts`:
+
+- `RepoCommentConfig`: add `ingestGithubAttachments?: boolean;`
+- `WorkspaceCommentDefaults`: add `ingestGithubAttachments?: boolean;`
+- `ResolvedCommentOptions`: add `ingestGithubAttachments: boolean;`
+- `AUTO_COMMENT_OPTIONS`: add `ingestGithubAttachments: false,`
+- `parseRepoCommentConfig`: add a boolean-parse branch identical in shape to `linkToFilePage`'s (accept `true`/`false`, warn otherwise).
+- `resolveCommentOptions`: add `"ingestGithubAttachments"` to the `apply` loop's key list; in the `wsAsRepo` conversion map `ws.ingestGithubAttachments` straight through (plain boolean, no fan-out).
+
+- [ ] **Step 4: Mirror the exact same edits into `packages/uploads/src/comment-config.ts`**
+
+The two files must stay copy-identical in the shared region. Apply the same diff.
+
+- [ ] **Step 5: Run both suites to verify they pass**
+
+Run: `pnpm vitest run packages/comment-config/src/index.test.ts packages/uploads/test/comment-config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Wire the workspace default in the API**
+
+In `apps/api/src/workspace.ts` add to `WorkspaceRecord` (next to the other `githubComment*` fields):
+
+```ts
+/** Workspace default for the repo `ingestGithubAttachments` knob (issue-spec 2026-08-11). */
+githubIngestAttachments?: boolean;
+```
+
+In `apps/api/src/repo-comment-config.ts` `workspaceCommentDefaults(ws)`, add:
+
+```ts
+ingestGithubAttachments: ws.githubIngestAttachments,
+```
+
+In `apps/api/src/routes/workspace-settings.ts`, extend the PATCH handler to accept `githubIngestAttachments` exactly like the existing boolean knobs (`githubCommentLinkToFilePage` is the template: type-check boolean, write via the versioned `mutateWorkspaceRecord` path the route already uses). Add a PATCH test case in the existing workspace-settings test file asserting the field round-trips and rejects non-booleans.
+
+- [ ] **Step 7: Run API config + settings tests**
+
+Run: `pnpm vitest run apps/api/src/repo-comment-config.test.ts apps/api/test/routes-workspace-settings.test.ts` (adjust to the actual settings test filename found in `apps/api/test/`).
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/comment-config packages/uploads/src/comment-config.ts test/fixtures/comment-config-golden.json apps/api/src
+git commit -m "feat(config): ingestGithubAttachments repo/workspace knob"
+```
+
+---
+
+### Task 2: Ingest ledger (migration + module)
+
+**Files:**
+
+- Create: `apps/api/migrations/20260811120000_github_ingested_assets.sql`
+- Create: `apps/api/src/github-ingest-ledger.ts`
+- Create: `apps/api/test/github-ingest-ledger-sqlite.test.ts`
+- Create: `apps/api/test/helpers/fake-ingest-ledger-table.ts`
+- Modify: `apps/api/test/usage-fake-d1.ts` (wire the fake table in)
+
+**Interfaces:**
+
+- Consumes: nothing from other tasks.
+- Produces (Task 4 depends on these exact signatures):
+
+```ts
+export interface IngestLedgerRow {
+  repo: string; // lowercase owner/name
+  assetId: string; // path after /user-attachments/, e.g. "assets/<uuid>" or "files/123/shot.png"
+  workspace: string;
+  objectKey: string;
+  kind: "pull" | "issues";
+  num: number;
+  source: string; // "body" | "comment:<id>"
+  createdAt: string; // ISO
+  detachedAt: string | null;
+}
+export async function ledgerRowsForSource(
+  db: D1Database,
+  repo: string,
+  source: string,
+): Promise<IngestLedgerRow[]>;
+export async function ledgerRow(
+  db: D1Database,
+  repo: string,
+  assetId: string,
+): Promise<IngestLedgerRow | null>;
+export async function recordIngestedAsset(
+  db: D1Database,
+  row: Omit<IngestLedgerRow, "detachedAt">,
+): Promise<void>;
+export async function setLedgerDetached(
+  db: D1Database,
+  repo: string,
+  assetId: string,
+  detachedAt: string | null,
+): Promise<void>;
+export async function setLedgerSource(
+  db: D1Database,
+  repo: string,
+  assetId: string,
+  source: string,
+): Promise<void>;
+```
+
+- [ ] **Step 1: Write the migration**
+
+`apps/api/migrations/20260811120000_github_ingested_assets.sql`:
+
+```sql
+-- Ledger of GitHub-native user-attachments mirrored into workspaces
+-- (spec docs/superpowers/specs/2026-08-11-github-attachment-ingestion-design.md).
+-- One row per (repo, asset); detached_at NULL == currently referenced.
+CREATE TABLE github_ingested_assets (
+  repo        TEXT NOT NULL,
+  asset_id    TEXT NOT NULL,
+  workspace   TEXT NOT NULL,
+  object_key  TEXT NOT NULL,
+  kind        TEXT NOT NULL,
+  num         INTEGER NOT NULL,
+  source      TEXT NOT NULL,
+  created_at  TEXT NOT NULL,
+  detached_at TEXT,
+  PRIMARY KEY (repo, asset_id)
+);
+CREATE INDEX github_ingested_assets_source_idx ON github_ingested_assets (repo, source);
+```
+
+- [ ] **Step 2: Write the failing real-SQL test**
+
+`apps/api/test/github-ingest-ledger-sqlite.test.ts`, modeled on `github-repo-links-sqlite.test.ts` (`SqliteD1` from `test/helpers/sqlite-d1.ts`, constructed with `["migrations/20260811120000_github_ingested_assets.sql"]`):
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  ledgerRow,
+  ledgerRowsForSource,
+  recordIngestedAsset,
+  setLedgerDetached,
+  setLedgerSource,
+} from "../src/github-ingest-ledger";
+import { SqliteD1 } from "./helpers/sqlite-d1";
+
+const row = (over: Partial<Parameters<typeof recordIngestedAsset>[1]> = {}) => ({
+  repo: "acme/app",
+  assetId: "assets/aaaa-bbbb",
+  workspace: "acme",
+  objectKey: "gh/acme-app/pull-7/aaaa-bbbb.png",
+  kind: "pull" as const,
+  num: 7,
+  source: "body",
+  createdAt: "2026-08-11T00:00:00.000Z",
+  ...over,
+});
+
+describe("github ingest ledger", () => {
+  it("records, reads back, and scopes by source", async () => {
+    const db = new SqliteD1(["migrations/20260811120000_github_ingested_assets.sql"]);
+    await recordIngestedAsset(db.d1, row());
+    await recordIngestedAsset(db.d1, row({ assetId: "files/9/x.png", source: "comment:44" }));
+    expect((await ledgerRow(db.d1, "acme/app", "assets/aaaa-bbbb"))?.objectKey).toBe(
+      "gh/acme-app/pull-7/aaaa-bbbb.png",
+    );
+    expect(await ledgerRowsForSource(db.d1, "acme/app", "body")).toHaveLength(1);
+  });
+
+  it("detach and re-attach flip detached_at; duplicate record is ignored", async () => {
+    const db = new SqliteD1(["migrations/20260811120000_github_ingested_assets.sql"]);
+    await recordIngestedAsset(db.d1, row());
+    await recordIngestedAsset(db.d1, row({ objectKey: "gh/other.png" })); // INSERT OR IGNORE
+    expect((await ledgerRow(db.d1, "acme/app", "assets/aaaa-bbbb"))?.objectKey).toBe(
+      "gh/acme-app/pull-7/aaaa-bbbb.png",
+    );
+    await setLedgerDetached(db.d1, "acme/app", "assets/aaaa-bbbb", "2026-08-12T00:00:00.000Z");
+    expect((await ledgerRow(db.d1, "acme/app", "assets/aaaa-bbbb"))?.detachedAt).not.toBeNull();
+    await setLedgerDetached(db.d1, "acme/app", "assets/aaaa-bbbb", null);
+    expect((await ledgerRow(db.d1, "acme/app", "assets/aaaa-bbbb"))?.detachedAt).toBeNull();
+  });
+
+  it("setLedgerSource moves an asset between sources", async () => {
+    const db = new SqliteD1(["migrations/20260811120000_github_ingested_assets.sql"]);
+    await recordIngestedAsset(db.d1, row());
+    await setLedgerSource(db.d1, "acme/app", "assets/aaaa-bbbb", "comment:44");
+    expect(await ledgerRowsForSource(db.d1, "acme/app", "body")).toHaveLength(0);
+    expect(await ledgerRowsForSource(db.d1, "acme/app", "comment:44")).toHaveLength(1);
+  });
+});
+```
+
+(Check how `SqliteD1` exposes the `D1Database` — if the instance itself is the D1, drop `.d1`. Mirror the existing sqlite suites exactly.)
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `pnpm vitest run apps/api/test/github-ingest-ledger-sqlite.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement the module**
+
+`apps/api/src/github-ingest-ledger.ts`, following `github-repo-links.ts`'s style (repo lowercased on every call; module doc comment explaining the ledger's role):
+
+```ts
+export async function recordIngestedAsset(db, row): Promise<void> {
+  await db
+    .prepare(
+      "INSERT OR IGNORE INTO github_ingested_assets (repo, asset_id, workspace, object_key, kind, num, source, created_at, detached_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+    )
+    .bind(
+      row.repo.toLowerCase(),
+      row.assetId,
+      row.workspace,
+      row.objectKey,
+      row.kind,
+      row.num,
+      row.source,
+      row.createdAt,
+    )
+    .run();
+}
+```
+
+`ledgerRowsForSource` / `ledgerRow`: `SELECT` mapping snake_case → the interface (write a private `fromRow`). `setLedgerDetached`: `UPDATE github_ingested_assets SET detached_at = ? WHERE repo = ? AND asset_id = ?`. `setLedgerSource`: same shape for `source`. These are consumed inside the queue consumer where D1 failures must THROW (retry semantics) — so unlike `findRepoLink`, do **not** swallow errors.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pnpm vitest run apps/api/test/github-ingest-ledger-sqlite.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Add the fake table for UsageFakeD1 suites**
+
+`apps/api/test/helpers/fake-ingest-ledger-table.ts`, modeled directly on `fake-repo-links-table.ts` (`tryRun`/`tryAll` matching the exact SQL strings from Step 4, whitespace-normalized), and register it in `apps/api/test/usage-fake-d1.ts` the same way the repo-links table is registered. Add one smoke assertion to the ledger sqlite test? No — the fake gets exercised by Task 4's tests; here just make `pnpm vitest run apps/api/test/usage-fake-d1.test.ts` (if it exists) or the full `apps/api` suite still pass.
+
+- [ ] **Step 7: Run the full api test suite**
+
+Run: `pnpm --filter @uploads/api test`
+Expected: PASS (no regressions).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/migrations apps/api/src/github-ingest-ledger.ts apps/api/test
+git commit -m "feat(api): github_ingested_assets ledger table + module"
+```
+
+---
+
+### Task 3: Attachment URL extraction (pure)
+
+**Files:**
+
+- Create: `apps/api/src/github-attachment-extract.ts`
+- Create: `apps/api/src/github-attachment-extract.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces (Tasks 4 and 5 depend on these):
+
+```ts
+export interface ExtractedAttachment {
+  id: string;
+  url: string;
+} // id = "assets/<uuid>" | "files/<n>/<name>"
+export function extractUserAttachments(text: string): ExtractedAttachment[]; // deduped by id, document order
+export function hasUserAttachmentUrl(text: string): boolean; // cheap substring gate for the pure extractor
+export function attachmentKeyBasename(id: string): string; // "assets/ab-cd" -> "ab-cd"; "files/9/My Shot.png" -> "9-my-shot.png"
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  attachmentKeyBasename,
+  extractUserAttachments,
+  hasUserAttachmentUrl,
+} from "./github-attachment-extract";
+
+describe("extractUserAttachments", () => {
+  it("finds bare, markdown-image, html img and video forms", () => {
+    const text = [
+      "intro https://github.com/user-attachments/assets/0a1b2c3d-1111-2222-3333-444455556666",
+      "![shot](https://github.com/user-attachments/assets/9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff)",
+      '<img src="https://github.com/user-attachments/assets/12345678-0000-0000-0000-000000000000" width="400">',
+      '<video src="https://github.com/user-attachments/assets/87654321-0000-0000-0000-000000000000"></video>',
+      "[log](https://github.com/user-attachments/files/1234/build-log.txt)",
+    ].join("\n");
+    const ids = extractUserAttachments(text).map((a) => a.id);
+    expect(ids).toEqual([
+      "assets/0a1b2c3d-1111-2222-3333-444455556666",
+      "assets/9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff",
+      "assets/12345678-0000-0000-0000-000000000000",
+      "assets/87654321-0000-0000-0000-000000000000",
+      "files/1234/build-log.txt",
+    ]);
+  });
+
+  it("dedupes repeated references and ignores other github urls", () => {
+    const u = "https://github.com/user-attachments/assets/0a1b2c3d-1111-2222-3333-444455556666";
+    const text = `${u} and again ![x](${u}) plus https://github.com/acme/app/pull/7`;
+    expect(extractUserAttachments(text)).toHaveLength(1);
+    expect(extractUserAttachments("plain text")).toEqual([]);
+  });
+
+  it("strips trailing markdown/html delimiters from captured urls", () => {
+    const text =
+      "(see https://github.com/user-attachments/assets/0a1b2c3d-1111-2222-3333-444455556666)";
+    expect(extractUserAttachments(text)[0]?.id).toBe("assets/0a1b2c3d-1111-2222-3333-444455556666");
+  });
+});
+
+describe("hasUserAttachmentUrl", () => {
+  it("is a cheap substring gate", () => {
+    expect(hasUserAttachmentUrl("x https://github.com/user-attachments/assets/a1b2 y")).toBe(true);
+    expect(hasUserAttachmentUrl("no attachments here")).toBe(false);
+  });
+});
+
+describe("attachmentKeyBasename", () => {
+  it("flattens ids into safe key basenames", () => {
+    expect(attachmentKeyBasename("assets/0a1b-2c3d")).toBe("0a1b-2c3d");
+    expect(attachmentKeyBasename("files/9/My Shot (final).png")).toBe("9-my-shot-final.png");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run apps/api/src/github-attachment-extract.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * Pure extraction of github.com/user-attachments references from PR/issue
+ * markdown. The asset id (path after /user-attachments/) is the stable
+ * identity the ingest ledger keys on — GitHub keeps it constant across
+ * renders/edits. No I/O; safe to call from extractWebhookEvent.
+ */
+const ATTACHMENT_RE =
+  /https:\/\/github\.com\/user-attachments\/(assets\/[0-9a-fA-F-]{8,}|files\/\d+\/[^\s)"'<>\]]+)/g;
+
+export interface ExtractedAttachment {
+  id: string;
+  url: string;
+}
+
+export function extractUserAttachments(text: string): ExtractedAttachment[] {
+  const seen = new Set<string>();
+  const out: ExtractedAttachment[] = [];
+  for (const m of text.matchAll(ATTACHMENT_RE)) {
+    const id = m[1].replace(/[.,;:]+$/, ""); // trailing prose punctuation
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, url: `https://github.com/user-attachments/${id}` });
+  }
+  return out;
+}
+
+export function hasUserAttachmentUrl(text: string): boolean {
+  return text.includes("github.com/user-attachments/");
+}
+
+export function attachmentKeyBasename(id: string): string {
+  const flat = id.replace(/^(assets|files)\//, "").replace(/\//g, "-");
+  return flat
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/-+\./g, ".") // "final-.png" -> "final.png"
+    .replace(/^[-.]+|-+$/g, "");
+}
+```
+
+(If files-core's `sanitizeKeyBasename` already does what `attachmentKeyBasename`'s sanitize step does, delegate to it instead of re-rolling — check its behavior first.)
+
+- [ ] **Step 4: Run to verify pass, then commit**
+
+Run: `pnpm vitest run apps/api/src/github-attachment-extract.test.ts` — PASS.
+
+```bash
+git add apps/api/src/github-attachment-extract.ts apps/api/src/github-attachment-extract.test.ts
+git commit -m "feat(api): user-attachments url extraction"
+```
+
+---
+
+### Task 4: Reconcile core + fetch/store pipeline
+
+**Files:**
+
+- Create: `apps/api/src/github-ingest.ts`
+- Create: `apps/api/src/github-ingest.test.ts`
+- Modify: `apps/api/src/file-metadata.ts` (add `updateFileMetadataValue`)
+- Modify: `apps/api/src/files-core.ts` only if `UploadSurface` is a closed union — add `"github"` to it (find the type; it may live in analytics-engine.ts)
+
+**Interfaces:**
+
+- Consumes: Task 2 ledger functions; Task 3 `extractUserAttachments`/`attachmentKeyBasename`; existing `putObject(env, ws, key, bytes, workspaceName, opts)`, `resolveUploadPolicy`, `detectContentType`, `maxBytesForContentType` (guards.ts), `githubAppConfig`/`installationForRepo`/`installationToken`/`githubHeaders`/`githubFetch` (github-app.ts), `findRepoLinkStrict` (github-repo-links.ts), `loadWorkspaceRecord` (workspace.ts), `resolveRepoCommentOptions` (repo-comment-config.ts, Task 1 knob), `getFileMetadata` (file-metadata.ts).
+- Produces (Tasks 5–6 depend on these exact signatures):
+
+```ts
+export interface IngestSourceRef {
+  repo: string;
+  kind: "pull" | "issues";
+  num: number;
+  source: string;
+}
+export interface IngestSummary {
+  ingested: string[]; // object keys written
+  reattached: string[]; // object keys un-detached
+  detached: string[]; // object keys detached
+  skipped: { url: string; reason: string }[];
+}
+export interface IngestDeps {
+  fetchImpl?: typeof fetch;
+  putImpl?: typeof putObject;
+  now?: () => Date;
+}
+
+/** Reconcile ONE source (a body or one comment) against `text` (null = source gone: detach all). */
+export async function reconcileIngestSource(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  ref: IngestSourceRef,
+  text: string | null,
+  author: string | null,
+  deps?: IngestDeps,
+): Promise<IngestSummary>;
+
+/** Webhook entry: link lookup + knob gate + fetch current text + reconcile. Throws on transient failure. */
+export async function ingestForWebhook(
+  env: Env,
+  ref: IngestSourceRef,
+  deps?: IngestDeps,
+): Promise<void>;
+
+/** Manual entry: reconcile the body + every issue comment (paginated). */
+export async function reconcileIngestTarget(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  target: { repo: string; kind: "pull" | "issues"; num: number },
+  deps?: IngestDeps,
+): Promise<IngestSummary>;
+```
+
+- [ ] **Step 1: Add the single-key metadata update helper (test first)**
+
+In the existing file-metadata test suite add:
+
+```ts
+it("updateFileMetadataValue flips one key without touching others", async () => {
+  // seed via replaceFileMetadata: { "gh.detached": "false", "path": "/x" } plus a
+  // server video.* row via setServerFileMetadata, then:
+  await updateFileMetadataValue(db, "ws", "k.png", "gh.detached", "true");
+  // assert gh.detached === "true", path untouched, video.* row untouched.
+});
+```
+
+Implement in `apps/api/src/file-metadata.ts`:
+
+```ts
+/**
+ * Targeted single-key value update. Exists because replaceFileMetadata is
+ * delete-then-insert over the whole key set and would wipe server-owned
+ * video.* rows — never use replace to flip one flag.
+ */
+export async function updateFileMetadataValue(
+  db: D1Database,
+  workspace: string,
+  objectKey: string,
+  metaKey: string,
+  value: string,
+): Promise<void> {
+  await db
+    .prepare(
+      "UPDATE file_metadata SET meta_value = ?, updated_at = ? WHERE workspace = ? AND object_key = ? AND meta_key = ?",
+    )
+    .bind(value, new Date().toISOString(), workspace, objectKey, metaKey)
+    .run();
+}
+```
+
+Run the file-metadata suite (both the sqlite and fake variants if both cover it): PASS. Check whether `fake-file-metadata-table.ts` needs a `tryRun` branch for this UPDATE shape — add it.
+
+- [ ] **Step 2: Write the failing reconcile tests**
+
+`apps/api/src/github-ingest.test.ts`. Harness: `UsageFakeD1` (now with the ledger fake from Task 2) as `env.DB`, `FakeKv` as `GITHUB_CACHE`, `GITHUB_APP_CFG_ENV` spread into env, a `fetchImpl` fake in the `repo-comment-config.test.ts` style (routes for installation, token, issue GET, comment GET, and the asset URLs returning PNG magic bytes `new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, ...])` with `content-type: image/png`), and a `putImpl` spy that records calls and returns `{ key, size, contentType: "image/png", replaced: false, url: null, embedUrl: null }`. `ws` is a minimal `{} as WorkspaceRecord` (plus plan-limit fields where a test needs them).
+
+Cover, one `it` each:
+
+1. **New asset in body → put + ledger row + metadata stamped.** `reconcileIngestSource` with text containing one asset URL. Assert: `putImpl` called once with key `gh/acme-app/pull-7/<uuid>.png` and `opts.metadata` equal to `{ "gh.repo": "acme/app", "gh.kind": "pull", "gh.number": "7", "gh.origin": "github", "gh.author": "octocat", "gh.detached": "false", "gh.source": "body" }` and `opts.surface: "github"`; summary `ingested` has the key; ledger row exists non-detached.
+2. **Already-ledgered asset → no re-fetch, no put.** Seed ledger; same text. Assert `putImpl` not called, summary all-empty.
+3. **Removal → detach.** Seed ledger (attached) + seed file metadata `gh.detached=false`; text without the URL. Assert ledger `detachedAt` set, `file_metadata` row now `"true"`, summary `detached` has the key.
+4. **Re-add → re-attach without re-fetch.** Seed detached ledger row; text with the URL. Assert `putImpl` not called, `detachedAt` null again, metadata `"false"`, summary `reattached`.
+5. **`text: null` (comment deleted) → detach all rows of that source only.** Two ledger rows, different sources; assert only the matching source's row detached.
+6. **Guard skip is permanent.** Asset route returns `content-type: text/html` + HTML bytes → `detectContentType` yields non-media → summary `skipped` with `reason: "unsupported_media_type"`, no put, no ledger row, **no throw**. Same for an asset route returning 404 → `reason: "asset_not_found"`.
+7. **Oversize skip.** Asset bytes longer than `maxBytesForContentType` for the sniffed type → `skipped` `reason: "too_large"`, no put.
+8. **Budget/put failure skip.** `putImpl` throws an error with `.code === "storage_quota_exceeded"` (build via the repo's error class) → `skipped` `reason: "storage_quota_exceeded"`; a plain `new Error("boom")` from `putImpl` → **rethrown** (transient).
+9. **Transient asset fetch → throws.** Asset route returns 503 → `reconcileIngestSource` rejects.
+10. **`ingestForWebhook` gates.** (a) no repo link → resolves, no fetches; (b) link + workspace but knob false (no `.uploads.yml`, ws default unset) → resolves, no asset fetches; (c) knob true via ws record `githubIngestAttachments: true` → fetches issue body (route `/repos/acme/app/issues/7` returns `{ body: "<url>", user: { login: "octocat" } }`), puts, ledgers. (d) comment source fetches `/repos/acme/app/issues/comments/44`; a 404 there → reconcile with `text: null` (detach-all for that source), not a throw.
+11. **`reconcileIngestTarget` walks body + comments.** Comments route returns two pages (`per_page=100`, page 2 shorter); assert one reconcile per comment + one for body; summary is the merged totals.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `pnpm vitest run apps/api/src/github-ingest.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement `apps/api/src/github-ingest.ts`**
+
+Skeleton (follow the file-doc-comment style of github-webhook.ts; key logic):
+
+```ts
+const SKIP_CODES = new Set([
+  "storage_quota_exceeded",
+  "upload_budget_exceeded",
+  "unsupported_media_type",
+  "file_metadata_limit_exceeded",
+  "empty_body",
+]);
+const EXT_BY_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+};
+
+function ingestKey(ref: IngestSourceRef, assetId: string, ext: string): string {
+  const repoSeg = ref.repo.toLowerCase().replace("/", "-");
+  return `gh/${repoSeg}/${ref.kind}-${ref.num}/${attachmentKeyBasename(assetId)}.${ext}`;
+}
+
+function ingestMetadata(ref: IngestSourceRef, author: string | null): Record<string, string> {
+  return {
+    "gh.repo": ref.repo.toLowerCase(),
+    "gh.kind": ref.kind,
+    "gh.number": String(ref.num),
+    "gh.origin": "github",
+    ...(author ? { "gh.author": author } : {}),
+    "gh.detached": "false",
+    "gh.source": ref.source,
+  };
+}
+```
+
+`reconcileIngestSource` flow:
+
+1. `const found = text === null ? [] : extractUserAttachments(text);`
+2. For each found attachment: `ledgerRow(db, ref.repo, id)`:
+   - row exists, `detachedAt === null` → nothing (but if `row.source !== ref.source`, call `setLedgerSource` — the image moved between sources).
+   - row exists, detached → `setLedgerDetached(db, repo, id, null)` + `updateFileMetadataValue(db, workspaceName, row.objectKey, "gh.detached", "false")` → `reattached`.
+   - no row → **fetch & store** (below) → `recordIngestedAsset` → `ingested`.
+3. `ledgerRowsForSource(db, ref.repo, ref.source)`: every non-detached row whose `assetId` is not in the found set → `setLedgerDetached(..., now)` + `updateFileMetadataValue(..., "gh.detached", "true")` → `detached`.
+
+Fetch & store (private `fetchAndStore`):
+
+1. Installation token: `githubAppConfig(env)` → null? push skip `app_not_configured`. `installationForRepo` → null? skip `app_not_installed`. `installationToken` → null? **throw** (transient — token mint outages should retry).
+2. `const res = await githubFetch(fetchImpl, url, { headers: { authorization: `Bearer ${token}`, "user-agent": "uploads.sh" } });` — 404/403/410 → skip `asset_not_found`; other non-ok → throw; ok → `new Uint8Array(await res.arrayBuffer())`.
+3. `const sniffed = detectContentType(bytes);` null or not in `EXT_BY_TYPE` → skip `unsupported_media_type`.
+4. `const policy = resolveUploadPolicy(ws);` `bytes.length > maxBytesForContentType(policy, sniffed)` → skip `too_large` (cheap pre-check so we don't hand 100 MB to putObject; putObject re-enforces).
+5. `putImpl(env, ws, ingestKey(ref, id, EXT_BY_TYPE[sniffed]), bytes, workspaceName, { metadata: ingestMetadata(ref, author), replace: true, surface: "github" })` — catch: error with `code` in `SKIP_CODES` → skip with that code as reason; anything else → rethrow.
+
+`ingestForWebhook`: `findRepoLinkStrict` (throws on D1 outage — desired) → null? return. `loadWorkspaceRecord` → null? return. `resolveRepoCommentOptions(env, ws, ref.repo)` → `!options.ingestGithubAttachments`? return. Fetch text+author: source `"body"` → `GET https://api.github.com/repos/${ref.repo}/issues/${ref.num}` (the issues API serves PR bodies too); source `comment:<id>` → `GET .../issues/comments/<id>`; both with `githubHeaders(token)` via `githubFetch`; 404 → `text = null`; non-ok non-404 → throw. Then `reconcileIngestSource`.
+
+`reconcileIngestTarget`: fetch the body (as above, author from `.user.login`), then `GET .../issues/${num}/comments?per_page=100&page=N` for N = 1..3 (stop early on a short page); reconcile `"body"` then `comment:<id>` per comment (comment author from each comment's `.user.login`); merge summaries. Log a structured line if page 3 was full (`{ message: "github ingest comment scan truncated", repo, num }`) — no silent caps.
+
+If `UploadSurface` is a closed union that rejects `"github"`, add `"github"` to it where it's defined.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `pnpm vitest run apps/api/src/github-ingest.test.ts`
+Expected: PASS. Then `pnpm --filter @uploads/api test` — no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src
+git commit -m "feat(api): github attachment ingest reconcile core"
+```
+
+---
+
+### Task 5: Webhook wiring
+
+**Files:**
+
+- Modify: `apps/api/src/github-webhook.ts` (`WebhookEvent`, `extractWebhookEvent`, `processWebhookEvent`)
+- Modify: `apps/api/src/github-webhook.test.ts` / `apps/api/src/github-webhook-queue.test.ts` (whichever covers `extractWebhookEvent` — extend it)
+
+**Interfaces:**
+
+- Consumes: Task 3 `hasUserAttachmentUrl`; Task 4 `ingestForWebhook` + `IngestSourceRef`.
+- Produces: `WebhookEvent.ingest?: IngestSourceRef` — consumed transparently by the existing queue consumer.
+
+- [ ] **Step 1: Write the failing extractor tests**
+
+In the suite that already unit-tests `extractWebhookEvent`, add cases (payload shapes mirror the existing tests):
+
+```ts
+const URL = "https://github.com/user-attachments/assets/0a1b2c3d-1111-2222-3333-444455556666";
+
+it("pull_request opened with attachment url sets ingest", () => {
+  const ev = extractWebhookEvent("pull_request", {
+    action: "opened",
+    repository: { full_name: "acme/app" },
+    pull_request: { number: 7, body: `hello ${URL}` },
+  });
+  expect(ev?.ingest).toEqual({ repo: "acme/app", kind: "pull", num: 7, source: "body" });
+});
+
+it("pull_request opened without attachment url sets no ingest", () => {
+  /* body: "hi" → ev?.ingest undefined */
+});
+
+it("issues edited with a body change always sets ingest (removal case)", () => {
+  const ev = extractWebhookEvent("issues", {
+    action: "edited",
+    changes: { body: { from: "old" } },
+    repository: { full_name: "acme/app" },
+    issue: { number: 3, body: "no urls anymore" },
+  });
+  expect(ev?.ingest).toEqual({ repo: "acme/app", kind: "issues", num: 3, source: "body" });
+});
+
+it("issues edited title-only (no changes.body) sets no ingest", () => {
+  /* changes: { title: {...} } */
+});
+
+it("issue_comment created with url sets ingest with comment source", () => {
+  const ev = extractWebhookEvent("issue_comment", {
+    action: "created",
+    repository: { full_name: "acme/app" },
+    issue: { number: 7, pull_request: {} },
+    comment: { id: 44, body: URL, user: { login: "octocat", type: "User" } },
+  });
+  expect(ev?.ingest).toEqual({ repo: "acme/app", kind: "pull", num: 7, source: "comment:44" });
+});
+
+it("issue_comment created without url sets no ingest", () => {
+  /* stays null overall if no other work */
+});
+
+it("issue_comment edited always sets ingest; deleted sets ingest only when the removed body had a url", () => {
+  /* edited: no url in body → still ingest. deleted with url body → ingest; deleted plain-text body → none */
+});
+```
+
+Also extend the queue-consumer test: a message whose body is `{ keys: [], ingest: {...} }` must invoke ingest processing (spy via module mock of `github-ingest`) and ack; an `ingestForWebhook` throw must `retry()`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run apps/api/src/github-webhook.test.ts apps/api/src/github-webhook-queue.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `github-webhook.ts`:
+
+```ts
+export interface WebhookEvent {
+  keys: string[];
+  promote?: { repo: string; num: number; branch: string };
+  reconcile?: { repo: string; num: number; kind: GhTarget["kind"] };
+  /** Opt-in GitHub-native attachment ingest (spec 2026-08-11). Source ref only —
+   * the consumer re-fetches current text, so this stays queue-compact. */
+  ingest?: IngestSourceRef;
+}
+```
+
+Gating in `extractWebhookEvent` (all pure, payload-only — mirror the existing defensive typeof style):
+
+- `issues` / `pull_request`, `action === "opened"`: set `ingest` iff `hasUserAttachmentUrl(body)`.
+- `issues` / `pull_request`, `action === "edited"`: set `ingest` iff the payload's `changes.body` exists (a body edit — covers both add and remove; title-only edits skip).
+- `issue_comment created`: iff `hasUserAttachmentUrl(comment.body)`. `source: \`comment:${comment.id}\``.
+- `issue_comment edited`: always (removal is invisible in the new body). Skip when `sender.type === "Bot"` — our own writes and other bots' churn.
+- `issue_comment deleted`: iff `hasUserAttachmentUrl(comment.body)` (payload carries the pre-deletion body). The consumer's comment GET will 404 → detach-all.
+- `kind` from `issue.pull_request ? "pull" : "issues"` (comments) / the event type (bodies). Repo lowercased? **No** — keep the exact `full_name` casing like `promote` does; the ledger lowercases internally.
+- Keep the final `return ev.keys.length || ev.promote || ev.reconcile || ev.ingest ? ev : null;`
+
+In `processWebhookEvent`, after the reconcile branch:
+
+```ts
+if (ev.ingest) {
+  await ingestForWebhook(env, ev.ingest);
+}
+```
+
+(Import from `./github-ingest`.) Update the retry-path log fields in `handleGithubWebhookBatch` / `processInline` to include `ingest: ev.ingest ?? null`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm vitest run apps/api/src/github-webhook.test.ts apps/api/src/github-webhook-queue.test.ts`, then `pnpm --filter @uploads/api test`.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src
+git commit -m "feat(api): webhook-driven github attachment ingest (opt-in)"
+```
+
+---
+
+### Task 6: Manual ingest endpoint
+
+**Files:**
+
+- Modify: `apps/api/src/routes/workspace-github.ts`
+- Test: the existing `apps/api/test/routes-workspace-github.test.ts` (or the file that covers the other `/v1/workspaces/:workspace/github/*` routes — extend it)
+
+**Interfaces:**
+
+- Consumes: Task 4 `reconcileIngestTarget`; existing `dualWorkspaceAuth`, `requireScope`-via-`scoped("files:write")`, `writeRateLimit`-via-`rateLimited`, `findRepoLink` + `deriveRepoBinding` (github-repo-links.ts), `loadWorkspaceRecord`.
+- Produces: `POST /v1/workspaces/:workspace/github/ingest`, JSON body `{ repo: string, pr?: number, issue?: number }` → 200 `{ repo, kind, num, ingested: string[], reattached: string[], detached: string[], skipped: {url, reason}[] }`. Task 7's CLI calls this.
+
+- [ ] **Step 1: Write the failing route tests**
+
+In the workspace-github route suite (reuse its app-builder + `UsageFakeD1` + fake-fetch setup):
+
+1. Token auth + linked repo + one asset in body → 200 with `ingested` length 1 (stub the GitHub routes as in Task 4's test; module-mock `github-ingest` only if the suite can't carry the full fake — prefer the real core with fakes).
+2. `pr` and `issue` both set → 400 `ValidationError` code `github_ingest_target`; neither set → same.
+3. Repo not linked to this workspace (no link, or linked elsewhere) → 404 (use `deriveRepoBinding` — must not leak the owning workspace's name in the "other" case).
+4. Works with the ingest knob **off** (manual bypasses it — assert with a ws record lacking `githubIngestAttachments`).
+5. Session (cookie) auth path also allowed (dualWorkspaceAuth default) — one smoke case.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run apps/api/test/routes-workspace-github.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the handler + route**
+
+In `workspace-github.ts` (new-endpoint-only, so the handler lives here rather than in a legacy router):
+
+```ts
+const githubIngestHandler: Handler<DualAuthVars> = async (c) => {
+  const ws = c.get("workspace");
+  const workspaceName = c.get("workspaceName");
+  const body = await c.req.json().catch(() => ({}));
+  const repo = typeof body.repo === "string" ? body.repo : "";
+  const pr = typeof body.pr === "number" ? body.pr : undefined;
+  const issue = typeof body.issue === "number" ? body.issue : undefined;
+  if (!REPO_RE.test(repo) || (pr === undefined) === (issue === undefined)) {
+    throw new ValidationError("repo plus exactly one of pr or issue required", {
+      code: "github_ingest_target",
+    });
+  }
+  const link = await findRepoLink(c.env.DB, repo);
+  if (deriveRepoBinding(link, workspaceName) !== "self") {
+    // 404 (not 403) so "other" can't confirm the repo is claimed elsewhere.
+    throw new NotFoundError("repo is not linked to this workspace", { code: "repo_not_linked" });
+  }
+  const target = {
+    repo,
+    kind: pr !== undefined ? ("pull" as const) : ("issues" as const),
+    num: (pr ?? issue) as number,
+  };
+  const summary = await reconcileIngestTarget(c.env, ws, workspaceName, target);
+  return c.json({ repo: repo.toLowerCase(), kind: target.kind, num: target.num, ...summary });
+};
+```
+
+(Reuse/import `REPO_RE` from github-app.ts if exported; otherwise inline the same pattern. Use the repo's actual error classes from `error-response.ts`.) Register:
+
+```ts
+.post("/:workspace/github/ingest", dualWorkspaceAuth(), rateLimited, scoped("files:write"), githubIngestHandler)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm vitest run apps/api/test/routes-workspace-github.test.ts`, then `pnpm --filter @uploads/api test` and `pnpm --filter @uploads/api types`.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src
+git commit -m "feat(api): manual github attachment ingest endpoint"
+```
+
+---
+
+### Task 7: CLI `uploads ingest`
+
+**Files:**
+
+- Modify: `packages/uploads/src/client.ts` (new client method)
+- Modify: `packages/uploads/src/commands.ts` (`runIngest` + `INGEST_HELP`)
+- Modify: `packages/uploads/src/cli.ts` (dispatch case)
+- Modify: `packages/uploads/src/cli-catalog.ts` (help + did-you-mean entry)
+- Test: `packages/uploads/test/commands-ingest.test.ts` (new, modeled on an existing `commands-*.test.ts` that fakes the API)
+- Modify: the CLI reference docs — find with `grep -rn "uploads usage" docs apps/web/src/pages/docs` and add an `ingest` section beside it; also the in-repo `uploads-cli` skill reference if it lists commands (`grep -rn "gallery" skills/` to locate)
+- Create: `.changeset/<generated>.md` (minor bump, published CLI package only)
+
+**Interfaces:**
+
+- Consumes: Task 6's endpoint contract; existing `CliContext`, `parseCommandArgs`, `flagInt`, `flagString`, `ghTargetFromFlags` (commands.ts), `writeJson`/`writeStdout` (io.ts), `UsageError`.
+- Produces: `uploads ingest --pr <n> | --issue <n> [--repo owner/name] [--workspace ws]`; JSON mode emits the endpoint response verbatim.
+
+- [ ] **Step 1: Write the failing command test**
+
+Model on an existing small-command test (find one that stubs the client, e.g. the usage or comment command test). Cases:
+
+1. `runIngest(ctx, ["--pr", "7"])` calls `client.ingestGithub({ repo: "<derived>", kind: "pull", num: 7 })` and prints a human summary line per bucket (`Ingested 2, re-attached 0, detached 1, skipped 0`), exit 0. Derive repo through the same `ghTargetFromFlags` path other commands use (stub the git runner).
+2. `--pr` and `--issue` together → `UsageError` (comes free from `makeGhTarget`).
+3. Neither `--pr` nor `--issue` and no auto-resolvable PR → `UsageError("--pr or --issue required")`.
+4. `ctx.json` true → `writeJson` with the raw response.
+5. Skipped entries render as `skipped: <url> (<reason>)` lines in human mode.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run packages/uploads/test/commands-ingest.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Client method in `client.ts` (copy the shape of an existing POST-JSON method — e.g. the comment or gallery-create method — same auth header + error mapping):
+
+```ts
+async ingestGithub(input: { repo: string; kind: "pull" | "issues"; num: number }): Promise<IngestGithubResult> {
+  const body = input.kind === "pull"
+    ? { repo: input.repo, pr: input.num }
+    : { repo: input.repo, issue: input.num };
+  return this.postJson(`/v1/workspaces/${encodeURIComponent(this.workspace)}/github/ingest`, body);
+}
+```
+
+(`postJson` = whatever the surrounding methods actually use; match it exactly. Define `IngestGithubResult` mirroring the Task 6 response.)
+
+`runIngest` in `commands.ts`, following `runUsage`'s exact shape: help gate → `ghTargetFromFlags(parseCommandArgs(args).flags, run)` (throws on the mutually-exclusive case; `UsageError("--pr or --issue required")` when undefined) → `ctx.client.ingestGithub(target)` → `writeJson` or human lines. `INGEST_HELP` template with an `Examples:` block:
+
+```
+uploads ingest — mirror GitHub-native attachments from a PR/issue into the workspace
+
+Usage:
+  uploads ingest --pr <n> [--repo owner/name]
+  uploads ingest --issue <n> [--repo owner/name]
+
+Scans the PR/issue description and comments for github.com/user-attachments
+media, mirrors new ones into the workspace (indexed, not added to the managed
+comment), and detaches ones no longer referenced. Works on any repo linked to
+the workspace; the .uploads.yml ingestGithubAttachments knob only gates the
+automatic webhook path.
+
+Examples:
+  uploads ingest --pr 123
+  uploads ingest --issue 45 --repo acme/app --format json
+```
+
+Register in `cli.ts` (`case "ingest":` following the `usage` case's `createContext` pattern) and add the catalog entry in `cli-catalog.ts`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm vitest run packages/uploads/test/commands-ingest.test.ts` then the package suite `pnpm --filter uploads test` (use the actual package name from `packages/uploads/package.json`).
+Expected: PASS.
+
+- [ ] **Step 5: Docs + changeset**
+
+- Add the `ingest` command to the CLI reference page found via the grep above (match the surrounding sections' voice; plain declaratives, no marketing).
+- If `skills/` contains the `uploads-cli` reference skill with a command list, add `ingest` there with the same one-paragraph contract.
+- `pnpm changeset` → minor, ONLY the published CLI package (`uploads`); message: `Add \`uploads ingest\` to mirror GitHub-native PR/issue attachments into the workspace.`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/uploads .changeset docs apps/web skills 2>/dev/null; git add -A packages/uploads .changeset
+git commit -m "feat(cli): uploads ingest command"
+```
+
+---
+
+### Task 8: Screenshots page "From GitHub" section
+
+**Files:**
+
+- Modify: `apps/web/src/components/ScreenshotsByPath.tsx`
+- Modify: `apps/web/src/lib/api-client.ts` only if a new fetch wrapper is needed (it is not — `searchWorkspaceFiles` already takes arbitrary meta filters)
+- Test: the existing ScreenshotsByPath/web test if one exists (`ls apps/web/src/components/*.test.*`); otherwise verify by typecheck + browser
+
+**Interfaces:**
+
+- Consumes: `searchWorkspaceFiles(apiOrigin, workspace, filters)` with `[{ key: "gh.origin", value: "github" }, { key: "gh.detached", value: "false" }]`; `SearchFileItem`; Task 4's metadata contract.
+- Produces: a "From GitHub" section on `/account/workspaces/:name/screenshots` listing non-detached mirrored assets, grouped visually below the by-path groups.
+
+- [ ] **Step 1: Implement the section**
+
+In `ScreenshotsByPath.tsx`, alongside the existing overview fetch, add a second parallel fetch:
+
+```ts
+const [ghState, setGhState] = useState<DrillState>({ status: "idle" });
+// in the same effect that loads the overview:
+searchWorkspaceFiles(apiOrigin, workspace, [
+  { key: "gh.origin", value: "github" },
+  { key: "gh.detached", value: "false" },
+]).then(/* map to DrillState exactly like the drill-in path does */);
+```
+
+Render below the by-path groups, only when non-empty (no empty-state block — absence is the norm), reusing the exact thumbnail/list markup the drill-in view uses (`shotKindFromKey` for image/video), with a section heading "From GitHub" and each item labeled by `metadata["gh.kind"]`+`metadata["gh.number"]` (e.g. `PR #7`) and `metadata["gh.author"]` when present. Follow the existing loading/error state handling; an error in this fetch must not break the by-path view (render nothing).
+
+- [ ] **Step 2: Typecheck + tests**
+
+Run: `pnpm --filter @uploads/web types` (note: this runs `wrangler types`, not a full typecheck — also run the web test/`astro check` command used in CI, found in `apps/web/package.json` scripts) and any component tests found in Step 0.
+Expected: PASS.
+
+- [ ] **Step 3: Browser verification**
+
+Serve via the local stack recipe (stack-raw on 127.0.0.1 for a signed-in session), seed one file with the Task 4 metadata via the API, and confirm the section renders; screenshot for the PR.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src
+git commit -m "feat(web): From GitHub section on the screenshots page"
+```
+
+---
+
+### Task 9: Integration verification + PR
+
+- [ ] **Step 1: Full-suite run**
+
+Run: `pnpm test` (root unified runner) and `pnpm --filter @uploads/api types && pnpm --filter @uploads/web types`. Also the repo's typecheck script if separate (`pnpm types` is NOT typecheck — check root package.json for the real one, e.g. `pnpm typecheck` or per-package `tsc`).
+Expected: all PASS.
+
+- [ ] **Step 2: End-to-end smoke against local fakes**
+
+One new test OR a scripted run proving the full chain: webhook delivery JSON (issue_comment created with an asset URL) → `handleWebhook` → queue message → `handleGithubWebhookBatch` → object written with correct key/metadata → `findObjectsByMetadata` returns it for `{ "gh.origin": "github", "gh.detached": "false" }`. If Task 5's consumer test already covers this end-to-end with the real reconcile core, point at it and skip.
+
+- [ ] **Step 3: Open the PR**
+
+Branch from this worktree, push, `gh pr create --body-file` with: summary, spec/plan links, the opt-in story (knob default off; manual path always available), the detach semantics, and the Task 8 screenshot embedded via the `github-screenshots` skill. Note in the PR body that the D1 migration auto-applies on merge. Do not request a CodeRabbit review by default.

--- a/docs/superpowers/specs/2026-08-11-github-attachment-ingestion-design.md
+++ b/docs/superpowers/specs/2026-08-11-github-attachment-ingestion-design.md
@@ -1,0 +1,156 @@
+# GitHub-native attachment ingestion
+
+**Date:** 2026-08-11
+**Status:** Approved design, pre-implementation
+**Delivery:** Orchestrated agents (see Delivery notes)
+
+## Problem
+
+People drag screenshots and screen recordings directly into GitHub PR/issue
+descriptions and comments (`github.com/user-attachments/...`). Those assets are
+invisible to uploads.sh: they don't appear in `find_files`, the Screenshots
+page, or any "latest screenshot for this PR" query. This feature mirrors them
+into the linked workspace so GitHub-native uploads participate in the same
+index as CLI/MCP uploads.
+
+## Decisions (settled during brainstorming)
+
+- **Trigger:** automatic via webhook, **opt-in per repo** (plus a manual
+  on-demand path — see below).
+- **Managed comment:** ingested assets are **index-only**; they never join the
+  managed attachments comment (they're already visible inline on GitHub).
+- **Media scope:** images and video/GIF — anything GitHub renders as media.
+- **Sources:** PR/issue **bodies + issue/PR comments**. Inline code-review
+  comments (`pull_request_review_comment`) are out of scope.
+- **Removal/replacement:** soft-detach, never auto-delete (see Reconciliation).
+
+## Architecture
+
+One reconciliation core, two triggers:
+
+1. **Webhook path (automatic, opt-in).** The existing webhook handler
+   ([apps/api/src/github-webhook.ts](../../../apps/api/src/github-webhook.ts))
+   already normalizes `issues`, `pull_request`, and `issue_comment` events. For
+   opted-in linked repos, it additionally enqueues ingest work on the existing
+   webhook queue (new message kind; per-message ack/retry already exists —
+   [apps/api/src/github-webhook-queue.ts](../../../apps/api/src/github-webhook-queue.ts)).
+   `issue_comment deleted` detaches everything that comment referenced.
+2. **Manual path (on demand, any linked repo).** `POST /v1/github/ingest`
+   with `{ repo, pr | issue }`, authenticated by session or workspace token,
+   gated on the repo being linked to the caller's workspace. Fetches the
+   current body + all comments via the installation token and runs the same
+   reconcile inline, returning `{ ingested, detached, skipped: [{url, reason}] }`.
+   Manual invocation is itself consent: it works regardless of the repo
+   opt-in knob. CLI: `uploads ingest --pr <n> | --issue <n>` (repo inferred
+   from git remote, `--format json` supported). Doubles as backfill and
+   webhook repair.
+
+### Opt-in configuration
+
+- `.uploads.yml`: new flat camelCase knob `ingestGithubAttachments: true`
+  (default false), alongside the existing comment knobs. Workspace-level
+  default `ingestGithubAttachments` in workspace settings, same repo →
+  workspace → auto layering as comment options.
+- **Sync constraint:** the repo-config parser exists in two deliberately
+  duplicated copies (`packages/comment-config/src/index.ts` and
+  `packages/uploads/src/comment-config.ts`), kept honest by
+  `test/fixtures/comment-config-golden.json` asserted from both sides. The new
+  knob must land in both copies + the golden fixture in the same change.
+
+### Extraction
+
+From the changed body/comment Markdown, extract
+`https://github.com/user-attachments/assets/<uuid>` (and the
+`.../user-attachments/files/...` form if present) in all shapes: bare URL,
+Markdown image/link, HTML `<img>`, `<video src>`. The asset UUID is the stable
+identity.
+
+### Ledger & reconciliation
+
+New D1 table (ingest ledger), one row per (repo, asset UUID), recording:
+object key, source anchor (comment id or `body` + issue/PR number), first-seen,
+and `detached_at` (nullable).
+
+Every scan of a source is a full reconcile of that source, not an append:
+
+- UUID present in text, not in ledger → **ingest** (fetch + store + row).
+- UUID present in text, ledger row detached → **re-attach** (clear
+  `detached_at` + metadata flag; no re-fetch).
+- UUID in ledger for this source, absent from text → **detach** (set
+  `detached_at`, stamp metadata so default queries exclude it).
+- Bytes are never auto-deleted. Detached files remain in the file table and
+  are deletable through the existing member delete flow. A future reaper
+  policy for old detached assets is explicitly out of scope.
+
+The ledger's uniqueness key makes concurrent webhook/manual runs idempotent;
+no additional locking.
+
+### Fetch & store
+
+- Fetch the asset URL with the **installation token** (private-repo assets
+  404 unauthenticated), following the redirect to the signed CDN URL. Trust
+  the response `Content-Type`, not the URL.
+- **Pre-write guards** (same family as hosted MCP `put`): media-type
+  allowlist (image/video), per-file size cap and video-cap ceiling from the
+  workspace's plan limits, budget check. Guard failures are **permanent
+  skips** with a structured log — never retried into the dead-letter path.
+- **Key layout:** `gh/{owner}-{repo}/{pull|issues}-{num}/{uuid}.{ext}` in the
+  linked workspace — collision-free and clearly separate from user-chosen keys.
+- **Write path:** through files-core (content-hash inheritance, usage
+  accounting, file table all apply), never a bare R2 put.
+
+### Metadata
+
+Reuse the existing lowercase `gh.*` vocabulary: `gh.repo`, `gh.kind`
+(`pull`/`issues`), `gh.number`, plus:
+
+- `gh.origin=github` — distinguishes mirrored assets from deliberate CLI/MCP
+  uploads; the include/exclude knob for queries.
+- `gh.author=<github-login>` — the human who posted the attachment. A new key:
+  `gh.uploader` is server-derived from the bearer token's minting identity and
+  must not be overloaded.
+- `gh.detached=false|true` — always stamped (initially `false`) so the
+  default "current screenshots" exclusion is a plain equality filter
+  (`meta.gh.detached=false`), matching the filter API's equality-only shape.
+  Not `gh.status`: that key is the staged/promoted staging state machine and
+  ingested files are not part of it.
+- Source anchor (comment id or `body`) so detach reconciliation can scope by
+  source.
+
+No derived `path`/`state` tier — we can't know what the screenshot depicts.
+
+Uploader identity (attribution) is the bot; the human stays in metadata.
+
+## Surfacing
+
+- Mirrored files appear in `find_files`/search, the file table, and the
+  Screenshots page — in an ungrouped section (no `path` metadata) — filtered
+  to non-detached by default; `gh.origin=github` available as an explicit
+  filter both ways.
+- `/f/` pages work as normal files. The managed comment ignores them.
+
+## Testing
+
+- **Unit:** URL extraction across all four shapes; reconcile diffing
+  (add / remove / re-add / replace / comment-delete); guard skips (oversize,
+  non-media, over budget) proving permanent-skip semantics.
+- **Integration:** existing fake-D1 + webhook-queue harness extended with a
+  fake `user-attachments` origin (redirect + bytes); opt-in gating (knob off →
+  no enqueue); manual endpoint through the same fakes, both PR and issue.
+- **CLI:** `uploads ingest` against the fake API like other CLI command tests.
+
+## Delivery notes
+
+Implementation will be orchestrated across agents. Natural seams:
+
+1. Config knob (both parser copies + golden fixture + workspace default).
+2. Ledger table + reconcile core + extraction (pure, heavily unit-tested).
+3. Webhook wiring (detection, enqueue, consumer message kind).
+4. Fetch/store pipeline with guards.
+5. Manual API endpoint.
+6. CLI command.
+7. Surfacing filters (Screenshots page / find_files detached handling).
+
+2 depends on nothing; 3–5 depend on 2; 6 depends on 5; 7 is independent of
+3–6 once metadata keys are fixed. Migration lands via the normal D1
+auto-apply-on-merge flow — no manual wrangler step.

--- a/packages/comment-config/src/index.ts
+++ b/packages/comment-config/src/index.ts
@@ -16,6 +16,7 @@ export interface RepoCommentConfig {
   metaState?: boolean;
   linkToFilePage?: boolean;
   note?: string;
+  ingestGithubAttachments?: boolean;
 }
 export interface WorkspaceCommentDefaults {
   imageWidth?: "full" | number;
@@ -23,6 +24,7 @@ export interface WorkspaceCommentDefaults {
   showMetadata?: boolean; // maps to BOTH metaPath and metaState
   linkToFilePage?: boolean;
   note?: string;
+  ingestGithubAttachments?: boolean;
 }
 export interface ResolvedCommentOptions {
   imageWidth: "auto" | "full" | number;
@@ -31,6 +33,7 @@ export interface ResolvedCommentOptions {
   metaState: boolean;
   linkToFilePage: boolean;
   note: string | null;
+  ingestGithubAttachments: boolean;
 }
 export type OptionSource = "repo" | "workspace" | "auto";
 
@@ -41,6 +44,7 @@ export const AUTO_COMMENT_OPTIONS: ResolvedCommentOptions = {
   metaState: true,
   linkToFilePage: true,
   note: null,
+  ingestGithubAttachments: false,
 };
 
 export const NOTE_MAX_CHARS = 500;
@@ -96,6 +100,13 @@ export function parseRepoCommentConfig(
     else warnings.push(`linkToFilePage: expected a boolean; dropped`);
   }
 
+  // ingestGithubAttachments: boolean
+  if ("ingestGithubAttachments" in c) {
+    const v = c.ingestGithubAttachments;
+    if (typeof v === "boolean") config.ingestGithubAttachments = v;
+    else warnings.push(`ingestGithubAttachments: expected a boolean; dropped`);
+  }
+
   // meta.path / meta.state: booleans nested under `meta`
   if ("meta" in c) {
     const v = c.meta;
@@ -146,6 +157,9 @@ export function resolveCommentOptions(
       : {}),
     ...(ws?.linkToFilePage !== undefined ? { linkToFilePage: ws.linkToFilePage } : {}),
     ...(ws?.note ? { note: ws.note } : {}),
+    ...(ws?.ingestGithubAttachments !== undefined
+      ? { ingestGithubAttachments: ws.ingestGithubAttachments }
+      : {}),
   };
   const options = { ...AUTO_COMMENT_OPTIONS };
   const source = Object.fromEntries(
@@ -158,6 +172,7 @@ export function resolveCommentOptions(
       "metaPath",
       "metaState",
       "linkToFilePage",
+      "ingestGithubAttachments",
     ] as const) {
       if (cfg[key] !== undefined && source[key] === "auto") {
         (options as Record<string, unknown>)[key] = cfg[key];

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -184,6 +184,11 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
     ],
   },
   {
+    name: "ingest",
+    usage: "ingest (--pr <n> | --issue <n>)",
+    summary: "Mirror GitHub-native user-attachments media from a PR/issue into the workspace",
+  },
+  {
     name: "list",
     summary: "List objects (--meta k=v filters by queryable metadata)",
     essential: true,

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -25,6 +25,7 @@ import {
   runDoctor,
   runComment,
   runGithub,
+  runIngest,
   runUsage,
   runReconcile,
   runPurgeExpired,
@@ -382,7 +383,8 @@ export async function runCli(argv: string[]): Promise<number> {
       case "purge-expired":
       case "doctor":
       case "comment":
-      case "github": {
+      case "github":
+      case "ingest": {
         const ctx = createContext(parsed.globals, !showHelp, cmdArgs);
         switch (parsed.command) {
           case "attach":
@@ -405,6 +407,9 @@ export async function runCli(argv: string[]): Promise<number> {
             break;
           case "github":
             code = await runGithub(ctx, cmdArgs, showHelp);
+            break;
+          case "ingest":
+            code = await runIngest(ctx, cmdArgs, showHelp);
             break;
           case "list":
             code = await runList(ctx, cmdArgs, showHelp);

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -355,6 +355,25 @@ export interface GithubRepoLinkResult {
   binding: "self" | "other" | "none";
 }
 
+/**
+ * `POST /v1/workspaces/:workspace/github/ingest` result (Task 6, manual/
+ * backfill entry point for GitHub-native `user-attachments` media). `repo`
+ * comes back lowercased by the server.
+ */
+export interface IngestGithubResult {
+  repo: string;
+  kind: "pull" | "issues";
+  num: number;
+  /** Object keys newly mirrored into the workspace this call. */
+  ingested: string[];
+  /** Object keys whose previously-detached ledger row was un-detached. */
+  reattached: string[];
+  /** Object keys detached because they're no longer referenced. */
+  detached: string[];
+  /** Attachment URLs skipped, with the reason. */
+  skipped: { url: string; reason: string }[];
+}
+
 export interface HealthResult {
   ok: boolean;
 }
@@ -1240,6 +1259,32 @@ export function createUploadsClient(config: UploadsClientConfig) {
      * `UploadsError` (status 404) on an older/self-hosted server without
      * this route — callers treat that as "unknown", not "broken".
      */
+    /**
+     * `POST /v1/workspaces/:workspace/github/ingest` (Task 6) — manual/
+     * backfill mirror of a PR/issue's `github.com/user-attachments` media
+     * into the workspace. Only mounted on the canonical `/v1/workspaces`
+     * surface (no old bearer-only alias), unlike the other `github/*`
+     * client methods above.
+     */
+    async ingestGithub(input: {
+      repo: string;
+      kind: "pull" | "issues";
+      num: number;
+    }): Promise<IngestGithubResult> {
+      const body =
+        input.kind === "pull"
+          ? { repo: input.repo, pr: input.num }
+          : { repo: input.repo, issue: input.num };
+      return request<IngestGithubResult>(
+        "POST",
+        `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/github/ingest`,
+        {
+          body: new TextEncoder().encode(JSON.stringify(body)),
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    },
+
     async githubHealth(): Promise<GithubHealthResult> {
       return request<GithubHealthResult>(
         "GET",

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -3166,6 +3166,56 @@ export async function runComment(
   return 0;
 }
 
+// --- ingest ---
+
+const INGEST_HELP = `uploads ingest — mirror GitHub-native attachments from a PR/issue into the workspace
+
+Usage:
+  uploads ingest --pr <n> [--repo owner/name]
+  uploads ingest --issue <n> [--repo owner/name]
+
+Scans the PR/issue description and comments for github.com/user-attachments
+media, mirrors new ones into the workspace (indexed, not added to the managed
+comment), and detaches ones no longer referenced. Works on any repo linked to
+the workspace; the .uploads.yml ingestGithubAttachments knob only gates the
+automatic webhook path.
+
+Examples:
+  uploads ingest --pr 123
+  uploads ingest --issue 45 --repo acme/app --format json
+`;
+
+export async function runIngest(
+  ctx: CliContext,
+  args: string[],
+  help = false,
+  run: CommandRunner = execRunner,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    writeCommandHelp(INGEST_HELP);
+    return 0;
+  }
+  const target = ghTargetFromFlags(parsed.flags, run);
+  if (!target) {
+    throw new UsageError("--pr or --issue required");
+  }
+
+  const result = await ctx.client.ingestGithub(target);
+  if (ctx.json) {
+    await writeJson(result);
+    return 0;
+  }
+  if (!ctx.quiet) {
+    let line = `Ingested ${result.ingested.length}, re-attached ${result.reattached.length}, detached ${result.detached.length}, skipped ${result.skipped.length}\n`;
+    for (const skip of result.skipped) {
+      line += `  skipped: ${skip.url} (${skip.reason})\n`;
+    }
+    process.stderr.write(line);
+  }
+  return 0;
+}
+
 // --- github link ---
 
 const GITHUB_HELP = `uploads github link [--repo <owner/name>] [--status] [--workspace <name>]

--- a/packages/uploads/src/comment-config.ts
+++ b/packages/uploads/src/comment-config.ts
@@ -22,6 +22,7 @@ export interface RepoCommentConfig {
   metaState?: boolean;
   linkToFilePage?: boolean;
   note?: string;
+  ingestGithubAttachments?: boolean;
 }
 export interface WorkspaceCommentDefaults {
   imageWidth?: "full" | number;
@@ -29,6 +30,7 @@ export interface WorkspaceCommentDefaults {
   showMetadata?: boolean; // maps to BOTH metaPath and metaState
   linkToFilePage?: boolean;
   note?: string;
+  ingestGithubAttachments?: boolean;
 }
 export interface ResolvedCommentOptions {
   imageWidth: "auto" | "full" | number;
@@ -37,6 +39,7 @@ export interface ResolvedCommentOptions {
   metaState: boolean;
   linkToFilePage: boolean;
   note: string | null;
+  ingestGithubAttachments: boolean;
 }
 export type OptionSource = "repo" | "workspace" | "auto";
 
@@ -47,6 +50,7 @@ export const AUTO_COMMENT_OPTIONS: ResolvedCommentOptions = {
   metaState: true,
   linkToFilePage: true,
   note: null,
+  ingestGithubAttachments: false,
 };
 
 export const NOTE_MAX_CHARS = 500;
@@ -102,6 +106,13 @@ export function parseRepoCommentConfig(
     else warnings.push(`linkToFilePage: expected a boolean; dropped`);
   }
 
+  // ingestGithubAttachments: boolean
+  if ("ingestGithubAttachments" in c) {
+    const v = c.ingestGithubAttachments;
+    if (typeof v === "boolean") config.ingestGithubAttachments = v;
+    else warnings.push(`ingestGithubAttachments: expected a boolean; dropped`);
+  }
+
   // meta.path / meta.state: booleans nested under `meta`
   if ("meta" in c) {
     const v = c.meta;
@@ -152,6 +163,9 @@ export function resolveCommentOptions(
       : {}),
     ...(ws?.linkToFilePage !== undefined ? { linkToFilePage: ws.linkToFilePage } : {}),
     ...(ws?.note ? { note: ws.note } : {}),
+    ...(ws?.ingestGithubAttachments !== undefined
+      ? { ingestGithubAttachments: ws.ingestGithubAttachments }
+      : {}),
   };
   const options = { ...AUTO_COMMENT_OPTIONS };
   const source = Object.fromEntries(
@@ -164,6 +178,7 @@ export function resolveCommentOptions(
       "metaPath",
       "metaState",
       "linkToFilePage",
+      "ingestGithubAttachments",
     ] as const) {
       if (cfg[key] !== undefined && source[key] === "auto") {
         (options as Record<string, unknown>)[key] = cfg[key];

--- a/packages/uploads/test/commands-ingest.test.ts
+++ b/packages/uploads/test/commands-ingest.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { UsageError } from "../src/cli-args.js";
+import type { IngestGithubResult, UploadsClient } from "../src/client.js";
+import { runIngest, type CliContext } from "../src/commands.js";
+import type { CommandRunner } from "../src/github-gh.js";
+
+function fakeClient(overrides: Partial<UploadsClient> = {}): UploadsClient {
+  return {
+    ingestGithub: async () => ({
+      repo: "acme/web",
+      kind: "pull",
+      num: 7,
+      ingested: [],
+      reattached: [],
+      detached: [],
+      skipped: [],
+    }),
+    ...overrides,
+  } as unknown as UploadsClient;
+}
+
+function ctxWith(client: UploadsClient, json = false): CliContext {
+  return {
+    config: {
+      apiUrl: "https://x.test",
+      workspace: "test",
+      token: "up_test_x",
+      workspaceSource: "override",
+      configPath: "/tmp/uploads-test-config",
+      configExists: false,
+    },
+    client,
+    json,
+    quiet: true,
+  };
+}
+
+/** git/gh runner that resolves the current repo to acme/web (gh unavailable → git remote fallback). */
+function repoRunner(): CommandRunner {
+  return (cmd, args) => {
+    if (cmd === "gh") throw new Error("gh not available");
+    if (cmd === "git" && args[0] === "config" && args.includes("remote.origin.url")) {
+      return "https://github.com/acme/web.git\n";
+    }
+    throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+  };
+}
+
+/** Run `fn` with process.stderr.write captured, returning the concatenated output. */
+async function captureStderr(fn: () => Promise<unknown>): Promise<string> {
+  const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  try {
+    await fn();
+    return writeSpy.mock.calls.map((c) => String(c[0])).join("");
+  } finally {
+    writeSpy.mockRestore();
+  }
+}
+
+describe("runIngest", () => {
+  it("resolves the repo and calls ingestGithub with the derived target", async () => {
+    const ingestGithub = vi.fn(
+      async (): Promise<IngestGithubResult> => ({
+        repo: "acme/web",
+        kind: "pull",
+        num: 7,
+        ingested: ["gh/acme/web/pull/7/a.png", "gh/acme/web/pull/7/b.png"],
+        reattached: [],
+        detached: ["gh/acme/web/pull/7/old.png"],
+        skipped: [],
+      }),
+    );
+    const client = fakeClient({ ingestGithub });
+    const err = await captureStderr(() =>
+      runIngest({ ...ctxWith(client), quiet: false }, ["--pr", "7"], false, repoRunner()),
+    );
+    expect(ingestGithub).toHaveBeenCalledWith({ repo: "acme/web", kind: "pull", num: 7 });
+    expect(err).toContain("Ingested 2, re-attached 0, detached 1, skipped 0");
+  });
+
+  it("throws UsageError when --pr and --issue are both given", async () => {
+    const client = fakeClient();
+    await expect(
+      runIngest(ctxWith(client), ["--pr", "1", "--issue", "2"], false, repoRunner()),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it("throws UsageError when neither --pr nor --issue is given", async () => {
+    const client = fakeClient();
+    await expect(runIngest(ctxWith(client), [], false, repoRunner())).rejects.toThrow(
+      "--pr or --issue required",
+    );
+  });
+
+  it("writes the raw response as JSON when ctx.json is true", async () => {
+    const result: IngestGithubResult = {
+      repo: "acme/web",
+      kind: "issues",
+      num: 45,
+      ingested: ["gh/acme/web/issues/45/a.png"],
+      reattached: [],
+      detached: [],
+      skipped: [],
+    };
+    const ingestGithub = vi.fn(async () => result);
+    const client = fakeClient({ ingestGithub });
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const code = await runIngest(ctxWith(client, true), ["--issue", "45"], false, repoRunner());
+      expect(code).toBe(0);
+      const printed = writeSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(JSON.parse(printed)).toEqual(result);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it("renders skipped entries as human-readable lines", async () => {
+    const ingestGithub = vi.fn(
+      async (): Promise<IngestGithubResult> => ({
+        repo: "acme/web",
+        kind: "pull",
+        num: 7,
+        ingested: [],
+        reattached: [],
+        detached: [],
+        skipped: [
+          { url: "https://github.com/user-attachments/x", reason: "unsupported content type" },
+        ],
+      }),
+    );
+    const client = fakeClient({ ingestGithub });
+    const err = await captureStderr(() =>
+      runIngest({ ...ctxWith(client), quiet: false }, ["--pr", "7"], false, repoRunner()),
+    );
+    expect(err).toContain(
+      "skipped: https://github.com/user-attachments/x (unsupported content type)",
+    );
+  });
+});

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -773,6 +773,26 @@ recommended so a deleted/mangled bot comment self-heals instead of waiting
 for the next PR push) — useful when webhook-driven behavior (auto-promotion,
 title updates, self-healing) seems to be silently doing nothing.
 
+### Mirroring GitHub-native attachments (`uploads ingest`)
+
+Images someone drops straight into a PR/issue via `github.com/user-attachments/…`
+only exist behind GitHub's own authenticated hosting — they're never public
+URLs. `uploads ingest --pr <n>` (or `--issue <n>`) scans the description and
+comments for that media, mirrors any new ones into the workspace (indexed,
+not added to the managed comment), and detaches ones no longer referenced —
+a reattached one un-detaches without a re-fetch:
+
+```bash
+uploads ingest --pr 123
+uploads ingest --issue 45 --repo owner/name --json
+```
+
+Requires the repo be linked to the workspace (`uploads github link`) and the
+GitHub App installed — otherwise it fails with a clear error rather than
+guessing. This is the manual/backfill entry point; the `.uploads.yml`
+`ingestGithubAttachments` knob only gates the automatic webhook path and has
+no effect on running `ingest` directly.
+
 ### Embedding best practices
 
 - **Meaningful alt text**, always — it's what readers with images off and search see.

--- a/test/fixtures/comment-config-golden.json
+++ b/test/fixtures/comment-config-golden.json
@@ -182,6 +182,24 @@
         "config": null,
         "warnings": []
       }
+    },
+    {
+      "name": "ingestGithubAttachments true",
+      "text": "comment:\n  ingestGithubAttachments: true\n",
+      "format": "yaml",
+      "expected": {
+        "config": { "ingestGithubAttachments": true },
+        "warnings": []
+      }
+    },
+    {
+      "name": "ingestGithubAttachments non-boolean warns",
+      "text": "comment:\n  ingestGithubAttachments: yes please\n",
+      "format": "yaml",
+      "expected": {
+        "config": {},
+        "warnings": ["ingestGithubAttachments: expected a boolean; dropped"]
+      }
     }
   ],
   "resolveCases": [
@@ -196,7 +214,8 @@
           "metaPath": true,
           "metaState": true,
           "linkToFilePage": true,
-          "note": null
+          "note": null,
+          "ingestGithubAttachments": false
         },
         "source": {
           "imageWidth": "auto",
@@ -204,7 +223,8 @@
           "metaPath": "auto",
           "metaState": "auto",
           "linkToFilePage": "auto",
-          "note": "auto"
+          "note": "auto",
+          "ingestGithubAttachments": "auto"
         }
       }
     },
@@ -224,7 +244,8 @@
           "metaPath": true,
           "metaState": true,
           "linkToFilePage": true,
-          "note": null
+          "note": null,
+          "ingestGithubAttachments": false
         },
         "source": {
           "imageWidth": "repo",
@@ -232,7 +253,8 @@
           "metaPath": "auto",
           "metaState": "auto",
           "linkToFilePage": "auto",
-          "note": "auto"
+          "note": "auto",
+          "ingestGithubAttachments": "auto"
         }
       }
     },
@@ -249,7 +271,8 @@
           "metaPath": false,
           "metaState": false,
           "linkToFilePage": true,
-          "note": null
+          "note": null,
+          "ingestGithubAttachments": false
         },
         "source": {
           "imageWidth": "auto",
@@ -257,7 +280,8 @@
           "metaPath": "workspace",
           "metaState": "workspace",
           "linkToFilePage": "auto",
-          "note": "auto"
+          "note": "auto",
+          "ingestGithubAttachments": "auto"
         }
       }
     },
@@ -276,7 +300,8 @@
           "metaPath": true,
           "metaState": false,
           "linkToFilePage": true,
-          "note": null
+          "note": null,
+          "ingestGithubAttachments": false
         },
         "source": {
           "imageWidth": "auto",
@@ -284,7 +309,33 @@
           "metaPath": "repo",
           "metaState": "workspace",
           "linkToFilePage": "auto",
-          "note": "auto"
+          "note": "auto",
+          "ingestGithubAttachments": "auto"
+        }
+      }
+    },
+    {
+      "name": "ingest knob repo over workspace",
+      "repo": { "ingestGithubAttachments": true },
+      "workspace": { "ingestGithubAttachments": false },
+      "expected": {
+        "options": {
+          "imageWidth": "auto",
+          "maxInlineImages": 16,
+          "metaPath": true,
+          "metaState": true,
+          "linkToFilePage": true,
+          "note": null,
+          "ingestGithubAttachments": true
+        },
+        "source": {
+          "imageWidth": "auto",
+          "maxInlineImages": "auto",
+          "metaPath": "auto",
+          "metaState": "auto",
+          "linkToFilePage": "auto",
+          "note": "auto",
+          "ingestGithubAttachments": "repo"
         }
       }
     }


### PR DESCRIPTION
Mirrors `github.com/user-attachments` assets from PR/issue bodies and comments into the linked workspace, so screenshots people drag directly into GitHub participate in search, `find_files`, and the Screenshots page alongside CLI uploads.

Spec: `docs/superpowers/specs/2026-08-11-github-attachment-ingestion-design.md` · Plan: `docs/superpowers/plans/2026-08-11-github-attachment-ingestion.md`

## How it works

One reconciliation core (`apps/api/src/github-ingest.ts`), two triggers:

- **Webhook path (opt-in per repo, default off).** New `.uploads.yml` knob `ingestGithubAttachments: true` (workspace default `githubIngestAttachments` in settings, repo → workspace → auto layering). On body/comment events the webhook queue carries a compact source ref; the consumer re-fetches current text, so every pass is a reconcile, not an append.
- **Manual path (any linked repo, knob bypassed).** `POST /v1/workspaces/:workspace/github/ingest` + `uploads ingest --pr N | --issue N`. Manual invocation is its own consent, and doubles as backfill/repair.

Details:

- **Ledger idempotency.** New D1 table `github_ingested_assets` keyed (repo, asset id) — assets are fetched once, edits diff against the ledger.
- **Soft detach, never delete.** An image removed or replaced in a body flips `gh.detached=true` (single-key metadata update; ordering is metadata-first for queue-retry safety) and drops out of default views. Re-adding re-attaches without re-fetching. Bytes stay in the file table and remain member-deletable.
- **Guards.** Media-only allowlist, plan size caps, budget checks — all permanent skips with structured logs, never queue retries. Transient GitHub failures retry via the existing webhook queue/DLQ.
- **Metadata.** `gh.repo`, `gh.kind`, `gh.number`, plus new `gh.origin=github`, `gh.author=<login>`, `gh.detached=false|true` (always stamped so exclusion stays an equality filter), `gh.source`. Never `gh.uploader` (reserved for minting identity). Writes go through `putObject`, so usage accounting and content-hash inheritance apply.
- **Index-only.** Ingested assets never join the managed attachments comment — they're already visible inline on GitHub.
- **Web.** The Screenshots page gains a "From GitHub" section (non-detached only), including when the workspace has no by-path groups.

## Screenshots page

<img width="900" alt="Screenshots page with the new From GitHub section" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/623/gh-section.webp">

## Migration

`20260811120000_github_ingested_assets.sql` auto-applies on merge via CI.

## Testing

- Unit: extraction shapes, reconcile diffing (add/remove/re-add/move/comment-delete), guard-skip vs throw split, retry-safety regression tests for the detach/reattach write ordering.
- Integration: end-to-end smoke (`github-ingest-e2e.test.ts`) drives `handleWebhook` → queue consumer → real `putObject` → `findObjectsByMetadata` with only GitHub HTTP faked.
- Route, CLI, and config-parser suites extended; both `.uploads.yml` parser copies synced via the golden fixture.
- Full monorepo suite: 282 files / 4035+ tests green; typechecks clean.
- Browser-verified on the local stack: attached file renders in the section with its `PR #7 · octocat` label; a seeded detached file is excluded.

## Changeset

Minor bump for `@buildinternet/uploads` (`uploads ingest`).
