### PR TITLE
refactor(cli): per-key file operations move to the canonical /v1/workspaces surface (#613)

### DIFF
--- a/.changeset/cli-canonical-file-key-ops.md
+++ b/.changeset/cli-canonical-file-key-ops.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Per-key file operations — upload PUT, head/metadata GET, metadata PATCH, and DELETE — now use the canonical `/v1/workspaces/:workspace/files/<key>` paths (#613). The server has shared identical handlers across both surfaces since #636, so behavior is unchanged; the legacy paths keep working.
+
+List, find, and facets stay on the legacy `/v1/:workspace/files` wildcard until the bearer list/search response shape is reconciled with the canonical one.

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -755,12 +755,19 @@ function encodeKeyPath(key: string): string {
 }
 
 // Stays on the legacy `/v1/:workspace/files` wildcard for now (issue #613):
-// the canonical files vertical has no upload PUT, POST /sign, or GET/PATCH
-// /:key metadata yet, and its list/search adopted the session response shape
-// rather than the bearer one. Move this once the canonical vertical grows
-// those routes and the bearer list shape is reconciled.
+// the canonical files vertical's list/search adopted the session response
+// shape rather than the bearer one, so list/find/facets keep the legacy
+// path until that shape is reconciled.
 function filesBase(config: UploadsClientConfig): string {
   return `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/files`;
+}
+
+// Canonical files surface (issue #613 phase 4): per-key operations —
+// upload PUT, head/metadata GET, metadata PATCH, DELETE — live at
+// `/v1/workspaces/:workspace/files` with identical handlers to the legacy
+// wildcard (shared server-side since #636).
+function canonicalFilesBase(config: UploadsClientConfig): string {
+  return `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/files`;
 }
 
 function usageBase(config: UploadsClientConfig): string {
@@ -941,7 +948,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
           embedUrl?: string | null;
           replaced?: boolean;
           wouldRefuse?: boolean;
-        }>("PUT", `${filesBase(config)}/${encodeKeyPath(key)}?${qs}`);
+        }>("PUT", `${canonicalFilesBase(config)}/${encodeKeyPath(key)}?${qs}`);
         if (preview.url == null) {
           throw new UploadsError(
             "workspace has no publicBaseUrl (cannot resolve a public URL)",
@@ -985,7 +992,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
         replaced?: boolean;
         provenance?: Record<string, string>;
         metadata?: Record<string, string>;
-      }>("PUT", `${filesBase(config)}/${encodeKeyPath(key)}`, {
+      }>("PUT", `${canonicalFilesBase(config)}/${encodeKeyPath(key)}`, {
         body,
         headers,
       });
@@ -1023,23 +1030,27 @@ export function createUploadsClient(config: UploadsClientConfig) {
     },
 
     async delete(key: string): Promise<DeleteResult> {
-      return request<DeleteResult>("DELETE", `${filesBase(config)}/${encodeKeyPath(key)}`);
+      return request<DeleteResult>("DELETE", `${canonicalFilesBase(config)}/${encodeKeyPath(key)}`);
     },
 
     /** `GET /v1/:workspace/files/:key?metadata=1` — the object's queryable metadata. */
     async getMetadata(key: string): Promise<GetMetadataResult> {
       return request<GetMetadataResult>(
         "GET",
-        `${filesBase(config)}/${encodeKeyPath(key)}?metadata=1`,
+        `${canonicalFilesBase(config)}/${encodeKeyPath(key)}?metadata=1`,
       );
     },
 
     /** `PATCH /v1/:workspace/files/:key` — merge `set`/`delete`; returns the merged map. */
     async patchMetadata(key: string, opts: PatchMetadataOptions): Promise<GetMetadataResult> {
-      return request<GetMetadataResult>("PATCH", `${filesBase(config)}/${encodeKeyPath(key)}`, {
-        body: new TextEncoder().encode(JSON.stringify(opts)),
-        headers: { "Content-Type": "application/json" },
-      });
+      return request<GetMetadataResult>(
+        "PATCH",
+        `${canonicalFilesBase(config)}/${encodeKeyPath(key)}`,
+        {
+          body: new TextEncoder().encode(JSON.stringify(opts)),
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     },
 
     /**
@@ -1074,7 +1085,10 @@ export function createUploadsClient(config: UploadsClientConfig) {
     },
 
     async head(key: string): Promise<HeadResult> {
-      const result = await request<HeadResult>("GET", `${filesBase(config)}/${encodeKeyPath(key)}`);
+      const result = await request<HeadResult>(
+        "GET",
+        `${canonicalFilesBase(config)}/${encodeKeyPath(key)}`,
+      );
       return { ...result, embedUrl: resolveEmbedUrl(result.url, result.embedUrl) };
     },
 

--- a/packages/uploads/test/client-metadata.test.ts
+++ b/packages/uploads/test/client-metadata.test.ts
@@ -71,7 +71,9 @@ describe("put metadata headers", () => {
 describe("metadata CRUD client methods", () => {
   it("getMetadata GETs the key-at-tail route with ?metadata=1", async () => {
     const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      expect(String(input)).toBe("https://api.test/v1/test/files/screenshots/a.png?metadata=1");
+      expect(String(input)).toBe(
+        "https://api.test/v1/workspaces/test/files/screenshots/a.png?metadata=1",
+      );
       expect(init?.method).toBe("GET");
       return new Response(JSON.stringify({ metadata: { app: "myapp" } }));
     });
@@ -86,7 +88,7 @@ describe("metadata CRUD client methods", () => {
 
   it("patchMetadata PATCHes { set, delete } to the key-at-tail route and returns the merged map", async () => {
     const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      expect(String(input)).toBe("https://api.test/v1/test/files/screenshots/a.png");
+      expect(String(input)).toBe("https://api.test/v1/workspaces/test/files/screenshots/a.png");
       expect(init?.method).toBe("PATCH");
       const body = JSON.parse(new TextDecoder().decode(init?.body as Uint8Array));
       expect(body).toEqual({ set: { app: "myapp" }, delete: ["page"] });


### PR DESCRIPTION
Follow-up to #636 (which added the canonical routes) and #632 (which moved github/usage/galleries): the CLI's per-key file operations now use `/v1/workspaces/:workspace/files/<key>`:

- upload `PUT` (incl. `?replace=` and dry-run)
- head `GET` and metadata `GET ?metadata=1`
- metadata `PATCH`
- `DELETE`

The server shares identical handler bodies across both surfaces since #636, so behavior is unchanged and the legacy paths keep working. **Still on the legacy wildcard**: list, find, and facets — they return the bearer `{items}` shape, which the canonical list/search deliberately doesn't (the #613 phase-1 punt). The `filesBase()` comment now documents exactly that remaining reason.

## Verification

- `@buildinternet/uploads`: 69 test files, 1143 tests green; `tsc --noEmit` clean.
- End-to-end prod smoke with the branch CLI against `api.uploads.sh`: `put` a PNG via canonical PUT (201 + URL), `meta set`/`meta get` round-trip (derived git tags and `gh.uploader` attribution stamped correctly through the shared handler), `delete` cleaned up. Also confirmed the canonical route is live in prod before smoking (auth-walled probe).
- Changeset: minor on `@buildinternet/uploads` only.

Refs #613. Remaining on the issue after this: bearer list/search shape reconciliation (unblocks list/find/facets + the `/me` stragglers), then alias + bare-wildcard retirement on telemetry.
