### PR TITLE
refactor(cli): move github/usage/galleries requests to the canonical /v1/workspaces surface (#613 step 3)

### DIFF
--- a/.changeset/cli-canonical-workspace-paths.md
+++ b/.changeset/cli-canonical-workspace-paths.md
@@ -1,0 +1,9 @@
+---
+"@buildinternet/uploads": minor
+---
+
+CLI workspace-scoped `github/comment`, `github/promote`, `github/link`, `github/repo-link`, `github/health`, `usage`, and `galleries` requests now use the canonical `/v1/workspaces/:workspace/...` paths instead of the legacy `/v1/:workspace/...` wildcard (#613). The old paths keep working server-side, so this is a client-only move.
+
+Files operations (`get`/`set`/`list`/`facets`/etc.) stay on the legacy wildcard for now — the canonical files vertical doesn't yet cover uploads, `/sign`, or `:key` metadata, and its list/search response shape differs from the bearer one.
+
+Note: the canonical `github/comment` route requires the `files:write` scope, where the legacy path also accepted `files:read`. Default-minted CLI tokens carry read+write, so this is transparent for normal use; a manually-minted read-only token will now get a 403 from `uploads comment`.

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -299,7 +299,7 @@ export type GithubCommentResult =
       required?: string[];
     };
 
-/** `POST /v1/:workspace/github/promote` request/response (server contract, PR #310). */
+/** `POST /v1/workspaces/:workspace/github/promote` request/response (server contract, PR #310). */
 export interface PromoteBranchAttachmentsOptions {
   repo: string;
   num: number;
@@ -316,7 +316,7 @@ export interface PromoteBranchAttachmentsResult {
   skipped: PromoteSkip[];
 }
 
-/** `GET`/`POST /v1/:workspace/github/link` result (server contract, phase 4b). */
+/** `GET`/`POST /v1/workspaces/:workspace/github/link` result (server contract, phase 4b). */
 export interface GithubLinkResult {
   repo: string;
   linked: boolean;
@@ -337,7 +337,7 @@ export interface GithubLinkClaimResult extends GithubLinkResult {
   reason?: "not_authorized";
 }
 
-/** `DELETE /v1/:workspace/github/link` result (issue #318, self-serve unlink). */
+/** `DELETE /v1/workspaces/:workspace/github/link` result (issue #318, self-serve unlink). */
 export interface GithubLinkUnlinkResult {
   repo: string;
   unlinked: boolean;
@@ -345,7 +345,7 @@ export interface GithubLinkUnlinkResult {
 }
 
 /**
- * `GET /v1/:workspace/github/repo-link` result (issue #398). Deliberately
+ * `GET /v1/workspaces/:workspace/github/repo-link` result (issue #398). Deliberately
  * minimal relative to `GithubLinkResult`: never names the owning workspace
  * when it isn't this one — "self"/"other"/"none" is all the stage-time
  * warning needs, and anything richer would leak cross-tenant info to a
@@ -378,7 +378,7 @@ export interface HealthResult {
   ok: boolean;
 }
 
-/** `GET /v1/:workspace/github/health` result (issue #293 follow-up). */
+/** `GET /v1/workspaces/:workspace/github/health` result (issue #293 follow-up). */
 export interface GithubHealthResult {
   configured: boolean;
   ok: boolean;
@@ -754,16 +754,21 @@ function encodeKeyPath(key: string): string {
   return key.split("/").map(encodeURIComponent).join("/");
 }
 
+// Stays on the legacy `/v1/:workspace/files` wildcard for now (issue #613):
+// the canonical files vertical has no upload PUT, POST /sign, or GET/PATCH
+// /:key metadata yet, and its list/search adopted the session response shape
+// rather than the bearer one. Move this once the canonical vertical grows
+// those routes and the bearer list shape is reconciled.
 function filesBase(config: UploadsClientConfig): string {
   return `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/files`;
 }
 
 function usageBase(config: UploadsClientConfig): string {
-  return `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/usage`;
+  return `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/usage`;
 }
 
 function galleriesBase(config: UploadsClientConfig): string {
-  return `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/galleries`;
+  return `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/galleries`;
 }
 
 function mapApiError(
@@ -1185,7 +1190,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
     }): Promise<GithubCommentResult> {
       return request<GithubCommentResult>(
         "POST",
-        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/comment`,
+        `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/github/comment`,
         {
           body: new TextEncoder().encode(JSON.stringify(opts)),
           headers: { "Content-Type": "application/json" },
@@ -1204,7 +1209,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
     ): Promise<PromoteBranchAttachmentsResult> {
       return request<PromoteBranchAttachmentsResult>(
         "POST",
-        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/promote`,
+        `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/github/promote`,
         {
           body: new TextEncoder().encode(JSON.stringify(opts)),
           headers: { "Content-Type": "application/json" },
@@ -1218,7 +1223,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
     async githubLinkStatus(repo: string): Promise<GithubLinkResult> {
       return request<GithubLinkResult>(
         "GET",
-        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/link?repo=${encodeURIComponent(repo)}`,
+        `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/github/link?repo=${encodeURIComponent(repo)}`,
       );
     },
 
@@ -1232,7 +1237,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
     async githubLinkClaim(repo: string): Promise<GithubLinkClaimResult> {
       return request<GithubLinkClaimResult>(
         "POST",
-        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/link`,
+        `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/github/link`,
         {
           body: new TextEncoder().encode(JSON.stringify({ repo })),
           headers: { "Content-Type": "application/json" },
@@ -1250,7 +1255,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
     async githubRepoLinkStatus(repo: string): Promise<GithubRepoLinkResult> {
       return request<GithubRepoLinkResult>(
         "GET",
-        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/repo-link?repo=${encodeURIComponent(repo)}`,
+        `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/github/repo-link?repo=${encodeURIComponent(repo)}`,
       );
     },
 
@@ -1262,9 +1267,9 @@ export function createUploadsClient(config: UploadsClientConfig) {
     /**
      * `POST /v1/workspaces/:workspace/github/ingest` (Task 6) — manual/
      * backfill mirror of a PR/issue's `github.com/user-attachments` media
-     * into the workspace. Only mounted on the canonical `/v1/workspaces`
-     * surface (no old bearer-only alias), unlike the other `github/*`
-     * client methods above.
+     * into the workspace. Only ever had the canonical `/v1/workspaces`
+     * route (no old bearer-only alias) — unlike the other `github/*` client
+     * methods above, which moved onto it in issue #613.
      */
     async ingestGithub(input: {
       repo: string;
@@ -1288,7 +1293,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
     async githubHealth(): Promise<GithubHealthResult> {
       return request<GithubHealthResult>(
         "GET",
-        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/health`,
+        `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/github/health`,
       );
     },
 
@@ -1302,7 +1307,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
     async githubLinkUnlink(repo: string): Promise<GithubLinkUnlinkResult> {
       return request<GithubLinkUnlinkResult>(
         "DELETE",
-        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/link?repo=${encodeURIComponent(repo)}`,
+        `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/github/link?repo=${encodeURIComponent(repo)}`,
       );
     },
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1319,7 +1319,7 @@ export async function uploadPuts(opts: {
 }
 
 /**
- * Best-effort call to `POST /v1/:workspace/github/promote` (server contract,
+ * Best-effort call to `POST /v1/workspaces/:workspace/github/promote` (server contract,
  * PR #310). Degrade-safe like `syncAttachmentsComment`'s bot path: an older
  * or self-hosted worker without this route (404), a forbidden token (403),
  * or a network error all collapse to "nothing promoted" — the caller must

--- a/packages/uploads/test/client-gallery.test.ts
+++ b/packages/uploads/test/client-gallery.test.ts
@@ -69,11 +69,17 @@ describe("gallery client methods", () => {
       deleted: true,
       id: "gal_example",
     });
-    expect(fetch.mock.calls[0][0]).toBe("https://api.test/v1/test/galleries");
-    expect(fetch.mock.calls[1][0]).toBe("https://api.test/v1/test/galleries/gal_example");
-    expect(fetch.mock.calls[2][0]).toBe("https://api.test/v1/test/galleries?limit=10");
-    expect(fetch.mock.calls[3][0]).toBe("https://api.test/v1/test/galleries/gal_example/items");
-    expect(fetch.mock.calls[4][0]).toBe("https://api.test/v1/test/galleries/gal_example");
+    expect(fetch.mock.calls[0][0]).toBe("https://api.test/v1/workspaces/test/galleries");
+    expect(fetch.mock.calls[1][0]).toBe(
+      "https://api.test/v1/workspaces/test/galleries/gal_example",
+    );
+    expect(fetch.mock.calls[2][0]).toBe("https://api.test/v1/workspaces/test/galleries?limit=10");
+    expect(fetch.mock.calls[3][0]).toBe(
+      "https://api.test/v1/workspaces/test/galleries/gal_example/items",
+    );
+    expect(fetch.mock.calls[4][0]).toBe(
+      "https://api.test/v1/workspaces/test/galleries/gal_example",
+    );
   });
 });
 
@@ -126,10 +132,10 @@ describe("gallery external-reference client methods", () => {
     });
 
     expect(fetch.mock.calls.map(([input]) => String(input))).toEqual([
-      "https://api.test/v1/test/galleries/gal_example/external-references",
-      "https://api.test/v1/test/galleries/gal_example/external-references",
-      "https://api.test/v1/test/galleries/gal_example/external-references/ref-1",
-      "https://api.test/v1/test/galleries/by-reference?provider=github&coordinate=buildinternet%2Fuploads%2358&limit=10&cursor=next",
+      "https://api.test/v1/workspaces/test/galleries/gal_example/external-references",
+      "https://api.test/v1/workspaces/test/galleries/gal_example/external-references",
+      "https://api.test/v1/workspaces/test/galleries/gal_example/external-references/ref-1",
+      "https://api.test/v1/workspaces/test/galleries/by-reference?provider=github&coordinate=buildinternet%2Fuploads%2358&limit=10&cursor=next",
     ]);
   });
 });
@@ -138,7 +144,7 @@ describe("gallery client workspace isolation", () => {
   it("keeps alpha and beta gallery requests under their own workspace paths", async () => {
     const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input);
-      const workspace = url.includes("/v1/alpha/") ? "alpha" : "beta";
+      const workspace = url.includes("/v1/workspaces/alpha/") ? "alpha" : "beta";
       if (url.endsWith("/galleries") && init?.method === "POST") {
         return new Response(
           JSON.stringify({
@@ -173,10 +179,10 @@ describe("gallery client workspace isolation", () => {
     await beta.listGalleries({ limit: 1 });
 
     expect(fetch.mock.calls.map(([input]) => String(input))).toEqual([
-      "https://api.test/v1/alpha/galleries",
-      "https://api.test/v1/beta/galleries",
-      "https://api.test/v1/alpha/galleries?limit=1",
-      "https://api.test/v1/beta/galleries?limit=1",
+      "https://api.test/v1/workspaces/alpha/galleries",
+      "https://api.test/v1/workspaces/beta/galleries",
+      "https://api.test/v1/workspaces/alpha/galleries?limit=1",
+      "https://api.test/v1/workspaces/beta/galleries?limit=1",
     ]);
   });
 });

--- a/packages/uploads/test/client-github-comment.test.ts
+++ b/packages/uploads/test/client-github-comment.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createUploadsClient } from "../src/client.js";
 
 describe("upsertGithubComment", () => {
-  it("POSTs { repo, num, kind } to /v1/:workspace/github/comment and returns the result", async () => {
+  it("POSTs { repo, num, kind } to /v1/workspaces/:workspace/github/comment and returns the result", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(
@@ -19,7 +19,7 @@ describe("upsertGithubComment", () => {
     const res = await client.upsertGithubComment({ repo: "acme/web", num: 12, kind: "pull" });
     expect(res).toEqual({ posted: true, action: "created", count: 2, commentUrl: "u" });
     const [url, init] = fetchSpy.mock.calls[0];
-    expect(url).toBe("https://api.test/v1/acme/github/comment");
+    expect(url).toBe("https://api.test/v1/workspaces/acme/github/comment");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(new TextDecoder().decode(init?.body as Uint8Array))).toEqual({
       repo: "acme/web",


### PR DESCRIPTION
Step 3 of the #613 migration: the CLI's workspace-scoped bearer requests move off the legacy `/v1/:workspace/...` wildcard onto the canonical `/v1/workspaces/:workspace/...` surface (#615-#617). Client-only — the old paths keep working server-side through the deprecation window. The local stdio MCP rides on this same client; the hosted MCP calls API services in-process and needs no change.

## Switched (canonical handlers proven bearer-compatible by the phase PRs' tests)

- `github/comment`, `github/promote`, `github/link` (GET/POST/DELETE), `github/repo-link`, `github/health` (`github/ingest` was already canonical-only)
- the `usage` base URL (covers `usage`, `reconcile`, `purge-expired`)
- the `galleries` base URL (all gallery, item, and external-reference calls)

## Deliberately NOT switched: the files vertical

`filesBase()` stays on `/v1/:workspace/files` (with an explanatory comment): the canonical files vertical has no upload `PUT`, `POST /sign`, or `GET`/`PATCH /:key` metadata routes, and its list/search adopted the session response shape (the flagged phase-1 punt). Moving files is API design work — a "phase 4" canonical files completion — not a client edit.

## Behavior note

Canonical `github/comment` requires `files:write` (the legacy path's `files:read`-for-a-write was a #613 wart, fixed on the canonical surface only). Default-minted CLI tokens carry read+write, so normal use is unaffected; a manually-minted read-only token now gets 403 from `uploads comment`. Called out in the changeset.

## Verification

- `@buildinternet/uploads`: 69 test files, 1143 tests green; `tsc --noEmit` clean.
- Changeset: minor bump on `@buildinternet/uploads` only.

Refs #613. Remaining after this: canonical files-vertical completion (put/sign/metadata + bearer list-shape reconciliation), then alias + bare-wildcard retirement once telemetry shows the old paths quiet.
