### PR TITLE
feat: project-aware grouping on the screenshots page

### DIFF
--- a/.changeset/screenshots-derived-repo-meta.md
+++ b/.changeset/screenshots-derived-repo-meta.md
@@ -1,0 +1,5 @@
+---
+"uploads": minor
+---
+
+Derive `repo` metadata (owner/name from the git remote) on `put` and `screenshot`, suppressed by `--no-git`.

--- a/apps/api/src/content-hash.ts
+++ b/apps/api/src/content-hash.ts
@@ -47,6 +47,7 @@ export const INHERITABLE_META_KEYS = [
   "captured",
   "state",
   "app",
+  "repo",
 ] as const;
 
 const INHERITABLE_KEY_SET: ReadonlySet<string> = new Set(INHERITABLE_META_KEYS);

--- a/apps/api/src/file-metadata-facets.test.ts
+++ b/apps/api/src/file-metadata-facets.test.ts
@@ -6,6 +6,7 @@ import {
   facetKeys,
   facetValues,
   groupObjectsByPath,
+  projectLabelFromMeta,
   BY_PATH_GROUP_LIMIT,
   BY_PATH_RECENT_LIMIT,
 } from "./file-metadata";
@@ -234,5 +235,27 @@ describe("groupObjectsByPath", () => {
   it("returns empty groups for a workspace with no path metadata", async () => {
     const result = await groupObjectsByPath(timedDb([]), "acme");
     expect(result).toEqual({ groups: [], truncated: false });
+  });
+});
+
+describe("projectLabelFromMeta", () => {
+  it("prefers repo over gh.repo over url origin", () => {
+    expect(
+      projectLabelFromMeta({ repo: "acme/web", ghRepo: "acme/other", url: "https://x.dev/p" }),
+    ).toBe("acme/web");
+    expect(projectLabelFromMeta({ ghRepo: "acme/other", url: "https://x.dev/p" })).toBe(
+      "acme/other",
+    );
+  });
+  it("falls back to the url host, keeping the port", () => {
+    expect(projectLabelFromMeta({ url: "https://uploads.localhost/settings" })).toBe(
+      "uploads.localhost",
+    );
+    expect(projectLabelFromMeta({ url: "http://localhost:3000/admin" })).toBe("localhost:3000");
+  });
+  it("returns Other for missing or unparseable url", () => {
+    expect(projectLabelFromMeta({})).toBe("Other");
+    expect(projectLabelFromMeta({ url: "not a url" })).toBe("Other");
+    expect(projectLabelFromMeta({ repo: null, ghRepo: null, url: null })).toBe("Other");
   });
 });

--- a/apps/api/src/file-metadata-facets.test.ts
+++ b/apps/api/src/file-metadata-facets.test.ts
@@ -182,9 +182,16 @@ describe("groupObjectsByPath", () => {
     );
     expect(result.truncated).toBe(false);
     expect(result.groups).toEqual([
-      { path: "/settings", count: 2, lastUpdated: at(3), recent: ["c.png", "a.png"] },
-      { path: "/home", count: 1, lastUpdated: at(2), recent: ["b.png"] },
+      {
+        project: "Other",
+        path: "/settings",
+        count: 2,
+        lastUpdated: at(3),
+        recent: ["c.png", "a.png"],
+      },
+      { project: "Other", path: "/home", count: 1, lastUpdated: at(2), recent: ["b.png"] },
     ]);
+    expect(result.projects).toEqual([{ label: "Other", count: 3, lastUpdated: at(3) }]);
   });
 
   it("caps recent keys per group at BY_PATH_RECENT_LIMIT but counts all", async () => {
@@ -228,13 +235,51 @@ describe("groupObjectsByPath", () => {
       "acme",
     );
     expect(result.groups).toEqual([
-      { path: "/home", count: 1, lastUpdated: at(1), recent: ["a.png"] },
+      { project: "Other", path: "/home", count: 1, lastUpdated: at(1), recent: ["a.png"] },
     ]);
   });
 
   it("returns empty groups for a workspace with no path metadata", async () => {
     const result = await groupObjectsByPath(timedDb([]), "acme");
-    expect(result).toEqual({ groups: [], truncated: false });
+    expect(result).toEqual({ groups: [], projects: [], truncated: false });
+  });
+
+  it("splits the same path across projects and summarizes projects", async () => {
+    const result = await groupObjectsByPath(
+      db([
+        { workspace: "acme", key: "a.png", meta: { path: "/admin", repo: "acme/web" } },
+        { workspace: "acme", key: "b.png", meta: { path: "/admin", "gh.repo": "acme/api" } },
+        { workspace: "acme", key: "c.png", meta: { path: "/admin", url: "https://x.dev/admin" } },
+        { workspace: "acme", key: "d.png", meta: { path: "/other", repo: "acme/web" } },
+      ]),
+      "acme",
+    );
+    expect(result.groups.map((g) => [g.project, g.path, g.count])).toEqual(
+      expect.arrayContaining([
+        ["acme/web", "/admin", 1],
+        ["acme/api", "/admin", 1],
+        ["x.dev", "/admin", 1],
+        ["acme/web", "/other", 1],
+      ]),
+    );
+    expect(result.groups).toHaveLength(4);
+    const labels = result.projects.map((p) => p.label).sort();
+    expect(labels).toEqual(["acme/api", "acme/web", "x.dev"]);
+    expect(result.projects.find((p) => p.label === "acme/web")?.count).toBe(2);
+  });
+
+  it("prefers repo over gh.repo over url when a file has several", async () => {
+    const result = await groupObjectsByPath(
+      db([
+        {
+          workspace: "acme",
+          key: "a.png",
+          meta: { path: "/p", repo: "acme/web", "gh.repo": "acme/api", url: "https://x.dev/p" },
+        },
+      ]),
+      "acme",
+    );
+    expect(result.groups[0]).toMatchObject({ project: "acme/web", path: "/p" });
   });
 });
 

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -721,6 +721,31 @@ export async function groupObjectsByPath(
   return { groups, truncated };
 }
 
+/**
+ * Project label for the screenshots page (spec:
+ * docs/superpowers/specs/2026-08-11-screenshots-project-grouping-design.md).
+ * Coalesces repo → gh.repo → url origin → "Other". Display/grouping only —
+ * never stored. Mirrored (with identical cases) by
+ * apps/web/src/lib/workspace-screenshots.ts.
+ */
+export function projectLabelFromMeta(meta: {
+  repo?: string | null;
+  ghRepo?: string | null;
+  url?: string | null;
+}): string {
+  if (meta.repo) return meta.repo;
+  if (meta.ghRepo) return meta.ghRepo;
+  if (meta.url) {
+    try {
+      const host = new URL(meta.url).host;
+      if (host) return host;
+    } catch {
+      // fall through — an unparseable url is just "no url"
+    }
+  }
+  return "Other";
+}
+
 export type FacetKeysResult = {
   keys: Array<{ key: string; count: number; distinctValues: number }>;
   truncated: boolean;

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -660,65 +660,92 @@ export const BY_PATH_GROUP_LIMIT = 50;
 export const BY_PATH_RECENT_LIMIT = 6;
 
 export type PathGroup = {
+  project: string;
   path: string;
   count: number;
   lastUpdated: string;
   recent: string[];
 };
 
+export type ProjectSummary = { label: string; count: number; lastUpdated: string };
+
 /**
- * Recent uploads grouped by their `path` metadata value — the screenshots
- * page's one query (spec: docs/superpowers/specs/2026-08-10-screenshots-by-path-design.md).
+ * Recent uploads grouped by (project, path) — the screenshots page's one
+ * query (spec: docs/superpowers/specs/2026-08-11-screenshots-project-grouping-design.md).
  * Groups come back most-recently-active first, each carrying its newest
- * BY_PATH_RECENT_LIMIT keys and total count.
+ * BY_PATH_RECENT_LIMIT keys and total count. `projects` summarizes the same
+ * data by project label alone, most-recent first.
  *
- * One windowed statement over the `path` rows only (seeked via
- * `file_metadata_lookup_idx (workspace, meta_key, meta_value)`), so rows-read
- * scales with path-tagged files, not the whole metadata table. For `path`
- * rows `updated_at` is effectively upload time — the key is written at
- * upload — which is what "recent" should mean here. The group cap is applied
- * while assembling (rows arrive grouped), keeping the newest groups.
+ * One flat scan of the `path` rows (seeked via `file_metadata_lookup_idx
+ * (workspace, meta_key, meta_value)`), with the three project-label keys
+ * pulled per object via correlated subselects on the same (workspace,
+ * object_key) index. Rows-read still scales with path-tagged files, not the
+ * whole metadata table. Grouping/windowing moves to JS because the group key
+ * (project label) is a coalesce SQL can't express cleanly — rows arrive
+ * newest-first, so first-seen order is the recency order.
  */
 export async function groupObjectsByPath(
   db: D1Database,
   workspace: string,
-): Promise<{ groups: PathGroup[]; truncated: boolean }> {
+): Promise<{ groups: PathGroup[]; projects: ProjectSummary[]; truncated: boolean }> {
   const result = await db
     .prepare(
-      `SELECT path, object_key, cnt, latest FROM (
-         SELECT meta_value AS path, object_key,
-                ROW_NUMBER() OVER (PARTITION BY meta_value ORDER BY updated_at DESC, object_key ASC) AS rn,
-                COUNT(*) OVER (PARTITION BY meta_value) AS cnt,
-                MAX(updated_at) OVER (PARTITION BY meta_value) AS latest
-         FROM file_metadata
-         WHERE workspace = ? AND meta_key = 'path'
-       )
-       WHERE rn <= ?
-       ORDER BY latest DESC, path ASC, rn ASC`,
+      `SELECT p.meta_value AS path, p.object_key AS object_key, p.updated_at AS updated_at,
+              (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'repo') AS repo,
+              (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'gh.repo') AS gh_repo,
+              (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'url') AS url
+       FROM file_metadata p
+       WHERE p.workspace = ? AND p.meta_key = 'path'
+       ORDER BY p.updated_at DESC, p.object_key ASC`,
     )
-    .bind(workspace, BY_PATH_RECENT_LIMIT)
-    .all<{ path: string; object_key: string; cnt: number; latest: string }>();
+    .bind(workspace)
+    .all<{
+      path: string;
+      object_key: string;
+      updated_at: string;
+      repo: string | null;
+      gh_repo: string | null;
+      url: string | null;
+    }>();
 
   const groups: PathGroup[] = [];
+  const byKey = new Map<string, PathGroup>();
   let truncated = false;
   for (const row of result.results) {
-    const current = groups[groups.length - 1];
-    if (current?.path === row.path) {
-      current.recent.push(row.object_key);
-      continue;
+    const project = projectLabelFromMeta({ repo: row.repo, ghRepo: row.gh_repo, url: row.url });
+    const groupKey = `${project} ${row.path}`;
+    let group = byKey.get(groupKey);
+    if (!group) {
+      if (groups.length === BY_PATH_GROUP_LIMIT) {
+        truncated = true;
+        continue; // existing groups keep counting; new ones are dropped
+      }
+      group = { project, path: row.path, count: 0, lastUpdated: row.updated_at, recent: [] };
+      byKey.set(groupKey, group);
+      groups.push(group);
     }
-    if (groups.length === BY_PATH_GROUP_LIMIT) {
-      truncated = true;
-      break;
-    }
-    groups.push({
-      path: row.path,
-      count: row.cnt,
-      lastUpdated: row.latest,
-      recent: [row.object_key],
-    });
+    group.count += 1;
+    if (group.recent.length < BY_PATH_RECENT_LIMIT) group.recent.push(row.object_key);
   }
-  return { groups, truncated };
+
+  const projectByLabel = new Map<string, ProjectSummary>();
+  for (const group of groups) {
+    const existing = projectByLabel.get(group.project);
+    if (existing) {
+      existing.count += group.count;
+      if (group.lastUpdated > existing.lastUpdated) existing.lastUpdated = group.lastUpdated;
+    } else {
+      projectByLabel.set(group.project, {
+        label: group.project,
+        count: group.count,
+        lastUpdated: group.lastUpdated,
+      });
+    }
+  }
+  const projects = [...projectByLabel.values()].sort((a, b) =>
+    b.lastUpdated.localeCompare(a.lastUpdated),
+  );
+  return { groups, projects, truncated };
 }
 
 /**

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1809,16 +1809,18 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       groups: {
+        project: string;
         path: string;
         count: number;
         lastUpdated: string;
         recent: { key: string; url: string | null; state?: string }[];
       }[];
+      projects: { label: string; count: number; lastUpdated: string }[];
       truncated: boolean;
     };
     expect(body.truncated).toBe(false);
     expect(body.groups).toHaveLength(1);
-    expect(body.groups[0]).toMatchObject({ path: "/settings", count: 2 });
+    expect(body.groups[0]).toMatchObject({ project: "Other", path: "/settings", count: 2 });
     const byKey = Object.fromEntries(body.groups[0]!.recent.map((r) => [r.key, r]));
     expect(byKey["shots/a.png"]).toMatchObject({
       url: "https://storage.uploads.sh/acme/shots/a.png",
@@ -1826,6 +1828,22 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
     });
     // `state` is present only when set — no empty-string placeholder.
     expect(byKey["shots/b.png"]).not.toHaveProperty("state");
+  });
+
+  it("labels groups with a project and returns the projects summary", async () => {
+    const db = metadataDb([
+      { workspace: "acme", key: "w.png", meta: { path: "/admin", repo: "acme/web" } },
+      { workspace: "acme", key: "o.png", meta: { path: "/admin", url: "https://x.dev/admin" } },
+    ]);
+    const env = memberEnv({ workspace: "acme", db, bucket: new FakeR2Bucket(), record: R2_RECORD });
+    const res = await app().request("/me/workspaces/acme/files/by-path", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      groups: { project: string; path: string }[];
+      projects: { label: string; count: number; lastUpdated: string }[];
+    };
+    expect(body.groups.map((g) => g.project).sort()).toEqual(["acme/web", "x.dev"]);
+    expect(body.projects.map((p) => p.label).sort()).toEqual(["acme/web", "x.dev"]);
   });
 
   it("returns empty groups for a workspace with no path metadata", async () => {
@@ -1837,7 +1855,7 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
     });
     const res = await app().request("/me/workspaces/acme/files/by-path", {}, env);
     expect(res.status).toBe(200);
-    expect((await res.json()) as unknown).toEqual({ groups: [], truncated: false });
+    expect((await res.json()) as unknown).toEqual({ groups: [], projects: [], truncated: false });
   });
 
   it("404s for a workspace the caller is not a member of", async () => {

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -127,7 +127,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   .get("/:workspace/files/by-path", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
     const record = c.get("workspace");
     const name = c.get("workspaceName");
-    const { groups, truncated } = await groupObjectsByPath(c.env.DB, name); // `projects` unused pending the next task
+    const { groups, projects, truncated } = await groupObjectsByPath(c.env.DB, name);
     const metaByKey = await getMetadataForKeys(
       c.env.DB,
       name,
@@ -138,6 +138,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
 
     return c.json({
       groups: groups.map((group) => ({
+        project: group.project,
         path: group.path,
         count: group.count,
         lastUpdated: group.lastUpdated,
@@ -152,6 +153,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
           };
         }),
       })),
+      projects,
       truncated,
     });
   })

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -127,7 +127,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   .get("/:workspace/files/by-path", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
     const record = c.get("workspace");
     const name = c.get("workspaceName");
-    const { groups, truncated } = await groupObjectsByPath(c.env.DB, name);
+    const { groups, truncated } = await groupObjectsByPath(c.env.DB, name); // `projects` unused pending the next task
     const metaByKey = await getMetadataForKeys(
       c.env.DB,
       name,

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -330,7 +330,7 @@ describe("GET /v1/workspaces/:workspace/files/by-path (dual auth)", () => {
       env,
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ groups: [], truncated: false });
+    expect(await res.json()).toEqual({ groups: [], projects: [], truncated: false });
   });
 
   it("session cookie: reaches the same handler", async () => {
@@ -342,7 +342,7 @@ describe("GET /v1/workspaces/:workspace/files/by-path (dual auth)", () => {
       env,
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ groups: [], truncated: false });
+    expect(await res.json()).toEqual({ groups: [], projects: [], truncated: false });
   });
 });
 

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -22,7 +22,7 @@ import { filePath } from "../lib/public-file";
 import { fetchWithTimeout } from "../lib/request";
 import {
   lastUpdatedLabel,
-  readScreenshotsPath,
+  readScreenshotsView,
   screenshotsSearch,
   shotKindFromKey,
 } from "../lib/workspace-screenshots";
@@ -192,8 +192,8 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
   const [infoRetryNonce, setInfoRetryNonce] = useState(0);
   const [overview, setOverview] = useState<OverviewState>({ status: "loading" });
   const [overviewRetryNonce, setOverviewRetryNonce] = useState(0);
-  const [drillPath, setDrillPath] = useState<string>(() =>
-    readScreenshotsPath(window.location.search),
+  const [drillPath, setDrillPath] = useState<string>(
+    () => readScreenshotsView(window.location.search).path,
   );
   const [drill, setDrill] = useState<DrillState>({ status: "idle" });
   const [drillRetryNonce, setDrillRetryNonce] = useState(0);
@@ -261,7 +261,7 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
   // same path. Clearing drillPath ("") goes back to the overview without a
   // search fetch.
   useEffect(() => {
-    history.replaceState(null, "", window.location.pathname + screenshotsSearch(drillPath));
+    history.replaceState(null, "", window.location.pathname + screenshotsSearch("", drillPath));
     if (!drillPath) {
       setDrill({ status: "idle" });
       return;

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -375,7 +375,7 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
           className="text-btn"
           onClick={() => setView({ project: view.project, path: "" })}
         >
-          {view.project ? `← ${view.project}` : "← all paths"}
+          {view.project ? `← ${view.project}` : "← all projects"}
         </button>
         <h2 className="wsp-drill__heading">{view.path}</h2>
         {drill.status === "loading" && (
@@ -408,9 +408,26 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
                 />
               ))}
             </div>
-            {drillItems.length === 0 && <p className="wft-end">No screenshots at this path.</p>}
-            {drill.truncated && (
-              <p className="wft-end">Showing the first 100 — narrow the path to see more.</p>
+            {/* The project scope is applied client-side AFTER the search's
+                100-item cap (the origin-labeled fallback can't be expressed
+                as a metadata filter — spec keeps URL-prefix search out of
+                scope), so a truncated response may hide project matches: say
+                so rather than claiming an empty/complete result. */}
+            {drillItems.length === 0 && (
+              <p className="wft-end">
+                {view.project && drill.truncated
+                  ? `None of the first 100 at this path belong to ${view.project} — there may be more beyond that.`
+                  : view.project
+                    ? "No screenshots at this path for this project."
+                    : "No screenshots at this path."}
+              </p>
+            )}
+            {drillItems.length > 0 && drill.truncated && (
+              <p className="wft-end">
+                {view.project
+                  ? "Project filter applied to the first 100 at this path — there may be more."
+                  : "Showing the first 100 — narrow the path to see more."}
+              </p>
             )}
           </>
         )}

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -13,6 +13,7 @@ import {
   searchWorkspaceFiles,
   type FilesPathGroup,
   type PathGroupItem,
+  type ProjectSummary,
   type SearchFileItem,
 } from "../lib/api-client";
 import { loadWorkspaces } from "../lib/workspaces-nav";
@@ -22,10 +23,14 @@ import { filePath } from "../lib/public-file";
 import { fetchWithTimeout } from "../lib/request";
 import {
   lastUpdatedLabel,
+  projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
   shotKindFromKey,
 } from "../lib/workspace-screenshots";
+
+/** How many path groups a project section previews before "view project →". */
+const PREVIEW_PATHS_PER_PROJECT = 3;
 
 interface ScreenshotsByPathProps {
   apiOrigin: string;
@@ -35,7 +40,12 @@ interface ScreenshotsByPathProps {
 type OverviewState =
   | { status: "loading" }
   | { status: "error" }
-  | { status: "ready"; groups: FilesPathGroup[]; truncated: boolean };
+  | {
+      status: "ready";
+      groups: FilesPathGroup[];
+      projects: ProjectSummary[];
+      truncated: boolean;
+    };
 
 type DrillState =
   | { status: "idle" }
@@ -192,8 +202,8 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
   const [infoRetryNonce, setInfoRetryNonce] = useState(0);
   const [overview, setOverview] = useState<OverviewState>({ status: "loading" });
   const [overviewRetryNonce, setOverviewRetryNonce] = useState(0);
-  const [drillPath, setDrillPath] = useState<string>(
-    () => readScreenshotsView(window.location.search).path,
+  const [view, setView] = useState<{ project: string; path: string }>(() =>
+    readScreenshotsView(window.location.search),
   );
   const [drill, setDrill] = useState<DrillState>({ status: "idle" });
   const [drillRetryNonce, setDrillRetryNonce] = useState(0);
@@ -224,7 +234,12 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
         if (cancelled) return;
         setOverview(
           result.kind === "ok"
-            ? { status: "ready", groups: result.groups, truncated: result.truncated }
+            ? {
+                status: "ready",
+                groups: result.groups,
+                projects: result.projects,
+                truncated: result.truncated,
+              }
             : { status: "error" },
         );
       });
@@ -258,18 +273,23 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
   }, [apiOrigin, workspace]);
 
   // Drill-in fetch — URL-synced so a reload or shared link lands on the
-  // same path. Clearing drillPath ("") goes back to the overview without a
-  // search fetch.
+  // same view. Clearing view.path ("") goes back to the overview/project
+  // view without a search fetch. Bare legacy `?path=` links keep working —
+  // they simply carry an empty view.project, so no project filter applies.
   useEffect(() => {
-    history.replaceState(null, "", window.location.pathname + screenshotsSearch("", drillPath));
-    if (!drillPath) {
+    history.replaceState(
+      null,
+      "",
+      window.location.pathname + screenshotsSearch(view.project, view.path),
+    );
+    if (!view.path) {
       setDrill({ status: "idle" });
       return;
     }
     let cancelled = false;
     setDrill({ status: "loading" });
     onSession(() => {
-      void searchWorkspaceFiles(apiOrigin, workspace, [{ key: "path", value: drillPath }]).then(
+      void searchWorkspaceFiles(apiOrigin, workspace, [{ key: "path", value: view.path }]).then(
         (result) => {
           if (cancelled) return;
           setDrill(
@@ -283,7 +303,7 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
     return () => {
       cancelled = true;
     };
-  }, [apiOrigin, workspace, drillPath, drillRetryNonce]);
+  }, [apiOrigin, workspace, view.project, view.path, drillRetryNonce]);
 
   if (info.status === "loading" || overview.status === "loading") {
     return <OverviewLoadingSkeleton />;
@@ -327,15 +347,37 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
 
   const open = (file: { key: string; pageUrl?: string }) =>
     openFile(apiOrigin, workspace, info.hasPublicUrl, file);
+  const onDrill = (group: { project: string; path: string }) =>
+    setView({ project: group.project, path: group.path });
 
-  // Drill-in view.
-  if (drillPath) {
+  // GitHub items bucketed by project label, for both the overview's
+  // per-project strips and the project view's full "From GitHub" section.
+  const ghByProject = new Map<string, SearchFileItem[]>();
+  if (ghState.status === "ready") {
+    for (const item of ghState.items) {
+      const label = projectLabelFromItemMeta(item.metadata);
+      ghByProject.set(label, [...(ghByProject.get(label) ?? []), item]);
+    }
+  }
+
+  // Drill-in view (?path=, optionally scoped to ?project=).
+  if (view.path) {
+    const drillItems =
+      drill.status === "ready"
+        ? view.project === ""
+          ? drill.items
+          : drill.items.filter((item) => projectLabelFromItemMeta(item.metadata) === view.project)
+        : [];
     return (
       <div className="wsp">
-        <button type="button" className="text-btn" onClick={() => setDrillPath("")}>
-          ← all paths
+        <button
+          type="button"
+          className="text-btn"
+          onClick={() => setView({ project: view.project, path: "" })}
+        >
+          {view.project ? `← ${view.project}` : "← all paths"}
         </button>
-        <h2 className="wsp-drill__heading">{drillPath}</h2>
+        <h2 className="wsp-drill__heading">{view.path}</h2>
         {drill.status === "loading" && (
           <div className="wsp-grid" aria-busy="true">
             {Array.from({ length: 8 }, (_, i) => (
@@ -358,7 +400,7 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
         {drill.status === "ready" && (
           <>
             <div className="wsp-grid">
-              {drill.items.map((item) => (
+              {drillItems.map((item) => (
                 <ShotThumb
                   key={item.key}
                   item={{ ...item, state: item.metadata?.state }}
@@ -366,7 +408,7 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
                 />
               ))}
             </div>
-            {drill.items.length === 0 && <p className="wft-end">No screenshots at this path.</p>}
+            {drillItems.length === 0 && <p className="wft-end">No screenshots at this path.</p>}
             {drill.truncated && (
               <p className="wft-end">Showing the first 100 — narrow the path to see more.</p>
             )}
@@ -376,16 +418,56 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
     );
   }
 
-  // Overview: by-path groups, or the empty state when no path-tagged
-  // screenshots exist at all — either way, the GitHub section (when
-  // non-empty) still renders below it, since GitHub-ingested files carry no
-  // `path` metadata and would otherwise never surface in a GitHub-only
-  // workspace.
-  const showGh = ghState.status === "ready" && ghState.items.length > 0;
+  // Project view (?project=, no ?path=): every path group and the full
+  // GitHub strip for a single project, no preview truncation.
+  if (view.project) {
+    const projectGroups = overview.groups.filter((group) => group.project === view.project);
+    const projectGh = ghByProject.get(view.project);
+    const isEmpty = projectGroups.length === 0 && !projectGh;
+    return (
+      <div className="wsp">
+        <button
+          type="button"
+          className="text-btn"
+          onClick={() => setView({ project: "", path: "" })}
+        >
+          ← all projects
+        </button>
+        <h2 className="wsp-drill__heading">{view.project}</h2>
+        {isEmpty ? (
+          <div className="ws-empty-state">
+            <p className="ws-empty-state__title">No screenshots for this project</p>
+            <p className="ws-empty-state__body">
+              <code>uploads screenshot</code> records the page it captured automatically, and any
+              upload can pass <code>--meta path=/settings</code> to group here. See{" "}
+              <a href="/docs">the docs</a> for details.
+            </p>
+          </div>
+        ) : (
+          <>
+            {projectGroups.map((group) => (
+              <PathGroupSection key={group.path} group={group} onDrill={onDrill} onOpen={open} />
+            ))}
+            {projectGh && <GitHubSection items={projectGh} onOpen={open} />}
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // Overview: one section per project (recency-ordered API projects, then
+  // GH-only labels), each with a preview of its path groups plus its
+  // "From GitHub" strip when present. The empty state shows only when there
+  // are no sections at all — a project with only GitHub-mirrored files (no
+  // `path` metadata) still gets a section via ghByProject.
+  const sectionLabels = [
+    ...overview.projects.map((p) => p.label),
+    ...[...ghByProject.keys()].filter((label) => !overview.projects.some((p) => p.label === label)),
+  ];
 
   return (
     <div className="wsp">
-      {overview.groups.length === 0 ? (
+      {sectionLabels.length === 0 ? (
         <div className="ws-empty-state">
           <p className="ws-empty-state__title">No screenshots with a path yet</p>
           <p className="ws-empty-state__body">
@@ -396,15 +478,70 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
         </div>
       ) : (
         <>
-          {overview.groups.map((group) => (
-            <PathGroupSection key={group.path} group={group} onDrill={setDrillPath} onOpen={open} />
-          ))}
+          {sectionLabels.map((label) => {
+            const projectSummary = overview.projects.find((p) => p.label === label);
+            const groups = overview.groups.filter((group) => group.project === label);
+            const ghItems = ghByProject.get(label);
+            return (
+              <ProjectSection
+                key={label}
+                label={label}
+                summary={projectSummary}
+                groups={groups.slice(0, PREVIEW_PATHS_PER_PROJECT)}
+                ghItems={ghItems}
+                onViewProject={() => setView({ project: label, path: "" })}
+                onDrill={onDrill}
+                onOpen={open}
+              />
+            );
+          })}
           {overview.truncated && (
             <p className="wft-end">Showing the most active paths — narrow with a specific path.</p>
           )}
         </>
       )}
-      {showGh && <GitHubSection items={ghState.items} onOpen={open} />}
+    </div>
+  );
+}
+
+function ProjectSection({
+  label,
+  summary,
+  groups,
+  ghItems,
+  onViewProject,
+  onDrill,
+  onOpen,
+}: {
+  label: string;
+  summary: ProjectSummary | undefined;
+  groups: FilesPathGroup[];
+  ghItems: SearchFileItem[] | undefined;
+  onViewProject: () => void;
+  onDrill: (group: { project: string; path: string }) => void;
+  onOpen: (file: PathGroupItem | SearchFileItem) => void;
+}) {
+  // A GH-only label (no by-path groups) has no ProjectSummary — fall back to
+  // the GitHub items' count so the header still reads sensibly.
+  const count = summary?.count ?? ghItems?.length ?? 0;
+  const lastUpdated = summary?.lastUpdated;
+
+  return (
+    <div className="wsp-project">
+      <div className="wsp-project__head">
+        <span className="wsp-project__label">{label}</span>
+        <span className="wsp-group__meta">
+          {count} {count === 1 ? "file" : "files"}
+          {lastUpdated ? ` · ${lastUpdatedLabel(lastUpdated, new Date())}` : ""}
+        </span>
+        <button type="button" className="text-btn wsp-project__viewall" onClick={onViewProject}>
+          view project →
+        </button>
+      </div>
+      {groups.map((group) => (
+        <PathGroupSection key={group.path} group={group} onDrill={onDrill} onOpen={onOpen} />
+      ))}
+      {ghItems && <GitHubSection items={ghItems} onOpen={onOpen} />}
     </div>
   );
 }
@@ -443,12 +580,12 @@ function PathGroupSection({
   onOpen,
 }: {
   group: FilesPathGroup;
-  onDrill: (path: string) => void;
+  onDrill: (group: { project: string; path: string }) => void;
   onOpen: (file: PathGroupItem) => void;
 }) {
   return (
     <div className="wsp-group">
-      <button type="button" className="wsp-group__head" onClick={() => onDrill(group.path)}>
+      <button type="button" className="wsp-group__head" onClick={() => onDrill(group)}>
         <span className="wsp-group__path">{group.path}</span>
         <span className="wsp-group__meta">
           {group.count} {group.count === 1 ? "file" : "files"} ·{" "}

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -317,6 +317,7 @@ describe("searchWorkspaceFiles", () => {
 
 describe("getWorkspaceFilesByPath", () => {
   const GROUP = {
+    project: "acme/web",
     path: "/settings",
     count: 2,
     lastUpdated: "2026-08-09T21:14:03.000Z",
@@ -330,14 +331,20 @@ describe("getWorkspaceFilesByPath", () => {
       { key: "shots/b.png", url: null, embedUrl: null },
     ],
   };
+  const PROJECT = { label: "acme/web", count: 2, lastUpdated: "2026-08-09T21:14:03.000Z" };
 
-  it("returns groups on a well-formed response", async () => {
+  it("returns groups and projects on a well-formed response", async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
-      Response.json({ groups: [GROUP], truncated: false }),
+      Response.json({ groups: [GROUP], projects: [PROJECT], truncated: false }),
     );
     vi.stubGlobal("fetch", fetchMock);
     const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
-    expect(result).toEqual({ kind: "ok", groups: [GROUP], truncated: false });
+    expect(result).toEqual({
+      kind: "ok",
+      groups: [GROUP],
+      projects: [PROJECT],
+      truncated: false,
+    });
     expect(fetchMock.mock.calls[0]![0]).toBe(
       "https://api.uploads.sh/me/workspaces/acme/files/by-path",
     );
@@ -346,10 +353,20 @@ describe("getWorkspaceFilesByPath", () => {
   it("is unavailable on a malformed body", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => Response.json({ groups: [{ path: 1 }] })),
+      vi.fn(async () => Response.json({ groups: [{ path: 1 }], projects: [] })),
     );
     const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
     expect(result.kind).toBe("unavailable");
+  });
+
+  it("is unavailable on malformed projects", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ groups: [GROUP], projects: [{ label: 1 }] })),
+    );
+    const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
+    expect(result.kind).toBe("unavailable");
+    expect((result as { reason: string }).reason).toBe("malformed");
   });
 
   it("is unavailable on a non-2xx response", async () => {

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -353,7 +353,7 @@ describe("getWorkspaceFilesByPath", () => {
   it("is unavailable on a malformed body", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => Response.json({ groups: [{ path: 1 }], projects: [] })),
+      vi.fn(async () => Response.json({ groups: [{ path: 1 }], projects: [], truncated: false })),
     );
     const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
     expect(result.kind).toBe("unavailable");
@@ -362,7 +362,9 @@ describe("getWorkspaceFilesByPath", () => {
   it("is unavailable on malformed projects", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => Response.json({ groups: [GROUP], projects: [{ label: 1 }] })),
+      vi.fn(async () =>
+        Response.json({ groups: [GROUP], projects: [{ label: 1 }], truncated: false }),
+      ),
     );
     const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
     expect(result.kind).toBe("unavailable");

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -831,14 +831,22 @@ export interface PathGroupItem {
 
 /** One `path` metadata value with its recent uploads. */
 export interface FilesPathGroup {
+  project: string;
   path: string;
   count: number;
   lastUpdated: string;
   recent: PathGroupItem[];
 }
 
+/** One project bucket summary alongside the by-path groups. */
+export interface ProjectSummary {
+  label: string;
+  count: number;
+  lastUpdated: string;
+}
+
 export type FilesByPathResult =
-  | { kind: "ok"; groups: FilesPathGroup[]; truncated: boolean }
+  | { kind: "ok"; groups: FilesPathGroup[]; projects: ProjectSummary[]; truncated: boolean }
   | { kind: "unavailable"; reason: RequestFailure | "server" | "malformed" };
 
 function isPathGroupItem(value: unknown): value is PathGroupItem {
@@ -856,11 +864,22 @@ function isFilesPathGroup(value: unknown): value is FilesPathGroup {
   if (!value || typeof value !== "object") return false;
   const group = value as Record<string, unknown>;
   return (
+    typeof group.project === "string" &&
     typeof group.path === "string" &&
     typeof group.count === "number" &&
     typeof group.lastUpdated === "string" &&
     Array.isArray(group.recent) &&
     group.recent.every(isPathGroupItem)
+  );
+}
+
+function isProjectSummary(value: unknown): value is ProjectSummary {
+  if (!value || typeof value !== "object") return false;
+  const project = value as Record<string, unknown>;
+  return (
+    typeof project.label === "string" &&
+    typeof project.count === "number" &&
+    typeof project.lastUpdated === "string"
   );
 }
 
@@ -876,17 +895,20 @@ export async function getWorkspaceFilesByPath(
   if (!response.ok) return { kind: "unavailable", reason: "server" };
   const body = (await response.json().catch(() => null)) as {
     groups?: unknown;
+    projects?: unknown;
     truncated?: unknown;
   } | null;
   if (
     !body ||
     !Array.isArray(body.groups) ||
+    !Array.isArray(body.projects) ||
     typeof body.truncated !== "boolean" ||
-    !body.groups.every(isFilesPathGroup)
+    !body.groups.every(isFilesPathGroup) ||
+    !body.projects.every(isProjectSummary)
   ) {
     return { kind: "unavailable", reason: "malformed" };
   }
-  return { kind: "ok", groups: body.groups, truncated: body.truncated };
+  return { kind: "ok", groups: body.groups, projects: body.projects, truncated: body.truncated };
 }
 
 /** One metadata key present in a workspace, with its file and value counts. */

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   lastUpdatedLabel,
-  readScreenshotsPath,
+  projectLabelFromItemMeta,
+  readScreenshotsView,
   screenshotsSearch,
   shotKindFromKey,
 } from "./workspace-screenshots";
@@ -30,14 +31,34 @@ describe("lastUpdatedLabel", () => {
   });
 });
 
-describe("screenshots path round-trip", () => {
-  it("reads ?path= and ignores its absence", () => {
-    expect(readScreenshotsPath("?path=%2Fsettings")).toBe("/settings");
-    expect(readScreenshotsPath("?other=1")).toBe("");
-    expect(readScreenshotsPath("")).toBe("");
+describe("projectLabelFromItemMeta", () => {
+  // Pinned to the same cases as apps/api projectLabelFromMeta — keep in sync.
+  it("prefers repo over gh.repo over url origin", () => {
+    expect(
+      projectLabelFromItemMeta({ repo: "acme/web", "gh.repo": "acme/api", url: "https://x.dev/p" }),
+    ).toBe("acme/web");
+    expect(projectLabelFromItemMeta({ "gh.repo": "acme/api" })).toBe("acme/api");
+    expect(projectLabelFromItemMeta({ url: "http://localhost:3000/admin" })).toBe("localhost:3000");
   });
-  it("writes a search string that reads back", () => {
-    expect(readScreenshotsPath(screenshotsSearch("/settings"))).toBe("/settings");
-    expect(screenshotsSearch("")).toBe("");
+  it("returns Other for missing/unparseable", () => {
+    expect(projectLabelFromItemMeta(undefined)).toBe("Other");
+    expect(projectLabelFromItemMeta({})).toBe("Other");
+    expect(projectLabelFromItemMeta({ url: "not a url" })).toBe("Other");
+  });
+});
+
+describe("screenshots view URL state", () => {
+  it("round-trips project and path", () => {
+    expect(readScreenshotsView("?project=acme%2Fweb&path=%2Fadmin")).toEqual({
+      project: "acme/web",
+      path: "/admin",
+    });
+    expect(screenshotsSearch("acme/web", "/admin")).toBe("?project=acme%2Fweb&path=%2Fadmin");
+    expect(screenshotsSearch("acme/web", "")).toBe("?project=acme%2Fweb");
+    expect(screenshotsSearch("", "")).toBe("");
+  });
+  it("keeps legacy bare ?path= links working", () => {
+    expect(readScreenshotsView("?path=%2Fadmin")).toEqual({ project: "", path: "/admin" });
+    expect(screenshotsSearch("", "/admin")).toBe("?path=%2Fadmin");
   });
 });

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -34,15 +34,37 @@ export function lastUpdatedLabel(iso: string, now: Date): string {
   return `${MONTHS[then.getUTCMonth()]} ${then.getUTCDate()}`;
 }
 
-/** `?path=` drill-in value, "" when absent. */
-export function readScreenshotsPath(search: string): string {
-  return new URLSearchParams(search.startsWith("?") ? search.slice(1) : search).get("path") ?? "";
+/**
+ * Client mirror of the API's projectLabelFromMeta (apps/api/src/file-metadata.ts)
+ * — reimplemented per this page's convention; test cases pinned to the same
+ * fixtures on both sides. Used to bucket search results and GitHub items
+ * into their project sections.
+ */
+export function projectLabelFromItemMeta(meta: Record<string, string> | undefined): string {
+  if (meta?.repo) return meta.repo;
+  if (meta?.["gh.repo"]) return meta["gh.repo"];
+  if (meta?.url) {
+    try {
+      const host = new URL(meta.url).host;
+      if (host) return host;
+    } catch {
+      // unparseable url is just "no url"
+    }
+  }
+  return "Other";
 }
 
-/** Search string for a drill-in URL ("" clears back to the overview). */
-export function screenshotsSearch(path: string): string {
-  if (!path) return "";
+/** `?project=` / `?path=` view state, "" when absent. */
+export function readScreenshotsView(search: string): { project: string; path: string } {
+  const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
+  return { project: params.get("project") ?? "", path: params.get("path") ?? "" };
+}
+
+/** Search string for a view ("" for both clears back to the overview). */
+export function screenshotsSearch(project: string, path: string): string {
   const params = new URLSearchParams();
-  params.set("path", path);
-  return `?${params.toString()}`;
+  if (project) params.set("project", project);
+  if (path) params.set("path", path);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
 }

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1780,6 +1780,35 @@ button.wft-card__name:focus-visible {
   display: grid;
   gap: 24px;
 }
+/* Overview project section — one level up from .wsp-group, so its head
+   reads slightly larger and its children (.wsp-group rows) sit stacked
+   underneath with the same rhythm as the rest of the page. */
+.wsp-project {
+  display: grid;
+  gap: 16px;
+}
+.wsp-project__head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  width: 100%;
+}
+.wsp-project__label {
+  font-weight: 600;
+  font-size: 15px;
+}
+.wsp-project__viewall {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 11.5px;
+  white-space: nowrap;
+  padding: 0;
+}
+.wsp-project__viewall:hover,
+.wsp-project__viewall:focus-visible {
+  color: var(--fg);
+}
+
 .wsp-group {
   display: grid;
   gap: 10px;

--- a/docs/superpowers/plans/2026-08-11-screenshots-project-grouping.md
+++ b/docs/superpowers/plans/2026-08-11-screenshots-project-grouping.md
@@ -1,0 +1,683 @@
+# Project-Aware Screenshots Grouping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Group the Screenshots page by project (repo/origin) so paths from different repos stop interleaving, and start recording the capturing git repo as derived `repo` metadata.
+
+**Architecture:** A project label (`repo` ?? `gh.repo` ?? origin from `url` ?? `"Other"`) is computed server-side inside the existing `files/by-path` aggregation, which now groups by (project, path) and returns a `projects` summary array. The web page renders nested per-project sections (overview), a `?project=` filtered view, and filters path drill-ins client-side with a small mirrored label helper. The CLI gains a derived `repo` metadata key from the git remote.
+
+**Tech Stack:** TypeScript everywhere. API: Hono on Workers, D1 (`file_metadata` table), vitest with in-process fakes. CLI: `packages/uploads`. Web: Astro + React island, plain CSS.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-screenshots-project-grouping-design.md`
+
+## Global Constraints
+
+- Label precedence exactly: `repo` → `gh.repo` → origin (host) of `url` → literal `"Other"`.
+- Derived `repo` values are `owner/name`, lowercase (matches the `gh.repo` convention), validated by `isValidRepo`.
+- Derived metadata must never fail an upload (`mergeDerivedMeta` semantics: explicit keys win, over-cap derived keys drop silently).
+- `--no-git` (and config `noGit`) suppresses the derived `repo` key; so does the shared derived-meta gate (`derivedMetaEnabled` / `UPLOADS_NO_DERIVED_META`).
+- No new endpoints, no URL-prefix search, no backfill, no alias/merge of origin- vs repo-labeled buckets (spec "Out of scope").
+- Old `?path=`-only links keep working (drill with no project filter).
+- Run tests from the repo root with `pnpm test -- <path>` (plain vitest, unified root runner) or `pnpm --filter <pkg> test -- <file>` per package convention — check nearest package.json if unsure.
+- Commit after every task; no changeset needed for web/api (ignored packages), **add a changeset** for the `uploads` CLI change (Task 4) — a changeset touching only ignored packages poisons the release, so scope it to the `uploads` package only.
+
+---
+
+### Task 1: Server-side project label helper
+
+**Files:**
+
+- Modify: `apps/api/src/file-metadata.ts` (add helper near `groupObjectsByPath`, ~line 655)
+- Test: `apps/api/src/file-metadata-facets.test.ts`
+
+**Interfaces:**
+
+- Produces: `projectLabelFromMeta(meta: { repo?: string | null; ghRepo?: string | null; url?: string | null }): string` — exported from `apps/api/src/file-metadata.ts`. Later tasks (2) call it per row; the web mirror (Task 6) pins the same cases.
+
+- [ ] **Step 1: Write the failing tests** — append to `file-metadata-facets.test.ts`:
+
+```ts
+import { projectLabelFromMeta } from "./file-metadata"; // add to existing import block
+
+describe("projectLabelFromMeta", () => {
+  it("prefers repo over gh.repo over url origin", () => {
+    expect(
+      projectLabelFromMeta({ repo: "acme/web", ghRepo: "acme/other", url: "https://x.dev/p" }),
+    ).toBe("acme/web");
+    expect(projectLabelFromMeta({ ghRepo: "acme/other", url: "https://x.dev/p" })).toBe(
+      "acme/other",
+    );
+  });
+  it("falls back to the url host, keeping the port", () => {
+    expect(projectLabelFromMeta({ url: "https://uploads.localhost/settings" })).toBe(
+      "uploads.localhost",
+    );
+    expect(projectLabelFromMeta({ url: "http://localhost:3000/admin" })).toBe("localhost:3000");
+  });
+  it("returns Other for missing or unparseable url", () => {
+    expect(projectLabelFromMeta({})).toBe("Other");
+    expect(projectLabelFromMeta({ url: "not a url" })).toBe("Other");
+    expect(projectLabelFromMeta({ repo: null, ghRepo: null, url: null })).toBe("Other");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test -- apps/api/src/file-metadata-facets.test.ts`
+Expected: FAIL — `projectLabelFromMeta` is not exported.
+
+- [ ] **Step 3: Implement** in `apps/api/src/file-metadata.ts`:
+
+```ts
+/**
+ * Project label for the screenshots page (spec:
+ * docs/superpowers/specs/2026-08-11-screenshots-project-grouping-design.md).
+ * Coalesces repo → gh.repo → url origin → "Other". Display/grouping only —
+ * never stored. Mirrored (with identical cases) by
+ * apps/web/src/lib/workspace-screenshots.ts.
+ */
+export function projectLabelFromMeta(meta: {
+  repo?: string | null;
+  ghRepo?: string | null;
+  url?: string | null;
+}): string {
+  if (meta.repo) return meta.repo;
+  if (meta.ghRepo) return meta.ghRepo;
+  if (meta.url) {
+    try {
+      const host = new URL(meta.url).host;
+      if (host) return host;
+    } catch {
+      // fall through — an unparseable url is just "no url"
+    }
+  }
+  return "Other";
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm test -- apps/api/src/file-metadata-facets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/file-metadata.ts apps/api/src/file-metadata-facets.test.ts
+git commit -m "feat(api): project label helper for screenshots grouping"
+```
+
+---
+
+### Task 2: Group by (project, path) in the aggregation
+
+**Files:**
+
+- Modify: `apps/api/src/file-metadata.ts:657-722` (`groupObjectsByPath`, `PathGroup`)
+- Test: `apps/api/src/file-metadata-facets.test.ts` (existing `groupObjectsByPath` describe, ~line 170)
+
+**Interfaces:**
+
+- Consumes: `projectLabelFromMeta` (Task 1).
+- Produces: evolved `groupObjectsByPath(db, workspace)` returning
+  `{ groups: PathGroup[]; projects: ProjectSummary[]; truncated: boolean }` where
+  `PathGroup = { project: string; path: string; count: number; lastUpdated: string; recent: string[] }` and
+  `ProjectSummary = { label: string; count: number; lastUpdated: string }` (exported types). `projects` ordered most-recent first; `groups` ordered by group recency as today.
+
+- [ ] **Step 1: Write the failing tests.** In the existing `groupObjectsByPath` describe block, update existing assertions to expect `project` on each group (existing fixtures have no repo/gh.repo/url meta → `project: "Other"`, and `projects: [{ label: "Other", … }]`), and add:
+
+```ts
+it("splits the same path across projects and summarizes projects", async () => {
+  const result = await groupObjectsByPath(
+    metadataDb([
+      { workspace: "acme", key: "a.png", meta: { path: "/admin", repo: "acme/web" } },
+      { workspace: "acme", key: "b.png", meta: { path: "/admin", "gh.repo": "acme/api" } },
+      { workspace: "acme", key: "c.png", meta: { path: "/admin", url: "https://x.dev/admin" } },
+      { workspace: "acme", key: "d.png", meta: { path: "/other", repo: "acme/web" } },
+    ]).DB,
+    "acme",
+  );
+  expect(result.groups.map((g) => [g.project, g.path, g.count])).toEqual(
+    expect.arrayContaining([
+      ["acme/web", "/admin", 1],
+      ["acme/api", "/admin", 1],
+      ["x.dev", "/admin", 1],
+      ["acme/web", "/other", 1],
+    ]),
+  );
+  expect(result.groups).toHaveLength(4);
+  const labels = result.projects.map((p) => p.label).sort();
+  expect(labels).toEqual(["acme/api", "acme/web", "x.dev"]);
+  expect(result.projects.find((p) => p.label === "acme/web")?.count).toBe(2);
+});
+
+it("prefers repo over gh.repo over url when a file has several", async () => {
+  const result = await groupObjectsByPath(
+    metadataDb([
+      {
+        workspace: "acme",
+        key: "a.png",
+        meta: { path: "/p", repo: "acme/web", "gh.repo": "acme/api", url: "https://x.dev/p" },
+      },
+    ]).DB,
+    "acme",
+  );
+  expect(result.groups[0]).toMatchObject({ project: "acme/web", path: "/p" });
+});
+```
+
+(Adapt the `metadataDb(...)` seeding call to however the existing tests in this file construct the fake D1 — reuse their exact helper and `.DB` access pattern.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test -- apps/api/src/file-metadata-facets.test.ts`
+Expected: FAIL — no `project` on groups, no `projects` in result.
+
+- [ ] **Step 3: Reimplement `groupObjectsByPath`.** Replace the windowed single-key SQL with a flat query joining the three label keys per object, then assemble groups in JS (rows arrive newest-first, so first-seen order is the recency order):
+
+```ts
+export type PathGroup = {
+  project: string;
+  path: string;
+  count: number;
+  lastUpdated: string;
+  recent: string[];
+};
+
+export type ProjectSummary = { label: string; count: number; lastUpdated: string };
+
+export async function groupObjectsByPath(
+  db: D1Database,
+  workspace: string,
+): Promise<{ groups: PathGroup[]; projects: ProjectSummary[]; truncated: boolean }> {
+  // One flat scan of the `path` rows (seeked via file_metadata_lookup_idx),
+  // with the three project-label keys pulled per object via correlated
+  // subselects on the same (workspace, object_key) index. Rows-read still
+  // scales with path-tagged files. Grouping/windowing moves to JS because
+  // the group key (project label) is a coalesce SQL can't express cleanly.
+  const result = await db
+    .prepare(
+      `SELECT p.meta_value AS path, p.object_key AS object_key, p.updated_at AS updated_at,
+              (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'repo') AS repo,
+              (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'gh.repo') AS gh_repo,
+              (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'url') AS url
+       FROM file_metadata p
+       WHERE p.workspace = ? AND p.meta_key = 'path'
+       ORDER BY p.updated_at DESC, p.object_key ASC`,
+    )
+    .bind(workspace)
+    .all<{
+      path: string;
+      object_key: string;
+      updated_at: string;
+      repo: string | null;
+      gh_repo: string | null;
+      url: string | null;
+    }>();
+
+  const groups: PathGroup[] = [];
+  const byKey = new Map<string, PathGroup>();
+  let truncated = false;
+  for (const row of result.results) {
+    const project = projectLabelFromMeta({ repo: row.repo, ghRepo: row.gh_repo, url: row.url });
+    const groupKey = `${project} ${row.path}`;
+    let group = byKey.get(groupKey);
+    if (!group) {
+      if (groups.length === BY_PATH_GROUP_LIMIT) {
+        truncated = true;
+        continue; // existing groups keep counting; new ones are dropped
+      }
+      group = { project, path: row.path, count: 0, lastUpdated: row.updated_at, recent: [] };
+      byKey.set(groupKey, group);
+      groups.push(group);
+    }
+    group.count += 1;
+    if (group.recent.length < BY_PATH_RECENT_LIMIT) group.recent.push(row.object_key);
+  }
+
+  const projectByLabel = new Map<string, ProjectSummary>();
+  for (const group of groups) {
+    const existing = projectByLabel.get(group.project);
+    if (existing) {
+      existing.count += group.count;
+      if (group.lastUpdated > existing.lastUpdated) existing.lastUpdated = group.lastUpdated;
+    } else {
+      projectByLabel.set(group.project, {
+        label: group.project,
+        count: group.count,
+        lastUpdated: group.lastUpdated,
+      });
+    }
+  }
+  const projects = [...projectByLabel.values()].sort((a, b) =>
+    b.lastUpdated.localeCompare(a.lastUpdated),
+  );
+  return { groups, projects, truncated };
+}
+```
+
+Update the doc comment above the function to reference the new spec.
+
+- [ ] **Step 4: Run to verify pass** (both new and pre-existing cases)
+
+Run: `pnpm test -- apps/api/src/file-metadata-facets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/file-metadata.ts apps/api/src/file-metadata-facets.test.ts
+git commit -m "feat(api): group screenshots by (project, path)"
+```
+
+---
+
+### Task 3: Route returns project + projects
+
+**Files:**
+
+- Modify: `apps/api/src/routes/workspace-files.ts:127-157` (the `files/by-path` handler)
+- Test: `apps/api/src/routes/me.test.ts` (existing by-path describe, ~line 1800)
+
+**Interfaces:**
+
+- Consumes: Task 2's return shape.
+- Produces: response JSON `{ groups: [{ project, path, count, lastUpdated, recent: [...] }], projects: [{ label, count, lastUpdated }], truncated }`. Task 5's client parser depends on exactly these field names.
+
+- [ ] **Step 1: Write the failing test** — in the by-path describe in `me.test.ts`:
+
+```ts
+it("labels groups with a project and returns the projects summary", async () => {
+  const db = metadataDb([
+    { workspace: "acme", key: "w.png", meta: { path: "/admin", repo: "acme/web" } },
+    { workspace: "acme", key: "o.png", meta: { path: "/admin", url: "https://x.dev/admin" } },
+  ]);
+  const env = memberEnv({ workspace: "acme", db, bucket: new FakeR2Bucket(), record: R2_RECORD });
+  const res = await app().request("/me/workspaces/acme/files/by-path", {}, env);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as {
+    groups: { project: string; path: string }[];
+    projects: { label: string; count: number; lastUpdated: string }[];
+  };
+  expect(body.groups.map((g) => g.project).sort()).toEqual(["acme/web", "x.dev"]);
+  expect(body.projects.map((p) => p.label).sort()).toEqual(["acme/web", "x.dev"]);
+});
+```
+
+Also update the existing by-path test's expectation: its fixture (path-only meta) now yields `groups[0].project === "Other"`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test -- apps/api/src/routes/me.test.ts`
+Expected: FAIL — no `project`/`projects` in the response.
+
+- [ ] **Step 3: Implement** — in the handler, destructure and pass through:
+
+```ts
+const { groups, projects, truncated } = await groupObjectsByPath(c.env.DB, name);
+// ... unchanged metadata/urls hydration ...
+return c.json({
+  groups: groups.map((group) => ({
+    project: group.project,
+    path: group.path,
+    count: group.count,
+    lastUpdated: group.lastUpdated,
+    recent: group.recent.map((key) => {
+      /* unchanged mapping */
+    }),
+  })),
+  projects,
+  truncated,
+});
+```
+
+- [ ] **Step 4: Run to verify pass** — plus the workspace-files token-auth twin if it has its own by-path test (`grep -n "by-path" apps/api/src/routes/*.test.ts`).
+
+Run: `pnpm test -- apps/api/src/routes/me.test.ts apps/api/src/file-metadata-facets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/workspace-files.ts apps/api/src/routes/me.test.ts
+git commit -m "feat(api): by-path response carries project labels"
+```
+
+---
+
+### Task 4: CLI derived `repo` metadata
+
+**Files:**
+
+- Modify: `packages/uploads/src/keys.ts` (new `deriveRepoSlugFromGit` next to `deriveRepoFromGit`)
+- Modify: `packages/uploads/src/metadata-vocab.ts:11-22` (`CANONICAL_META_KEYS`)
+- Modify: `packages/uploads/src/commands.ts` (~line 2255, after the gh/staging/auto metadata branches)
+- Modify: `packages/uploads/src/commands/screenshot.ts:436-439` (`withFacts`)
+- Modify: `packages/uploads/src/mcp/tools.ts` (~line 846 screenshot tool, and the put tool's metadata assembly near line 500)
+- Test: `packages/uploads/test/keys.test.ts`, `packages/uploads/test/commands-put.test.ts`, `packages/uploads/test/commands-screenshot.test.ts`
+- Create: `.changeset/screenshots-derived-repo-meta.md`
+
+**Interfaces:**
+
+- Consumes: `parseRepoFromRemoteUrl` (`packages/uploads/src/github.ts`), `mergeDerivedMeta` (`metadata-vocab.ts`).
+- Produces: `deriveRepoSlugFromGit(run?: (cmd: string, args: string[], input?: string) => string): string | undefined` exported from `keys.ts` — full `owner/name` lowercase slug or undefined. Uploads now carry `repo` metadata when derivable.
+
+- [ ] **Step 1: Write the failing helper tests** in `keys.test.ts`:
+
+```ts
+import { deriveRepoSlugFromGit } from "../src/keys.js"; // extend existing import
+
+describe("deriveRepoSlugFromGit", () => {
+  it("parses ssh and https remotes to a lowercase owner/name slug", () => {
+    expect(deriveRepoSlugFromGit(() => "git@github.com:BuildInternet/Uploads.git\n")).toBe(
+      "buildinternet/uploads",
+    );
+    expect(deriveRepoSlugFromGit(() => "https://github.com/acme/web\n")).toBe("acme/web");
+  });
+  it("returns undefined when git fails or the remote is unparseable", () => {
+    expect(
+      deriveRepoSlugFromGit(() => {
+        throw new Error("not a git repo");
+      }),
+    ).toBeUndefined();
+    expect(deriveRepoSlugFromGit(() => "not-a-remote")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter uploads test -- keys.test.ts` (or root `pnpm test -- packages/uploads/test/keys.test.ts` — match how other CLI tests are run)
+Expected: FAIL — not exported.
+
+- [ ] **Step 3: Implement the helper** in `keys.ts` (import `parseRepoFromRemoteUrl` from `./github.js`):
+
+```ts
+/**
+ * Full `owner/name` slug (lowercase, matching the `gh.repo` convention) from
+ * the cwd's git remote — the derived `repo` metadata value. Unlike
+ * `deriveRepoFromGit` above (key-segment name only), this keeps the owner.
+ */
+export function deriveRepoSlugFromGit(
+  run?: (cmd: string, args: string[], input?: string) => string,
+): string | undefined {
+  try {
+    const url = run
+      ? run("git", ["config", "--get", "remote.origin.url"])
+      : execSync("git config --get remote.origin.url", { encoding: "utf8" });
+    return parseRepoFromRemoteUrl(url)?.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+```
+
+Add `"repo"` to `CANONICAL_META_KEYS` in `metadata-vocab.ts` (alphabetical position irrelevant — append near `url`/`path`).
+
+- [ ] **Step 4: Run helper tests to verify pass**, then **write the failing wiring tests**:
+
+In `commands-put.test.ts` (reuse the file's existing runner-injection pattern — the fake `run` that answers `git config --get remote.origin.url`):
+
+```ts
+it("records derived repo metadata from the git remote", async () => {
+  // seed runner: remote.origin.url → "git@github.com:Acme/Web.git"
+  // run: uploads put <file>
+  // assert: sentMetadata (or the request the fake client captured) includes repo: "acme/web"
+});
+it("suppresses derived repo with --no-git and lets --meta repo= win", async () => {
+  // --no-git run: metadata has no `repo` key
+  // --meta repo=custom/one run: metadata.repo === "custom/one"
+});
+```
+
+In `commands-screenshot.test.ts`, mirror the positive + `--no-git` cases on the screenshot path. Flesh the test bodies out against the file's actual fake-client capture helpers (they exist — see how existing tests assert on uploaded metadata like `path`/`url`).
+
+- [ ] **Step 5: Wire it in.**
+
+`commands.ts` put path — after the `if (ghTarget) { … } else if (stagingTarget) { … } else { … }` metadata assembly (all three branches), add:
+
+```ts
+// Derived `repo` (spec: 2026-08-11-screenshots-project-grouping-design.md):
+// the capturing repo, on every layout including gh/staging. mergeDerivedMeta
+// keeps explicit --meta repo= wins and never breaks the caps.
+if (!noGit && derivedMetaEnabled(parsed.flags, defaults)) {
+  const slug = deriveRepoSlugFromGit(run);
+  if (slug) metadata = mergeDerivedMeta(metadata, { repo: slug });
+}
+```
+
+`commands/screenshot.ts` — extend the derived map at line ~436:
+
+```ts
+const repoSlug = deriveMeta && !noGit ? deriveRepoSlugFromGit(run) : undefined;
+const withFacts = mergeDerivedMeta(explicitMeta, {
+  ...(deriveMeta ? safeCaptureFacts(target, viewport, colorScheme) : {}),
+  ...(repoSlug ? { repo: repoSlug } : {}),
+});
+```
+
+`mcp/tools.ts` — same two insertions on the stdio MCP put and screenshot tools (they run in the caller's cwd; use each tool's existing `noGit` local and runner if one is threaded, else call `deriveRepoSlugFromGit()` bare). Follow the CLI comment convention ("Same derivation the CLI does").
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `pnpm test -- packages/uploads/test/keys.test.ts packages/uploads/test/commands-put.test.ts packages/uploads/test/commands-screenshot.test.ts packages/uploads/test/mcp-screenshot.test.ts`
+Expected: PASS (fix any mcp-screenshot test that pins exact metadata maps).
+
+- [ ] **Step 7: Changeset + commit**
+
+`.changeset/screenshots-derived-repo-meta.md`:
+
+```markdown
+---
+"uploads": minor
+---
+
+Derive `repo` metadata (owner/name from the git remote) on `put` and `screenshot`, suppressed by `--no-git`.
+```
+
+```bash
+git add packages/uploads .changeset/screenshots-derived-repo-meta.md
+git commit -m "feat(cli): derived repo metadata on put and screenshot"
+```
+
+---
+
+### Task 5: Web client types + URL state helpers
+
+**Files:**
+
+- Modify: `apps/web/src/lib/api-client.ts:824-890` (types, guards, parser)
+- Modify: `apps/web/src/lib/workspace-screenshots.ts` (label mirror + URL helpers)
+- Test: `apps/web/src/lib/workspace-screenshots.test.ts` (and the api-client test file if one covers by-path parsing — `grep -n "by-path" apps/web/src/lib/*.test.ts`)
+
+**Interfaces:**
+
+- Consumes: Task 3's response shape.
+- Produces (for Task 6):
+  - `FilesPathGroup` gains `project: string`; `FilesByPathResult` ok-variant gains `projects: ProjectSummary[]` with `interface ProjectSummary { label: string; count: number; lastUpdated: string }`.
+  - `projectLabelFromItemMeta(meta: Record<string, string> | undefined): string` — client mirror of `projectLabelFromMeta`, reading `meta.repo` / `meta["gh.repo"]` / `meta.url`.
+  - `readScreenshotsView(search: string): { project: string; path: string }` (replaces `readScreenshotsPath`) and `screenshotsSearch(project: string, path: string): string` (project param first; "" omits).
+
+- [ ] **Step 1: Write the failing tests** in `workspace-screenshots.test.ts`:
+
+```ts
+describe("projectLabelFromItemMeta", () => {
+  // Pinned to the same cases as apps/api projectLabelFromMeta — keep in sync.
+  it("prefers repo over gh.repo over url origin", () => {
+    expect(
+      projectLabelFromItemMeta({ repo: "acme/web", "gh.repo": "acme/api", url: "https://x.dev/p" }),
+    ).toBe("acme/web");
+    expect(projectLabelFromItemMeta({ "gh.repo": "acme/api" })).toBe("acme/api");
+    expect(projectLabelFromItemMeta({ url: "http://localhost:3000/admin" })).toBe("localhost:3000");
+  });
+  it("returns Other for missing/unparseable", () => {
+    expect(projectLabelFromItemMeta(undefined)).toBe("Other");
+    expect(projectLabelFromItemMeta({})).toBe("Other");
+    expect(projectLabelFromItemMeta({ url: "not a url" })).toBe("Other");
+  });
+});
+
+describe("screenshots view URL state", () => {
+  it("round-trips project and path", () => {
+    expect(readScreenshotsView("?project=acme%2Fweb&path=%2Fadmin")).toEqual({
+      project: "acme/web",
+      path: "/admin",
+    });
+    expect(screenshotsSearch("acme/web", "/admin")).toBe("?project=acme%2Fweb&path=%2Fadmin");
+    expect(screenshotsSearch("acme/web", "")).toBe("?project=acme%2Fweb");
+    expect(screenshotsSearch("", "")).toBe("");
+  });
+  it("keeps legacy bare ?path= links working", () => {
+    expect(readScreenshotsView("?path=%2Fadmin")).toEqual({ project: "", path: "/admin" });
+    expect(screenshotsSearch("", "/admin")).toBe("?path=%2Fadmin");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test -- apps/web/src/lib/workspace-screenshots.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** in `workspace-screenshots.ts` (replacing `readScreenshotsPath`/`screenshotsSearch`):
+
+```ts
+/**
+ * Client mirror of the API's projectLabelFromMeta (apps/api/src/file-metadata.ts)
+ * — reimplemented per this page's convention; test cases pinned to the same
+ * fixtures on both sides. Used to bucket search results and GitHub items
+ * into their project sections.
+ */
+export function projectLabelFromItemMeta(meta: Record<string, string> | undefined): string {
+  if (meta?.repo) return meta.repo;
+  if (meta?.["gh.repo"]) return meta["gh.repo"];
+  if (meta?.url) {
+    try {
+      const host = new URL(meta.url).host;
+      if (host) return host;
+    } catch {
+      // unparseable url is just "no url"
+    }
+  }
+  return "Other";
+}
+
+/** `?project=` / `?path=` view state, "" when absent. */
+export function readScreenshotsView(search: string): { project: string; path: string } {
+  const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
+  return { project: params.get("project") ?? "", path: params.get("path") ?? "" };
+}
+
+/** Search string for a view ("" for both clears back to the overview). */
+export function screenshotsSearch(project: string, path: string): string {
+  const params = new URLSearchParams();
+  if (project) params.set("project", project);
+  if (path) params.set("path", path);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+```
+
+In `api-client.ts`: add `project: string` to `FilesPathGroup` + `isFilesPathGroup`; add
+
+```ts
+export interface ProjectSummary {
+  label: string;
+  count: number;
+  lastUpdated: string;
+}
+```
+
+with a guard (`label`/`count`/`lastUpdated` typeof checks), include `projects: ProjectSummary[]` in the ok-variant of `FilesByPathResult`, and validate/return it in `getWorkspaceFilesByPath` (malformed → `{ kind: "unavailable", reason: "malformed" }`, same as groups).
+
+- [ ] **Step 4: Run to verify pass** — also typecheck the web app since the `readScreenshotsPath` rename breaks `ScreenshotsByPath.tsx` imports until Task 6; if the repo's checks would fail on it, fold the minimal component import fix into this task's commit or squash Tasks 5–6 into one commit at the end of Task 6.
+
+Run: `pnpm test -- apps/web/src/lib/workspace-screenshots.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** (or defer to Task 6's commit if the rename breaks the build)
+
+```bash
+git add apps/web/src/lib/api-client.ts apps/web/src/lib/workspace-screenshots.ts apps/web/src/lib/workspace-screenshots.test.ts
+git commit -m "feat(web): project label mirror + project-aware view state"
+```
+
+---
+
+### Task 6: Overview sections + project view in the component
+
+**Files:**
+
+- Modify: `apps/web/src/components/ScreenshotsByPath.tsx`
+- Modify: `apps/web/src/styles/account-content.css` (`.wsp-*` block)
+
+**Interfaces:**
+
+- Consumes: Task 5's `FilesPathGroup.project`, `projects`, `projectLabelFromItemMeta`, `readScreenshotsView`, `screenshotsSearch`.
+- Produces: the shipped UI. No exports consumed elsewhere.
+
+- [ ] **Step 1: Restructure state.** Replace `drillPath` with a single view state:
+
+```ts
+const [view, setView] = useState<{ project: string; path: string }>(() =>
+  readScreenshotsView(window.location.search),
+);
+```
+
+URL-sync effect becomes `history.replaceState(null, "", window.location.pathname + screenshotsSearch(view.project, view.path))`; the drill fetch keys off `view.path` exactly as before (bare legacy `?path=` still fetches with `view.project === ""`).
+
+- [ ] **Step 2: Overview rendering.** With `overview.groups` now project-labeled and `overview.projects` recency-ordered, plus GitHub items bucketed by `projectLabelFromItemMeta(item.metadata)`:
+
+```ts
+const PREVIEW_PATHS_PER_PROJECT = 3;
+const ghByProject = new Map<string, SearchFileItem[]>();
+if (ghState.status === "ready") {
+  for (const item of ghState.items) {
+    const label = projectLabelFromItemMeta(item.metadata);
+    ghByProject.set(label, [...(ghByProject.get(label) ?? []), item]);
+  }
+}
+// Section order: API projects (recency-ordered), then GH-only labels.
+const sectionLabels = [
+  ...overview.projects.map((p) => p.label),
+  ...[...ghByProject.keys()].filter((l) => !overview.projects.some((p) => p.label === l)),
+];
+```
+
+Each overview section renders: a project header (label + total count + `lastUpdatedLabel`, a "view project →" button calling `setView({ project: label, path: "" })`), the project's first `PREVIEW_PATHS_PER_PROJECT` path groups (existing `PathGroupSection`, whose `onDrill` now calls `setView({ project: group.project, path: group.path })`), and — when `ghByProject.has(label)` — the GitHub strip (existing `GitHubSection` markup, retitled "From GitHub" only inside the section). The empty state keeps its current copy and shows when there are no sections at all.
+
+- [ ] **Step 3: Project view.** When `view.project && !view.path`: render "← all projects" (`setView({ project: "", path: "" })`), an `<h2>` with the label, then **all** of that project's path groups + its GitHub strip. Unknown label → the existing empty-state block with the title "No screenshots for this project". When `view.path`: current drill-in UI, but filter items when a project is set:
+
+```ts
+const drillItems =
+  view.project === ""
+    ? drill.items
+    : drill.items.filter((item) => projectLabelFromItemMeta(item.metadata) === view.project);
+```
+
+Back-link from drill goes to the project view (`setView({ project: view.project, path: "" })`) when a project is set, else to the overview.
+
+- [ ] **Step 4: CSS.** Add to the `.wsp-*` block in `account-content.css`: `.wsp-project` (section spacing), `.wsp-project__head` (flex row: label, meta, view-all — reuse the `.wsp-group__head` pattern one level up, slightly larger type), keeping the design-system tokens the file already uses. Match the existing class naming and custom-property usage — no new colors.
+
+- [ ] **Step 5: Verify in the browser.** Follow the local signed-in recipe (memory: stack-raw on 127.0.0.1 is the only way to get a signed-in in-app-browser session — see `uploads local browser-verify recipe`): seed files across two fake projects (one `repo`-tagged, one url-only), then check overview sections, "view project →", path drill with mixed-project same-path files, legacy `?path=` link, and dark mode. Screenshot the overview for the PR.
+
+- [ ] **Step 6: Full web test + typecheck pass**
+
+Run: `pnpm test -- apps/web` and the repo's web typecheck (`pnpm --filter web typecheck` or as package.json names it).
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/ScreenshotsByPath.tsx apps/web/src/styles/account-content.css
+git commit -m "feat(web): project sections and filtered view on screenshots page"
+```
+
+---
+
+### Task 7: Full-suite verification + PR
+
+- [ ] **Step 1:** `pnpm test` from the repo root — full unified runner. Expected: PASS.
+- [ ] **Step 2:** `pnpm lint` (and `pnpm types` if the repo defines it — note memory: `pnpm types` ≠ typecheck; run the real typecheck target). Expected: clean.
+- [ ] **Step 3:** Push the branch, open a PR against `main` titled "feat: project-aware grouping on the screenshots page", body covering: the label coalesce, the derived `repo` CLI key, the additive by-path shape, and the overview/project-view UX. Embed the Task 6 Step 5 screenshot via the `github-screenshots` skill (front-end change — a visual is warranted). Do not request a CodeRabbit review by default.

--- a/docs/superpowers/specs/2026-08-11-screenshots-project-grouping-design.md
+++ b/docs/superpowers/specs/2026-08-11-screenshots-project-grouping-design.md
@@ -1,0 +1,103 @@
+# Screenshots page: project-aware grouping
+
+Date: 2026-08-11
+Status: approved (brainstormed with Zach)
+Builds on: 2026-08-10-screenshots-by-path-design.md
+
+## Problem
+
+The Screenshots page groups purely by the `path` metadata key. Paths from
+different repos/sites interleave (`/admin/inventory` from one project next to
+`/admin/oauth` from uploads), and same-named paths from different projects
+merge into a single group. There is also no record of which git repo a
+screenshot was captured from — a gap independent of this page.
+
+## Design
+
+### 1. Project label (server-side only)
+
+Each file resolves to a **project label** by coalescing, in order:
+
+1. `repo` metadata (new derived key, below)
+2. `gh.repo` metadata (already present on attached/branch-staged files)
+3. the origin (host) parsed from the `url` metadata
+4. otherwise the literal bucket `"Other"`
+
+The label is computed **only where grouping happens** (the by-path
+aggregation) plus one small mirrored client helper for drill-in filtering
+(see §4). It is a display/grouping label, not stored metadata. No aliasing,
+no localhost→repo inference, no backfill: the same project may appear as an
+origin label for old files and a repo label for new ones; recency resolves
+this over time.
+
+### 2. CLI: derived `repo` key
+
+- Add `repo` to `CANONICAL_META_KEYS` in `packages/uploads/src/metadata-vocab.ts`.
+- Derived at upload time by `uploads screenshot` and `uploads put` from the
+  git remote slug of the cwd: `owner/name`, lowercase — same convention as
+  `gh.repo`.
+- Suppressed by `--no-git` (it is git-derived).
+- Hand-supplied `--meta repo=` wins, per the existing replace-vs-preserve
+  contract. Value validated with the same shape check as `gh.repo`
+  (`isValidRepo`).
+
+### 3. API: project-aware `files/by-path`
+
+Extend the existing `GET /:workspace/files/by-path` aggregation
+(`groupObjectsByPath`) to group by **(project label, path)** instead of path
+alone. Additive response shape:
+
+- each group gains a `project` field (the label);
+- top-level `projects` array: `{ label, count, lastUpdated }`, ordered by
+  recency, so the client can render section headers and the overview's
+  "recently active" ordering without re-deriving.
+
+No new endpoint. Files with no `path` metadata but with GitHub context keep
+surfacing (the current "From GitHub" query) — but the section folds into its
+project by label rather than staying a separate catch-all; the GitHub search
+results are bucketed client-side with the mirrored helper.
+
+### 4. Web UI: overview + project view
+
+Single fetch (the extended by-path payload) drives both views:
+
+- **Overview** (default): one nested section per recently active project,
+  ordered by project recency. Each section previews its top 2–3 path groups
+  (by recency) with a "view project →" link. Same-named paths from different
+  projects no longer merge.
+- **Project view** (`?project=<label>`, URL-synced like `?path=` today):
+  the overview filtered to one project's sections — all of that project's
+  path groups. No new search capability; it is a client-side filter over the
+  same payload.
+- **Path drill-in** (`?project=<label>&path=<path>`): reuses
+  `files/search?meta.path=…`, then filters items to the project label
+  client-side using a small mirrored label helper (coalesce over each item's
+  `repo`/`gh.repo`/`url` metadata, which search already returns). The helper
+  is ~5 lines, duplicated per the page's existing "reimplement rather than
+  export" convention, with tests on both sides pinned to the same cases.
+- Bare `?path=` (old shared links) still works: drill without a project
+  filter.
+
+### Out of scope (deliberate)
+
+- Project renaming/aliasing or merging origin-labeled and repo-labeled
+  buckets for the same project.
+- URL-prefix search affordances on `files/search`.
+- Backfilling `repo` metadata onto existing files.
+- Filter chips beyond the project view itself.
+
+## Error handling
+
+Unchanged from the current page: by-path failure → error callout with retry;
+GitHub search failure renders nothing; drill failure → per-view callout.
+Unknown `?project=` label renders the project view's empty state.
+
+## Testing
+
+- CLI: derived `repo` present/absent (no remote, `--no-git`, hand-supplied
+  override) in the capture-facts/sidecar tests.
+- API: by-path grouping splits same path across projects; precedence
+  (repo > gh.repo > origin > Other); `projects` ordering; origin parsing of
+  bad/missing `url`.
+- Web: label helper parity cases; overview section rendering; project view
+  filtering; URL sync for `?project=` / `?project=&path=`; legacy `?path=`.

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -64,7 +64,7 @@ import {
   upsertAttachmentsComment,
   type CommandRunner,
 } from "./github-gh.js";
-import { deriveRepoFromGit } from "./keys.js";
+import { deriveRepoFromGit, deriveRepoSlugFromGit } from "./keys.js";
 import { resolvePutPrefix } from "./destinations.js";
 import {
   optimizeImageForUpload,
@@ -2253,6 +2253,14 @@ export async function runPut(
         }
       }
     }
+  }
+
+  // Derived `repo` (spec: 2026-08-11-screenshots-project-grouping-design.md):
+  // the capturing repo, on every layout including gh/staging. mergeDerivedMeta
+  // keeps explicit --meta repo= wins and never breaks the caps.
+  if (!noGit && derivedMetaEnabled(parsed.flags, defaults)) {
+    const slug = deriveRepoSlugFromGit(run);
+    if (slug) metadata = mergeDerivedMeta(metadata ?? {}, { repo: slug });
   }
 
   // Bare-put nudge (issue #393): only relevant when staging didn't take over

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -2258,9 +2258,18 @@ export async function runPut(
   // Derived `repo` (spec: 2026-08-11-screenshots-project-grouping-design.md):
   // the capturing repo, on every layout including gh/staging. mergeDerivedMeta
   // keeps explicit --meta repo= wins and never breaks the caps.
-  if (!noGit && derivedMetaEnabled(parsed.flags, defaults)) {
+  //
+  // `metadata === undefined` means "leave whatever's already stored for this
+  // key untouched" (client.ts only sends X-Uploads-Meta-* when the map is
+  // defined; a defined map is a full replace server-side). A bare `uploads
+  // put` with no --meta/gh/staging context leaves `metadata` undefined by
+  // design — never synthesize `{ repo }` there just because a repo happens
+  // to be derivable, or a plain re-upload of an existing key would silently
+  // wipe everything already stored on it. Only fold repo in when `metadata`
+  // is already a defined object for another reason.
+  if (!noGit && derivedMetaEnabled(parsed.flags, defaults) && metadata !== undefined) {
     const slug = deriveRepoSlugFromGit(run);
-    if (slug) metadata = mergeDerivedMeta(metadata ?? {}, { repo: slug });
+    if (slug) metadata = mergeDerivedMeta(metadata, { repo: slug });
   }
 
   // Bare-put nudge (issue #393): only relevant when staging didn't take over

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -40,6 +40,7 @@ import {
   type CommandRunner,
 } from "../github-gh.js";
 import { ghBranchAttachmentKey } from "../github.js";
+import { deriveRepoSlugFromGit } from "../keys.js";
 import { safeCaptureFacts } from "../capture-facts.js";
 import { parseMetaFlags, validateMetaMap } from "../metadata.js";
 import { mergeDerivedMeta } from "../metadata-vocab.js";
@@ -433,10 +434,11 @@ export async function runScreenshot(
   // Explicit input (--meta plus the dedicated flags) wins over capture facts.
   const explicitMeta = { ...metaExtras, ...stateAppMetaFromFlags(parsed.flags) };
   const deriveMeta = derivedMetaEnabled(parsed.flags, putDefaults);
-  const withFacts = mergeDerivedMeta(
-    explicitMeta,
-    deriveMeta ? safeCaptureFacts(target, viewport, colorScheme) : {},
-  );
+  const repoSlug = deriveMeta && !noGit ? deriveRepoSlugFromGit(run) : undefined;
+  const withFacts = mergeDerivedMeta(explicitMeta, {
+    ...(deriveMeta ? safeCaptureFacts(target, viewport, colorScheme) : {}),
+    ...(repoSlug ? { repo: repoSlug } : {}),
+  });
 
   let metadata: Record<string, string> | undefined = withFacts;
   if (ghTarget) {

--- a/packages/uploads/src/keys.ts
+++ b/packages/uploads/src/keys.ts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import { parseRepoFromRemoteUrl } from "./github.js";
 
 export function sanitizeKeySegment(s: string): string {
   return s.replace(/[^A-Za-z0-9._-]/g, "-");
@@ -28,6 +29,24 @@ export function deriveRepoFromGit(
       : execSync("git config --get remote.origin.url", { encoding: "utf8" }).trim();
     const match = url.match(/[/:]([^/]+?)(?:\.git)?$/);
     return match?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Full `owner/name` slug (lowercase, matching the `gh.repo` convention) from
+ * the cwd's git remote — the derived `repo` metadata value. Unlike
+ * `deriveRepoFromGit` above (key-segment name only), this keeps the owner.
+ */
+export function deriveRepoSlugFromGit(
+  run?: (cmd: string, args: string[], input?: string) => string,
+): string | undefined {
+  try {
+    const url = run
+      ? run("git", ["config", "--get", "remote.origin.url"])
+      : execSync("git config --get remote.origin.url", { encoding: "utf8" });
+    return parseRepoFromRemoteUrl(url)?.toLowerCase();
   } catch {
     return undefined;
   }

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -29,6 +29,7 @@ import {
 import { resolvePutPrefix } from "../destinations.js";
 import { ghBranchAttachmentKey, ghKeyPrefix, type GhTarget } from "../github.js";
 import { safeCaptureFacts } from "../capture-facts.js";
+import { deriveRepoSlugFromGit } from "../keys.js";
 import { validateMetaMap } from "../metadata.js";
 import { mergeDerivedMeta } from "../metadata-vocab.js";
 import { type OptimizeImageOptions } from "../optimize.js";
@@ -517,7 +518,16 @@ export function createUploadsMcpTools(opts: {
           repoArg: optString(args, "repo") ?? defaults.repo,
           run,
         });
-        const putMetadata = stagingTarget ? mergeStagingMeta(metadata, stagingTarget) : metadata;
+        // Derived `repo` metadata (spec: 2026-08-11-screenshots-project-grouping-design.md).
+        // Same derivation the CLI does; MCP always derives (no --no-auto), so
+        // this is only suppressed by noGit.
+        const repoSlug = !noGit ? deriveRepoSlugFromGit(run) : undefined;
+        const metadataWithRepo = repoSlug
+          ? mergeDerivedMeta(metadata ?? {}, { repo: repoSlug })
+          : metadata;
+        const putMetadata = stagingTarget
+          ? mergeStagingMeta(metadataWithRepo, stagingTarget)
+          : metadataWithRepo;
 
         const putShared = {
           client,
@@ -848,10 +858,16 @@ export function createUploadsMcpTools(opts: {
           viewport,
           colorSchemeArg as "dark" | "light" | undefined,
         );
+        // Derived `repo` metadata (spec: 2026-08-11-screenshots-project-grouping-design.md).
+        // Same derivation the CLI does, suppressed by noGit.
+        const repoSlug = !noGit ? deriveRepoSlugFromGit(run) : undefined;
+        const captureDerivedWithRepo = repoSlug
+          ? { ...captureDerived, repo: repoSlug }
+          : captureDerived;
         const metadataBase =
-          metadata === undefined && Object.keys(captureDerived).length === 0
+          metadata === undefined && Object.keys(captureDerivedWithRepo).length === 0
             ? undefined
-            : mergeDerivedMeta(metadata ?? {}, captureDerived);
+            : mergeDerivedMeta(metadata ?? {}, captureDerivedWithRepo);
         // gh.* metadata: explicit pr/issue target wins; staging wins the same
         // way (matches attach --branch/bare put); otherwise capture-derived +
         // explicit only.

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -520,11 +520,19 @@ export function createUploadsMcpTools(opts: {
         });
         // Derived `repo` metadata (spec: 2026-08-11-screenshots-project-grouping-design.md).
         // Same derivation the CLI does; MCP always derives (no --no-auto), so
-        // this is only suppressed by noGit.
+        // this is only suppressed by noGit. metadataProp's contract: omitting
+        // `metadata` means "leave what's already stored for this key
+        // untouched" — an object (even {}) triggers a full replace. So only
+        // fold the derived repo into a defined object when the caller already
+        // supplied metadata, or branch staging is building one below anyway
+        // (mergeStagingMeta always returns a defined object); never
+        // synthesize metadata on a bare re-upload just to add repo, or a
+        // no-metadata put would silently wipe everything already stored.
         const repoSlug = !noGit ? deriveRepoSlugFromGit(run) : undefined;
-        const metadataWithRepo = repoSlug
-          ? mergeDerivedMeta(metadata ?? {}, { repo: repoSlug })
-          : metadata;
+        const metadataWithRepo =
+          repoSlug !== undefined && (metadata !== undefined || stagingTarget !== undefined)
+            ? mergeDerivedMeta(metadata ?? {}, { repo: repoSlug })
+            : metadata;
         const putMetadata = stagingTarget
           ? mergeStagingMeta(metadataWithRepo, stagingTarget)
           : metadataWithRepo;

--- a/packages/uploads/src/metadata-vocab.ts
+++ b/packages/uploads/src/metadata-vocab.ts
@@ -19,6 +19,7 @@ export const CANONICAL_META_KEYS = [
   "captured",
   "state",
   "app",
+  "repo",
 ] as const;
 
 export type CanonicalMetaKey = (typeof CANONICAL_META_KEYS)[number];

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -904,7 +904,14 @@ describe("runPut derived repo metadata (spec: 2026-08-11-screenshots-project-gro
     };
   }
 
-  it("records derived repo metadata from the git remote (mixed-case remote -> lowercase slug)", async () => {
+  // Critical regression guard: `metadata === undefined` means "leave
+  // whatever's already stored for this key untouched" (client.ts only sends
+  // X-Uploads-Meta-* when the map is defined; a defined map is a full
+  // server-side replace). A bare put with no --meta/gh/staging context must
+  // NOT get a repo derived just because one happens to be resolvable — that
+  // would turn every re-upload of an existing key inside a git checkout into
+  // a silent metadata wipe.
+  it("does NOT synthesize metadata just to add repo on a bare put (metadata stays undefined)", async () => {
     const { client, puts } = fakeClient();
     await runPut(
       ctxWith(client),
@@ -912,12 +919,28 @@ describe("runPut derived repo metadata (spec: 2026-08-11-screenshots-project-gro
       false,
       repoOnlyRunner("git@github.com:Acme/Web.git"),
     );
-    expect(puts[0].metadata).toMatchObject({ repo: "acme/web" });
+    expect(puts[0].metadata).toBeUndefined();
+  });
+
+  it("folds derived repo into metadata that's already defined via --meta (mixed-case remote -> lowercase slug)", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(
+      ctxWith(client),
+      [tmpFile(), "--repo", "o/r", "--ref", "manual", "--meta", "app=myapp"],
+      false,
+      repoOnlyRunner("git@github.com:Acme/Web.git"),
+    );
+    expect(puts[0].metadata).toMatchObject({ app: "myapp", repo: "acme/web" });
   });
 
   it("suppresses derived repo with --no-git", async () => {
     const { client, puts } = fakeClient();
-    await runPut(ctxWith(client), [tmpFile(), "--repo", "myapp", "--no-git"], false, noRun);
+    await runPut(
+      ctxWith(client),
+      [tmpFile(), "--repo", "myapp", "--no-git", "--meta", "app=myapp"],
+      false,
+      noRun,
+    );
     expect(puts[0].metadata?.repo).toBeUndefined();
   });
 

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -893,6 +893,46 @@ describe("runPut auto gh.* metadata (default path)", () => {
   });
 });
 
+describe("runPut derived repo metadata (spec: 2026-08-11-screenshots-project-grouping)", () => {
+  /** Answers only `git config --get remote.origin.url`; anything else (the
+   * auto gh.* resolution's rev-parse/gh calls) throws, so autoTarget stays
+   * undefined and only the derived `repo` metadata is under test here. */
+  function repoOnlyRunner(originUrl: string): CommandRunner {
+    return (cmd, args) => {
+      if (cmd === "git" && args[0] === "config") return `${originUrl}\n`;
+      throw new Error(`unexpected: ${cmd} ${args.join(" ")}`);
+    };
+  }
+
+  it("records derived repo metadata from the git remote (mixed-case remote -> lowercase slug)", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(
+      ctxWith(client),
+      [tmpFile(), "--repo", "o/r", "--ref", "manual"],
+      false,
+      repoOnlyRunner("git@github.com:Acme/Web.git"),
+    );
+    expect(puts[0].metadata).toMatchObject({ repo: "acme/web" });
+  });
+
+  it("suppresses derived repo with --no-git", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(ctxWith(client), [tmpFile(), "--repo", "myapp", "--no-git"], false, noRun);
+    expect(puts[0].metadata?.repo).toBeUndefined();
+  });
+
+  it("lets an explicit --meta repo= win over the derived value", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(
+      ctxWith(client),
+      [tmpFile(), "--repo", "o/r", "--ref", "manual", "--meta", "repo=custom/one"],
+      false,
+      repoOnlyRunner("git@github.com:Acme/Web.git"),
+    );
+    expect(puts[0].metadata?.repo).toBe("custom/one");
+  });
+});
+
 describe("runPut gh.title metadata (issue #267)", () => {
   it("stamps gh.title on the explicit --pr path when the title resolves", async () => {
     const { client, puts } = fakeClient();

--- a/packages/uploads/test/commands-screenshot.test.ts
+++ b/packages/uploads/test/commands-screenshot.test.ts
@@ -836,6 +836,56 @@ describe("runScreenshot gh.title metadata (issue #267)", () => {
   });
 });
 
+describe("runScreenshot derived repo metadata (spec: 2026-08-11-screenshots-project-grouping)", () => {
+  /** Answers only `git config --get remote.origin.url`; anything else throws
+   * so gh.* auto resolution stays out of the picture. */
+  function repoOnlyRunner(originUrl: string): CommandRunner {
+    return (cmd, args) => {
+      if (cmd === "git" && args[0] === "config") return `${originUrl}\n`;
+      throw new Error(`unexpected: ${cmd} ${args.join(" ")}`);
+    };
+  }
+
+  it("records derived repo metadata from the git remote (mixed-case remote -> lowercase slug)", async () => {
+    const { client, puts } = fakeClient();
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com"],
+      false,
+      repoOnlyRunner("git@github.com:Acme/Web.git"),
+      fakeCapture("remote"),
+    );
+    expect(code).toBe(0);
+    expect(puts[0]?.metadata).toMatchObject({ repo: "acme/web" });
+  });
+
+  it("suppresses derived repo with --no-git", async () => {
+    const { client, puts } = fakeClient();
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--no-git"],
+      false,
+      noRun,
+      fakeCapture("remote"),
+    );
+    expect(code).toBe(0);
+    expect(puts[0]?.metadata?.repo).toBeUndefined();
+  });
+
+  it("lets an explicit --meta repo= win over the derived value", async () => {
+    const { client, puts } = fakeClient();
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--meta", "repo=custom/one"],
+      false,
+      repoOnlyRunner("git@github.com:Acme/Web.git"),
+      fakeCapture("remote"),
+    );
+    expect(code).toBe(0);
+    expect(puts[0]?.metadata?.repo).toBe("custom/one");
+  });
+});
+
 describe("screenshot canonical metadata", () => {
   /** Run a capture with --no-git (no repo resolution) and return the put options. */
   async function metaFor(args: string[]): Promise<Record<string, string> | undefined> {

--- a/packages/uploads/test/keys.test.ts
+++ b/packages/uploads/test/keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deriveRepoFromGit } from "../src/keys.js";
+import { deriveRepoFromGit, deriveRepoSlugFromGit } from "../src/keys.js";
 
 describe("deriveRepoFromGit (injectable run, issue #393)", () => {
   it("parses the repo name from an SSH remote via an injected runner", () => {
@@ -21,5 +21,22 @@ describe("deriveRepoFromGit (injectable run, issue #393)", () => {
   it("returns undefined when the remote URL doesn't match the expected shape", () => {
     const run = () => "not-a-url\n";
     expect(deriveRepoFromGit(run)).toBeUndefined();
+  });
+});
+
+describe("deriveRepoSlugFromGit", () => {
+  it("parses ssh and https remotes to a lowercase owner/name slug", () => {
+    expect(deriveRepoSlugFromGit(() => "git@github.com:BuildInternet/Uploads.git\n")).toBe(
+      "buildinternet/uploads",
+    );
+    expect(deriveRepoSlugFromGit(() => "https://github.com/acme/web\n")).toBe("acme/web");
+  });
+  it("returns undefined when git fails or the remote is unparseable", () => {
+    expect(
+      deriveRepoSlugFromGit(() => {
+        throw new Error("not a git repo");
+      }),
+    ).toBeUndefined();
+    expect(deriveRepoSlugFromGit(() => "not-a-remote")).toBeUndefined();
   });
 });

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -235,6 +235,16 @@ const noRun: CommandRunner = () => {
   throw new Error("runner should not be called");
 };
 
+/** Answers only `git config --get remote.origin.url`; anything else throws,
+ * so staging/gh auto-resolution stay out of the picture and only the
+ * derived-`repo` wiring is under test. */
+function repoOnlyRunner(originUrl: string): CommandRunner {
+  return (cmd, args) => {
+    if (cmd === "git" && args[0] === "config") return `${originUrl}\n`;
+    throw new Error(`unexpected: ${cmd} ${args.join(" ")}`);
+  };
+}
+
 /**
  * Fake gh/git runner for the bare-put branch-staging trigger (issue #403),
  * mirroring `stagingRunner` in commands-put.test.ts for the MCP `put` tool.
@@ -694,6 +704,58 @@ describe("tools/call put", () => {
     });
     expect(res.result.isError).toBe(true);
     expect(res.result.content[0].text).toContain("invalid metadata key");
+  });
+
+  describe("derived repo metadata (spec: 2026-08-11-screenshots-project-grouping)", () => {
+    it("folds derived repo into explicitly-supplied metadata", async () => {
+      const { server, puts } = serverWith({
+        runner: repoOnlyRunner("git@github.com:Acme/Web.git"),
+      });
+      const res = await rpc(server, "tools/call", {
+        name: "put",
+        arguments: {
+          contentBase64: PNG_B64,
+          filename: "shot.png",
+          key: "tagged/shot.png",
+          metadata: { app: "myapp" },
+        },
+      });
+      expect(res.result.isError).toBe(false);
+      expect(puts[0].metadata).toEqual({ app: "myapp", repo: "acme/web" });
+    });
+
+    // Critical regression guard: metadataProp's contract is "omit means leave
+    // stored metadata untouched; a defined object (even {}) fully replaces
+    // it". A derivable repo must never turn an omitted `metadata` argument
+    // into a defined object — that would silently wipe everything already
+    // stored on a bare re-upload of an existing key.
+    it("does NOT synthesize a metadata object just to add repo when metadata is omitted", async () => {
+      const { server, puts } = serverWith({
+        runner: repoOnlyRunner("git@github.com:Acme/Web.git"),
+      });
+      const res = await rpc(server, "tools/call", {
+        name: "put",
+        arguments: { contentBase64: PNG_B64, filename: "shot.png", key: "plain/shot.png" },
+      });
+      expect(res.result.isError).toBe(false);
+      expect(puts[0].metadata).toBeUndefined();
+    });
+
+    it("suppresses derived repo with noGit even when metadata is supplied", async () => {
+      const { server, puts } = serverWith();
+      const res = await rpc(server, "tools/call", {
+        name: "put",
+        arguments: {
+          contentBase64: PNG_B64,
+          filename: "shot.png",
+          key: "tagged/shot.png",
+          metadata: { app: "myapp" },
+          noGit: true,
+        },
+      });
+      expect(res.result.isError).toBe(false);
+      expect(puts[0].metadata).toEqual({ app: "myapp" });
+    });
   });
 });
 


### PR DESCRIPTION
Fixes the Screenshots page mixing paths from unrelated repos into one flat list (`/admin` from two different projects merged into a single row, with nothing saying which repo anything belongs to).

Spec: `docs/superpowers/specs/2026-08-11-screenshots-project-grouping-design.md`.

## What changed

**Project label (server-side).** Each file resolves to a project label by coalescing `repo` → `gh.repo` → the host of its `url` metadata → `"Other"`. Computed only where grouping happens (plus a small pinned client mirror for drill-in filtering) — it's a display label, never stored.

**CLI: derived `repo` metadata.** `uploads screenshot` and `uploads put` now record the capturing repo (`owner/name`, lowercase, from the git remote) as a canonical `repo` key. Suppressed by `--no-git` and the derived-meta gate; explicit `--meta repo=` wins. One deliberate carve-out: a *bare* `put` (no `--meta`, no PR/staging target) keeps `metadata` undefined on the wire so the preserve-on-reupload contract holds — it does not synthesize a metadata map just to add `repo` (same guard on the stdio MCP put tool).

**API.** `files/by-path` now groups by *(project, path)* — same endpoint, additive shape: each group carries `project`, plus a recency-ordered `projects` summary array. `repo` also joins the content-hash inheritable keys.

**Web.** The overview renders nested per-project sections (recency-ordered, top 3 paths previewed each); `?project=` gives a filtered single-project view; path drill-ins filter to the project; the "From GitHub" strip folds into its project section. Legacy bare `?path=` links still work.

| Overview (nested project sections) | Project view (`?project=`) |
| --- | --- |
| <img width="420" alt="Screenshots overview grouped by project" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/629/screenshots-overview.webp"> | <img width="420" alt="Filtered project view" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/629/screenshots-project-view.webp"> |

## Notes

- Old screenshots have no `repo`, so they group by origin; the same project can appear as an origin-label bucket (old shots) and a repo-label bucket (new shots) until recency settles it. Deliberately no aliasing/merging.
- Verified in the local stack end-to-end: overview sections, project view, filtered drill, legacy `?path=`, unknown-project empty state, both themes' tokens.
- Full suite green (283 files / 4068 tests), lint clean, per-package typechecks clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Screenshots are now grouped by project as well as file path, with project summaries and project-specific browsing.
  * Added project and path filtering with URL navigation, while preserving existing path links.
  * Uploads and screenshots can automatically include repository metadata from Git.
  * Explicit metadata remains prioritized, and Git-derived metadata can be disabled with `--no-git`.
* **Improvements**
  * Project names use repository information, URL hosts, or a fallback label when unavailable.
  * Related overview sections and navigation have been refined for easier browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->