### PR TITLE
fix(release): correct the changeset package key and catch it in CI

### DIFF
--- a/.changeset/screenshots-derived-repo-meta.md
+++ b/.changeset/screenshots-derived-repo-meta.md
@@ -1,5 +1,5 @@
 ---
-"uploads": minor
+"@buildinternet/uploads": minor
 ---
 
 Derive `repo` metadata (owner/name from the git remote) on `put` and `screenshot`, suppressed by `--no-git`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,10 @@ jobs:
       - name: Oxfmt
         run: pnpm format:check
 
-      # A changeset for an ignored package yields an empty version PR and blocks
-      # the npm publish — reject it here before it can merge.
+      # Two ways a changeset can break the Release workflow after merge, both
+      # rejected here: naming a package outside the workspace (changeset status),
+      # and naming an ignored package, which yields an empty version PR and
+      # blocks the npm publish (changeset-lint.mjs).
       - name: Changeset lint
         run: pnpm changeset:lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,10 @@ jobs:
         run: pnpm format:check
 
       # Two ways a changeset can break the Release workflow after merge, both
-      # rejected here: naming a package outside the workspace (changeset status),
-      # and naming an ignored package, which yields an empty version PR and
-      # blocks the npm publish (changeset-lint.mjs).
+      # rejected here: naming a package outside the workspace (hard failure), and
+      # naming an ignored package, which yields an empty version PR and silently
+      # blocks the npm publish. Static by design — `changeset status` covers only
+      # the first and needs git history this shallow checkout does not have.
       - name: Changeset lint
         run: pnpm changeset:lint
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "preuploads": "pnpm --filter @buildinternet/uploads run build",
     "uploads": "pnpm exec uploads",
     "changeset": "changeset",
-    "changeset:lint": "changeset status && node scripts/changeset-lint.mjs",
+    "changeset:lint": "node scripts/changeset-lint.mjs",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
     "changeset:publish": "changeset publish",
     "prepare": "husky"
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@buildinternet/uploads": "workspace:*",
     "@changesets/cli": "^2.31.0",
+    "@manypkg/get-packages": "1.1.3",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",
     "oxfmt": "^0.57.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "preuploads": "pnpm --filter @buildinternet/uploads run build",
     "uploads": "pnpm exec uploads",
     "changeset": "changeset",
-    "changeset:lint": "node scripts/changeset-lint.mjs",
+    "changeset:lint": "changeset status && node scripts/changeset-lint.mjs",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
     "changeset:publish": "changeset publish",
     "prepare": "husky"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@26.1.0)
+      '@manypkg/get-packages':
+        specifier: 1.1.3
+        version: 1.1.3
       husky:
         specifier: ^9.1.7
         version: 9.1.7

--- a/scripts/changeset-lint.mjs
+++ b/scripts/changeset-lint.mjs
@@ -1,6 +1,13 @@
 /**
  * Fail if any changeset targets a package in the changesets `ignore` list.
  *
+ * This runs *after* `changeset status` (see the `changeset:lint` script), which
+ * is the upstream check and rejects a changeset naming a package that is not in
+ * the workspace at all — e.g. the root `uploads` instead of the published
+ * `@buildinternet/uploads`. `changeset status` does NOT catch the ignored-package
+ * case below: it reports such a changeset as a clean, empty release plan. The two
+ * checks are complementary; keep both.
+ *
  * Such a changeset can never produce a release (the package is versioned out of
  * band — Workers Builds, not npm), yet it makes `changeset version` yield an
  * empty diff. The Release workflow's changesets/action then dies creating the

--- a/scripts/changeset-lint.mjs
+++ b/scripts/changeset-lint.mjs
@@ -1,33 +1,51 @@
 /**
- * Fail if any changeset targets a package in the changesets `ignore` list.
+ * Fail if any changeset names a package that cannot be released. Two distinct
+ * ways this breaks the Release workflow, both rejected here at PR time:
  *
- * This runs *after* `changeset status` (see the `changeset:lint` script), which
- * is the upstream check and rejects a changeset naming a package that is not in
- * the workspace at all — e.g. the root `uploads` instead of the published
- * `@buildinternet/uploads`. `changeset status` does NOT catch the ignored-package
- * case below: it reports such a changeset as a clean, empty release plan. The two
- * checks are complementary; keep both.
+ * 1. UNKNOWN — a name that is not a workspace package at all, e.g. the private
+ *    root `uploads` instead of the published `@buildinternet/uploads`. This is a
+ *    hard failure: `changeset version` throws "Found changeset X for package Y
+ *    which is not in the workspace" and the Release job dies. Landed twice
+ *    (#518, #629).
  *
- * Such a changeset can never produce a release (the package is versioned out of
- * band — Workers Builds, not npm), yet it makes `changeset version` yield an
- * empty diff. The Release workflow's changesets/action then dies creating the
- * version PR ("No commits between main and changeset-release/main") *before*
- * the publish step, silently blocking every npm publish. This guard keeps such
- * a changeset from ever landing. See the uploads-release-changeset-poison note.
+ * 2. IGNORED — a package in the changesets `ignore` list. It can never produce a
+ *    release (versioned out of band via Workers Builds, not npm), yet it makes
+ *    `changeset version` yield an empty diff. The Release workflow's
+ *    changesets/action then dies creating the version PR ("No commits between
+ *    main and changeset-release/main") *before* the publish step, silently
+ *    blocking every npm publish. See the uploads-release-changeset-poison note.
+ *
+ * Why not `changeset status`? It catches (1) but not (2) — an ignored-package
+ * changeset reports as a clean, empty release plan, exit 0. It also resolves the
+ * base branch through git history, so it fails outright on CI's shallow checkout
+ * ("Failed to find where HEAD diverged from main") before validating anything.
+ * This check is purely static: no git, no network, same shallow clone as lint.
+ *
+ * The workspace package list comes from @manypkg/get-packages, the same resolver
+ * changesets itself uses, so membership here means membership there.
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { getPackages } from "@manypkg/get-packages";
 
-const changesetDir = join(dirname(fileURLToPath(import.meta.url)), "..", ".changeset");
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const changesetDir = join(root, ".changeset");
 const config = JSON.parse(readFileSync(join(changesetDir, "config.json"), "utf8"));
 const ignored = new Set(config.ignore ?? []);
+
+// Mirrors how changesets resolves the workspace: the root package is excluded
+// unless it is itself a workspace member, which is exactly why a changeset keyed
+// "uploads" (the private root) is invalid.
+const { packages } = await getPackages(root);
+const known = new Set(packages.map((p) => p.packageJson.name));
 
 const files = readdirSync(changesetDir).filter(
   (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
 );
 
-const offenders = [];
+const unknown = [];
+const ignoredHits = [];
 for (const file of files) {
   const text = readFileSync(join(changesetDir, file), "utf8");
   const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(text);
@@ -35,11 +53,26 @@ for (const file of files) {
   for (const line of frontmatter[1].split(/\r?\n/)) {
     // Frontmatter entries look like: "@uploads/web": patch
     const match = /^\s*["']?(@?[\w./-]+)["']?\s*:/.exec(line);
-    if (match && ignored.has(match[1])) offenders.push({ file, pkg: match[1] });
+    if (!match) continue;
+    const pkg = match[1];
+    if (ignored.has(pkg)) ignoredHits.push({ file, pkg });
+    else if (!known.has(pkg)) unknown.push({ file, pkg });
   }
 }
 
-if (offenders.length > 0) {
+if (unknown.length > 0) {
+  console.error(
+    "changeset-lint: changeset(s) name a package that is not in the workspace.\n" +
+      '`changeset version` will throw "Found changeset ... which is not in the\n' +
+      'workspace" and FAIL the Release job. Note the published CLI is\n' +
+      "`@buildinternet/uploads` — `uploads` is the private root package, which is\n" +
+      "not a valid changeset target. Fix the package name below:\n",
+  );
+  for (const { file, pkg } of unknown) console.error(`  - .changeset/${file} → ${pkg}`);
+  console.error(`\nValid targets: ${[...known].sort().join(", ")}`);
+}
+
+if (ignoredHits.length > 0) {
   console.error(
     "changeset-lint: changeset(s) target packages in the changesets `ignore` list.\n" +
       "These can never be released (they deploy via Workers Builds, not npm) and\n" +
@@ -47,8 +80,11 @@ if (offenders.length > 0) {
       'workflow fails with "No commits between main and changeset-release/main".\n' +
       "Remove the changeset(s) below (the underlying change ships on its own):\n",
   );
-  for (const { file, pkg } of offenders) console.error(`  - .changeset/${file} → ${pkg}`);
-  process.exit(1);
+  for (const { file, pkg } of ignoredHits) console.error(`  - .changeset/${file} → ${pkg}`);
 }
 
-console.log(`changeset-lint: ${files.length} changeset(s) OK — none target ignored packages.`);
+if (unknown.length > 0 || ignoredHits.length > 0) process.exit(1);
+
+console.log(
+  `changeset-lint: ${files.length} changeset(s) OK — all name releasable workspace packages.`,
+);


### PR DESCRIPTION
## What broke

The Release job failed twice on `main` — on the [#629 merge](https://github.com/buildinternet/uploads/actions/runs/31545070911) and again on the [#624 version-packages merge](https://github.com/buildinternet/uploads/actions/runs/31545470144):

```
Found changeset screenshots-derived-repo-meta for package uploads which is not in the workspace
```

`.changeset/screenshots-derived-repo-meta.md` (from #629) was keyed `"uploads"` — the private **root** package.json name, which the `apps/*` / `packages/*` workspace globs don't cover. The published CLI is `@buildinternet/uploads`.

## Why CI didn't catch it

`scripts/changeset-lint.mjs` only rejected names on the changesets `ignore` list. A name that isn't a workspace package *at all* isn't in that set, so it sailed through — the lint answered "is this package unreleasable?" not "is this package real?"

Second occurrence: the same typo landed in #518, corrected by #519.

## The fix

Correct the changeset key, and extend the lint to validate names against the workspace.

**First attempt was wrong, and is worth recording.** I added `changeset status` — the upstream command for this — and it failed CI. It resolves the base branch through git history and dies on the shallow checkout:

```
Failed to find where HEAD diverged from "main"
  at getVersionableChangedPackages
```

Note the frame: that's the *git diff* step, which runs **before** `assembleReleasePlan` — the part that actually validates names. So `changeset status` couples the check we want to git history we don't need, and would have required `fetch-depth: 0` (a full-history clone on every lint run) to buy nothing extra. It passed on my machine only because a dev worktree has full history and a local `main`.

So the validation is static instead, using `@manypkg/get-packages` — the same resolver changesets uses internally, so membership here means membership there. No git, no network, same shallow clone as the rest of the lint job. The script now reports the two failure modes separately with distinct remediation.

## Verification

Run in a `--depth 1` clone with no `main` ref, reproducing the CI environment that broke:

| changeset | new lint | `changeset status` |
| --- | --- | --- |
| clean tree | exit 0 ✅ | **exit 1** ❌ (spurious) |
| `"uploads"` (not in workspace) | **exit 1** ✅ | exit 1 (for the wrong reason) |
| `"@uploads/web"` (ignored) | **exit 1** ✅ | exit 0 ❌ |
| both in one changeset | **exit 1** ✅ | — |
| no changesets at all | exit 0 ✅ | — |

That middle row is why `changeset status` alone was never sufficient: an ignored-package changeset reports as a clean empty release plan, which is precisely the silent publish-block that #223 was written to prevent. `pnpm lint` and `pnpm format:check` pass.

Merging this unblocks the Version Packages PR.
