### PR TITLE
refactor(api,web): canonical homes for the /me stragglers; /me becomes forwards (#613)

### DIFF
--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1004,10 +1004,14 @@ describe("GET /me/workspaces/:name/galleries", () => {
 
   it("returns an empty gallery list for a workspace named 'default' just like any other", async () => {
     const db = galleriesDb();
-    const env = memberEnv({ workspace: "default", db: new SQLiteD1(db) });
+    // Issue #613 final phase: this route now forwards to the canonical
+    // dual-auth galleries vertical (`workspace-galleries.ts`), which — unlike
+    // the pre-#613 inline handler — loads the workspace record as part of
+    // `dualWorkspaceAuth`, so a record must be seeded in `REGISTRY`.
+    const env = memberEnv({ workspace: "default", db: new SQLiteD1(db), record: R2_RECORD });
     const res = await app().request("/me/workspaces/default/galleries", {}, env);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ galleries: [] });
+    expect(await res.json()).toEqual({ galleries: [], nextCursor: null });
   });
 
   it("returns gallery summaries for a member's workspace", async () => {
@@ -1019,7 +1023,7 @@ describe("GET /me/workspaces/:name/galleries", () => {
          ('gal_aaaaaaaaaaaaaaaaaaaaaa', 'acme', 'Launch media', NULL, 'public', NULL, 1,
           '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z', NULL)`,
     );
-    const env = memberEnv({ workspace: "acme", db: new SQLiteD1(db) });
+    const env = memberEnv({ workspace: "acme", db: new SQLiteD1(db), record: R2_RECORD });
     const res = await app().request("/me/workspaces/acme/galleries", {}, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
@@ -1039,6 +1043,7 @@ describe("GET /me/workspaces/:name/galleries", () => {
           references: [],
         },
       ],
+      nextCursor: null,
     });
   });
 
@@ -1064,7 +1069,7 @@ describe("GET /me/workspaces/:name/galleries", () => {
           'https://github.com/buildinternet/uploads/pull/58',
           '2026-07-02T00:00:00.000Z', '2026-07-02T00:00:00.000Z')`,
     );
-    const env = memberEnv({ workspace: "acme", db: new SQLiteD1(db) });
+    const env = memberEnv({ workspace: "acme", db: new SQLiteD1(db), record: R2_RECORD });
     const res = await app().request("/me/workspaces/acme/galleries", {}, env);
     expect(res.status).toBe(200);
     const body = (await res.json()) as {

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -10,31 +10,10 @@
  * for workspace existence any more precisely than for any other workspace.
  */
 import { resolveWorkspaceCreateQuota } from "@uploads/billing";
-import {
-  resolveCommentOptions,
-  type OptionSource,
-  type ResolvedCommentOptions,
-} from "@uploads/comment-config";
-import { NotFoundError, ValidationError } from "@uploads/errors";
-import { createFilesRouter } from "@uploads/storage";
+import { NotFoundError } from "@uploads/errors";
 import { Hono, type Context } from "hono";
-import { parseExternalReference } from "../external-references";
-import { previewFixtureItems } from "../comment-preview-fixtures";
-import { badKey, listObjects } from "../files-core";
-import { listGalleries } from "../galleries";
-import { galleryListSummaries } from "../gallery-service";
+import { badKey } from "../files-core";
 import {
-  attachmentsCommentBody,
-  attachmentsMarker,
-  type AttachmentItem,
-} from "../github-comment-render";
-import { githubInstallStatus, type GithubInstallStatus } from "../github-install-status";
-import { findRepoLink, listRepoLinksForWorkspace } from "../github-repo-links";
-import { resolveRepoCommentOptions, workspaceCommentDefaults } from "../repo-comment-config";
-import { resolveTitles } from "../github-titles";
-import {
-  adminWorkspaceOr403,
-  memberWorkspaceOr404,
   membershipsForUser,
   myWorkspaceFromMembership,
   workspacesFromMembership,
@@ -42,10 +21,11 @@ import {
 } from "../org-workspaces";
 import { presetResolvedSessionUser } from "../dual-workspace-auth";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
-import { storage } from "../storage";
 import { loadWorkspaceRecord } from "../workspace";
 import { planResponse } from "../workspace-plan";
 import { workspaceFiles } from "./workspace-files";
+import { workspaceGalleries } from "./workspace-galleries";
+import { workspaceGithub } from "./workspace-github";
 import { workspaceMembers } from "./workspace-members";
 import { workspaceSettings } from "./workspace-settings";
 import { workspaceUsage } from "./workspace-usage";
@@ -100,6 +80,31 @@ function forwardToWorkspaceFiles(c: Context<SessionVars>, path: string): Promise
 }
 
 /**
+ * Forwards to the canonical dual-auth galleries vertical
+ * (`routes/workspace-galleries.ts`, issue #613 final phase) — routes
+ * registered as `/:workspace/galleries*`. Its `GET /:workspace/galleries`
+ * list is now enriched with `itemCount`/`references` for every caller (see
+ * that router's `listGalleriesEnrichedHandler`), matching this route's old
+ * inline shape exactly — so this is now a genuine forward, not a
+ * reimplementation.
+ */
+function forwardToWorkspaceGalleries(c: Context<SessionVars>, path: string): Promise<Response> {
+  return forwardTo(workspaceGalleries, c, path);
+}
+
+/**
+ * Forwards to the canonical dual-auth github vertical
+ * (`routes/workspace-github.ts`, issue #613 final phase) — routes registered
+ * as `/:workspace/github/*`. The canonical `titles`/`status`/`repo-links`
+ * handlers are session-member/admin-gated (a bearer 403s
+ * `github_requires_session`/`github_repo_links_requires_session`), moved
+ * verbatim from this file's original bodies, so this is a genuine forward.
+ */
+function forwardToWorkspaceGithub(c: Context<SessionVars>, path: string): Promise<Response> {
+  return forwardTo(workspaceGithub, c, path);
+}
+
+/**
  * Forwards to the canonical usage vertical (`routes/workspace-usage.ts`,
  * issue #613 phase 2). Response shape is a strict superset of the pre-#613
  * session shape (adds `scopes`/`plan`; every other field —
@@ -144,9 +149,6 @@ function forwardToWorkspaceInvite(c: Context<SessionVars>, name: string): Promis
 function forwardToWorkspaceSettings(c: Context<SessionVars>, path: string): Promise<Response> {
   return forwardTo(workspaceSettings, c, path);
 }
-
-/** `?repo=` shape for the comment preview endpoint: exactly one `/`, no empty segments. */
-const REPO_SHAPE_RE = /^[^/\s]+\/[^/\s]+$/;
 
 /**
  * Every workspace the user's memberships map to. Memberships already include
@@ -258,25 +260,19 @@ export const me = new Hono<SessionVars>()
     forwardToWorkspaceMembers(c, `/${encodeURIComponent(c.req.param("name"))}/people`),
   )
 
-  // Galleries in one workspace — member-gated. Issue #613 phase 2: NOT
-  // forwarded to the canonical `/v1/workspaces/:workspace/galleries` list —
-  // this session shape carries `itemCount`/`references` per gallery (from
-  // `galleryListSummaries`) that the canonical/bearer list route omits (it
-  // uses the cheaper `gallerySummary` projection instead), so canonical is
-  // not a strict superset. `apps/web/src/lib/api-client.ts`'s `GallerySummary`
-  // does mark both fields optional ("Omitted on older API deployments"), but
-  // per the conservative rule for this migration (keep-and-document over
-  // inventing a new shape), this handler stays as-is rather than either
-  // dropping those fields for everyone or growing the canonical route to add
-  // them just for this alias. See `.context/613-api-consolidation-plan.md`.
-  .get("/workspaces/:name/galleries", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-    const page = await listGalleries(c.env.DB, name, { limit: 50 });
-    return c.json({
-      galleries: await galleryListSummaries(c.env, name, page.galleries),
-    });
-  })
+  // Galleries in one workspace — member-gated. Issue #613 final phase: the
+  // canonical `/v1/workspaces/:workspace/galleries` list is now enriched
+  // with `itemCount`/`references` per gallery for every caller (see
+  // `workspace-galleries.ts`'s `listGalleriesEnrichedHandler`), so this
+  // route forwards there instead of reimplementing. The pre-#613 shape had
+  // no `limit`/`cursor`/`nextCursor` — the canonical route defaults `limit`
+  // to 50 (same default this handler used) and adds `nextCursor`, an
+  // additive field this response shape tolerates the same way
+  // `apps/web/src/lib/api-client.ts`'s `GallerySummary` already marks
+  // `itemCount`/`references` optional.
+  .get("/workspaces/:name/galleries", (c) =>
+    forwardToWorkspaceGalleries(c, `/${encodeURIComponent(c.req.param("name"))}/galleries`),
+  )
 
   // Issue #613 phase 1: list/search/facets/by-path/file-url/visibility/delete
   // now forward to the canonical dual-auth handlers in
@@ -317,27 +313,14 @@ export const me = new Hono<SessionVars>()
     );
   })
 
-  // files-sdk's folder-aware browser gateway. Authorization happens before a
-  // storage instance is constructed; readonly plus this operation allow-list
-  // independently prevent member UI requests from mutating storage.
-  .all("/workspaces/:name/file-browser", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
-    const router = createFilesRouter({
-      files: (await storage(c.env, record)).readonly(),
-      operations: ["list"],
-      maxListLimit: 100,
-      // files-sdk resolves a signing secret even when signing operations are
-      // disabled. This value is intentionally non-secret and cannot authorize
-      // anything on this list-only, authenticated gateway.
-      secret: `readonly-list:${name}`,
-    });
-    return router.handle(c.req.raw);
-  })
+  // files-sdk's folder-aware browser gateway. Issue #613 final phase:
+  // forwards to the canonical session-member-gated handler in
+  // `routes/workspace-files.ts` — the extracted handler is byte-for-byte the
+  // body this route used to run, so response shape can't drift. See
+  // `forwardToWorkspaceFiles`'s docblock.
+  .all("/workspaces/:name/file-browser", (c) =>
+    forwardToWorkspaceFiles(c, `/${encodeURIComponent(c.req.param("name"))}/file-browser`),
+  )
 
   // Invite an email to the org backing this workspace (Better Auth invitation).
   // Workspace org admin|owner only. Returns acceptUrl so self-hosted installs
@@ -393,44 +376,23 @@ export const me = new Hono<SessionVars>()
   // gated: title text for private repos is sensitive, and membership scoping
   // keeps this from becoming a public title oracle for whatever repos the
   // App can read. Per-ref failures are nulls — the endpoint never fails the
-  // batch wholesale.
-  .get("/workspaces/:name/github-titles", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-
-    const raw = (c.req.query("refs") ?? "").split(",").filter((s) => s.length > 0);
-    if (raw.length === 0) {
-      throw new ValidationError("refs query parameter required", { code: "refs_required" });
-    }
-    if (raw.length > 20) {
-      throw new ValidationError("at most 20 refs per request", { code: "too_many_refs" });
-    }
-    const normalized = raw.map((coordinate) => {
-      const parsed = parseExternalReference("github", coordinate);
-      if (!parsed.ok) {
-        throw new ValidationError(`invalid ref: ${coordinate}`, { code: "invalid_ref" });
-      }
-      // normalizedKey carries a `github:item:` provider prefix — the gh.ref
-      // metadata shape (and this response's keys) is bare
-      // `owner/repo#number`, so derive it from the locator instead.
-      const { owner, repository, number } = parsed.value.locator;
-      return `${owner}/${repository}#${number}`;
-    });
-
-    const titles = await resolveTitles(c.env, [...new Set(normalized)]);
-    return c.json({ refs: titles });
-  })
+  // batch wholesale. Issue #613 final phase: forwards to the canonical
+  // session-member-gated handler in `routes/workspace-github.ts` — the
+  // extracted handler is byte-for-byte the body this route used to run, so
+  // response shape can't drift. See `forwardToWorkspaceGithub`'s docblock.
+  .get("/workspaces/:name/github-titles", (c) =>
+    forwardToWorkspaceGithub(c, `/${encodeURIComponent(c.req.param("name"))}/github/titles`),
+  )
 
   // Whether this workspace already has the GitHub App installed (issue #492),
   // so the rail's `install github app` CTA can stop nagging workspaces that
   // installed it. Member-gated like the sibling `/github-titles`: the answer
   // is derived from the workspace's repo bindings, which aren't public.
   // Never fails — see `githubInstallStatus` for the degrade-to-false rule.
-  .get("/workspaces/:name/github-status", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-    return c.json<GithubInstallStatus>(await githubInstallStatus(c.env, name));
-  })
+  // Same forward as above.
+  .get("/workspaces/:name/github-status", (c) =>
+    forwardToWorkspaceGithub(c, `/${encodeURIComponent(c.req.param("name"))}/github/status`),
+  )
 
   // Repos this workspace has linked (issue #307, Task 7) — feeds the comment
   // settings preview panel's repo picker. Admin/owner-gated like the
@@ -441,13 +403,13 @@ export const me = new Hono<SessionVars>()
   // `ADMIN_TOKEN`, which the web app's Better Auth session can't produce.
   // Repo names only: the web client has no use for installationId/source/
   // createdAt, and trimming them keeps this from becoming a second surface
-  // to keep in sync with `repoLinkResponse` in admin-ui.ts.
-  .get("/workspaces/:name/repo-links", async (c) => {
-    const name = c.req.param("name");
-    await adminWorkspaceOr403(c.env, requireUserId(c), name);
-    const links = await listRepoLinksForWorkspace(c.env.DB, name);
-    return c.json({ repos: links.map((link) => link.repo) });
-  })
+  // to keep in sync with `repoLinkResponse` in admin-ui.ts. Issue #613 final
+  // phase: forwards to the canonical session-admin-gated handler in
+  // `routes/workspace-github.ts`, which keeps this exact `{repos}`
+  // projection. Same forward pattern as above.
+  .get("/workspaces/:name/repo-links", (c) =>
+    forwardToWorkspaceGithub(c, `/${encodeURIComponent(c.req.param("name"))}/github/repo-links`),
+  )
 
   // Workspace-level managed-comment defaults (issue #307): image width,
   // inline-image cap, the two legacy booleans, and a short note. Admin/owner
@@ -465,80 +427,14 @@ export const me = new Hono<SessionVars>()
   )
 
   // Preview the production managed-comment body against resolved comment
-  // settings (issue #307). Admin/owner-gated like the settings routes above:
-  // the response includes per-key source attribution ("repo" | "workspace" |
-  // "auto"), which a plain member has no reason to see. With no `repo` query
-  // param, resolution runs against workspace defaults only (`repoConfig:
-  // null`) via the same `resolveCommentOptions(null, ...)` entrypoint
-  // `resolveRepoCommentOptions` wraps. With `repo`, it must already be
-  // linked to THIS workspace (github-repo-links.ts) — otherwise 404, so a
-  // preview can't be used to probe another workspace's repo binding or
-  // `.uploads.yml` contents.
-  //
-  // Renders from a page of the workspace's own `gh/`-prefixed attachments
-  // (first page only, mirrors gatherAttachments's url/pageUrl mapping but
-  // skips the D1 metadata read — the preview needs no per-item meta beyond
-  // what the static fixtures already carry). `listObjects` pages in
-  // lexicographic key order, not upload recency, so this is a representative
-  // sample rather than the "most recent" uploads. An empty workspace falls
-  // back to `previewFixtureItems` so the preview is never blank.
-  .get("/workspaces/:name/comment-preview", async (c) => {
-    const name = c.req.param("name");
-    await adminWorkspaceOr403(c.env, requireUserId(c), name);
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-
-    const repo = c.req.query("repo");
-    let resolved: ResolvedCommentOptions;
-    let source: Record<keyof ResolvedCommentOptions, OptionSource>;
-    let repoConfig: { found: boolean; path: string | null; warnings: string[] } | null = null;
-
-    if (repo !== undefined) {
-      if (!REPO_SHAPE_RE.test(repo)) {
-        throw new ValidationError("repo must be in owner/name form", { code: "invalid_repo" });
-      }
-      const link = await findRepoLink(c.env.DB, repo);
-      if (!link || link.workspaceName !== name) {
-        throw new NotFoundError("repo not linked to this workspace", { code: "repo_not_linked" });
-      }
-      const resolvedRepo = await resolveRepoCommentOptions(c.env, record, repo);
-      resolved = resolvedRepo.options;
-      source = resolvedRepo.source;
-      repoConfig = {
-        found: resolvedRepo.fetch.found,
-        path: resolvedRepo.fetch.path,
-        warnings: resolvedRepo.fetch.warnings,
-      };
-    } else {
-      const resolvedDefaults = resolveCommentOptions(null, workspaceCommentDefaults(record));
-      resolved = resolvedDefaults.options;
-      source = resolvedDefaults.source;
-    }
-
-    const { items: page } = await listObjects(c.env, record, { prefix: "gh/", limit: 8 });
-    const linkToFilePage = resolved.linkToFilePage;
-    let items: AttachmentItem[] = page.map((o) => ({
-      key: o.key,
-      url: o.url,
-      embedUrl: o.embedUrl,
-      pageUrl: linkToFilePage ? (o.pageUrl ?? null) : null,
-    }));
-    let sample: "workspace" | "fixtures" = "workspace";
-    if (items.length === 0) {
-      items = previewFixtureItems(c.env);
-      sample = "fixtures";
-    }
-
-    const body = attachmentsCommentBody(items, [], attachmentsMarker(name), {
-      imageWidth: resolved.imageWidth,
-      maxInlineImages: resolved.maxInlineImages,
-      metaPath: resolved.metaPath,
-      metaState: resolved.metaState,
-      note: resolved.note,
-    });
-
-    return c.json({ resolved, source, repoConfig, body, sample });
-  })
+  // settings (issue #307). Admin/owner-gated like the settings routes above.
+  // Issue #613 final phase: forwards to the canonical session-admin-gated
+  // handler in `routes/workspace-settings.ts` — the extracted handler is
+  // byte-for-byte the body this route used to run, so response shape can't
+  // drift. See that router's `commentPreviewHandler` docblock.
+  .get("/workspaces/:name/comment-preview", (c) =>
+    forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/comment-preview`),
+  )
 
   // Self-serve BYO R2 bucket (issue #583 Task 1.1): read/verify/write/detach
   // of a workspace's storage config. Same audience as the comment-settings

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -27,10 +27,15 @@
  * once the key contains raw slashes in the deployed (non-vitest) router.
  * Kept out of scope for this phase — see `.context/613-api-consolidation-plan.md`.
  */
-import { NotFoundError, ValidationError } from "@uploads/errors";
-import { signedDownloadUrl } from "@uploads/storage";
-import { Hono, type Handler, type MiddlewareHandler } from "hono";
-import { dualWorkspaceAuth, type DualAuthVars } from "../dual-workspace-auth";
+import { ForbiddenError, NotFoundError, ValidationError } from "@uploads/errors";
+import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
+import { Hono, type Context, type Handler, type MiddlewareHandler } from "hono";
+import {
+  dualWorkspaceAuth,
+  hasPreresolvedSession,
+  resolveSessionUserId,
+  type DualAuthVars,
+} from "../dual-workspace-auth";
 import { respondError } from "../error-response";
 import { badKey, deleteObject, listObjects, setObjectVisibility } from "../files-core";
 import { getMetadataForKeys, groupObjectsByPath, listFacets } from "../file-metadata";
@@ -40,9 +45,11 @@ import {
   searchFilesByNameAndMeta,
 } from "../file-search";
 import { writeRateLimit } from "../guards";
+import { memberWorkspaceOr404 } from "../org-workspaces";
+import type { SessionVars } from "../session-auth";
 import { objectPublicUrls, publicUrl, storage, storageConfig } from "../storage";
 import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
-import { requireScope } from "../workspace";
+import { loadWorkspaceRecord, requireScope } from "../workspace";
 import {
   getFileHandler,
   patchFileHandler,
@@ -61,6 +68,31 @@ function scoped(scope: Parameters<typeof requireScope>[0]): MiddlewareHandler<Du
 const rateLimited = writeRateLimit as unknown as MiddlewareHandler<DualAuthVars>;
 function shared(handler: SharedFilesHandler): Handler<DualAuthVars> {
   return handler as unknown as Handler<DualAuthVars>;
+}
+
+/**
+ * Session-only member gate for `file-browser` (issue #613 final phase): a
+ * bearer `Authorization` header 403s `file_browser_requires_session` — the
+ * files-sdk folder-browser gateway has no bearer analog today and this PR
+ * mints none, same posture as `workspace-members.ts`'s `sessionMemberGate`
+ * and `workspace-settings.ts`'s tiered gates. Bearer discrimination mirrors
+ * those: a preset (`hasPreresolvedSession`, e.g. a forwarded `/me` request)
+ * always wins, unconditionally, before ever looking at the `Authorization`
+ * header — a forwarded request keeps its original headers verbatim, so a
+ * caller who authenticated to `/me` with a Better Auth bearer session (no
+ * cookie) must not be rejected a second time here.
+ */
+function sessionFileBrowserGate(): MiddlewareHandler<DualAuthVars> {
+  return async (c, next) => {
+    if (!hasPreresolvedSession(c.req.raw) && c.req.header("Authorization")?.startsWith("Bearer ")) {
+      throw new ForbiddenError("requires a session", { code: "file_browser_requires_session" });
+    }
+    const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+    const name = c.req.param("workspace") ?? "";
+    if (!name) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    await memberWorkspaceOr404(c.env, userId, name);
+    await next();
+  };
 }
 
 export const workspaceFiles = new Hono<DualAuthVars>()
@@ -231,6 +263,31 @@ export const workspaceFiles = new Hono<DualAuthVars>()
       return c.json({ key, visibility: sanitizeVisibility(requested) ?? "public" });
     },
   )
+
+  // files-sdk's folder-aware browser gateway (issue #613 final phase, moved
+  // verbatim from `routes/me.ts`). Session-member-gated only — see
+  // `sessionFileBrowserGate`'s docblock. Its path is `/:workspace/file-browser`
+  // (a sibling of `/:workspace/files*`, not nested under it), so it can never
+  // collide with this router's `/:workspace/files/:key{.+}` catch-alls
+  // below regardless of registration order — kept above them anyway to match
+  // this file's established "static routes before catch-alls" convention.
+  .all("/:workspace/file-browser", sessionFileBrowserGate(), async (c) => {
+    const name = c.req.param("workspace") ?? "";
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+    const router = createFilesRouter({
+      files: (await storage(c.env, record)).readonly(),
+      operations: ["list"],
+      maxListLimit: 100,
+      // files-sdk resolves a signing secret even when signing operations are
+      // disabled. This value is intentionally non-secret and cannot
+      // authorize anything on this list-only, authenticated gateway.
+      secret: `readonly-list:${name}`,
+    });
+    return router.handle(c.req.raw);
+  })
 
   // These four key operations share their handler bodies with the legacy
   // bearer router. Keep every catch-all route after the static paths above:

--- a/apps/api/src/routes/workspace-galleries.ts
+++ b/apps/api/src/routes/workspace-galleries.ts
@@ -13,12 +13,25 @@
  * INTO this canonical router — see `forwardToWorkspaceUsage`/the galleries
  * divergence note in `.context/613-api-consolidation-plan.md` for why the
  * old `/me/workspaces/:name/galleries` list is NOT aliased here).
+ *
+ * `GET /:workspace/galleries` is the one exception to the "reuse
+ * `routes/galleries.ts`'s handler bodies verbatim" rule above (issue #613
+ * final phase): it uses a LOCAL `listGalleriesEnrichedHandler`, not the
+ * shared `listGalleriesHandler`, so the enrichment below can't leak onto the
+ * pre-existing bearer-only `/v1/:workspace/galleries` list (`routes/galleries.ts`,
+ * mounted separately in `index.ts`) — that handler function is shared
+ * between this router and the old one, so mutating it in place would have
+ * changed both surfaces at once. See `listGalleriesEnrichedHandler`'s
+ * docblock.
  */
-import { Hono, type MiddlewareHandler } from "hono";
+import { ValidationError } from "@uploads/errors";
+import { Hono, type Context, type MiddlewareHandler } from "hono";
 import { dualWorkspaceAuth, type DualAuthVars } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
+import { listGalleries } from "../galleries";
+import { decodeGalleryCursor, encodeGalleryCursor, galleryListSummaries } from "../gallery-service";
 import { writeRateLimit } from "../guards";
-import { requireScope } from "../workspace";
+import { requireScope, type WorkspaceVars } from "../workspace";
 import {
   addExternalReferenceHandler,
   addGalleryItemHandler,
@@ -27,12 +40,39 @@ import {
   galleriesByReferenceHandler,
   getGalleryHandler,
   listExternalReferencesHandler,
-  listGalleriesHandler,
   removeExternalReferenceHandler,
   removeGalleryItemHandler,
   reorderGalleryItemsHandler,
   updateGalleryHandler,
 } from "./galleries";
+
+/**
+ * `GET /:workspace/galleries` — canonical list, enriched with `itemCount`/
+ * `references` per gallery (`galleryListSummaries`, `gallery-service.ts`) for
+ * EVERY caller, bearer and session alike (issue #613 final phase). Body is
+ * otherwise identical to `listGalleriesHandler` (`routes/galleries.ts`):
+ * same `limit`/`cursor` query contract, same `nextCursor` envelope —
+ * `GalleryListSummaryDto` extends `GallerySummaryDto` with additive fields
+ * only, so this is a strict superset of the old canonical shape. Local to
+ * this router (not exported/shared) so it can never be reused by the
+ * pre-existing bearer-only `/v1/:workspace/galleries` list, which keeps its
+ * current cheaper `gallerySummary` projection untouched.
+ */
+async function listGalleriesEnrichedHandler(c: Context<WorkspaceVars>) {
+  const rawLimit = c.req.query("limit");
+  const limit = rawLimit === undefined ? 50 : Number(rawLimit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100)
+    throw new ValidationError("limit must be an integer from 1 to 100.");
+  const name = c.get("workspaceName");
+  const page = await listGalleries(c.env.DB, name, {
+    limit,
+    cursor: decodeGalleryCursor(c.req.query("cursor")),
+  });
+  return c.json({
+    galleries: await galleryListSummaries(c.env, name, page.galleries),
+    nextCursor: page.nextCursor ? encodeGalleryCursor(page.nextCursor) : null,
+  });
+}
 
 // Same cross-cast pattern as `routes/workspace-files.ts`'s `scoped`: these
 // helpers/handlers are typed against `WorkspaceVars`, a strict subset of this
@@ -55,7 +95,7 @@ export const workspaceGalleries = new Hono<DualAuthVars>()
     "/:workspace/galleries",
     dualWorkspaceAuth(),
     scoped("files:read"),
-    listGalleriesHandler as unknown as MiddlewareHandler<DualAuthVars>,
+    listGalleriesEnrichedHandler as unknown as MiddlewareHandler<DualAuthVars>,
   )
   .get(
     "/:workspace/galleries/by-reference",

--- a/apps/api/src/routes/workspace-github.ts
+++ b/apps/api/src/routes/workspace-github.ts
@@ -36,19 +36,40 @@
  *    `dualWorkspaceAuth`); member-but-not-admin -> 403
  *    `workspace_admin_required`.
  *
- * `GET /me/workspaces/:name/repo-links` is deliberately NOT forwarded/aliased
- * here — its stripped `{repos: string[]}` projection diverges from the
- * bearer/canonical `linkResponse` shape (`{repo, linked, workspace, source,
- * createdAt}`), same "don't forward a shape that isn't a strict superset"
- * rule phase 2 applied to the galleries list alias.
+ *  - `titles`/`status` (GET, issue #613 final phase): session-only,
+ *    member-tier. A bearer 403s `github_requires_session` — no bearer
+ *    capability exists for either read today and this PR mints none (giving
+ *    a workspace token access to batch title resolution or install status
+ *    would be a new capability, out of scope). Moved verbatim from
+ *    `routes/me.ts`; `/me` now forwards.
+ *  - `repo-links` (GET, issue #613 final phase): session-only, admin/owner
+ *    tier, its own coded error (`github_repo_links_requires_session`) since
+ *    it's a stricter tier than `titles`/`status` above. Its stripped
+ *    `{repos: string[]}` projection is kept EXACTLY as-is — deliberately
+ *    distinct from the dual-auth `linkResponse` shape at `GET
+ *    /:workspace/github/repo-link` (singular, `{repo, linked, workspace,
+ *    source, createdAt}`) above, so this is a new route at a new path, not a
+ *    reuse of that one. Moved verbatim from `routes/me.ts`; `/me` now
+ *    forwards.
  */
 import { ForbiddenError, NotFoundError, ValidationError } from "@uploads/errors";
-import { Hono, type Handler, type MiddlewareHandler } from "hono";
-import { dualWorkspaceAuth, requireSessionAdmin, type DualAuthVars } from "../dual-workspace-auth";
+import { Hono, type Context, type Handler, type MiddlewareHandler } from "hono";
+import {
+  dualWorkspaceAuth,
+  hasPreresolvedSession,
+  requireSessionAdmin,
+  resolveSessionUserId,
+  type DualAuthVars,
+} from "../dual-workspace-auth";
+import { parseExternalReference } from "../external-references";
 import { respondError } from "../error-response";
+import { githubInstallStatus, type GithubInstallStatus } from "../github-install-status";
 import { reconcileIngestTarget } from "../github-ingest";
-import { deriveRepoBinding, findRepoLink } from "../github-repo-links";
+import { deriveRepoBinding, findRepoLink, listRepoLinksForWorkspace } from "../github-repo-links";
+import { resolveTitles } from "../github-titles";
 import { writeRateLimit } from "../guards";
+import { adminWorkspaceOr403, memberWorkspaceOr404 } from "../org-workspaces";
+import type { SessionVars } from "../session-auth";
 import { requireScope } from "../workspace";
 import { githubActivityHandler } from "./github-activity";
 import { githubCommentHandler } from "./github-comment";
@@ -130,6 +151,114 @@ const requireToken: MiddlewareHandler<DualAuthVars> = async (c, next) => {
   await next();
 };
 
+/**
+ * Session-only member gate for `titles`/`status` (issue #613 final phase):
+ * mirrors `workspace-members.ts`'s `sessionMemberGate` and
+ * `workspace-settings.ts`'s `sessionMemberGate` — a bearer `Authorization`
+ * header 403s `github_requires_session` (neither route has a bearer analog
+ * today and this PR mints none), otherwise resolves the session + membership
+ * with a uniform 404 for non-members. A preset (`hasPreresolvedSession`,
+ * e.g. a forwarded `/me` request) always wins over the bearer check, same
+ * discrimination as every other session gate in this vertical migration.
+ */
+function sessionMemberGate(): MiddlewareHandler<DualAuthVars> {
+  return async (c, next) => {
+    if (!hasPreresolvedSession(c.req.raw) && c.req.header("Authorization")?.startsWith("Bearer ")) {
+      throw new ForbiddenError("requires a session", { code: "github_requires_session" });
+    }
+    const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+    const name = c.req.param("workspace") ?? "";
+    if (!name) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    await memberWorkspaceOr404(c.env, userId, name);
+    await next();
+  };
+}
+
+/**
+ * Session-only admin/owner gate for `repo-links` (issue #613 final phase):
+ * same bearer-403 posture as `sessionMemberGate` above, but its own coded
+ * error (`github_repo_links_requires_session`) since it's a stricter
+ * privilege tier than the member-gated routes in this same router —
+ * mirrors `workspace-settings.ts`'s two-tier `sessionMemberGate`/
+ * `sessionAdminGate` split. `adminWorkspaceOr403` produces the 404-then-403
+ * ordering (non-member -> `workspace_not_found`, member-not-admin ->
+ * `workspace_admin_required`), same as this route's pre-#613 `/me` handler.
+ */
+function sessionAdminGate(): MiddlewareHandler<DualAuthVars> {
+  return async (c, next) => {
+    if (!hasPreresolvedSession(c.req.raw) && c.req.header("Authorization")?.startsWith("Bearer ")) {
+      throw new ForbiddenError("requires a session", {
+        code: "github_repo_links_requires_session",
+      });
+    }
+    const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+    const name = c.req.param("workspace") ?? "";
+    if (!name) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    await adminWorkspaceOr403(c.env, userId, name);
+    await next();
+  };
+}
+
+/**
+ * `GET /:workspace/github/titles` — batch PR/issue titles for the
+ * connected-work rail (issue #267), moved verbatim from `routes/me.ts`
+ * (issue #613 final phase). Member-gated: title text for private repos is
+ * sensitive, and membership scoping keeps this from becoming a public title
+ * oracle for whatever repos the App can read. Per-ref failures are nulls —
+ * the endpoint never fails the batch wholesale.
+ */
+const githubTitlesHandler: Handler<DualAuthVars> = async (c) => {
+  const raw = (c.req.query("refs") ?? "").split(",").filter((s) => s.length > 0);
+  if (raw.length === 0) {
+    throw new ValidationError("refs query parameter required", { code: "refs_required" });
+  }
+  if (raw.length > 20) {
+    throw new ValidationError("at most 20 refs per request", { code: "too_many_refs" });
+  }
+  const normalized = raw.map((coordinate) => {
+    const parsed = parseExternalReference("github", coordinate);
+    if (!parsed.ok) {
+      throw new ValidationError(`invalid ref: ${coordinate}`, { code: "invalid_ref" });
+    }
+    // normalizedKey carries a `github:item:` provider prefix — the gh.ref
+    // metadata shape (and this response's keys) is bare `owner/repo#number`,
+    // so derive it from the locator instead.
+    const { owner, repository, number } = parsed.value.locator;
+    return `${owner}/${repository}#${number}`;
+  });
+
+  const titles = await resolveTitles(c.env, [...new Set(normalized)]);
+  return c.json({ refs: titles });
+};
+
+/**
+ * `GET /:workspace/github/status` — whether this workspace already has the
+ * GitHub App installed (issue #492), moved verbatim from `routes/me.ts`
+ * (issue #613 final phase). Member-gated like `titles`: the answer is
+ * derived from the workspace's repo bindings, which aren't public. Never
+ * fails — see `githubInstallStatus` for the degrade-to-false rule.
+ */
+const githubStatusHandler: Handler<DualAuthVars> = async (c) => {
+  const name = c.req.param("workspace") ?? "";
+  return c.json<GithubInstallStatus>(await githubInstallStatus(c.env, name));
+};
+
+/**
+ * `GET /:workspace/github/repo-links` — repos this workspace has linked
+ * (issue #307, Task 7), moved verbatim from `routes/me.ts` (issue #613 final
+ * phase). Admin/owner-gated — same audience as the comment-settings/preview
+ * routes: whoever can edit the defaults is whoever should see which repos
+ * they apply to. Repo names only: trimmed projection, distinct from the
+ * dual-auth `linkResponse` shape at `GET /:workspace/github/repo-link`
+ * (singular) above — deliberately not aliased to that route (see the module
+ * docblock's `/me/workspaces/:name/repo-links` note).
+ */
+const githubRepoLinksHandler: Handler<DualAuthVars> = async (c) => {
+  const name = c.req.param("workspace") ?? "";
+  const links = await listRepoLinksForWorkspace(c.env.DB, name);
+  return c.json({ repos: links.map((link) => link.repo) });
+};
+
 export const workspaceGithub = new Hono<DualAuthVars>()
   .post(
     "/:workspace/github/comment",
@@ -201,9 +330,14 @@ export const workspaceGithub = new Hono<DualAuthVars>()
     scoped("files:write"),
     githubIngestHandler,
   )
-  // `.fetch()`-ed directly by nothing today (no old-path alias forwards
-  // through this router — see the module docblock's repo-links note), but
-  // this still needs its own error boundary for consistency with the other
-  // canonical verticals and in case a future alias does re-dispatch through
-  // it directly.
+  // Issue #613 final phase: session-only routes moved verbatim from
+  // `routes/me.ts` — see each handler's docblock and the module docblock's
+  // updated posture note.
+  .get("/:workspace/github/titles", sessionMemberGate(), githubTitlesHandler)
+  .get("/:workspace/github/status", sessionMemberGate(), githubStatusHandler)
+  .get("/:workspace/github/repo-links", sessionAdminGate(), githubRepoLinksHandler)
+  // `.fetch()`-ed directly by `routes/me.ts`'s `forwardToWorkspaceGithub`
+  // (issue #613 final phase, `titles`/`status` — see the module docblock's
+  // repo-links note for why `repo-links` itself is NOT aliased), so this
+  // needs its own error boundary the same way `workspace-files.ts` does.
   .onError((err, c) => respondError(c, err));

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -1,29 +1,35 @@
 /**
- * Canonical comment-settings, storage, and billing/summary verticals (issue
- * #613 phase 3): `/:workspace/comment-settings`, `/:workspace/storage`,
- * `/:workspace/storage/verify`, `/:workspace/summary`, `/:workspace/billing`,
- * mounted at `/v1/workspaces` in `index.ts` so its public paths are
- * `/v1/workspaces/:workspace/...`. Same self-contained-router shape as
- * `workspace-members.ts`/`workspace-github.ts`: own auth, own `.onError()`,
- * `.fetch()`-able directly by an alias with no parent-mount dependency for
- * its `:workspace` param.
+ * Canonical comment-settings, storage, billing/summary, and comment-preview
+ * verticals (issue #613 phase 3, comment-preview added final phase):
+ * `/:workspace/comment-settings`, `/:workspace/comment-preview`,
+ * `/:workspace/storage`, `/:workspace/storage/verify`, `/:workspace/summary`,
+ * `/:workspace/billing`, mounted at `/v1/workspaces` in `index.ts` so its
+ * public paths are `/v1/workspaces/:workspace/...`. Same self-contained-
+ * router shape as `workspace-members.ts`/`workspace-github.ts`: own auth,
+ * own `.onError()`, `.fetch()`-able directly by an alias with no
+ * parent-mount dependency for its `:workspace` param.
  *
  * Posture (`.context/613-api-consolidation-plan.md`, "comment-settings",
- * "storage", "billing/summary"):
+ * "storage", "billing/summary"; comment-preview follows the comment-settings
+ * tier exactly):
  *
- *  - `GET/PATCH /comment-settings`, `GET/POST-verify/PUT/DELETE /storage` —
- *    **session-only, admin/owner tier**. A bearer `Authorization` header
- *    403s `settings_requires_session` on every route in this tier — neither
- *    vertical has a bearer analog today (comment-settings: no
+ *  - `GET/PATCH /comment-settings`, `GET /comment-preview`,
+ *    `GET/POST-verify/PUT/DELETE /storage` — **session-only, admin/owner
+ *    tier**. A bearer `Authorization` header 403s `settings_requires_session`
+ *    on every route in this tier — none of these verticals has a bearer
+ *    analog today (comment-settings/comment-preview: no
  *    `/v1/:workspace/github/comment-settings` exists; storage is
  *    credential-adjacent and a token was never in scope for it), and this PR
- *    mints no new bearer capability for either. Flat 5-key comment-settings
- *    envelope (`imageWidth`/`maxInlineImages`/`showMetadata`/
- *    `linkToFilePage`/`note`) preserved EXACTLY — the admin-ui operator
- *    surface's prefixed 6-key naming (`/admin-ui/workspaces/:name/settings`)
- *    is a different privilege tier entirely and stays untouched. Storage's
- *    masked `storageStatusResponse` projection (never credential values) is
- *    likewise preserved exactly — see `workspace-storage.ts`.
+ *    mints no new bearer capability for any of them. Flat 5-key
+ *    comment-settings envelope (`imageWidth`/`maxInlineImages`/
+ *    `showMetadata`/`linkToFilePage`/`note`) preserved EXACTLY — the
+ *    admin-ui operator surface's prefixed 6-key naming
+ *    (`/admin-ui/workspaces/:name/settings`) is a different privilege tier
+ *    entirely and stays untouched. Storage's masked `storageStatusResponse`
+ *    projection (never credential values) is likewise preserved exactly —
+ *    see `workspace-storage.ts`. `comment-preview`'s response body (moved
+ *    verbatim from `routes/me.ts`) is unchanged — see
+ *    `commentPreviewHandler`'s docblock.
  *  - `GET /summary`, `GET /billing` — **session-only, member tier**. A
  *    bearer header 403s `billing_requires_session` — same "no bearer analog,
  *    none minted" posture, distinct code from the admin tier above so the
@@ -40,7 +46,12 @@
  * "one get-session call per forwarded request" property every other
  * vertical gets from the `presetResolvedSessionUser` WeakMap handoff.
  */
-import { NOTE_MAX_CHARS } from "@uploads/comment-config";
+import {
+  NOTE_MAX_CHARS,
+  resolveCommentOptions,
+  type OptionSource,
+  type ResolvedCommentOptions,
+} from "@uploads/comment-config";
 import {
   ConflictError,
   ForbiddenError,
@@ -51,8 +62,16 @@ import {
 import { type R2Jurisdiction } from "@uploads/storage";
 import { Hono, type Context, type MiddlewareHandler } from "hono";
 import { usageWithLimits } from "../budget";
+import { previewFixtureItems } from "../comment-preview-fixtures";
 import { resolveSessionUserId } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
+import { listObjects } from "../files-core";
+import { findRepoLink } from "../github-repo-links";
+import {
+  attachmentsCommentBody,
+  attachmentsMarker,
+  type AttachmentItem,
+} from "../github-comment-render";
 import { allowWrite } from "../guards";
 import {
   adminWorkspaceOr403,
@@ -60,6 +79,7 @@ import {
   subscriptionForOrg,
   type MyWorkspace,
 } from "../org-workspaces";
+import { resolveRepoCommentOptions, workspaceCommentDefaults } from "../repo-comment-config";
 import { sealCredentialFieldsStrict } from "../secrets";
 import { selfServeWorkspaceRecord } from "../self-serve-defaults";
 import type { SessionVars } from "../session-auth";
@@ -73,6 +93,9 @@ import {
   storageStatusResponse,
   storageVerify,
 } from "./workspace-storage";
+
+/** `?repo=` shape for the comment preview endpoint: exactly one `/`, no empty segments. */
+const REPO_SHAPE_RE = /^[^/\s]+\/[^/\s]+$/;
 
 /** Context vars a `sessionMemberGate`/`sessionAdminGate`-guarded route can rely on. */
 export type SettingsVars = {
@@ -656,11 +679,90 @@ export async function billingHandler(c: Context<SettingsVars>) {
   });
 }
 
+/**
+ * `GET /:workspace/comment-preview` — preview the production managed-comment
+ * body against resolved comment settings (issue #307), moved verbatim from
+ * `routes/me.ts` (issue #613 final phase). Admin/owner-gated like the
+ * comment-settings/storage tier above: the response includes per-key source
+ * attribution ("repo" | "workspace" | "auto"), which a plain member has no
+ * reason to see. With no `repo` query param, resolution runs against
+ * workspace defaults only (`repoConfig: null`) via the same
+ * `resolveCommentOptions(null, ...)` entrypoint `resolveRepoCommentOptions`
+ * wraps. With `repo`, it must already be linked to THIS workspace
+ * (github-repo-links.ts) — otherwise 404, so a preview can't be used to
+ * probe another workspace's repo binding or `.uploads.yml` contents.
+ *
+ * Renders from a page of the workspace's own `gh/`-prefixed attachments
+ * (first page only, mirrors gatherAttachments's url/pageUrl mapping but
+ * skips the D1 metadata read — the preview needs no per-item meta beyond
+ * what the static fixtures already carry). `listObjects` pages in
+ * lexicographic key order, not upload recency, so this is a representative
+ * sample rather than the "most recent" uploads. An empty workspace falls
+ * back to `previewFixtureItems` so the preview is never blank.
+ */
+export async function commentPreviewHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  const record = await loadWorkspaceRecord(c.env, name);
+  if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+
+  const repo = c.req.query("repo");
+  let resolved: ResolvedCommentOptions;
+  let source: Record<keyof ResolvedCommentOptions, OptionSource>;
+  let repoConfig: { found: boolean; path: string | null; warnings: string[] } | null = null;
+
+  if (repo !== undefined) {
+    if (!REPO_SHAPE_RE.test(repo)) {
+      throw new ValidationError("repo must be in owner/name form", { code: "invalid_repo" });
+    }
+    const link = await findRepoLink(c.env.DB, repo);
+    if (!link || link.workspaceName !== name) {
+      throw new NotFoundError("repo not linked to this workspace", { code: "repo_not_linked" });
+    }
+    const resolvedRepo = await resolveRepoCommentOptions(c.env, record, repo);
+    resolved = resolvedRepo.options;
+    source = resolvedRepo.source;
+    repoConfig = {
+      found: resolvedRepo.fetch.found,
+      path: resolvedRepo.fetch.path,
+      warnings: resolvedRepo.fetch.warnings,
+    };
+  } else {
+    const resolvedDefaults = resolveCommentOptions(null, workspaceCommentDefaults(record));
+    resolved = resolvedDefaults.options;
+    source = resolvedDefaults.source;
+  }
+
+  const { items: page } = await listObjects(c.env, record, { prefix: "gh/", limit: 8 });
+  const linkToFilePage = resolved.linkToFilePage;
+  let items: AttachmentItem[] = page.map((o) => ({
+    key: o.key,
+    url: o.url,
+    embedUrl: o.embedUrl,
+    pageUrl: linkToFilePage ? (o.pageUrl ?? null) : null,
+  }));
+  let sample: "workspace" | "fixtures" = "workspace";
+  if (items.length === 0) {
+    items = previewFixtureItems(c.env);
+    sample = "fixtures";
+  }
+
+  const body = attachmentsCommentBody(items, [], attachmentsMarker(name), {
+    imageWidth: resolved.imageWidth,
+    maxInlineImages: resolved.maxInlineImages,
+    metaPath: resolved.metaPath,
+    metaState: resolved.metaState,
+    note: resolved.note,
+  });
+
+  return c.json({ resolved, source, repoConfig, body, sample });
+}
+
 export const workspaceSettings = new Hono<SettingsVars>()
   .get("/:workspace/summary", sessionMemberGate(), summaryHandler)
   .get("/:workspace/billing", sessionMemberGate(), billingHandler)
   .get("/:workspace/comment-settings", sessionAdminGate(), commentSettingsGetHandler)
   .patch("/:workspace/comment-settings", sessionAdminGate(), commentSettingsPatchHandler)
+  .get("/:workspace/comment-preview", sessionAdminGate(), commentPreviewHandler)
   .get("/:workspace/storage", sessionAdminGate(), storageGetHandler)
   .post("/:workspace/storage/verify", sessionAdminGate(), storageVerifyHandler)
   .put("/:workspace/storage", sessionAdminGate(), storagePutHandler)

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -63,7 +63,7 @@ import { type R2Jurisdiction } from "@uploads/storage";
 import { Hono, type Context, type MiddlewareHandler } from "hono";
 import { usageWithLimits } from "../budget";
 import { previewFixtureItems } from "../comment-preview-fixtures";
-import { resolveSessionUserId } from "../dual-workspace-auth";
+import { hasPreresolvedSession, resolveSessionUserId } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
 import { listObjects } from "../files-core";
 import { findRepoLink } from "../github-repo-links";
@@ -116,7 +116,11 @@ export type SettingsVars = {
  */
 function sessionMemberGate(): MiddlewareHandler<SettingsVars> {
   return async (c, next) => {
-    if (c.req.header("Authorization")?.startsWith("Bearer ")) {
+    // Preset check first: a forwarded `/me` request keeps its original
+    // headers, so a caller who authenticated there with a Better Auth bearer
+    // session must not be re-rejected here (same ordering as every other
+    // session gate — the #617 review's lesson).
+    if (!hasPreresolvedSession(c.req.raw) && c.req.header("Authorization")?.startsWith("Bearer ")) {
       throw new ForbiddenError("requires a session", { code: "billing_requires_session" });
     }
     const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
@@ -140,7 +144,8 @@ function sessionMemberGate(): MiddlewareHandler<SettingsVars> {
  */
 function sessionAdminGate(): MiddlewareHandler<SettingsVars> {
   return async (c, next) => {
-    if (c.req.header("Authorization")?.startsWith("Bearer ")) {
+    // Preset-first ordering — see `sessionMemberGate` above.
+    if (!hasPreresolvedSession(c.req.raw) && c.req.header("Authorization")?.startsWith("Bearer ")) {
       throw new ForbiddenError("requires a session", { code: "settings_requires_session" });
     }
     const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -431,3 +431,75 @@ describe("old-path aliases forward unchanged (issue #613)", () => {
     expect(body.error?.code).toBe("workspace_not_found");
   });
 });
+
+describe("ALL /v1/workspaces/:workspace/file-browser (session-only, member-gated, issue #613 final phase)", () => {
+  it("member session reaches the files-sdk readonly list gateway", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/file-browser",
+      {
+        method: "POST",
+        headers: { cookie: "session=x", "content-type": "application/json" },
+        body: JSON.stringify({ op: "list" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("bearer 403s with file_browser_requires_session", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/file-browser",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({ op: "list" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("file_browser_requires_session");
+  });
+
+  it("non-member session 404s", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/file-browser",
+      {
+        method: "POST",
+        headers: { cookie: "session=x", "content-type": "application/json" },
+        body: JSON.stringify({ op: "list" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("/me/workspaces/:name/file-browser forwards to the same handler (identical body)", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const direct = await app.request(
+      "/v1/workspaces/acme/file-browser",
+      {
+        method: "POST",
+        headers: { cookie: "session=x", "content-type": "application/json" },
+        body: JSON.stringify({ op: "list" }),
+      },
+      env,
+    );
+    const viaMe = await app.request(
+      "/me/workspaces/acme/file-browser",
+      {
+        method: "POST",
+        headers: { cookie: "session=x", "content-type": "application/json" },
+        body: JSON.stringify({ op: "list" }),
+      },
+      env,
+    );
+    expect(viaMe.status).toBe(direct.status);
+    expect(await viaMe.json()).toEqual(await direct.json());
+  });
+});

--- a/apps/api/test/routes-workspace-galleries.test.ts
+++ b/apps/api/test/routes-workspace-galleries.test.ts
@@ -326,8 +326,8 @@ describe("GET /v1/workspaces/:workspace/galleries (session auth)", () => {
   });
 });
 
-describe("old-path /me/workspaces/:name/galleries is NOT forwarded (issue #613 phase 2 divergence)", () => {
-  it("keeps its own richer shape (itemCount/references) rather than the canonical bearer-shaped list", async () => {
+describe("old-path /me/workspaces/:name/galleries now forwards to the canonical list (issue #613 final phase)", () => {
+  it("returns the same enriched (itemCount/references) body as the canonical route", async () => {
     const env = await makeEnv();
     await createViaCanonical(env);
 
@@ -340,17 +340,15 @@ describe("old-path /me/workspaces/:name/galleries is NOT forwarded (issue #613 p
     const oldBody = (await oldPath.json()) as { galleries: Record<string, unknown>[] };
     expect(oldBody.galleries[0]).toHaveProperty("itemCount");
     expect(oldBody.galleries[0]).toHaveProperty("references");
-    // No `nextCursor` on the old shape — confirms this is still the
-    // pre-#613 handler, not a forward through the canonical route.
-    expect(oldBody).not.toHaveProperty("nextCursor");
+    expect(oldBody).toHaveProperty("nextCursor");
 
     const canonical = await app.request(
       "/v1/workspaces/acme/galleries",
       { headers: { cookie: "session=x" } },
       env,
     );
-    const canonicalBody = (await canonical.json()) as { galleries: Record<string, unknown>[] };
-    expect(canonicalBody.galleries[0]).not.toHaveProperty("itemCount");
-    expect(canonicalBody).toHaveProperty("nextCursor");
+    // Byte-identical: both paths now run through the same canonical handler
+    // (`listGalleriesEnrichedHandler`, `workspace-galleries.ts`).
+    expect(oldBody).toEqual(await canonical.json());
   });
 });

--- a/apps/api/test/routes-workspace-github.test.ts
+++ b/apps/api/test/routes-workspace-github.test.ts
@@ -732,3 +732,163 @@ describe("old-path bearer routes are untouched by the canonical mount (issue #61
     expect(res.status).toBe(200);
   });
 });
+
+describe("GET /v1/workspaces/:workspace/github/titles (session-only, member-gated, issue #613 final phase)", () => {
+  it("member session 200s", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/github/titles",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(400); // no `refs` query param
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("refs_required");
+  });
+
+  it("bearer 403s with github_requires_session", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request("/v1/workspaces/acme/github/titles", { headers: bearer() }, env);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("github_requires_session");
+  });
+
+  it("non-member session 404s", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/titles",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("/me/workspaces/:name/github-titles forwards to the same handler (identical body)", async () => {
+    const { env } = await makeEnv();
+    const direct = await app.request(
+      "/v1/workspaces/acme/github/titles",
+      { headers: sessionCookie },
+      env,
+    );
+    const viaMe = await app.request(
+      "/me/workspaces/acme/github-titles",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(viaMe.status).toBe(direct.status);
+    expect(await viaMe.json()).toEqual(await direct.json());
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/github/status (session-only, member-gated, issue #613 final phase)", () => {
+  it("member session 200s with no bound repos", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/github/status",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ checkedRepos: 0 });
+  });
+
+  it("bearer 403s with github_requires_session", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request("/v1/workspaces/acme/github/status", { headers: bearer() }, env);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("github_requires_session");
+  });
+
+  it("non-member session 404s", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/status",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("/me/workspaces/:name/github-status forwards to the same handler (identical body)", async () => {
+    const { env } = await makeEnv();
+    const direct = await app.request(
+      "/v1/workspaces/acme/github/status",
+      { headers: sessionCookie },
+      env,
+    );
+    const viaMe = await app.request(
+      "/me/workspaces/acme/github-status",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(viaMe.status).toBe(direct.status);
+    expect(await viaMe.json()).toEqual(await direct.json());
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/github/repo-links (session-only, admin-gated, issue #613 final phase)", () => {
+  it("admin session 200s with the stripped {repos} projection", async () => {
+    const { env, db } = await makeEnv({ role: "admin" });
+    await recordRepoLink(db as unknown as D1Database, "acme/web", WS, "claim");
+    const res = await app.request(
+      "/v1/workspaces/acme/github/repo-links",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ repos: ["acme/web"] });
+  });
+
+  it("member (non-admin) session 403s with github_repo_links_requires_session", async () => {
+    const { env } = await makeEnv({ role: "member" });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/repo-links",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("workspace_admin_required");
+  });
+
+  it("bearer 403s with github_repo_links_requires_session", async () => {
+    const { env } = await makeEnv({ role: "admin" });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/repo-links",
+      { headers: bearer() },
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("github_repo_links_requires_session");
+  });
+
+  it("non-member session 404s", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/repo-links",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("/me/workspaces/:name/repo-links forwards to the same handler (identical body)", async () => {
+    const { env, db } = await makeEnv({ role: "admin" });
+    await recordRepoLink(db as unknown as D1Database, "acme/web", WS, "claim");
+    const direct = await app.request(
+      "/v1/workspaces/acme/github/repo-links",
+      { headers: sessionCookie },
+      env,
+    );
+    const viaMe = await app.request(
+      "/me/workspaces/acme/repo-links",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(viaMe.status).toBe(direct.status);
+    expect(await viaMe.json()).toEqual(await direct.json());
+  });
+});

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -622,6 +622,30 @@ describe("/me alias forwards (issue #613 phase 3)", () => {
     expect(await alias.json()).toEqual(await canonical.json());
   });
 
+  // A Better Auth bearer session (device-flow token, no cookie) authenticates
+  // at /me; the forwarded request keeps its Authorization header, so the
+  // settings gates must honor the pre-resolved-session handoff instead of
+  // rejecting the bearer header (the #617 review's ordering lesson).
+  it("GET /me/workspaces/:name/summary works via a Better Auth bearer session", async () => {
+    const { env } = makeEnv({ sessionUser: MEMBER, role: "member", usage: { objects: 0 } });
+    const res = await app.request(
+      "/me/workspaces/acme/summary",
+      { headers: { Authorization: "Bearer ba-session-token" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("GET /me/workspaces/:name/comment-settings works via a Better Auth bearer session", async () => {
+    const { env } = makeEnv({ role: "admin" });
+    const res = await app.request(
+      "/me/workspaces/acme/comment-settings",
+      { headers: { Authorization: "Bearer ba-session-token" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
   it("PATCH /me/workspaces/:name/comment-settings still works via the forward", async () => {
     const { env } = makeEnv({ role: "admin" });
     const res = await app.request(

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -12,6 +12,7 @@ import {
   setStorageVerifyForTests,
 } from "../src/routes/workspace-storage";
 import { fakeRegistry } from "./fake-kv";
+import { FakeR2Bucket } from "./fake-r2";
 import { UsageFakeD1 } from "./usage-fake-d1";
 
 const ADMIN = { id: "u-admin", email: "admin@example.com", name: "Admin" };
@@ -692,5 +693,92 @@ describe("/me alias forwards (issue #613 phase 3)", () => {
     expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
       "workspace_not_found",
     );
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/comment-preview (issue #613 final phase)", () => {
+  function makePreviewEnv(opts: EnvOpts = {}) {
+    const { registry, db, env } = (() => {
+      const bucket = new FakeR2Bucket();
+      const record = {
+        ...SHARED_RECORD,
+        binding: "UPLOADS_DEFAULT",
+      };
+      const base = makeEnv({ ...opts, record });
+      return {
+        ...base,
+        env: {
+          ...base.env,
+          UPLOADS_DEFAULT: bucket,
+          WEB_ORIGIN: "https://uploads.test",
+        } as unknown as Env,
+      };
+    })();
+    return { env, registry, db };
+  }
+
+  it("200s for an admin session with the fixture fallback when the workspace has no gh/ uploads", async () => {
+    const { env } = makePreviewEnv({ role: "admin" });
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-preview",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { sample: string; body: string };
+    expect(body.sample).toBe("fixtures");
+    expect(typeof body.body).toBe("string");
+  });
+
+  it("403s a non-admin member session", async () => {
+    const { env } = makePreviewEnv({ sessionUser: MEMBER, role: "member" });
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-preview",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_admin_required",
+    );
+  });
+
+  it("404s a non-member session", async () => {
+    const { env } = makePreviewEnv({ noMembership: true });
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-preview",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("403s a bearer token with settings_requires_session", async () => {
+    const { env } = makePreviewEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-preview",
+      { headers: bearerHeaders },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "settings_requires_session",
+    );
+  });
+
+  it("/me/workspaces/:name/comment-preview forwards to the same handler (identical body)", async () => {
+    const { env } = makePreviewEnv({ role: "admin" });
+    const canonical = await app.request(
+      "/v1/workspaces/acme/comment-preview",
+      { headers: sessionHeaders },
+      env,
+    );
+    const alias = await app.request(
+      "/me/workspaces/acme/comment-preview",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(alias.status).toBe(200);
+    expect(await alias.json()).toEqual(await canonical.json());
   });
 });

--- a/apps/web/src/components/AccountFileBrowser.tsx
+++ b/apps/web/src/components/AccountFileBrowser.tsx
@@ -45,7 +45,7 @@ export function AccountFileBrowser({
   onPrefixChange,
 }: Props) {
   const files = useFiles({
-    endpoint: `${apiOrigin.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/file-browser`,
+    endpoint: `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/file-browser`,
     fetchImpl: credentialedFetch,
   });
   // Keys with an in-flight visibility PATCH, so the toggle button disables

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -111,7 +111,7 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
         <div class="ws-rail__actions">
           {
             /* Server-rendered visible, then hidden by `initWorkspaceRail` when
-              `/me/workspaces/:name/github-status` reports the App installed
+              `/v1/workspaces/:name/github/status` reports the App installed
               (issue #492). Shown on every other outcome — a workspace that has
               it already sees one extra muted link; one that doesn't would
               otherwise never learn the App exists. */

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -908,7 +908,7 @@ describe("getGithubInstalled", () => {
     );
 
     await expect(getGithubInstalled("https://api.test", "acme")).resolves.toBe(true);
-    expect(requested).toBe("https://api.test/me/workspaces/acme/github-status");
+    expect(requested).toBe("https://api.test/v1/workspaces/acme/github/status");
   });
 
   it("keeps the CTA visible when the workspace has no install", async () => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -203,8 +203,8 @@ export async function getWorkspaceSummary(
 }
 
 /**
- * Shared GET for the array-returning `/me/workspaces/:name/<segment>` endpoints
- * (galleries, files). Reads `body[key]`, drops malformed entries via `isValid`,
+ * Shared GET for the array-returning `/v1/workspaces/:name/<segment>` endpoints
+ * (galleries). Reads `body[key]`, drops malformed entries via `isValid`,
  * and returns [] on any non-2xx or malformed body.
  */
 async function fetchWorkspaceList<T>(
@@ -215,7 +215,7 @@ async function fetchWorkspaceList<T>(
   isValid: (value: unknown) => value is T,
 ): Promise<T[]> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/${segment}`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/${segment}`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable" || !result.response.ok) return [];
@@ -270,7 +270,7 @@ function isGallerySummary(value: unknown): value is GallerySummary {
   return true;
 }
 
-/** GET /me/workspaces/:name/galleries. See {@link fetchWorkspaceList}. */
+/** GET /v1/workspaces/:name/galleries. See {@link fetchWorkspaceList}. */
 export function getMyWorkspaceGalleries(
   apiOrigin: string,
   name: string,
@@ -1022,7 +1022,7 @@ export interface GithubTitleInfo {
 }
 export type GithubTitleMap = Record<string, GithubTitleInfo | null>;
 
-/** Server-enforced per-request ref cap on `/me/workspaces/:name/github-titles`. */
+/** Server-enforced per-request ref cap on `/v1/workspaces/:name/github/titles`. */
 export const GITHUB_TITLES_MAX_REFS = 20;
 
 /**
@@ -1038,7 +1038,7 @@ export async function getGithubTitles(
   if (refs.length === 0) return {};
   const qs = encodeURIComponent(refs.slice(0, GITHUB_TITLES_MAX_REFS).join(","));
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/github-titles?refs=${qs}`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/github/titles?refs=${qs}`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable" || !result.response.ok) return null;
@@ -1066,7 +1066,7 @@ export async function getGithubTitles(
  */
 export async function getGithubInstalled(apiOrigin: string, name: string): Promise<boolean> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/github-status`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/github/status`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable" || !result.response.ok) return false;
@@ -1296,14 +1296,14 @@ export async function patchWorkspaceCommentSettings(
 }
 
 /**
- * GET /me/workspaces/:name/repo-links — repo names this workspace has
+ * GET /v1/workspaces/:name/github/repo-links — repo names this workspace has
  * linked (issue #307, Task 7's repo picker). Fails open to `[]`: an empty
  * picker just means "no repo config" is the only option, same as a
  * workspace that genuinely has no linked repos.
  */
 export async function getWorkspaceRepoLinks(apiOrigin: string, name: string): Promise<string[]> {
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/repo-links`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/github/repo-links`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable" || !result.response.ok) return [];
@@ -1340,7 +1340,7 @@ export type CommentPreviewResult =
     };
 
 /**
- * GET /me/workspaces/:name/comment-preview[?repo=owner/name]. `repo` must
+ * GET /v1/workspaces/:name/comment-preview[?repo=owner/name]. `repo` must
  * already be linked to this workspace — an unlinked or malformed repo 404s/
  * 400s server-side, surfaced here as `not_found`/`invalid_repo` so the
  * preview panel can tell the two apart (a stale picker entry vs. a typo).
@@ -1352,7 +1352,7 @@ export async function getWorkspaceCommentPreview(
 ): Promise<CommentPreviewResult> {
   const qs = repo ? `?repo=${encodeURIComponent(repo)}` : "";
   const result = await fetchWithTimeout(
-    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/comment-preview${qs}`,
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/comment-preview${qs}`,
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable") return result;


### PR DESCRIPTION
The last build phase of #613: the six session routes that still lived inline in `me.ts` get canonical homes, `/me` shrinks to genuine viewer identity (profile + memberships) plus pure forwards, and the web app follows.

## Canonical homes

- **galleries list** — resolved by ENRICHMENT: the canonical `GET /v1/workspaces/:workspace/galleries` now returns `galleryListSummaries` (`itemCount`/`references`) for ALL callers. Additive for bearers (the CLI's `GallerySummary` and the web client both tolerate/mark these optional). The old bearer-only `/v1/:workspace/galleries` list keeps its cheaper shape untouched.
- **`ALL …/file-browser`** (workspace-files.ts) — session-member-gated, bearer 403 `file_browser_requires_session`; the gate honors the pre-resolved-session handoff before ever looking at the Authorization header (the Better Auth bearer-session ordering lesson from #617).
- **`GET …/github/titles`**, **`…/github/status`** (workspace-github.ts) — session-member-gated (403 `github_requires_session` for bearers; granting tokens access would be a new capability).
- **`GET …/github/repo-links`** (workspace-github.ts) — session-admin-gated, stripped `{repos}` projection preserved exactly (403 `github_repo_links_requires_session`).
- **`GET …/comment-preview`** (workspace-settings.ts) — session-admin-gated via the router's existing gate.

All six `/me` routes now forward via the established `forwardTo`/`presetResolvedSessionUser` pattern (single get-session call, byte-identical bodies).

## Web app

The six matching call sites flip to canonical: galleries, file-browser, github titles/status (note path renames `github-titles`→`github/titles`, `github-status`→`github/status`, `repo-links`→`github/repo-links`), repo-links, comment-preview. `/me` remains only for the memberships list — exactly the issue's end state.

## Verification

- `apps/api`: 1802 tests green (new per-route matrices: member/admin success, wrong-tier 403, non-member uniform 404, bearer 403 with coded errors, /me forward parity; galleries enrichment covered for both credential types with the old bearer list proven unchanged); `tsc` clean.
- `apps/web`: 587 tests green; worker `tsc` clean.

Refs #613. After this: the issue's remaining work is retirement only — `/me` aliases and the bare `/v1/:workspace` wildcard once telemetry shows the legacy paths quiet (gated on CLI release adoption).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace file browsing with session-based access and membership validation.
  * Added GitHub titles, installation status, and linked repository details for authorized workspace members and admins.
  * Added comment previews with workspace and repository settings.
  * Gallery listings now include item counts, references, and pagination details.

* **Improvements**
  * Workspace APIs now use consistent canonical routes across gallery, file browser, GitHub, and comment-preview features.
  * Legacy routes continue forwarding to the updated behavior for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->