### PR TITLE
refactor(api): canonical files vertical gains sign/put/get/patch (#613 phase 4)

### DIFF
--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -1,0 +1,276 @@
+import {
+  ConflictError,
+  NotFoundError,
+  UnsupportedMediaTypeError,
+  ValidationError,
+} from "@uploads/errors";
+import type { Context, Handler } from "hono";
+import {
+  badKey,
+  finalizeUploadKey,
+  headObjectJson,
+  isManagedGithubKey,
+  putObject,
+} from "../files-core";
+import { getFileMetadata, META_MAX_KEYS, setFileMetadata } from "../file-metadata";
+import { checkDeclaredLength, maxBytesForContentType, resolveUploadPolicy } from "../guards";
+import { splitUploadMetaHeaders } from "../provenance";
+import { objectPublicUrls, storage, storageConfig } from "../storage";
+import { hasGithubTags, uploaderTags } from "../uploader-identity";
+import { sanitizeVisibility } from "../visibility";
+import type { WorkspaceVars } from "../workspace";
+
+/** Handler shape shared by the legacy bearer and canonical dual-auth routers. */
+export type SharedFilesHandler = Handler<WorkspaceVars>;
+
+/** Normalize a client Content-Type for allowlist compare (type/subtype only, lowercased). */
+function normalizePresignContentType(raw: string): string {
+  const beforeParams = raw.split(";", 1)[0] ?? raw;
+  return beforeParams.trim().toLowerCase();
+}
+
+export async function signFileHandler(c: Context<WorkspaceVars>) {
+  const body = await c.req
+    .json<{
+      key?: string;
+      contentType?: string;
+      maxSize?: number;
+      expiresIn?: number;
+      replace?: boolean;
+    }>()
+    .catch(
+      () =>
+        ({}) as {
+          key?: string;
+          contentType?: string;
+          maxSize?: number;
+          expiresIn?: number;
+          replace?: boolean;
+        },
+    );
+
+  const rawKey = typeof body.key === "string" ? body.key : "";
+  if (!rawKey) throw new ValidationError("invalid key", { code: "invalid_key" });
+
+  const ws = c.get("workspace");
+  const key = finalizeUploadKey(rawKey, ws);
+
+  const policy = resolveUploadPolicy(ws);
+
+  // Content-type is required on presign: the direct-to-bucket PUT cannot
+  // magic-byte sniff, so the allowlist must be enforced at mint time.
+  const rawContentType = typeof body.contentType === "string" ? body.contentType : "";
+  if (!rawContentType.trim()) {
+    throw new ValidationError("contentType is required for presign", {
+      code: "content_type_required",
+    });
+  }
+  const contentType = normalizePresignContentType(rawContentType);
+  if (!policy.allowed.has(contentType)) {
+    throw new UnsupportedMediaTypeError("unsupported media type", {
+      code: "unsupported_media_type",
+      details: { allowed: [...policy.allowed] },
+    });
+  }
+
+  const typeCeiling = maxBytesForContentType(policy, contentType);
+  const maxSize =
+    typeof body.maxSize === "number" && body.maxSize > 0
+      ? Math.min(body.maxSize, typeCeiling)
+      : typeCeiling;
+  const expiresIn =
+    typeof body.expiresIn === "number" && body.expiresIn > 0 && body.expiresIn <= 86400
+      ? Math.floor(body.expiresIn)
+      : 3600;
+
+  try {
+    const store = await storage(c.env, ws);
+
+    // Strict-overwrite gate (issue #174), best-effort here: /sign mints a
+    // presigned URL for a direct-to-bucket PUT that happens later (up to
+    // `expiresIn`, max 24h) and entirely outside this worker, so there is
+    // no atomic check-then-write available the way there is in the
+    // regular PUT route (files-core.ts `putObject`) — the client may sign
+    // now and write minutes or hours after this check, or never. This
+    // still rejects the common case (an existing strict key, checked at
+    // mint time) and mirrors the PUT route's `replace` opt-in / gh/
+    // hot-swap exemption, but it is NOT a security boundary: a signed URL
+    // for a free key can still land on an object created after signing.
+    // Treat this as UX guardrail parity with PUT, not a guarantee.
+    const replaced = await store.exists(key);
+    if (replaced && !body.replace && !isManagedGithubKey(key)) {
+      const cfg = await storageConfig(c.env, ws);
+      const urls = objectPublicUrls(c.env, cfg, key);
+      throw new ConflictError(
+        `An object already exists at "${key}". Pass replace: true to sign an overwrite.`,
+        { code: "key_exists", details: { key, url: urls.url, embedUrl: urls.embedUrl } },
+      );
+    }
+
+    const upload = await store.signedUploadUrl(key, {
+      expiresIn,
+      contentType,
+      maxSize,
+    });
+    const cfg = await storageConfig(c.env, ws);
+    const urls = objectPublicUrls(c.env, cfg, key);
+    return c.json({
+      workspace: c.get("workspaceName"),
+      key,
+      maxSize,
+      expiresIn,
+      publicUrl: urls.url,
+      embedUrl: urls.embedUrl,
+      upload,
+    });
+  } catch (err) {
+    if (err instanceof ConflictError) throw err;
+    if (err instanceof ValidationError || err instanceof UnsupportedMediaTypeError) throw err;
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(JSON.stringify({ message: "presign failed", error: message }));
+    throw new ValidationError(
+      "presign unavailable for this workspace (needs S3 HTTP credentials; binding-only cannot sign)",
+      { code: "presign_unavailable", cause: err },
+    );
+  }
+}
+
+export async function putFileHandler(c: Context<WorkspaceVars>) {
+  const key = c.req.param("key")!;
+  if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
+
+  // ?replace=1 (or header X-Uploads-Replace: 1) — opt in to overwriting an
+  // existing object on a "strict" (non-`gh/`) key; see files-core.ts
+  // `putObject`'s `replace` option / issue #174. Ignored on managed `gh/`
+  // paths, which always hot-swap.
+  const replaceParam = c.req.query("replace") ?? c.req.header("x-uploads-replace");
+  const wantReplace = replaceParam === "1" || replaceParam === "true";
+
+  // ?dryRun=1 — validate key + resolve public URL; no R2 write, no usage/budget check.
+  // Prefixed keys match a real put; bare keys may re-govern to a new f/<id>/… on upload.
+  // `replaced` is whether an object already lives at the final key (would overwrite);
+  // `wouldRefuse` mirrors the real-put strict-overwrite gate so dry-run previews it too.
+  const dryRun = c.req.query("dryRun");
+  if (dryRun === "1" || dryRun === "true") {
+    const ws = c.get("workspace");
+    const finalKey = finalizeUploadKey(key, ws);
+    const store = await storage(c.env, ws);
+    const replaced = await store.exists(finalKey);
+    const wouldRefuse = replaced && !wantReplace && !isManagedGithubKey(finalKey);
+    const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), finalKey);
+    return c.json({
+      workspace: c.get("workspaceName"),
+      key: finalKey,
+      url: urls.url,
+      embedUrl: urls.embedUrl,
+      replaced,
+      wouldRefuse,
+      dryRun: true,
+    });
+  }
+
+  const policy = resolveUploadPolicy(c.get("workspace"));
+  const declared = checkDeclaredLength(c.req.header("Content-Length"), policy);
+  if (declared) throw declared.error;
+
+  const body = await c.req.arrayBuffer();
+  const visibility = sanitizeVisibility(c.req.header("x-uploads-visibility"));
+  const { provenance, custom } = splitUploadMetaHeaders(c.req.raw.headers);
+  // No custom (non-provenance) X-Uploads-Meta-* headers at all: pass
+  // `metadata: undefined` so putObject leaves any existing D1 metadata
+  // untouched (matches the MCP `put` tool's omit-preserves semantics).
+  // At least one custom header: keep the existing full-replace behavior,
+  // even when that header's value alone ends up empty/invalid (putObject
+  // still validates and rejects before any write).
+  const hasCustomMeta = Object.keys(custom).length > 0;
+  // Uploader attribution (issue #340): gh.*-tagged uploads get server-derived
+  // `gh.uploader`/`gh.uploader-id` stamped from the bearer token's minting
+  // user — spread AFTER the client's pairs so a client-supplied value of
+  // those keys can't impersonate someone else. Attribution only (a shared
+  // token attributes to its minter); non-gh uploads and legacy tokens are
+  // untouched.
+  let metadata = hasCustomMeta ? custom : undefined;
+  if (metadata && hasGithubTags(metadata)) {
+    const uploader = await uploaderTags(c.env, c.get("mintingUserId"), metadata["gh.repo"]);
+    if (uploader) {
+      // Attribution must never break an upload that was valid without it:
+      // if the merged set would blow the per-object key cap (validated
+      // inside putObject), keep the client's pairs and drop the server tags.
+      const merged = { ...metadata, ...uploader };
+      if (Object.keys(merged).length <= META_MAX_KEYS) metadata = merged;
+    }
+  }
+  const result = await putObject(
+    c.env,
+    c.get("workspace"),
+    key,
+    new Uint8Array(body),
+    c.get("workspaceName"),
+    { provenance, visibility, metadata, replace: wantReplace, surface: "api" },
+  );
+  return c.json({ workspace: c.get("workspaceName"), ...result }, 201);
+}
+
+export async function getFileHandler(c: Context<WorkspaceVars>) {
+  const key = c.req.param("key")!;
+  if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
+  const ws = c.get("workspace");
+  const store = await storage(c.env, ws);
+  if (!(await store.exists(key))) throw new NotFoundError();
+
+  const metadataParam = c.req.query("metadata");
+  if (metadataParam === "1" || metadataParam === "true") {
+    const metadata = await getFileMetadata(c.env.DB, c.get("workspaceName"), key);
+    return c.json({ metadata });
+  }
+
+  const meta = await store.head(key);
+  const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), key);
+  return c.json(headObjectJson(key, meta, urls.url, urls.embedUrl));
+}
+
+export async function patchFileHandler(c: Context<WorkspaceVars>) {
+  const key = c.req.param("key")!;
+  if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
+  const ws = c.get("workspace");
+  const store = await storage(c.env, ws);
+  if (!(await store.exists(key))) throw new NotFoundError();
+
+  const body = await c.req.json().catch(() => null);
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    throw new ValidationError("invalid request body", { code: "invalid_body" });
+  }
+  const { set, delete: remove } = body as {
+    set?: unknown;
+    delete?: unknown;
+  };
+  if (set !== undefined && (typeof set !== "object" || set === null || Array.isArray(set))) {
+    throw new ValidationError("`set` must be an object of string values", {
+      code: "invalid_body",
+    });
+  }
+  if (set !== undefined) {
+    for (const value of Object.values(set as Record<string, unknown>)) {
+      if (typeof value !== "string") {
+        throw new ValidationError("`set` values must be strings", { code: "invalid_body" });
+      }
+    }
+  }
+  if (
+    remove !== undefined &&
+    (!Array.isArray(remove) || remove.some((item) => typeof item !== "string"))
+  ) {
+    throw new ValidationError("`delete` must be an array of strings", {
+      code: "invalid_body",
+    });
+  }
+
+  const metadata = await setFileMetadata(
+    c.env.DB,
+    c.get("workspaceName"),
+    key,
+    (set as Record<string, string> | undefined) ?? {},
+    (remove as string[] | undefined) ?? [],
+  );
+  return c.json({ metadata });
+}

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -1,237 +1,31 @@
-import {
-  ConflictError,
-  NotFoundError,
-  UnsupportedMediaTypeError,
-  ValidationError,
-} from "@uploads/errors";
 import { Hono } from "hono";
-import {
-  badKey,
-  deleteObject,
-  finalizeUploadKey,
-  headObjectJson,
-  isManagedGithubKey,
-  listObjects,
-  putObject,
-} from "../files-core";
-import {
-  getFileMetadata,
-  getMetadataForKeys,
-  listFacets,
-  META_MAX_KEYS,
-  setFileMetadata,
-} from "../file-metadata";
+import { deleteObject, listObjects } from "../files-core";
+import { getMetadataForKeys, listFacets } from "../file-metadata";
 import {
   clampSearchLimit,
   normalizeSearchName,
   parseMetaQueryFilters,
   searchFilesByNameAndMeta,
 } from "../file-search";
-import { splitUploadMetaHeaders } from "../provenance";
-import { objectPublicUrls, storage, storageConfig } from "../storage";
+import { objectPublicUrls, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
+import { writeRateLimit } from "../guards";
 import {
-  checkDeclaredLength,
-  maxBytesForContentType,
-  resolveUploadPolicy,
-  writeRateLimit,
-} from "../guards";
-import { hasGithubTags, uploaderTags } from "../uploader-identity";
-import { sanitizeVisibility } from "../visibility";
-
-/** Normalize a client Content-Type for allowlist compare (type/subtype only, lowercased). */
-function normalizePresignContentType(raw: string): string {
-  const beforeParams = raw.split(";", 1)[0] ?? raw;
-  return beforeParams.trim().toLowerCase();
-}
+  getFileHandler,
+  patchFileHandler,
+  putFileHandler,
+  signFileHandler,
+} from "./files-shared-handlers";
 
 export const files = new Hono<WorkspaceVars>()
 
   // Presigned direct-to-bucket upload (workspace needs S3 HTTP credentials).
-  .post("/sign", writeRateLimit, requireScope("files:write"), async (c) => {
-    const body = await c.req
-      .json<{
-        key?: string;
-        contentType?: string;
-        maxSize?: number;
-        expiresIn?: number;
-        replace?: boolean;
-      }>()
-      .catch(
-        () =>
-          ({}) as {
-            key?: string;
-            contentType?: string;
-            maxSize?: number;
-            expiresIn?: number;
-            replace?: boolean;
-          },
-      );
-
-    const rawKey = typeof body.key === "string" ? body.key : "";
-    if (!rawKey) throw new ValidationError("invalid key", { code: "invalid_key" });
-
-    const ws = c.get("workspace");
-    const key = finalizeUploadKey(rawKey, ws);
-
-    const policy = resolveUploadPolicy(ws);
-
-    // Content-type is required on presign: the direct-to-bucket PUT cannot
-    // magic-byte sniff, so the allowlist must be enforced at mint time.
-    const rawContentType = typeof body.contentType === "string" ? body.contentType : "";
-    if (!rawContentType.trim()) {
-      throw new ValidationError("contentType is required for presign", {
-        code: "content_type_required",
-      });
-    }
-    const contentType = normalizePresignContentType(rawContentType);
-    if (!policy.allowed.has(contentType)) {
-      throw new UnsupportedMediaTypeError("unsupported media type", {
-        code: "unsupported_media_type",
-        details: { allowed: [...policy.allowed] },
-      });
-    }
-
-    const typeCeiling = maxBytesForContentType(policy, contentType);
-    const maxSize =
-      typeof body.maxSize === "number" && body.maxSize > 0
-        ? Math.min(body.maxSize, typeCeiling)
-        : typeCeiling;
-    const expiresIn =
-      typeof body.expiresIn === "number" && body.expiresIn > 0 && body.expiresIn <= 86400
-        ? Math.floor(body.expiresIn)
-        : 3600;
-
-    try {
-      const store = await storage(c.env, ws);
-
-      // Strict-overwrite gate (issue #174), best-effort here: /sign mints a
-      // presigned URL for a direct-to-bucket PUT that happens later (up to
-      // `expiresIn`, max 24h) and entirely outside this worker, so there is
-      // no atomic check-then-write available the way there is in the
-      // regular PUT route (files-core.ts `putObject`) — the client may sign
-      // now and write minutes or hours after this check, or never. This
-      // still rejects the common case (an existing strict key, checked at
-      // mint time) and mirrors the PUT route's `replace` opt-in / gh/
-      // hot-swap exemption, but it is NOT a security boundary: a signed URL
-      // for a free key can still land on an object created after signing.
-      // Treat this as UX guardrail parity with PUT, not a guarantee.
-      const replaced = await store.exists(key);
-      if (replaced && !body.replace && !isManagedGithubKey(key)) {
-        const cfg = await storageConfig(c.env, ws);
-        const urls = objectPublicUrls(c.env, cfg, key);
-        throw new ConflictError(
-          `An object already exists at "${key}". Pass replace: true to sign an overwrite.`,
-          { code: "key_exists", details: { key, url: urls.url, embedUrl: urls.embedUrl } },
-        );
-      }
-
-      const upload = await store.signedUploadUrl(key, {
-        expiresIn,
-        contentType,
-        maxSize,
-      });
-      const cfg = await storageConfig(c.env, ws);
-      const urls = objectPublicUrls(c.env, cfg, key);
-      return c.json({
-        workspace: c.get("workspaceName"),
-        key,
-        maxSize,
-        expiresIn,
-        publicUrl: urls.url,
-        embedUrl: urls.embedUrl,
-        upload,
-      });
-    } catch (err) {
-      if (err instanceof ConflictError) throw err;
-      if (err instanceof ValidationError || err instanceof UnsupportedMediaTypeError) throw err;
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(JSON.stringify({ message: "presign failed", error: message }));
-      throw new ValidationError(
-        "presign unavailable for this workspace (needs S3 HTTP credentials; binding-only cannot sign)",
-        { code: "presign_unavailable", cause: err },
-      );
-    }
-  })
+  .post("/sign", writeRateLimit, requireScope("files:write"), signFileHandler)
 
   // Upload: raw body PUT. The stored content type is sniffed from the bytes,
   // not taken from the client header — size/type policy is enforced in
   // files-core's putObject (shared with the MCP worker); see guards.ts.
-  .put("/:key{.+}", writeRateLimit, requireScope("files:write"), async (c) => {
-    const key = c.req.param("key");
-    if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
-
-    // ?replace=1 (or header X-Uploads-Replace: 1) — opt in to overwriting an
-    // existing object on a "strict" (non-`gh/`) key; see files-core.ts
-    // `putObject`'s `replace` option / issue #174. Ignored on managed `gh/`
-    // paths, which always hot-swap.
-    const replaceParam = c.req.query("replace") ?? c.req.header("x-uploads-replace");
-    const wantReplace = replaceParam === "1" || replaceParam === "true";
-
-    // ?dryRun=1 — validate key + resolve public URL; no R2 write, no usage/budget check.
-    // Prefixed keys match a real put; bare keys may re-govern to a new f/<id>/… on upload.
-    // `replaced` is whether an object already lives at the final key (would overwrite);
-    // `wouldRefuse` mirrors the real-put strict-overwrite gate so dry-run previews it too.
-    const dryRun = c.req.query("dryRun");
-    if (dryRun === "1" || dryRun === "true") {
-      const ws = c.get("workspace");
-      const finalKey = finalizeUploadKey(key, ws);
-      const store = await storage(c.env, ws);
-      const replaced = await store.exists(finalKey);
-      const wouldRefuse = replaced && !wantReplace && !isManagedGithubKey(finalKey);
-      const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), finalKey);
-      return c.json({
-        workspace: c.get("workspaceName"),
-        key: finalKey,
-        url: urls.url,
-        embedUrl: urls.embedUrl,
-        replaced,
-        wouldRefuse,
-        dryRun: true,
-      });
-    }
-
-    const policy = resolveUploadPolicy(c.get("workspace"));
-    const declared = checkDeclaredLength(c.req.header("Content-Length"), policy);
-    if (declared) throw declared.error;
-
-    const body = await c.req.arrayBuffer();
-    const visibility = sanitizeVisibility(c.req.header("x-uploads-visibility"));
-    const { provenance, custom } = splitUploadMetaHeaders(c.req.raw.headers);
-    // No custom (non-provenance) X-Uploads-Meta-* headers at all: pass
-    // `metadata: undefined` so putObject leaves any existing D1 metadata
-    // untouched (matches the MCP `put` tool's omit-preserves semantics).
-    // At least one custom header: keep the existing full-replace behavior,
-    // even when that header's value alone ends up empty/invalid (putObject
-    // still validates and rejects before any write).
-    const hasCustomMeta = Object.keys(custom).length > 0;
-    // Uploader attribution (issue #340): gh.*-tagged uploads get server-derived
-    // `gh.uploader`/`gh.uploader-id` stamped from the bearer token's minting
-    // user — spread AFTER the client's pairs so a client-supplied value of
-    // those keys can't impersonate someone else. Attribution only (a shared
-    // token attributes to its minter); non-gh uploads and legacy tokens are
-    // untouched.
-    let metadata = hasCustomMeta ? custom : undefined;
-    if (metadata && hasGithubTags(metadata)) {
-      const uploader = await uploaderTags(c.env, c.get("mintingUserId"), metadata["gh.repo"]);
-      if (uploader) {
-        // Attribution must never break an upload that was valid without it:
-        // if the merged set would blow the per-object key cap (validated
-        // inside putObject), keep the client's pairs and drop the server tags.
-        const merged = { ...metadata, ...uploader };
-        if (Object.keys(merged).length <= META_MAX_KEYS) metadata = merged;
-      }
-    }
-    const result = await putObject(
-      c.env,
-      c.get("workspace"),
-      key,
-      new Uint8Array(body),
-      c.get("workspaceName"),
-      { provenance, visibility, metadata, replace: wantReplace, surface: "api" },
-    );
-    return c.json({ workspace: c.get("workspaceName"), ...result }, 201);
-  })
+  .put("/:key{.+}", writeRateLimit, requireScope("files:write"), putFileHandler)
 
   // Repeatable `meta.<key>=<value>` params and optional `?name=` switch the
   // listing to the shared D1/storage search path (issue #528) instead of the
@@ -315,69 +109,9 @@ export const files = new Hono<WorkspaceVars>()
   // the deployed worker 404s on any real key. `?metadata=1` on GET and a bare
   // PATCH (which has no other meaning on this route) avoid the fragile
   // suffix pattern entirely.
-  .get("/:key{.+}", requireScope("files:read"), async (c) => {
-    const key = c.req.param("key");
-    if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
-    const ws = c.get("workspace");
-    const store = await storage(c.env, ws);
-    if (!(await store.exists(key))) throw new NotFoundError();
+  .get("/:key{.+}", requireScope("files:read"), getFileHandler)
 
-    const metadataParam = c.req.query("metadata");
-    if (metadataParam === "1" || metadataParam === "true") {
-      const metadata = await getFileMetadata(c.env.DB, c.get("workspaceName"), key);
-      return c.json({ metadata });
-    }
-
-    const meta = await store.head(key);
-    const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), key);
-    return c.json(headObjectJson(key, meta, urls.url, urls.embedUrl));
-  })
-
-  .patch("/:key{.+}", writeRateLimit, requireScope("files:write"), async (c) => {
-    const key = c.req.param("key");
-    if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
-    const ws = c.get("workspace");
-    const store = await storage(c.env, ws);
-    if (!(await store.exists(key))) throw new NotFoundError();
-
-    const body = await c.req.json().catch(() => null);
-    if (body === null || typeof body !== "object" || Array.isArray(body)) {
-      throw new ValidationError("invalid request body", { code: "invalid_body" });
-    }
-    const { set, delete: remove } = body as {
-      set?: unknown;
-      delete?: unknown;
-    };
-    if (set !== undefined && (typeof set !== "object" || set === null || Array.isArray(set))) {
-      throw new ValidationError("`set` must be an object of string values", {
-        code: "invalid_body",
-      });
-    }
-    if (set !== undefined) {
-      for (const value of Object.values(set as Record<string, unknown>)) {
-        if (typeof value !== "string") {
-          throw new ValidationError("`set` values must be strings", { code: "invalid_body" });
-        }
-      }
-    }
-    if (
-      remove !== undefined &&
-      (!Array.isArray(remove) || remove.some((item) => typeof item !== "string"))
-    ) {
-      throw new ValidationError("`delete` must be an array of strings", {
-        code: "invalid_body",
-      });
-    }
-
-    const metadata = await setFileMetadata(
-      c.env.DB,
-      c.get("workspaceName"),
-      key,
-      (set as Record<string, string> | undefined) ?? {},
-      (remove as string[] | undefined) ?? [],
-    );
-    return c.json({ metadata });
-  })
+  .patch("/:key{.+}", writeRateLimit, requireScope("files:write"), patchFileHandler)
 
   .delete("/:key{.+}", writeRateLimit, requireScope("files:delete"), async (c) => {
     return c.json(

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -14,6 +14,11 @@
  *    route adopts, fixing the issue's "DELETE keys off a query param" wart
  *    for the canonical surface (the old `/me` query-param path is preserved
  *    verbatim as an alias, not removed).
+ *  - sign/put/get/patch: shared with the legacy bearer router through
+ *    `files-shared-handlers.ts`; both paths execute the same handler bodies.
+ *
+ * The canonical list/search response remains distinct from the legacy
+ * bearer's list/search contract. Reconciling those shapes stays out of scope.
  *
  * `visibility` keeps the query-param key convention rather than a path
  * segment: this router already relies on Hono's `:key{.+}` catch-all for
@@ -24,7 +29,7 @@
  */
 import { NotFoundError, ValidationError } from "@uploads/errors";
 import { signedDownloadUrl } from "@uploads/storage";
-import { Hono, type MiddlewareHandler } from "hono";
+import { Hono, type Handler, type MiddlewareHandler } from "hono";
 import { dualWorkspaceAuth, type DualAuthVars } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
 import { badKey, deleteObject, listObjects, setObjectVisibility } from "../files-core";
@@ -38,6 +43,13 @@ import { writeRateLimit } from "../guards";
 import { objectPublicUrls, publicUrl, storage, storageConfig } from "../storage";
 import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
 import { requireScope } from "../workspace";
+import {
+  getFileHandler,
+  patchFileHandler,
+  putFileHandler,
+  signFileHandler,
+  type SharedFilesHandler,
+} from "./files-shared-handlers";
 
 // `requireScope`/`writeRateLimit` are typed against `WorkspaceVars`; this
 // router's `DualAuthVars` is that type plus session fields, so a Context for
@@ -47,6 +59,9 @@ function scoped(scope: Parameters<typeof requireScope>[0]): MiddlewareHandler<Du
   return requireScope(scope) as unknown as MiddlewareHandler<DualAuthVars>;
 }
 const rateLimited = writeRateLimit as unknown as MiddlewareHandler<DualAuthVars>;
+function shared(handler: SharedFilesHandler): Handler<DualAuthVars> {
+  return handler as unknown as Handler<DualAuthVars>;
+}
 
 export const workspaceFiles = new Hono<DualAuthVars>()
 
@@ -211,6 +226,37 @@ export const workspaceFiles = new Hono<DualAuthVars>()
 
       return c.json({ key, visibility: sanitizeVisibility(requested) ?? "public" });
     },
+  )
+
+  // These four key operations share their handler bodies with the legacy
+  // bearer router. Keep every catch-all route after the static paths above:
+  // Hono's `:key{.+}` matching otherwise risks swallowing a static suffix.
+  .post(
+    "/:workspace/files/sign",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    shared(signFileHandler),
+  )
+  .put(
+    "/:workspace/files/:key{.+}",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    shared(putFileHandler),
+  )
+  .get(
+    "/:workspace/files/:key{.+}",
+    dualWorkspaceAuth(),
+    scoped("files:read"),
+    shared(getFileHandler),
+  )
+  .patch(
+    "/:workspace/files/:key{.+}",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    shared(patchFileHandler),
   )
 
   // Delete a file — path-keyed (the shape the bearer-token surface already

--- a/apps/api/test/routes-workspace-files-core.test.ts
+++ b/apps/api/test/routes-workspace-files-core.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Issue #613 phase 4: canonical dual-auth coverage for the four legacy file
+ * operations whose handler bodies are now shared by both routers.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { app } from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { FakeR2Bucket } from "./fake-r2";
+import { withMintingUserToken } from "./helpers/fake-minting-user-token";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+const WS = "acme";
+const LEGACY_TOKEN = "canonical-core-legacy-token";
+const SCOPED_TOKEN = "canonical-core-scoped-token";
+const USER = { id: "u-1", email: "member@example.com", name: "Member" };
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+const KEY = "shots/a.png";
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+type Operation = "sign" | "put" | "get" | "patch";
+
+interface EnvOptions {
+  member?: boolean;
+  scopedTokenScopes?: string[];
+  writeLimiterOk?: boolean;
+}
+
+function addRouteTestQueries(db: UsageFakeD1): void {
+  const originalPrepare = db.prepare.bind(db);
+  db.prepare = ((sql: string) => {
+    const normalized = sql.replace(/\s+/g, " ").trim();
+    if (normalized.startsWith("SELECT p.meta_value AS path")) {
+      return {
+        bind() {
+          return this;
+        },
+        async all<T>() {
+          return { success: true, results: [] as T[], meta: {} };
+        },
+      };
+    }
+    if (normalized.startsWith("INSERT INTO daily_metrics")) {
+      return {
+        bind() {
+          return this;
+        },
+        async run() {
+          return { success: true, results: [], meta: { changes: 1 } };
+        },
+      };
+    }
+    return originalPrepare(sql);
+  }) as UsageFakeD1["prepare"];
+}
+
+async function makeEnv(opts: EnvOptions = {}) {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: `${WS}/`,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(LEGACY_TOKEN),
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  addRouteTestQueries(db);
+  if (opts.scopedTokenScopes) {
+    withMintingUserToken(db, {
+      workspace: WS,
+      tokenHash: await sha256Hex(SCOPED_TOKEN),
+      mintingUserId: USER.id,
+      scopes: opts.scopedTokenScopes,
+    });
+  }
+
+  const env = {
+    REGISTRY: { get: async (key: string) => (key === `ws:${WS}` ? record : null) },
+    UPLOADS_DEFAULT: bucket,
+    DB: db,
+    WRITE_LIMITER: { limit: async () => ({ success: opts.writeLimiterOk ?? true }) },
+    WEB_ORIGIN: "https://uploads.sh",
+    GITHUB_CACHE: { get: async () => null, put: async () => undefined },
+    AUTH: {
+      fetch: async (input: RequestInfo | URL) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        if (url.pathname === "/api/auth/get-session") {
+          return Response.json({ session: {}, user: USER });
+        }
+        if (url.pathname === "/internal/memberships") {
+          return Response.json(
+            opts.member === false
+              ? []
+              : [
+                  {
+                    organizationId: "org-1",
+                    organizationSlug: WS,
+                    organizationName: "Acme",
+                    role: "member",
+                  },
+                ],
+          );
+        }
+        return Response.json({ githubAccountId: null });
+      },
+    },
+  };
+  return { env: env as unknown as Parameters<typeof app.request>[2], bucket, db };
+}
+
+async function seed(bucket: FakeR2Bucket, key = KEY): Promise<void> {
+  await bucket.put(`${WS}/${key}`, PNG, { httpMetadata: { contentType: "image/png" } });
+  bucket.setUploaded(`${WS}/${key}`, new Date("2026-08-11T12:00:00.000Z"));
+}
+
+function authHeaders(kind: "legacy" | "scoped" | "session"): Record<string, string> {
+  if (kind === "session") return { cookie: "session=x" };
+  return { Authorization: `Bearer ${kind === "legacy" ? LEGACY_TOKEN : SCOPED_TOKEN}` };
+}
+
+function operationRequest(
+  operation: Operation,
+  canonical: boolean,
+  auth: "legacy" | "scoped" | "session",
+): { path: string; init: RequestInit } {
+  const base = canonical ? `/v1/workspaces/${WS}/files` : `/v1/${WS}/files`;
+  const headers = authHeaders(auth);
+  if (operation === "sign") {
+    return {
+      path: `${base}/sign`,
+      init: {
+        method: "POST",
+        headers: { ...headers, "content-type": "application/json" },
+        body: JSON.stringify({ key: KEY, contentType: "image/png" }),
+      },
+    };
+  }
+  if (operation === "put") {
+    return {
+      path: `${base}/${KEY}`,
+      init: {
+        method: "PUT",
+        headers: { ...headers, "content-type": "image/png" },
+        body: PNG,
+      },
+    };
+  }
+  if (operation === "patch") {
+    return {
+      path: `${base}/${KEY}`,
+      init: {
+        method: "PATCH",
+        headers: { ...headers, "content-type": "application/json" },
+        body: JSON.stringify({ set: { app: "web" } }),
+      },
+    };
+  }
+  return { path: `${base}/${KEY}`, init: { headers } };
+}
+
+async function requestOperation(
+  operation: Operation,
+  canonical: boolean,
+  auth: "legacy" | "scoped" | "session",
+  env: Parameters<typeof app.request>[2],
+): Promise<Response> {
+  const { path, init } = operationRequest(operation, canonical, auth);
+  return app.request(path, init, env);
+}
+
+async function prepareOperation(operation: Operation, bucket: FakeR2Bucket): Promise<void> {
+  if (operation === "get" || operation === "patch") await seed(bucket);
+}
+
+function expectHandlerResult(operation: Operation, status: number, body: unknown): void {
+  if (operation === "sign") {
+    expect(status).toBe(400);
+    expect(body).toMatchObject({ error: { code: "presign_unavailable" } });
+  } else if (operation === "put") {
+    expect(status).toBe(201);
+    expect(body).toMatchObject({ workspace: WS, key: KEY, contentType: "image/png" });
+  } else if (operation === "get") {
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ key: KEY, contentType: "image/png" });
+  } else {
+    expect(status).toBe(200);
+    expect(body).toEqual({ metadata: { app: "web" } });
+  }
+}
+
+const OPERATION_SCOPES: Array<{
+  operation: Operation;
+  required: "files:read" | "files:write";
+  insufficient: "files:read" | "files:write";
+}> = [
+  { operation: "sign", required: "files:write", insufficient: "files:read" },
+  { operation: "put", required: "files:write", insufficient: "files:read" },
+  { operation: "get", required: "files:read", insufficient: "files:write" },
+  { operation: "patch", required: "files:write", insufficient: "files:read" },
+];
+
+describe.each(OPERATION_SCOPES)(
+  "$operation /v1/workspaces/:workspace/files canonical core operation",
+  ({ operation, required, insufficient }) => {
+    it(`accepts a bearer token with ${required}`, async () => {
+      const { env, bucket, db } = await makeEnv({ scopedTokenScopes: [required] });
+      await prepareOperation(operation, bucket);
+      const res = await requestOperation(operation, true, "scoped", env);
+      expectHandlerResult(operation, res.status, await res.json());
+      if (operation === "put") {
+        expect(bucket.store.has(`${WS}/${KEY}`)).toBe(true);
+        expect(db.usage.get(WS)).toMatchObject({ bytes: PNG.byteLength, objects: 1 });
+      }
+    });
+
+    it(`403s a bearer token with only ${insufficient}`, async () => {
+      const { env, bucket } = await makeEnv({ scopedTokenScopes: [insufficient] });
+      await prepareOperation(operation, bucket);
+      const res = await requestOperation(operation, true, "scoped", env);
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({
+        error: { type: "insufficient_scope", details: { required_scope: required } },
+      });
+      if (operation === "put") expect(bucket.store.has(`${WS}/${KEY}`)).toBe(false);
+    });
+
+    it("accepts a member session and reaches the same handler", async () => {
+      const { env, bucket } = await makeEnv();
+      await prepareOperation(operation, bucket);
+      const res = await requestOperation(operation, true, "session", env);
+      expectHandlerResult(operation, res.status, await res.json());
+    });
+
+    it("404s a non-member session before handler mutation", async () => {
+      const { env, bucket } = await makeEnv({ member: false });
+      await prepareOperation(operation, bucket);
+      const before = bucket.store.get(`${WS}/${KEY}`);
+      const res = await requestOperation(operation, true, "session", env);
+      expect(res.status).toBe(404);
+      expect(await res.json()).toMatchObject({ error: { code: "workspace_not_found" } });
+      expect(bucket.store.get(`${WS}/${KEY}`)).toEqual(before);
+    });
+
+    it("matches the legacy bearer path status and JSON body", async () => {
+      const legacy = await makeEnv();
+      const canonical = await makeEnv();
+      await prepareOperation(operation, legacy.bucket);
+      await prepareOperation(operation, canonical.bucket);
+      const legacyRes = await requestOperation(operation, false, "legacy", legacy.env);
+      const canonicalRes = await requestOperation(operation, true, "legacy", canonical.env);
+      expect(canonicalRes.status).toBe(legacyRes.status);
+      expect(await canonicalRes.json()).toEqual(await legacyRes.json());
+    });
+  },
+);
+
+describe("canonical file catch-all route ordering", () => {
+  it("keeps files/search on the static search handler", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket, "search");
+    const res = await app.request(
+      `/v1/workspaces/${WS}/files/search`,
+      { headers: authHeaders("legacy") },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: { code: "file_metadata_invalid_key" } });
+  });
+
+  it("keeps files/facets on the static facets handler", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket, "facets");
+    const res = await app.request(
+      `/v1/workspaces/${WS}/files/facets`,
+      { headers: authHeaders("legacy") },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ keys: [], truncated: false });
+  });
+
+  it("keeps files/by-path on the static grouping handler", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket, "by-path");
+    const res = await app.request(
+      `/v1/workspaces/${WS}/files/by-path`,
+      { headers: authHeaders("legacy") },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ groups: [], projects: [], truncated: false });
+  });
+
+  it("keeps files/file-url on the static URL handler", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket, "file-url");
+    const res = await app.request(
+      `/v1/workspaces/${WS}/files/file-url`,
+      { headers: authHeaders("legacy") },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: { type: "not_found" } });
+  });
+
+  it("matches legacy reserved-key shadowing and still reaches nested ordinary keys", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket, "facets");
+    await seed(bucket, "shots/search");
+
+    const legacyReserved = await app.request(
+      `/v1/${WS}/files/facets`,
+      { headers: authHeaders("legacy") },
+      env,
+    );
+    expect(legacyReserved.status).toBe(200);
+    expect(await legacyReserved.json()).toEqual({ keys: [], truncated: false });
+
+    const nested = await app.request(
+      `/v1/workspaces/${WS}/files/shots/search`,
+      { headers: authHeaders("legacy") },
+      env,
+    );
+    expect(nested.status).toBe(200);
+    expect(await nested.json()).toMatchObject({ key: "shots/search" });
+  });
+});


### PR DESCRIPTION
Phase 4 of #613: the canonical files vertical gains the four operations that until now existed only on the legacy bearer wildcard, closing the coverage gap that kept the CLI's `filesBase()` on `/v1/:workspace/files` in #632.

## New canonical routes (`apps/api/src/routes/workspace-files.ts`)

- `POST /v1/workspaces/:workspace/files/sign`
- `PUT /v1/workspaces/:workspace/files/:key` (upload, incl. `?replace=`/`X-Uploads-Replace`)
- `GET /v1/workspaces/:workspace/files/:key` (head JSON, or `?metadata=1` for the D1 metadata map)
- `PATCH /v1/workspaces/:workspace/files/:key` (metadata merge)

All `dualWorkspaceAuth()` with the legacy scopes (`files:write` for sign/put/patch + write rate limit, `files:read` for get). Sessions gain these operations, consistent with phase 1's file-plane decision — `dualWorkspaceAuth` sets `mintingUserId` from the session user, so `gh.uploader` attribution stamps correctly on session uploads too.

## No-drift extraction

Handler bodies moved verbatim to `routes/files-shared-handlers.ts`; both routers call the same functions. The legacy router keeps its own middleware untouched — pre-existing `routes-files` tests pass unmodified.

## Route ordering

The new `:key{.+}` catch-alls register after the vertical's static routes (`search`, `facets`, `by-path`, `file-url`), with tests proving each static route still resolves and that reserved-key shadowing matches the legacy router's behavior exactly (parity, not new invention).

## Still out of scope (documented in the module docblock)

The bearer-vs-session list/search shape reconciliation — the phase-1 punt stays a punt.

## Verification

- `apps/api`: 136 test files, 1779 tests green (new `routes-workspace-files-core.test.ts`: per-route 5-case matrix — bearer with scope, insufficient scope 403, member session, non-member uniform 404, legacy-parity body equality — plus the ordering suite); `tsc --noEmit` clean.

Refs #613. Follow-up after this deploys: flip the CLI's sign/put/get/patch to canonical (list/find stays until the shape work); then alias + wildcard retirement on telemetry.
