### PR TITLE
chore: bump files-sdk to 2.2.3, re-cut the pinned patch

### DIFF
--- a/.changeset/files-sdk-2-2-3.md
+++ b/.changeset/files-sdk-2-2-3.md
@@ -1,0 +1,6 @@
+---
+"@buildinternet/uploads": patch
+"@uploads/ui": patch
+---
+
+Bump the files-sdk peer range to ^2.2.3 (>=2.2.3 for @uploads/ui). 2.2.3 fixes list() content types on the S3/HTTP paths upstream; the pinned patch is re-cut against 2.2.3 and still carries the r2 endpoint override and the binding-path list() metadata hunk.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,7 @@
     "@uploads/billing": "workspace:^",
     "@uploads/ui": "workspace:*",
     "astro": "^7.1.6",
-    "files-sdk": "^2.1.0",
+    "files-sdk": "^2.2.3",
     "img-comparison-slider": "^8.0.7",
     "markdown-for-agents": "^1.3.4",
     "react": "^19.2.7",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -15,7 +15,7 @@
     "@aws-sdk/client-s3": "^3.1080.0",
     "@aws-sdk/s3-presigned-post": "^3.1080.0",
     "@aws-sdk/s3-request-presigner": "^3.1080.0",
-    "files-sdk": "^2.1.0"
+    "files-sdk": "^2.2.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260706.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,7 +32,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "files-sdk": ">=2.1.0",
+    "files-sdk": ">=2.2.3",
     "react": ">=18",
     "react-dom": ">=18"
   },
@@ -43,7 +43,7 @@
     "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "files-sdk": "^2.1.0",
+    "files-sdk": "^2.2.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tsup": "^8.3.5",

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -45,7 +45,7 @@
     "node": ">=22"
   },
   "peerDependencies": {
-    "files-sdk": "^2.1.0"
+    "files-sdk": "^2.2.3"
   },
   "peerDependenciesMeta": {
     "files-sdk": {
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@types/node": "^26.1.0",
     "ai": "^6.0.0",
-    "files-sdk": "^2.1.0",
+    "files-sdk": "^2.2.3",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   },

--- a/patches/files-sdk@2.2.3.patch
+++ b/patches/files-sdk@2.2.3.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/r2/index.d.ts b/dist/r2/index.d.ts
-index 4359929d2d8a9f7ef0586a482b5e06dcb4013bbc..b1c9bf5315f0ef3dc0010839c72f9c89374d5035 100644
+index 384b7e676dea11a61312e2452a74832cd9c81aa3..9269aba06c4db80d34804890034df280382f51a7 100644
 --- a/dist/r2/index.d.ts
 +++ b/dist/r2/index.d.ts
-@@ -31,6 +31,12 @@ export interface R2HttpOptions {
+@@ -32,6 +32,12 @@ export interface R2HttpOptions {
       * Defaults to 3600.
       */
      defaultUrlExpiresIn?: number;
@@ -12,10 +12,10 @@ index 4359929d2d8a9f7ef0586a482b5e06dcb4013bbc..b1c9bf5315f0ef3dc0010839c72f9c89
 +     * buckets (e.g. `https://<accountId>.eu.r2.cloudflarestorage.com`).
 +     */
 +    endpoint?: string;
- }
- export interface R2BindingOptions {
-     /** Workers `R2Bucket` binding. Reads and writes go through the binding. */
-@@ -62,6 +68,12 @@ export interface R2BindingOptions {
+     /**
+      * Which HTTP engine backs the adapter.
+      *
+@@ -90,6 +96,12 @@ export interface R2BindingOptions {
       * signing (hybrid mode without `publicBaseUrl`). Defaults to 3600.
       */
      defaultUrlExpiresIn?: number;
@@ -27,21 +27,21 @@ index 4359929d2d8a9f7ef0586a482b5e06dcb4013bbc..b1c9bf5315f0ef3dc0010839c72f9c89
 +    endpoint?: string;
  }
  export type R2AdapterOptions = R2BindingOptions | R2HttpOptions;
- export type R2Adapter = Adapter<S3Client | R2Bucket>;
+ export type R2Adapter = Adapter<S3Client | R2Bucket | AwsClient>;
 diff --git a/dist/r2/index.js b/dist/r2/index.js
-index 291ca05dee674c7845e5e18868d481a3e4168b10..654e4b2a617aba3d4eff1074d9dbcf8ed5cf4e3a 100644
+index 7d4a03a71d8d0e6bd99b65d842520d14822c9f61..bfcb3612e17a6d63c00196667ff833e05b5a4fb6 100644
 --- a/dist/r2/index.js
 +++ b/dist/r2/index.js
-@@ -137,7 +137,7 @@ var r2FromBinding = (opts) => {
-     ...opts.defaultUrlExpiresIn !== undefined && {
-       defaultUrlExpiresIn: opts.defaultUrlExpiresIn
-     },
+@@ -504,7 +504,7 @@ var r2FromBinding = (opts) => {
+   const hybrid = opts.accountId && opts.accessKeyId && opts.secretAccessKey && httpBucket ? s3FetchAdapter({
+     accessKeyId: opts.accessKeyId,
+     bucket: httpBucket,
 -    endpoint: `https://${opts.accountId}.r2.cloudflarestorage.com`,
 +    endpoint: opts.endpoint ?? `https://${opts.accountId}.r2.cloudflarestorage.com`,
      forcePathStyle: true,
-     region: "auto"
-   }) : null;
-@@ -231,7 +231,11 @@ var r2FromBinding = (opts) => {
+     name: "r2-hybrid-signer",
+     providerLabel: "R2 error",
+@@ -601,7 +601,11 @@ var r2FromBinding = (opts) => {
            ...options?.prefix && { prefix: options.prefix },
            ...options?.limit !== undefined && { limit: options.limit },
            ...options?.cursor && { cursor: options.cursor },
@@ -54,7 +54,16 @@ index 291ca05dee674c7845e5e18868d481a3e4168b10..654e4b2a617aba3d4eff1074d9dbcf8e
          });
        } catch (error) {
          throw mapR2Error(error);
-@@ -336,7 +340,7 @@ var r2FromHttp = (opts) => {
+@@ -705,7 +709,7 @@ var r2FromHttp = (opts) => {
+       ...opts.defaultUrlExpiresIn !== undefined && {
+         defaultUrlExpiresIn: opts.defaultUrlExpiresIn
+       },
+-      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
++      endpoint: opts.endpoint ?? `https://${accountId}.r2.cloudflarestorage.com`,
+       ...opts.fetch && { fetch: opts.fetch },
+       forcePathStyle: true,
+       name: "r2-http-fetch",
+@@ -729,7 +733,7 @@ var r2FromHttp = (opts) => {
      ...opts.defaultUrlExpiresIn !== undefined && {
        defaultUrlExpiresIn: opts.defaultUrlExpiresIn
      },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  files-sdk@2.1.0: 57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831
+  files-sdk@2.2.3: fa6d7fbed553b3bf9fed7ed4b34a385fc3808d23cb77812a51cd835d554f071c
 
 importers:
 
@@ -169,7 +169,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: ^14.1.2
-        version: 14.1.2(@types/node@26.1.0)(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.1)(terser@5.49.0)(workerd@1.20260701.1)(wrangler@4.110.0)(yaml@2.9.0)
+        version: 14.1.2(@types/node@26.1.0)(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.1)(terser@5.49.0)(workerd@1.20260701.1)(wrangler@4.110.0)(yaml@2.9.0)
       '@astrojs/react':
         specifier: ^6.0.1
         version: 6.0.1(@types/node@26.1.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(terser@5.49.0)(yaml@2.9.0)
@@ -181,10 +181,10 @@ importers:
         version: link:../../packages/ui
       astro:
         specifier: ^7.1.6
-        version: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
+        version: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
       files-sdk:
-        specifier: ^2.1.0
-        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        specifier: ^2.2.3
+        version: 2.2.3(patch_hash=fa6d7fbed553b3bf9fed7ed4b34a385fc3808d23cb77812a51cd835d554f071c)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       img-comparison-slider:
         specifier: ^8.0.7
         version: 8.0.7
@@ -275,8 +275,8 @@ importers:
         specifier: ^3.1080.0
         version: 3.1080.0
       files-sdk:
-        specifier: ^2.1.0
-        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        specifier: ^2.2.3
+        version: 2.2.3(patch_hash=fa6d7fbed553b3bf9fed7ed4b34a385fc3808d23cb77812a51cd835d554f071c)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^5.20260706.1
@@ -304,8 +304,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       files-sdk:
-        specifier: ^2.1.0
-        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        specifier: ^2.2.3
+        version: 2.2.3(patch_hash=fa6d7fbed553b3bf9fed7ed4b34a385fc3808d23cb77812a51cd835d554f071c)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -350,8 +350,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.220(zod@4.4.3)
       files-sdk:
-        specifier: ^2.1.0
-        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        specifier: ^2.2.3
+        version: 2.2.3(patch_hash=fa6d7fbed553b3bf9fed7ed4b34a385fc3808d23cb77812a51cd835d554f071c)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -3119,6 +3119,9 @@ packages:
       '@astrojs/markdown-remark':
         optional: true
 
+  aws4fetch@1.0.20:
+    resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -3797,8 +3800,8 @@ packages:
       picomatch:
         optional: true
 
-  files-sdk@2.1.0:
-    resolution: {integrity: sha512-5V0o7b4yEbyheD6Qmhsn9GuO3HRBW1u5WdpLxqY4KF8MGY6RflT7mhsOwz/cU7aY8KYXdJcPjDAnffEQw4Sfww==}
+  files-sdk@2.2.3:
+    resolution: {integrity: sha512-1xCCh5yBhNwVfpeLKSaU7ejmh2kesw9mnU9dus0rw9EzNuNmcIuECZ91DlD0YsEP5ojXlPaPB8G7pQ25tqdebQ==}
     hasBin: true
     peerDependencies:
       '@anthropic-ai/claude-agent-sdk': ^0.3.0
@@ -3813,6 +3816,7 @@ packages:
       '@google-cloud/storage': ^7.19.0
       '@googleapis/drive': ^20.0.0
       '@microsoft/microsoft-graph-client': ^3.0.7
+      '@nestjs/common': ^10.0.0 || ^11.0.0
       '@netlify/blobs': ^10.7.4
       '@openai/agents': ^0.11.0
       '@opentelemetry/api': ^1.9.0
@@ -3870,6 +3874,8 @@ packages:
       '@googleapis/drive':
         optional: true
       '@microsoft/microsoft-graph-client':
+        optional: true
+      '@nestjs/common':
         optional: true
       '@netlify/blobs':
         optional: true
@@ -5946,12 +5952,12 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/cloudflare@14.1.2(@types/node@26.1.0)(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.1)(terser@5.49.0)(workerd@1.20260701.1)(wrangler@4.110.0)(yaml@2.9.0)':
+  '@astrojs/cloudflare@14.1.2(@types/node@26.1.0)(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.1)(terser@5.49.0)(workerd@1.20260701.1)(wrangler@4.110.0)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/underscore-redirects': 1.0.3
       '@cloudflare/vite-plugin': 1.44.0(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(workerd@1.20260701.1)(wrangler@4.110.0)
-      astro: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
+      astro: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
       piccolore: 0.1.3
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
       wrangler: 4.110.0
@@ -8498,7 +8504,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0):
+  astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
       '@astrojs/internal-helpers': 0.10.2
@@ -8547,7 +8553,7 @@ snapshots:
       tinyglobby: 0.2.17
       ultrahtml: 1.6.0
       unifont: 0.7.4
-      unstorage: 1.17.5
+      unstorage: 1.17.5(aws4fetch@1.0.20)
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
@@ -8589,6 +8595,8 @@ snapshots:
       - tsx
       - uploadthing
       - yaml
+
+  aws4fetch@1.0.20: {}
 
   axobject-query@4.1.0: {}
 
@@ -9167,8 +9175,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  files-sdk@2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  files-sdk@2.2.3(patch_hash=fa6d7fbed553b3bf9fed7ed4b34a385fc3808d23cb77812a51cd835d554f071c)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
+      aws4fetch: 1.0.20
       commander: 15.0.0
       picomatch: 4.0.5
       safe-regex2: 5.1.1
@@ -9179,7 +9188,7 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@opentelemetry/api': 1.9.1
       ai: 6.0.220(zod@4.4.3)
-      astro: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
+      astro: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(aws4fetch@1.0.20)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
       h3: 1.15.11
       hono: 4.12.28
       react: 19.2.7
@@ -10808,7 +10817,7 @@ snapshots:
   unpipe@1.0.0:
     optional: true
 
-  unstorage@1.17.5:
+  unstorage@1.17.5(aws4fetch@1.0.20):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -10818,6 +10827,8 @@ snapshots:
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
       ufo: 1.6.4
+    optionalDependencies:
+      aws4fetch: 1.0.20
 
   update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ minimumReleaseAgeExclude:
   - "@aws-sdk/s3-request-presigner@3.1080.0"
   - "@aws-sdk/token-providers@3.1080.0"
   - "@cloudflare/workers-types@5.20260706.1"
-  - files-sdk@2.1.0
+  - files-sdk@2.2.3
   - hono@4.12.28
 patchedDependencies:
-  files-sdk@2.1.0: patches/files-sdk@2.1.0.patch
+  files-sdk@2.2.3: patches/files-sdk@2.2.3.patch


### PR DESCRIPTION
Refs #599.

Bumps files-sdk from 2.1.0 to 2.2.3 and re-cuts the pinned pnpm patch against the new version.

## What changed upstream

- 2.2.3 ships [files-sdk#128](https://github.com/haydenbleasel/files-sdk/pull/128), which infers list() content types from the key on the S3/HTTP paths — the same problem class our original patch hunk addresses, but on different code paths (theirs: `s3-fetch`/`s3`; ours: the R2 **binding** path, using the actual stored `httpMetadata` rather than extension inference).
- The R2 HTTP adapter grew a third construction site (a new `client: "fetch"` engine), so the endpoint-override hunk now covers three sites instead of two.

## The re-cut patch still carries both hunks

1. **Endpoint override** — optional `endpoint` on `R2HttpOptions`/`R2BindingOptions` falling back to `https://<accountId>.r2.cloudflarestorage.com`; makes jurisdiction buckets (`eu`, `fedramp`) attachable as BYO storage. Still absent upstream in 2.2.3 (checked: hardcoded at all three sites). Upstreaming tracked in #599.
2. **Binding-path list() metadata** — `include: ["httpMetadata", "customMetadata"]` so binding-mode list() reports stored content types. Not covered by files-sdk#128.

## Verification

- `pnpm test`: 283 files, 4068 tests, all passing
- `pnpm run typecheck`: clean
- The `pnpm peers check` astro warning is pre-existing (files-sdk peers astro ^4–6; we're on 7) and unchanged by this bump.
