### PR TITLE
refactor(web): switch the web app to the canonical /v1/workspaces surface (#613 step 2)

### DIFF
--- a/apps/web/src/components/AccountFileBrowser.tsx
+++ b/apps/web/src/components/AccountFileBrowser.tsx
@@ -93,7 +93,7 @@ export function AccountFileBrowser({
     if (tab) tab.opener = null;
     try {
       const response = await credentialedFetch(
-        `${apiOrigin.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/file-url?key=${encodeURIComponent(key)}`,
+        `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url?key=${encodeURIComponent(key)}`,
       );
       const body = (await response.json().catch(() => ({}))) as { url?: string };
       if (!(response.ok && body.url)) throw new Error("file URL unavailable");

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -54,7 +54,7 @@ async function resolveSignedFileUrl(
   key: string,
 ): Promise<string | null> {
   const result = await fetchWithTimeout(
-    `${apiOrigin.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/file-url?key=${encodeURIComponent(key)}`,
+    `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url?key=${encodeURIComponent(key)}`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable") return null;

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -383,7 +383,7 @@ async function resolveSignedFileUrl(
   key: string,
 ): Promise<string | null> {
   const result = await fetchWithTimeout(
-    `${apiOrigin.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/file-url?key=${encodeURIComponent(key)}`,
+    `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url?key=${encodeURIComponent(key)}`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable") return null;

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -176,7 +176,7 @@ describe("setFileVisibility", () => {
   it("PATCHes with credentials and returns the resulting visibility", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       expect(String(input)).toBe(
-        "http://127.0.0.1:8787/me/workspaces/acme/files/visibility?key=f%2Fx%2Fshot.png",
+        "http://127.0.0.1:8787/v1/workspaces/acme/files/visibility?key=f%2Fx%2Fshot.png",
       );
       expect(init?.method).toBe("PATCH");
       expect(init?.credentials).toBe("include");
@@ -228,9 +228,7 @@ describe("setFileVisibility", () => {
 describe("deleteWorkspaceFile", () => {
   it("DELETEs with credentials and reports success", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe(
-        "http://127.0.0.1:8787/me/workspaces/acme/files?key=f%2Fx%2Fshot.png",
-      );
+      expect(String(input)).toBe("http://127.0.0.1:8787/v1/workspaces/acme/files/f/x/shot.png");
       expect(init?.method).toBe("DELETE");
       expect(init?.credentials).toBe("include");
       return Response.json({ key: "f/x/shot.png", deleted: true });
@@ -339,7 +337,7 @@ describe("getWorkspaceFilesByPath", () => {
     const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
     expect(result).toEqual({ kind: "ok", groups: [GROUP], truncated: false });
     expect(fetchMock.mock.calls[0]![0]).toBe(
-      "https://api.uploads.sh/me/workspaces/acme/files/by-path",
+      "https://api.uploads.sh/v1/workspaces/acme/files/by-path",
     );
   });
 
@@ -377,7 +375,7 @@ describe("getWorkspaceFacets", () => {
       keys: [{ key: "app", count: 2, distinctValues: 2 }],
       truncated: false,
     });
-    expect(fetchMock.mock.calls[0]![0]).toBe("https://api.test/me/workspaces/acme/files/facets");
+    expect(fetchMock.mock.calls[0]![0]).toBe("https://api.test/v1/workspaces/acme/files/facets");
   });
 
   it("reports unavailable on a malformed body", async () => {
@@ -421,7 +419,7 @@ describe("getWorkspaceFacetValues", () => {
       truncated: false,
     });
     expect(fetchMock.mock.calls[0]![0]).toBe(
-      "https://api.test/me/workspaces/acme/files/facets?key=app",
+      "https://api.test/v1/workspaces/acme/files/facets?key=app",
     );
   });
 
@@ -432,7 +430,7 @@ describe("getWorkspaceFacetValues", () => {
     vi.stubGlobal("fetch", fetchMock);
     await getWorkspaceFacetValues("https://api.test", "acme", "gh.repo");
     expect(fetchMock.mock.calls[0]![0]).toBe(
-      "https://api.test/me/workspaces/acme/files/facets?key=gh.repo",
+      "https://api.test/v1/workspaces/acme/files/facets?key=gh.repo",
     );
   });
 
@@ -443,7 +441,7 @@ describe("getWorkspaceFacetValues", () => {
     vi.stubGlobal("fetch", fetchMock);
     await getWorkspaceFacetValues("https://api.test", "acme", "team/name here");
     expect(fetchMock.mock.calls[0]![0]).toBe(
-      "https://api.test/me/workspaces/acme/files/facets?key=team%2Fname%20here",
+      "https://api.test/v1/workspaces/acme/files/facets?key=team%2Fname%20here",
     );
   });
 
@@ -488,7 +486,7 @@ describe("searchWorkspaceFiles with a name term", () => {
       name: "hero",
     });
     expect(fetchMock.mock.calls[0]![0]).toBe(
-      "https://api.test/me/workspaces/acme/files/search?meta.app=web&name=hero",
+      "https://api.test/v1/workspaces/acme/files/search?meta.app=web&name=hero",
     );
   });
 
@@ -499,7 +497,7 @@ describe("searchWorkspaceFiles with a name term", () => {
     vi.stubGlobal("fetch", fetchMock);
     await searchWorkspaceFiles("https://api.test", "acme", [], { name: "hero" });
     expect(fetchMock.mock.calls[0]![0]).toBe(
-      "https://api.test/me/workspaces/acme/files/search?name=hero",
+      "https://api.test/v1/workspaces/acme/files/search?name=hero",
     );
   });
 });
@@ -508,7 +506,7 @@ describe("listWorkspaceFolder", () => {
   it("builds the querystring from opts, omitting absent params", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       expect(String(input)).toBe(
-        "http://127.0.0.1:8787/me/workspaces/acme/files?delimiter=%2F&prefix=f%2F&cursor=abc&limit=50",
+        "http://127.0.0.1:8787/v1/workspaces/acme/files?delimiter=%2F&prefix=f%2F&cursor=abc&limit=50",
       );
       expect(init?.credentials).toBe("include");
       return Response.json({ files: [], prefixes: [], cursor: null });
@@ -540,7 +538,7 @@ describe("listWorkspaceFolder", () => {
 
   it("still sends the folder delimiter when no opts are given", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      expect(String(input)).toBe("http://127.0.0.1:8787/me/workspaces/acme/files?delimiter=%2F");
+      expect(String(input)).toBe("http://127.0.0.1:8787/v1/workspaces/acme/files?delimiter=%2F");
       return Response.json({ files: [], prefixes: [], cursor: null });
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -792,7 +790,7 @@ describe("manage mutations map status codes", () => {
 
   it("updateWorkspaceMemberRole → ok on 200, sending role in the PATCH body", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe("https://api.test/me/workspaces/acme/members/m1");
+      expect(String(input)).toBe("https://api.test/v1/workspaces/acme/members/m1");
       expect(init?.method).toBe("PATCH");
       expect(init?.credentials).toBe("include");
       expect(JSON.parse(init!.body as string)).toEqual({ role: "admin" });
@@ -808,7 +806,7 @@ describe("manage mutations map status codes", () => {
 
   it("removeWorkspaceMember → ok on 200 via DELETE", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe("https://api.test/me/workspaces/acme/members/m1");
+      expect(String(input)).toBe("https://api.test/v1/workspaces/acme/members/m1");
       expect(init?.method).toBe("DELETE");
       expect(init?.credentials).toBe("include");
       return new Response(null, { status: 200 });
@@ -966,7 +964,7 @@ const CANDIDATE: StorageCandidate = {
 describe("getWorkspaceStorageStatus", () => {
   it("GETs with credentials and returns the shared/byo status", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe("http://127.0.0.1:8787/me/workspaces/acme/storage");
+      expect(String(input)).toBe("http://127.0.0.1:8787/v1/workspaces/acme/storage");
       expect(init?.credentials).toBe("include");
       return Response.json({
         mode: "shared",
@@ -1065,7 +1063,7 @@ describe("getWorkspaceStorageStatus", () => {
 describe("verifyWorkspaceStorage", () => {
   it("POSTs the candidate and returns the check list", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe("http://127.0.0.1:8787/me/workspaces/acme/storage/verify");
+      expect(String(input)).toBe("http://127.0.0.1:8787/v1/workspaces/acme/storage/verify");
       expect(init?.method).toBe("POST");
       expect(init?.credentials).toBe("include");
       expect(JSON.parse(init!.body as string)).toEqual(CANDIDATE);
@@ -1119,7 +1117,7 @@ describe("verifyWorkspaceStorage", () => {
 describe("putWorkspaceStorage", () => {
   it("PUTs the candidate and returns the resulting status on success", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe("http://127.0.0.1:8787/me/workspaces/acme/storage");
+      expect(String(input)).toBe("http://127.0.0.1:8787/v1/workspaces/acme/storage");
       expect(init?.method).toBe("PUT");
       expect(init?.credentials).toBe("include");
       expect(JSON.parse(init!.body as string)).toEqual(CANDIDATE);
@@ -1197,7 +1195,7 @@ describe("putWorkspaceStorage", () => {
 describe("deleteWorkspaceStorage", () => {
   it("DELETEs without force by default", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe("http://127.0.0.1:8787/me/workspaces/acme/storage");
+      expect(String(input)).toBe("http://127.0.0.1:8787/v1/workspaces/acme/storage");
       expect(init?.method).toBe("DELETE");
       expect(init?.credentials).toBe("include");
       return Response.json({ mode: "shared", byoBucketEnabled: true });
@@ -1212,7 +1210,7 @@ describe("deleteWorkspaceStorage", () => {
 
   it("appends ?force=true when force is requested", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      expect(String(input)).toBe("http://127.0.0.1:8787/me/workspaces/acme/storage?force=true");
+      expect(String(input)).toBe("http://127.0.0.1:8787/v1/workspaces/acme/storage?force=true");
       return Response.json({ mode: "shared", byoBucketEnabled: true });
     });
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -155,13 +155,13 @@ function parseWorkspaceUsage(body: unknown): WorkspaceUsage | null {
   return body as WorkspaceUsage;
 }
 
-/** GET /me/workspaces/:name/usage. Returns null on any non-2xx or malformed body. */
+/** GET /v1/workspaces/:name/usage. Returns null on any non-2xx or malformed body. */
 export async function getMyWorkspaceUsage(
   apiOrigin: string,
   name: string,
 ): Promise<WorkspaceUsage | null> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/usage`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/usage`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable" || !result.response.ok) return null;
@@ -177,7 +177,7 @@ export type WorkspaceSummaryResult =
   | { kind: "unavailable"; reason: RequestFailure | "server" | "malformed" | "not_found" };
 
 /**
- * GET /me/workspaces/:name/summary — membership + public URL + usage for the
+ * GET /v1/workspaces/:name/summary — membership + public URL + usage for the
  * workspace shell/rail (one authz pass instead of full list + usage).
  */
 export async function getWorkspaceSummary(
@@ -185,7 +185,7 @@ export async function getWorkspaceSummary(
   name: string,
 ): Promise<WorkspaceSummaryResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/summary`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/summary`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable") return result;
@@ -296,9 +296,22 @@ function isWorkspaceFile(value: unknown): value is WorkspaceFile {
   return typeof f.key === "string" && (f.url === null || typeof f.url === "string");
 }
 
-/** GET /me/workspaces/:name/files. See {@link fetchWorkspaceList}. */
-export function getMyWorkspaceFiles(apiOrigin: string, name: string): Promise<WorkspaceFile[]> {
-  return fetchWorkspaceList(apiOrigin, name, "files", "files", isWorkspaceFile);
+/**
+ * GET /v1/workspaces/:name/files. Same contract as {@link fetchWorkspaceList}
+ * but on the canonical dual-auth surface rather than `/me`.
+ */
+export async function getMyWorkspaceFiles(
+  apiOrigin: string,
+  name: string,
+): Promise<WorkspaceFile[]> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable" || !result.response.ok) return [];
+  const body = (await result.response.json().catch(() => null)) as Record<string, unknown> | null;
+  const list = body?.files;
+  return Array.isArray(list) ? list.filter(isWorkspaceFile) : [];
 }
 
 export type FileVisibility = "public" | "private";
@@ -308,7 +321,7 @@ export type SetFileVisibilityResult =
   | { kind: "unavailable"; reason: RequestFailure | "server" | "malformed" };
 
 /**
- * PATCH /me/workspaces/:name/files/visibility — toggles a file's private flag
+ * PATCH /v1/workspaces/:name/files/visibility — toggles a file's private flag
  * (issue #139). Key travels as a query param, matching `file-url`'s
  * convention, since embedding an arbitrary (possibly `/`-containing) key in
  * the path segment fights routing.
@@ -320,7 +333,7 @@ export async function setFileVisibility(
   visibility: FileVisibility,
 ): Promise<SetFileVisibilityResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/files/visibility?key=${encodeURIComponent(key)}`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/visibility?key=${encodeURIComponent(key)}`,
     {
       method: "PATCH",
       credentials: "include",
@@ -346,17 +359,20 @@ export type DeleteWorkspaceFileResult =
   | { kind: "unavailable"; reason: RequestFailure | "server" };
 
 /**
- * DELETE /me/workspaces/:name/files — permanently deletes a file (spec
- * 2026-07-30). Key travels as a query param, matching `file-url` and the
- * visibility route.
+ * DELETE /v1/workspaces/:name/files/<keyPath> — permanently deletes a file
+ * (spec 2026-07-30). Unlike the legacy `/me` alias, the canonical route keys
+ * the file off path segments rather than a `?key=` query param: each `/`
+ * separated component of `key` is percent-encoded individually and joined
+ * back with `/`, matching the API's own alias rewrite (apps/api/src/routes/me.ts).
  */
 export async function deleteWorkspaceFile(
   apiOrigin: string,
   name: string,
   key: string,
 ): Promise<DeleteWorkspaceFileResult> {
+  const keyPath = key.split("/").map(encodeURIComponent).join("/");
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/files?key=${encodeURIComponent(key)}`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/${keyPath}`,
     { method: "DELETE", credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable") return result;
@@ -412,13 +428,13 @@ function mapWorkspaceMembers(list: unknown[]): WorkspaceMember[] {
   }));
 }
 
-/** GET /me/workspaces/:name/members — teammates in the workspace, member-gated. */
+/** GET /v1/workspaces/:name/members — teammates in the workspace, member-gated. */
 export async function getWorkspaceMembers(
   apiOrigin: string,
   name: string,
 ): Promise<WorkspaceMembersResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/members`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/members`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable" || !result.response.ok) return { kind: "unavailable" };
@@ -442,7 +458,7 @@ export type WorkspacePeopleResult =
   | { kind: "unavailable"; reason?: "not_found" | "server" | RequestFailure };
 
 /**
- * GET /me/workspaces/:name/people — members + invites (+ role) for the people
+ * GET /v1/workspaces/:name/people — members + invites (+ role) for the people
  * tab in one request.
  */
 export async function getWorkspacePeople(
@@ -450,7 +466,7 @@ export async function getWorkspacePeople(
   name: string,
 ): Promise<WorkspacePeopleResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/people`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/people`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable") return result;
@@ -507,7 +523,7 @@ export interface WorkspaceBilling {
   planApplied: boolean;
   limits: WorkspaceBillingLimits;
   usage: Record<string, unknown> | null;
-  /** Issue #445: additive fields — see GET /me/workspaces/:name/billing. */
+  /** Issue #445: additive fields — see GET /v1/workspaces/:name/billing. */
   planSource: WorkspacePlanSource;
   subscription: WorkspaceSubscription | null;
 }
@@ -517,7 +533,7 @@ export type WorkspaceBillingResult =
   | { kind: "unavailable"; reason?: "not_found" | "server" | RequestFailure };
 
 /**
- * GET /me/workspaces/:name/billing — plan metadata, resolved effective
+ * GET /v1/workspaces/:name/billing — plan metadata, resolved effective
  * limits, usage, and (always-null-for-now) subscription for the billing tab.
  */
 export async function getWorkspaceBilling(
@@ -525,7 +541,7 @@ export async function getWorkspaceBilling(
   name: string,
 ): Promise<WorkspaceBillingResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/billing`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/billing`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable") return result;
@@ -576,7 +592,7 @@ export async function getWorkspaceBilling(
 }
 
 /**
- * POST /me/workspaces/:name/invites — workspace admin|owner invites an email.
+ * POST /v1/workspaces/:name/invites — workspace admin|owner invites an email.
  * Always prefer showing `acceptUrl` (works without outbound email).
  */
 export async function inviteToWorkspace(
@@ -585,7 +601,7 @@ export async function inviteToWorkspace(
   email: string,
 ): Promise<InviteResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/invites`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/invites`,
     {
       method: "POST",
       credentials: "include",
@@ -650,13 +666,13 @@ function manageResultFor(status: number): ManageResult {
   return { kind: "unavailable", reason: "server" };
 }
 
-/** GET /me/workspaces/:name/invites — pending invites, admin/owner only. */
+/** GET /v1/workspaces/:name/invites — pending invites, admin/owner only. */
 export async function getWorkspaceInvites(
   apiOrigin: string,
   name: string,
 ): Promise<WorkspaceInvitesResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/invites`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/invites`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable" || !result.response.ok) return { kind: "unavailable" };
@@ -685,7 +701,7 @@ async function manageMutation(
   return manageResultFor(result.response.status);
 }
 
-/** DELETE /me/workspaces/:name/invites/:id */
+/** DELETE /v1/workspaces/:name/invites/:id */
 export async function revokeWorkspaceInvite(
   apiOrigin: string,
   name: string,
@@ -693,12 +709,12 @@ export async function revokeWorkspaceInvite(
 ): Promise<ManageResult> {
   return manageMutation(
     apiOrigin,
-    `/me/workspaces/${encodeURIComponent(name)}/invites/${encodeURIComponent(inviteId)}`,
+    `/v1/workspaces/${encodeURIComponent(name)}/invites/${encodeURIComponent(inviteId)}`,
     { method: "DELETE" },
   );
 }
 
-/** DELETE /me/workspaces/:name/members/:memberId */
+/** DELETE /v1/workspaces/:name/members/:memberId */
 export async function removeWorkspaceMember(
   apiOrigin: string,
   name: string,
@@ -706,12 +722,12 @@ export async function removeWorkspaceMember(
 ): Promise<ManageResult> {
   return manageMutation(
     apiOrigin,
-    `/me/workspaces/${encodeURIComponent(name)}/members/${encodeURIComponent(memberId)}`,
+    `/v1/workspaces/${encodeURIComponent(name)}/members/${encodeURIComponent(memberId)}`,
     { method: "DELETE" },
   );
 }
 
-/** PATCH /me/workspaces/:name/members/:memberId */
+/** PATCH /v1/workspaces/:name/members/:memberId */
 export async function updateWorkspaceMemberRole(
   apiOrigin: string,
   name: string,
@@ -720,7 +736,7 @@ export async function updateWorkspaceMemberRole(
 ): Promise<ManageResult> {
   return manageMutation(
     apiOrigin,
-    `/me/workspaces/${encodeURIComponent(name)}/members/${encodeURIComponent(memberId)}`,
+    `/v1/workspaces/${encodeURIComponent(name)}/members/${encodeURIComponent(memberId)}`,
     {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -791,7 +807,7 @@ function isSearchFileItem(value: unknown): value is SearchFileItem {
   );
 }
 
-/** GET /me/workspaces/:name/files/search — session-authed metadata + name search. */
+/** GET /v1/workspaces/:name/files/search — session-authed metadata + name search. */
 export async function searchWorkspaceFiles(
   apiOrigin: string,
   name: string,
@@ -800,7 +816,7 @@ export async function searchWorkspaceFiles(
 ): Promise<SearchFilesResult> {
   const params = new URLSearchParams(buildSearchQuery(filters));
   if (opts.name) params.set("name", opts.name);
-  const url = `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/files/search?${params.toString()}`;
+  const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/search?${params.toString()}`;
   const result = await fetchWithTimeout(url, { credentials: "include", cache: "no-store" });
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -864,12 +880,12 @@ function isFilesPathGroup(value: unknown): value is FilesPathGroup {
   );
 }
 
-/** GET /me/workspaces/:name/files/by-path — recent uploads grouped by `path` metadata. */
+/** GET /v1/workspaces/:name/files/by-path — recent uploads grouped by `path` metadata. */
 export async function getWorkspaceFilesByPath(
   apiOrigin: string,
   name: string,
 ): Promise<FilesByPathResult> {
-  const url = `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/files/by-path`;
+  const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/by-path`;
   const result = await fetchWithTimeout(url, { credentials: "include", cache: "no-store" });
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -926,7 +942,7 @@ function isFacetValue(value: unknown): value is FacetValue {
 }
 
 /**
- * GET /me/workspaces/:name/files/facets — which metadata keys this workspace
+ * GET /v1/workspaces/:name/files/facets — which metadata keys this workspace
  * contains. A single `unavailable` kind (no `reason`) is enough here: the
  * filter bar degrades to its syntax hint either way and never surfaces the
  * distinction, unlike a search failure which the user must be told about.
@@ -935,7 +951,7 @@ export async function getWorkspaceFacets(
   apiOrigin: string,
   name: string,
 ): Promise<FacetKeysResult> {
-  const url = `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/files/facets`;
+  const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/facets`;
   const result = await fetchWithTimeout(url, { credentials: "include", cache: "no-store" });
   if (result.kind === "unavailable" || !result.response.ok) return { kind: "unavailable" };
   const body = (await result.response.json().catch(() => null)) as {
@@ -953,13 +969,13 @@ export async function getWorkspaceFacets(
   return { kind: "ok", keys: body.keys, truncated: body.truncated };
 }
 
-/** GET /me/workspaces/:name/files/facets?key= — one key's values. */
+/** GET /v1/workspaces/:name/files/facets?key= — one key's values. */
 export async function getWorkspaceFacetValues(
   apiOrigin: string,
   name: string,
   key: string,
 ): Promise<FacetValuesResult> {
-  const url = `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/files/facets?key=${encodeURIComponent(key)}`;
+  const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/facets?key=${encodeURIComponent(key)}`;
   const result = await fetchWithTimeout(url, { credentials: "include", cache: "no-store" });
   if (result.kind === "unavailable" || !result.response.ok) return { kind: "unavailable" };
   const body = (await result.response.json().catch(() => null)) as {
@@ -1108,7 +1124,7 @@ function toWorkspaceFolderFile(raw: Record<string, unknown>): WorkspaceFolderFil
 }
 
 /**
- * GET /me/workspaces/:name/files?prefix=&cursor=&limit= — folder-aware,
+ * GET /v1/workspaces/:name/files?prefix=&cursor=&limit= — folder-aware,
  * gh.*-metadata-hydrated workspace file listing (commit 0f9ac65). Backs the
  * settings-page files tab's folder browser, so like {@link fetchWorkspaceList}
  * this is a "less central" detail helper: any transport failure, non-2xx, or
@@ -1131,7 +1147,7 @@ export async function listWorkspaceFolder(
   if (opts.cursor !== undefined) params.set("cursor", opts.cursor);
   if (opts.limit !== undefined) params.set("limit", String(opts.limit));
   const query = params.toString();
-  const url = `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(workspace)}/files${query ? `?${query}` : ""}`;
+  const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(workspace)}/files${query ? `?${query}` : ""}`;
 
   const result = await fetchWithTimeout(url, { credentials: "include", cache: "no-store" });
   if (result.kind === "unavailable" || !result.response.ok) return emptyFolderListing();
@@ -1195,13 +1211,13 @@ function toCommentSettings(body: unknown): CommentSettings | null {
   };
 }
 
-/** GET /me/workspaces/:name/comment-settings — admin/owner only. */
+/** GET /v1/workspaces/:name/comment-settings — admin/owner only. */
 export async function getWorkspaceCommentSettings(
   apiOrigin: string,
   name: string,
 ): Promise<CommentSettingsResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/comment-settings`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/comment-settings`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable") return result;
@@ -1220,7 +1236,7 @@ export type CommentSettingsPatchResult =
   | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
 
 /**
- * PATCH /me/workspaces/:name/comment-settings. `patch` is partial — an
+ * PATCH /v1/workspaces/:name/comment-settings. `patch` is partial — an
  * omitted key leaves the field unchanged server-side, an explicit `null`
  * clears it. On a 400 the server's `error.message` is surfaced verbatim
  * (already a complete sentence naming the offending field/bounds) so the
@@ -1232,7 +1248,7 @@ export async function patchWorkspaceCommentSettings(
   patch: Partial<CommentSettings>,
 ): Promise<CommentSettingsPatchResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/comment-settings`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/comment-settings`,
     {
       method: "PATCH",
       credentials: "include",
@@ -1389,7 +1405,7 @@ export type WorkspaceStorageStatusResult =
   | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
 
 /**
- * GET /me/workspaces/:name/storage — admin/owner only, but readable
+ * GET /v1/workspaces/:name/storage — admin/owner only, but readable
  * regardless of `byoBucketEnabled` so the settings panel can decide whether
  * to reveal itself at all (mirrors `loadCommentSettings`'s
  * hidden-until-`ok` convention in settings.astro).
@@ -1399,7 +1415,7 @@ export async function getWorkspaceStorageStatus(
   name: string,
 ): Promise<WorkspaceStorageStatusResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/storage`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/storage`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable") return result;
@@ -1472,7 +1488,7 @@ export type StorageVerifyApiResult =
   | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
 
 /**
- * POST /me/workspaces/:name/storage/verify — runs the server-side probe
+ * POST /v1/workspaces/:name/storage/verify — runs the server-side probe
  * pipeline against `candidate` without persisting anything (step 3 of the
  * connect wizard). 403 means `byoBucketEnabled` is off for this workspace.
  */
@@ -1482,7 +1498,7 @@ export async function verifyWorkspaceStorage(
   candidate: StorageCandidate,
 ): Promise<StorageVerifyApiResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/storage/verify`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/storage/verify`,
     {
       method: "POST",
       credentials: "include",
@@ -1510,7 +1526,7 @@ export type StorageSaveResult =
   | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
 
 /**
- * PUT /me/workspaces/:name/storage — attach or rotate a BYO config. The
+ * PUT /v1/workspaces/:name/storage — attach or rotate a BYO config. The
  * server re-verifies `candidate` itself (never trusts a client-side
  * "verified" claim), so a 422 here carries a fresh `StorageVerifyResult`
  * the wizard can render exactly like the standalone verify call's.
@@ -1521,7 +1537,7 @@ export async function putWorkspaceStorage(
   candidate: StorageCandidate,
 ): Promise<StorageSaveResult> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/storage`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/storage`,
     {
       method: "PUT",
       credentials: "include",
@@ -1561,7 +1577,7 @@ export type StorageDetachResult =
   | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
 
 /**
- * DELETE /me/workspaces/:name/storage — detach BYO storage and restore
+ * DELETE /v1/workspaces/:name/storage — detach BYO storage and restore
  * shared-bucket defaults. `force: true` bypasses the empty-bucket guard
  * (caller must have already confirmed with the user — never touches the
  * customer's bucket or its objects either way).
@@ -1573,7 +1589,7 @@ export async function deleteWorkspaceStorage(
 ): Promise<StorageDetachResult> {
   const qs = opts.force ? "?force=true" : "";
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/storage${qs}`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/storage${qs}`,
     { method: "DELETE", credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable") return result;

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -688,7 +688,7 @@ const ogImage = file
       // gate parallel to the server-side one this page already applied via
       // fetchPublicFile()/objectVisibility (apps/api's GET /public/files/...,
       // see apps/api/src/routes/public-files.ts). Both this probe and the
-      // /me/workspaces/:name/file-url resolver it calls must keep enforcing
+      // /v1/workspaces/:name/files/file-url resolver it calls must keep enforcing
       // the same auth_required condition as that server gate, or a signed-out
       // viewer could see one page disagree with the other about access.
       (async function () {
@@ -696,7 +696,7 @@ const ogImage = file
         const checking = document.getElementById("auth-checking");
         try {
           const endpoint = new URL(
-            `/me/workspaces/${encodeURIComponent(workspace)}/file-url`,
+            `/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url`,
             apiOrigin,
           );
           endpoint.searchParams.set("key", key);
@@ -722,13 +722,13 @@ const ogImage = file
       })();
 
       // Member-only delete control (spec 2026-07-30). Reveal is progressive
-      // enhancement: the same /me/workspaces/:name/file-url probe the unlisted
+      // enhancement: the same /v1/workspaces/:name/files/file-url probe the unlisted
       // flow uses doubles as the membership check — 200 means member.
       (async function () {
         const zone = document.getElementById("delete-zone");
         if (!zone) return;
         const endpoint = new URL(
-          `/me/workspaces/${encodeURIComponent(workspace)}/file-url`,
+          `/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url`,
           apiOrigin,
         );
         endpoint.searchParams.set("key", key);
@@ -798,7 +798,7 @@ const ogImage = file
           stepBtn.disabled = true;
           try {
             const target = new URL(
-              `/me/workspaces/${encodeURIComponent(workspace)}/files`,
+              `/v1/workspaces/${encodeURIComponent(workspace)}/files`,
               apiOrigin,
             );
             target.searchParams.set("key", key);


### PR DESCRIPTION
Step 2 of the #613 migration: the web app (first-party client) moves off the legacy `/me/workspaces/:name/...` session paths onto the canonical dual-auth surface `/v1/workspaces/:name/...` established in #615/#616/#617. API untouched — the canonical routes already accept the session cookie with credentialed CORS (since #249's `/v1/workspaces` carve-out).

## Switched (identical handlers via the alias forwarding, so zero response-shape change)

- `api-client.ts`: usage, summary, billing, members, people, invites (create/list/revoke), member remove/role-change, files list (`getMyWorkspaceFiles` + `listWorkspaceFolder`), files search/facets/by-path, visibility PATCH, comment-settings GET/PATCH, storage GET/PUT/DELETE/verify.
- Two deliberate shape adoptions on the canonical surface:
  - `file-url` → `files/file-url` (nested per #615's wart fix);
  - file DELETE goes **path-keyed** (`DELETE .../files/<key>`, segments `encodeURIComponent`-encoded) instead of `?key=` — the exact rewrite the `/me` alias performs server-side.
- Inline call sites: `WorkspaceFileTable`, `ScreenshotsByPath`, `AccountFileBrowser` (file-url), and the `/f/[workspace]/[...key]` page (file-url probes + DELETE).

## Deliberately still on `/me` (no canonical equivalent yet, or a different session projection)

`/me/workspaces` (viewer identity — stays per the issue's end-state), galleries (session shape carries `itemCount`/`references` the canonical list omits), `file-browser`, `github-titles`, `github-status`, `repo-links` (stripped `{repos}` projection), `comment-preview`. These need canonical-route design work before they can move.

## Verification

- `apps/web`: 40 test files, 584 tests green (includes updated `api-client.test.ts` URL expectations).
- `tsc -p tsconfig.worker.json --noEmit` clean after `wrangler types`.
- `astro check` failures are pre-existing on main (TS 7 / @astrojs/check, #610) and none reference the changed files.

Refs #613. Next steps on the issue after this: CLI/MCP move over releases, then alias retirement once telemetry shows the old paths quiet.
