### PR TITLE
fix(cli): github doctor prints the full subscribed event list

### DIFF
--- a/.changeset/doctor-full-event-list.md
+++ b/.changeset/doctor-full-event-list.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads github doctor` now prints the App's actual subscribed webhook events (including recommended ones like `issue_comment`) instead of only the required subset.

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -3237,7 +3237,8 @@ owns it; an operator can reassign or remove that binding instead.
 
 \`doctor\` checks the GitHub App itself: whether it's configured on the
 server, and whether it's subscribed to the webhook events uploads.sh's
-handler needs (issues, pull_request — see docs/github-app). A missing
+handler needs (required: issues, pull_request; recommended: issue_comment —
+see docs/github-app). A missing
 subscription is the classic silent failure: the App's ping stays green
 while webhook auto-promotion and title-cache invalidation quietly do
 nothing.
@@ -3258,7 +3259,7 @@ function missingRecommendedEventsOf(result: GithubHealthResult): string[] {
 function recommendedNoteLine(result: GithubHealthResult): string {
   const missing = missingRecommendedEventsOf(result);
   if (missing.length === 0) return "";
-  return `note: not subscribed to ${missing.join(", ")} (recommended) — enables bot-comment self-healing; subscribe under the App's Permissions & events\n`;
+  return `note: not subscribed to ${missing.join(", ")} (recommended) — enables bot-comment self-healing and comment-attachment ingestion; subscribe under the App's Permissions & events\n`;
 }
 
 function formatGithubDoctor(result: GithubHealthResult): string {
@@ -3269,8 +3270,19 @@ function formatGithubDoctor(result: GithubHealthResult): string {
     return `github app: configured, but health check failed${result.hint ? ` — ${result.hint}` : ""}\n`;
   }
   if (result.ok) {
+    // The ACTUAL subscribed list, not just the required subset — printing
+    // requiredEvents here once misdiagnosed a live App as "not subscribed to
+    // issue_comment" when it was (2026-08-11). `events` is non-null on every
+    // ok result (the null case returns above); the requiredEvents fallback
+    // only guards a malformed payload from an older server.
+    const subscribed = Array.isArray(result.events)
+      ? [...result.events].sort()
+      : [...result.requiredEvents];
+    const allPresent = missingRecommendedEventsOf(result).length === 0;
     return (
-      `github app: ok — subscribed to ${result.requiredEvents.join(", ")}\n` +
+      `github app: ok — subscribed to ${subscribed.join(", ")}` +
+      (allPresent ? " (all required + recommended events)" : "") +
+      "\n" +
       recommendedNoteLine(result)
     );
   }

--- a/packages/uploads/test/commands-github-doctor.test.ts
+++ b/packages/uploads/test/commands-github-doctor.test.ts
@@ -44,7 +44,38 @@ describe("runGithub (doctor)", () => {
         ["doctor"],
       );
       expect(code).toBe(0);
-      expect(stdout.join("")).toContain("ok");
+      // The ACTUAL subscribed list (sorted), not just the required subset.
+      expect(stdout.join("")).toContain("ok — subscribed to issues, ping, pull_request");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("lists recommended events in the ok line when subscribed", async () => {
+    const stdout: string[] = [];
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: unknown) => (stdout.push(String(chunk)), true));
+    try {
+      const code = await runGithub(
+        ctxWith(
+          clientWith({
+            configured: true,
+            ok: true,
+            events: ["pull_request", "issue_comment", "issues"],
+            missingEvents: [],
+            requiredEvents: ["issues", "pull_request"],
+            recommendedEvents: ["issue_comment"],
+            missingRecommendedEvents: [],
+          }),
+        ),
+        ["doctor"],
+      );
+      expect(code).toBe(0);
+      expect(stdout.join("")).toContain(
+        "ok — subscribed to issue_comment, issues, pull_request (all required + recommended events)",
+      );
+      expect(stdout.join("")).not.toContain("note: not subscribed");
     } finally {
       spy.mockRestore();
     }


### PR DESCRIPTION
`uploads github doctor`'s ok line printed `requiredEvents` instead of the App's actual subscribed events, so a fully-subscribed App read as "subscribed to issues, pull_request" with no mention of `issue_comment`. This misled a live diagnosis on 2026-08-11 into concluding `issue_comment` wasn't subscribed (it was), sending the investigation down the wrong path.

Now the ok line lists the actual subscribed events (sorted), appends "(all required + recommended events)" when nothing recommended is missing, and the missing-recommended note also mentions comment-attachment ingestion, which now depends on `issue_comment` alongside self-healing. Patch changeset for the CLI package.