### PR TITLE
refactor(cli,api): list/find/facets move to canonical paths; search gains ?limit (#613)

### DIFF
--- a/.changeset/cli-canonical-list-find-facets.md
+++ b/.changeset/cli-canonical-list-find-facets.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+List, find, and facets complete the CLI's move to the canonical `/v1/workspaces/:workspace/files` surface (#613) — no legacy `/v1/:workspace` paths remain in the client. The client's own return shapes are unchanged: `list` adapts the canonical `{files, prefixes, cursor}` envelope back to `{items, cursor}` (and still honors `metadata: true` opt-in), and `findFiles` now calls `files/search`, which is non-paginated (server cap 100, narrowable with `limit`), so its `cursor` is always `null`.

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -108,13 +108,17 @@ export const workspaceFiles = new Hono<DualAuthVars>()
       });
     }
 
+    // `limit` narrows the page below the server cap (never raises it) — added
+    // for the bearer-find migration (#613), whose callers pass `--limit`.
     const SEARCH_LIMIT = 100;
+    const rawLimit = Number(c.req.query("limit") ?? SEARCH_LIMIT) || SEARCH_LIMIT;
+    const pageSize = Math.min(Math.max(1, Math.floor(rawLimit)), SEARCH_LIMIT);
     const cfg = await storageConfig(c.env, record);
     const { matches, truncated } = await searchFilesByNameAndMeta(c.env, record, name, {
       filters: hasMeta ? filters : undefined,
       nameTerm,
       prefix: query.prefix,
-      pageSize: SEARCH_LIMIT,
+      pageSize,
     });
 
     return c.json({

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -318,6 +318,25 @@ describe("GET /v1/workspaces/:workspace/files/facets and /search (dual auth)", (
     expect(bearer.status).toBe(400);
     expect(session.status).toBe(400);
   });
+
+  it("search: ?limit= narrows the page and reports truncation", async () => {
+    const { env, bucket } = await makeEnv();
+    await bucket.put("acme/shots/hero-a.png", new Uint8Array([1]).buffer, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await bucket.put("acme/shots/hero-b.png", new Uint8Array([1]).buffer, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const res = await app.request(
+      "/v1/workspaces/acme/files/search?name=hero&limit=1",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[]; truncated: boolean };
+    expect(body.items).toHaveLength(1);
+    expect(body.truncated).toBe(true);
+  });
 });
 
 describe("GET /v1/workspaces/:workspace/files/by-path (dual auth)", () => {

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -754,18 +754,10 @@ function encodeKeyPath(key: string): string {
   return key.split("/").map(encodeURIComponent).join("/");
 }
 
-// Stays on the legacy `/v1/:workspace/files` wildcard for now (issue #613):
-// the canonical files vertical's list/search adopted the session response
-// shape rather than the bearer one, so list/find/facets keep the legacy
-// path until that shape is reconciled.
-function filesBase(config: UploadsClientConfig): string {
-  return `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/files`;
-}
-
-// Canonical files surface (issue #613 phase 4): per-key operations —
-// upload PUT, head/metadata GET, metadata PATCH, DELETE — live at
-// `/v1/workspaces/:workspace/files` with identical handlers to the legacy
-// wildcard (shared server-side since #636).
+// Canonical files surface (issue #613): every file operation now goes to
+// `/v1/workspaces/:workspace/files`. Per-key ops share handlers with the
+// legacy wildcard (#636); list/find/facets adapt the canonical envelopes in
+// their wrappers below (#613 shape reconciliation).
 function canonicalFilesBase(config: UploadsClientConfig): string {
   return `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/files`;
 }
@@ -911,13 +903,25 @@ export function createUploadsClient(config: UploadsClientConfig) {
     if (opts.cursor) params.set("cursor", opts.cursor);
     if (opts.metadata) params.set("metadata", "1");
     const qs = params.toString();
-    const page = await request<ListResult>("GET", `${filesBase(config)}${qs ? `?${qs}` : ""}`);
+    // Canonical list envelope is `{files, prefixes, cursor}` with queryable
+    // metadata always hydrated (issue #613 — the session shape won the
+    // reconciliation). This client keeps its historical `{items, cursor}`
+    // contract: rename the array and honor `opts.metadata` by stripping the
+    // hydrated maps when the caller didn't ask for them.
+    const page = await request<{ files: ListItem[]; cursor: string | null }>(
+      "GET",
+      `${canonicalFilesBase(config)}${qs ? `?${qs}` : ""}`,
+    );
     return {
-      ...page,
-      items: page.items.map((item) => ({
-        ...item,
-        embedUrl: resolveEmbedUrl(item.url, item.embedUrl),
-      })),
+      cursor: page.cursor,
+      items: page.files.map((item) => {
+        const { metadata, ...rest } = item;
+        return {
+          ...rest,
+          ...(opts.metadata && metadata !== undefined ? { metadata } : {}),
+          embedUrl: resolveEmbedUrl(item.url, item.embedUrl),
+        };
+      }),
     };
   }
 
@@ -1054,10 +1058,12 @@ export function createUploadsClient(config: UploadsClientConfig) {
     },
 
     /**
-     * `GET /v1/:workspace/files?meta.<k>=<v>&…&name=…` — ANDed equality filter
-     * over queryable metadata and/or a case-insensitive filename substring.
-     * At least one of non-empty `filters` or `opts.name` is required.
-     * `filters` must be pre-validated when present (see `metadata.ts`).
+     * `GET /v1/workspaces/:workspace/files/search?meta.<k>=<v>&…&name=…` —
+     * ANDed equality filter over queryable metadata and/or a case-insensitive
+     * filename substring. At least one of non-empty `filters` or `opts.name`
+     * is required. `filters` must be pre-validated when present (see
+     * `metadata.ts`). The canonical search route is non-paginated (server cap
+     * 100, narrowable via `limit`), so `cursor` is always null.
      */
     async findFiles(
       filters: Record<string, string> = {},
@@ -1068,19 +1074,23 @@ export function createUploadsClient(config: UploadsClientConfig) {
       if (opts.name) params.set("name", opts.name);
       if (opts.prefix) params.set("prefix", opts.prefix);
       if (opts.limit != null) params.set("limit", String(opts.limit));
-      return request<FindFilesResult>("GET", `${filesBase(config)}?${params.toString()}`);
+      const result = await request<{ items: FindFilesItem[]; truncated: boolean }>(
+        "GET",
+        `${canonicalFilesBase(config)}/search?${params.toString()}`,
+      );
+      return { items: result.items, cursor: null, truncated: result.truncated };
     },
 
     /** `GET /v1/:workspace/files/facets` — workspace metadata key vocabulary. */
     async listMetadataKeys(): Promise<MetadataKeysResult> {
-      return request<MetadataKeysResult>("GET", `${filesBase(config)}/facets`);
+      return request<MetadataKeysResult>("GET", `${canonicalFilesBase(config)}/facets`);
     },
 
     /** `GET /v1/:workspace/files/facets?key=` — distinct values for one key. */
     async listMetadataValues(key: string): Promise<MetadataValuesResult> {
       return request<MetadataValuesResult>(
         "GET",
-        `${filesBase(config)}/facets?${new URLSearchParams({ key })}`,
+        `${canonicalFilesBase(config)}/facets?${new URLSearchParams({ key })}`,
       );
     },
 

--- a/packages/uploads/test/client-metadata.test.ts
+++ b/packages/uploads/test/client-metadata.test.ts
@@ -108,7 +108,7 @@ describe("metadata CRUD client methods", () => {
   it("findFiles sends repeatable ANDed meta.<key> params plus prefix/limit", async () => {
     const fetch = vi.fn(async (input: string | URL | Request) => {
       const url = new URL(String(input));
-      expect(url.pathname).toBe("/v1/test/files");
+      expect(url.pathname).toBe("/v1/workspaces/test/files/search");
       expect(url.searchParams.getAll("meta.gh.repo")).toEqual(["buildinternet/uploads"]);
       expect(url.searchParams.getAll("meta.gh.number")).toEqual(["123"]);
       expect(url.searchParams.get("prefix")).toBe("gh/");
@@ -137,7 +137,7 @@ describe("metadata CRUD client methods", () => {
   it("findFiles sends ?name= with optional empty filters", async () => {
     const fetch = vi.fn(async (input: string | URL | Request) => {
       const url = new URL(String(input));
-      expect(url.pathname).toBe("/v1/test/files");
+      expect(url.pathname).toBe("/v1/workspaces/test/files/search");
       expect(url.searchParams.get("name")).toBe("hero");
       expect(url.searchParams.getAll("meta.app")).toEqual(["web"]);
       return new Response(
@@ -161,7 +161,7 @@ describe("metadata CRUD client methods", () => {
 
   it("listMetadataKeys GETs /files/facets", async () => {
     const fetch = vi.fn(async (input: string | URL | Request) => {
-      expect(String(input)).toBe("https://api.test/v1/test/files/facets");
+      expect(String(input)).toBe("https://api.test/v1/workspaces/test/files/facets");
       return new Response(
         JSON.stringify({
           keys: [{ key: "app", count: 2, distinctValues: 1 }],
@@ -183,7 +183,7 @@ describe("metadata CRUD client methods", () => {
 
   it("listMetadataValues GETs /files/facets?key=", async () => {
     const fetch = vi.fn(async (input: string | URL | Request) => {
-      expect(String(input)).toBe("https://api.test/v1/test/files/facets?key=app");
+      expect(String(input)).toBe("https://api.test/v1/workspaces/test/files/facets?key=app");
       return new Response(
         JSON.stringify({
           key: "app",
@@ -213,7 +213,7 @@ describe("list metadata hydration", () => {
       seenUrl = String(input);
       return new Response(
         JSON.stringify({
-          items: [
+          files: [
             {
               key: "gh/acme/web/pull/12/before.webp",
               url: "https://storage.test/before.webp",
@@ -242,7 +242,7 @@ describe("list metadata hydration", () => {
     let seenUrl = "";
     const fetch = vi.fn(async (input: string | URL | Request) => {
       seenUrl = String(input);
-      return new Response(JSON.stringify({ items: [], cursor: null }), { status: 200 });
+      return new Response(JSON.stringify({ files: [], cursor: null }), { status: 200 });
     });
     vi.stubGlobal("fetch", fetch);
     const client = createUploadsClient({

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -93,7 +93,7 @@ describe("runLogin", () => {
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(response({ workspace: "default", token }, 201))
       .mockResolvedValueOnce(response({ ok: true }))
-      .mockResolvedValueOnce(response({ items: [], cursor: null }));
+      .mockResolvedValueOnce(response({ files: [], cursor: null }));
     const output = captureOutput();
     expect(await runLogin(["--non-interactive", "--path", path], { json: true })).toBe(0);
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -206,7 +206,7 @@ describe("runLogin device flow", () => {
       ) // POST /v1/tokens
       .mockResolvedValueOnce(response({ session: { cliVersion: "0.0.0" } })) // update-session
       .mockResolvedValueOnce(response({ ok: true })) // doctor health
-      .mockResolvedValueOnce(response({ items: [], cursor: null })); // doctor list
+      .mockResolvedValueOnce(response({ files: [], cursor: null })); // doctor list
     const output = captureOutput();
 
     expect(await runLogin(["--path", path], { json: true }, false, silentIo)).toBe(0);


### PR DESCRIPTION
The #613 list-shape reconciliation, resolved as: **the canonical (session) envelope is the wire contract, and the CLI adapts client-side.** With this, no legacy `/v1/:workspace` path remains anywhere in the CLI.

## Why this was smaller than the punt suggested

Comparing the live contracts: facets are byte-identical on both surfaces (same `listFacets()` call); canonical `files/search` already returns `{items: [{key,url,embedUrl,metadata}], truncated}` — effectively the bearer find shape minus pagination; only the list envelope truly diverged (`{files, prefixes, cursor}` + always-hydrated metadata vs `{items, cursor}` + opt-in).

## Changes

**API** (one small addition): canonical `files/search` accepts `?limit=` (clamped 1..100, never raises the server cap) so bearer-find callers keep their `--limit`. With a truncation test.

**CLI**:
- `list` calls the canonical route and adapts `{files, …}` back to its historical `{items, cursor}` return shape; `metadata: true` opt-in preserved by stripping the always-hydrated maps when not requested.
- `findFiles` calls `files/search`; `cursor` is always `null` (the canonical search is non-paginated — matching the practical behavior of the legacy meta-filtered list).
- facets flip verbatim. `filesBase()` (the last legacy URL builder) is deleted.

## Verification

- `apps/api`: 1780 tests green (new `?limit=` truncation test); `@buildinternet/uploads`: 1143 tests green; both `tsc --noEmit` clean.
- Prod smoke with the branch CLI: `list --limit 3` (canonical envelope adapted, cursor works), `find --meta app=web`, `find --name hero`, `meta keys` — all returning real data through `/v1/workspaces/...`. (Prod ignores `?limit=` until this deploys — harmless, the server cap applies.)
- Changeset: minor on `@buildinternet/uploads` only.

Refs #613. Remaining on the issue after this: deciding the `/me` stragglers (galleries projection, github-status/titles, comment-preview, file-browser), and alias + bare-wildcard retirement once telemetry shows the legacy paths quiet — which now just means waiting out CLI release adoption.
