### PR TITLE
fix: detach orphan-source ingested assets in manual reconcile; honor --format json

### DIFF
--- a/.changeset/ingest-format-json-and-orphan-detach.md
+++ b/.changeset/ingest-format-json-and-orphan-detach.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads ingest`: honor --format json; note manual reconcile now detaches assets from deleted comments.

--- a/apps/api/src/github-ingest-ledger.ts
+++ b/apps/api/src/github-ingest-ledger.ts
@@ -119,6 +119,23 @@ export async function ledgerRowsForSource(
   return (results ?? []).map(fromRow);
 }
 
+/** All ledger rows for `repo` currently attributed to `kind`/`num` (across every source). */
+export async function ledgerRowsForTarget(
+  db: D1Database,
+  repo: string,
+  kind: "pull" | "issues",
+  num: number,
+): Promise<IngestLedgerRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT repo, asset_id, workspace, object_key, kind, num, source, created_at, detached_at
+       FROM github_ingested_assets WHERE repo = ? AND kind = ? AND num = ?`,
+    )
+    .bind(normalizeRepo(repo), kind, num)
+    .all<IngestLedgerDbRow>();
+  return (results ?? []).map(fromRow);
+}
+
 /**
  * Flips `detachedAt` for a ledger row — set to a timestamp when the
  * reconciler no longer finds the asset referenced, or back to null when it

--- a/apps/api/src/github-ingest.test.ts
+++ b/apps/api/src/github-ingest.test.ts
@@ -756,6 +756,125 @@ describe("reconcileIngestTarget", () => {
     }
   });
 
+  it("detaches a ledger row whose comment source was deleted on GitHub (absent from the fetched list)", async () => {
+    const { env } = baseEnv();
+    const orphanAssetId = "assets/44444444-4444-4444-4444-444444444444";
+    const orphanKey = `gh/acme-app/pull-7/${attachmentKeyBasename(orphanAssetId)}.png`;
+    // Row attributed to comment:999, which GitHub no longer returns — the
+    // comment was deleted.
+    await recordIngestedAsset(env.DB, {
+      repo: REPO,
+      assetId: orphanAssetId,
+      workspace: WS,
+      objectKey: orphanKey,
+      kind: "pull",
+      num: 7,
+      source: "comment:999",
+      createdAt: new Date().toISOString(),
+    });
+    await replaceFileMetadata(env.DB, WS, orphanKey, { "gh.detached": "false" });
+
+    const otherComment = { id: 500, body: "no attachment here", user: { login: "eve" } };
+    const impl = (async (url: string) => {
+      const u = String(url);
+      if (u.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (u.includes("/installation")) {
+        return new Response(JSON.stringify({ id: 42 }), { status: 200 });
+      }
+      if (u.includes("/issues/7/comments")) {
+        if (u.includes("&page=1")) {
+          return new Response(JSON.stringify([otherComment]), { status: 200 });
+        }
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (u.includes("/repos/acme/app/issues/7")) {
+        return new Response(JSON.stringify({ body: "", user: { login: "bob" } }), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const summary = await reconcileIngestTarget(
+      env,
+      ws,
+      WS,
+      { repo: REPO, kind: "pull", num: 7 },
+      { fetchImpl: impl },
+    );
+
+    expect(summary.detached).toContain(orphanKey);
+    const row = await ledgerRow(env.DB, REPO, orphanAssetId);
+    expect(row?.detachedAt).not.toBeNull();
+    const meta = await getFileMetadata(env.DB, WS, orphanKey);
+    expect(meta["gh.detached"]).toBe("true");
+  });
+
+  it("does NOT run orphan detection when the comment scan was truncated (3 full pages)", async () => {
+    const { env } = baseEnv();
+    const orphanAssetId = "assets/55555555-5555-5555-5555-555555555555";
+    const orphanKey = `gh/acme-app/pull-7/${attachmentKeyBasename(orphanAssetId)}.png`;
+    await recordIngestedAsset(env.DB, {
+      repo: REPO,
+      assetId: orphanAssetId,
+      workspace: WS,
+      objectKey: orphanKey,
+      kind: "pull",
+      num: 7,
+      source: "comment:999",
+      createdAt: new Date().toISOString(),
+    });
+    await replaceFileMetadata(env.DB, WS, orphanKey, { "gh.detached": "false" });
+
+    const pageOf = (start: number) =>
+      Array.from({ length: 100 }, (_, i) => ({
+        id: start + i,
+        body: "no attachment here",
+        user: { login: "bob" },
+      }));
+    const page1 = pageOf(1000);
+    const page2 = pageOf(2000);
+    const page3 = pageOf(3000);
+    const impl = (async (url: string) => {
+      const u = String(url);
+      if (u.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (u.includes("/installation")) {
+        return new Response(JSON.stringify({ id: 42 }), { status: 200 });
+      }
+      if (u.includes("/issues/7/comments")) {
+        if (u.includes("&page=1")) return new Response(JSON.stringify(page1), { status: 200 });
+        if (u.includes("&page=2")) return new Response(JSON.stringify(page2), { status: 200 });
+        if (u.includes("&page=3")) return new Response(JSON.stringify(page3), { status: 200 });
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (u.includes("/repos/acme/app/issues/7")) {
+        return new Response(JSON.stringify({ body: "", user: { login: "bob" } }), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const summary = await reconcileIngestTarget(
+        env,
+        ws,
+        WS,
+        { repo: REPO, kind: "pull", num: 7 },
+        { fetchImpl: impl },
+      );
+
+      expect(summary.detached).not.toContain(orphanKey);
+      const row = await ledgerRow(env.DB, REPO, orphanAssetId);
+      expect(row?.detachedAt).toBeNull();
+      const meta = await getFileMetadata(env.DB, WS, orphanKey);
+      expect(meta["gh.detached"]).toBe("false");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it("throws github_app_not_installed instead of an empty summary when the app isn't configured", async () => {
     const db = new UsageFakeD1();
     const kv = new FakeKv(); // no ghinst:/ghtok: cache entries seeded

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -36,6 +36,7 @@ import {
 import {
   ledgerRow,
   ledgerRowsForSource,
+  ledgerRowsForTarget,
   recordIngestedAsset,
   setLedgerDetached,
   setLedgerSource,
@@ -419,6 +420,11 @@ export async function reconcileIngestTarget(
     num: target.num,
     source: "body",
   };
+  // Sources actually reconciled this pass — drives orphan detection below.
+  // A comment absent from GitHub's response (deleted) never gets a source
+  // ref built for it, so it's never added here; a non-detached ledger row
+  // whose source isn't in this set was deleted out from under the ledger.
+  const seenSources = new Set<string>(["body"]);
   mergeSummary(
     merged,
     await reconcileIngestSource(
@@ -455,6 +461,7 @@ export async function reconcileIngestTarget(
         num: target.num,
         source: `comment:${comment.id}`,
       };
+      seenSources.add(commentRef.source);
       mergeSummary(
         merged,
         await reconcileIngestSource(
@@ -481,6 +488,24 @@ export async function reconcileIngestTarget(
         num: target.num,
       }),
     );
+  } else {
+    // Orphan detection: a comment deleted on GitHub is simply absent from
+    // the paginated list above — it never gets a `reconcileIngestSource`
+    // pass, so its ledger rows never enter that function's own
+    // no-longer-referenced detach loop. Catch those here by detaching every
+    // non-detached row for this target whose source we didn't just scan.
+    // Skipped entirely when the scan was truncated (above): unseen later
+    // pages mean an absent source isn't proof of deletion.
+    const rows = await ledgerRowsForTarget(env.DB, target.repo, target.kind, target.num);
+    for (const row of rows) {
+      if (row.detachedAt !== null) continue;
+      if (seenSources.has(row.source)) continue;
+      // Metadata-first, same retry-safety ordering as the per-source detach
+      // path in reconcileIngestSource.
+      await updateFileMetadataValue(env.DB, row.workspace, row.objectKey, "gh.detached", "true");
+      await setLedgerDetached(env.DB, target.repo, row.assetId, new Date().toISOString());
+      merged.detached.push(row.objectKey);
+    }
   }
 
   return merged;

--- a/apps/api/test/github-ingest-ledger-sqlite.test.ts
+++ b/apps/api/test/github-ingest-ledger-sqlite.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   ledgerRow,
   ledgerRowsForSource,
+  ledgerRowsForTarget,
   recordIngestedAsset,
   setLedgerDetached,
   setLedgerSource,
@@ -53,6 +54,42 @@ describe("github ingest ledger", () => {
       expect((await ledgerRow(db, "acme/app", "assets/aaaa-bbbb"))?.detachedAt).not.toBeNull();
       await setLedgerDetached(db, "acme/app", "assets/aaaa-bbbb", null);
       expect((await ledgerRow(db, "acme/app", "assets/aaaa-bbbb"))?.detachedAt).toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("ledgerRowsForTarget scopes by repo+kind+num across every source", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordIngestedAsset(db, row()); // source: "body"
+      await recordIngestedAsset(
+        db,
+        row({ assetId: "files/9/x.png", source: "comment:44", objectKey: "gh/other-comment.png" }),
+      );
+      await recordIngestedAsset(
+        db,
+        row({
+          assetId: "files/1/y.png",
+          num: 8,
+          objectKey: "gh/other-num.png",
+        }),
+      ); // different num — must not be included
+      await recordIngestedAsset(
+        db,
+        row({
+          assetId: "files/2/z.png",
+          kind: "issues",
+          objectKey: "gh/other-kind.png",
+        }),
+      ); // different kind — must not be included
+
+      const rows = await ledgerRowsForTarget(db, "acme/app", "pull", 7);
+      expect(rows).toHaveLength(2);
+      expect(new Set(rows.map((r) => r.assetId))).toEqual(
+        new Set(["assets/aaaa-bbbb", "files/9/x.png"]),
+      );
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/helpers/fake-ingest-ledger-table.ts
+++ b/apps/api/test/helpers/fake-ingest-ledger-table.ts
@@ -103,6 +103,15 @@ export class IngestLedgerTable {
       );
       return { success: true, results: results as T[], meta: {} };
     }
+    if (
+      normalizedSql.includes("FROM github_ingested_assets WHERE repo = ? AND kind = ? AND num = ?")
+    ) {
+      const [repo, kind, num] = args as [string, "pull" | "issues", number];
+      const results = [...this.rows.values()].filter(
+        (row) => row.repo === repo && row.kind === kind && row.num === num,
+      );
+      return { success: true, results: results as T[], meta: {} };
+    }
     return undefined;
   }
 }

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -3202,7 +3202,8 @@ export async function runIngest(
   }
 
   const result = await ctx.client.ingestGithub(target);
-  if (ctx.json) {
+  const jsonMode = ctx.json || flagString(parsed.flags, "--format") === "json";
+  if (jsonMode) {
     await writeJson(result);
     return 0;
   }

--- a/packages/uploads/test/commands-ingest.test.ts
+++ b/packages/uploads/test/commands-ingest.test.ts
@@ -115,6 +115,34 @@ describe("runIngest", () => {
     }
   });
 
+  it("writes the raw response as JSON when --format json is given without ctx.json", async () => {
+    const result: IngestGithubResult = {
+      repo: "acme/web",
+      kind: "pull",
+      num: 7,
+      ingested: ["gh/acme/web/pull/7/a.png"],
+      reattached: [],
+      detached: [],
+      skipped: [],
+    };
+    const ingestGithub = vi.fn(async () => result);
+    const client = fakeClient({ ingestGithub });
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const code = await runIngest(
+        ctxWith(client),
+        ["--pr", "7", "--format", "json"],
+        false,
+        repoRunner(),
+      );
+      expect(code).toBe(0);
+      const printed = writeSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(JSON.parse(printed)).toEqual(result);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
   it("renders skipped entries as human-readable lines", async () => {
     const ingestGithub = vi.fn(
       async (): Promise<IngestGithubResult> => ({


### PR DESCRIPTION
Two defects found while verifying #623 in production.

## Manual reconcile never detached assets from deleted comments

`reconcileIngestTarget` only reconciles sources GitHub returns (body + existing comments). A deleted comment is simply absent from that list, so its ledger rows never entered any detach pass — reproduced in prod: comment ingested, comment deleted, `uploads ingest --pr 623` reported `detached 0` and the asset stayed attached.

Fix: track the set of sources actually scanned, then detach every non-detached ledger row for the target whose source wasn't seen (new `ledgerRowsForTarget` query; metadata-first ordering matching the existing retry-safe detach path). Orphan detection is skipped entirely when the comment scan was truncated at 3 full pages — an unseen page means absence isn't proof of deletion.

The webhook path already handled deletion via the `issue_comment deleted` event; this closes the gap for the manual path, which is documented as the repair/backfill tool.

## `uploads ingest --format json` printed human output

`runIngest` only honored the global `--json` while its help advertises `--format json`. It now resolves JSON mode the same way put-style commands do. Patch changeset for `@buildinternet/uploads` (the command is still unpublished, so this rides the pending minor).

## Testing

Orphan-detach + truncation-guard tests, `ledgerRowsForTarget` sqlite test, CLI `--format json` test; full monorepo suite green (283 files / 4046 tests), typechecks clean. Will re-verify the detach loop against PR #623 in prod once merged.
