### PR TITLE
fix(api): comment-preview loads path/state metadata like the real comment

### DIFF
--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -2265,7 +2265,11 @@ describe("GET /me/workspaces/:name/comment-preview", () => {
       }
       return new Response(null, { status: 404 });
     });
-    const sqlite = new SqliteD1(["migrations/20260720120000_github_repo_links.sql"]);
+    const sqlite = new SqliteD1([
+      "migrations/20260720120000_github_repo_links.sql",
+      // The preview now reads path/state metadata like the real comment.
+      "migrations/20260713210559_file_metadata.sql",
+    ]);
     const env = {
       AUTH: auth,
       DB: d1FromSqlite(sqlite),

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -65,6 +65,7 @@ import { usageWithLimits } from "../budget";
 import { previewFixtureItems } from "../comment-preview-fixtures";
 import { hasPreresolvedSession, resolveSessionUserId } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
+import { getMetadataForKeys } from "../file-metadata";
 import { listObjects } from "../files-core";
 import { findRepoLink } from "../github-repo-links";
 import {
@@ -698,9 +699,9 @@ export async function billingHandler(c: Context<SettingsVars>) {
  * probe another workspace's repo binding or `.uploads.yml` contents.
  *
  * Renders from a page of the workspace's own `gh/`-prefixed attachments
- * (first page only, mirrors gatherAttachments's url/pageUrl mapping but
- * skips the D1 metadata read — the preview needs no per-item meta beyond
- * what the static fixtures already carry). `listObjects` pages in
+ * (first page only, mirrors gatherAttachments's url/pageUrl mapping and its
+ * `path`/`state` D1 metadata read, so captions and before/after pairing
+ * preview the way the production comment renders). `listObjects` pages in
  * lexicographic key order, not upload recency, so this is a representative
  * sample rather than the "most recent" uploads. An empty workspace falls
  * back to `previewFixtureItems` so the preview is never blank.
@@ -749,6 +750,23 @@ export async function commentPreviewHandler(c: Context<SettingsVars>) {
   if (items.length === 0) {
     items = previewFixtureItems(c.env);
     sample = "fixtures";
+  } else if (resolved.metaPath || resolved.metaState) {
+    // Same narrow key set and skip condition as gatherAttachments — the
+    // preview must caption and pair exactly like the production comment.
+    const metaByKey = await getMetadataForKeys(
+      c.env.DB,
+      name,
+      items.map((item) => item.key),
+      { metaKeys: ["path", "state"] },
+    );
+    for (const item of items) {
+      const meta = metaByKey.get(item.key);
+      if (!meta) continue;
+      const { path, state } = meta;
+      if (path || state) {
+        item.meta = { ...(path ? { path } : {}), ...(state ? { state } : {}) };
+      }
+    }
   }
 
   const body = attachmentsCommentBody(items, [], attachmentsMarker(name), {

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -722,15 +722,17 @@ describe("/me alias forwards (issue #613 phase 3)", () => {
 
 describe("GET /v1/workspaces/:workspace/comment-preview (issue #613 final phase)", () => {
   function makePreviewEnv(opts: EnvOpts = {}) {
-    const { registry, db, env } = (() => {
+    const { registry, db, env, bucket } = (() => {
       const bucket = new FakeR2Bucket();
       const record = {
         ...SHARED_RECORD,
         binding: "UPLOADS_DEFAULT",
+        publicBaseUrl: "https://cdn.uploads.test",
       };
       const base = makeEnv({ ...opts, record });
       return {
         ...base,
+        bucket,
         env: {
           ...base.env,
           UPLOADS_DEFAULT: bucket,
@@ -738,7 +740,7 @@ describe("GET /v1/workspaces/:workspace/comment-preview (issue #613 final phase)
         } as unknown as Env,
       };
     })();
-    return { env, registry, db };
+    return { env, registry, db, bucket };
   }
 
   it("200s for an admin session with the fixture fallback when the workspace has no gh/ uploads", async () => {
@@ -752,6 +754,44 @@ describe("GET /v1/workspaces/:workspace/comment-preview (issue #613 final phase)
     const body = (await res.json()) as { sample: string; body: string };
     expect(body.sample).toBe("fixtures");
     expect(typeof body.body).toBe("string");
+  });
+
+  it("renders workspace attachments with their D1 path/state metadata (before/after pairing)", async () => {
+    const { env, db, bucket } = makePreviewEnv({ role: "admin" });
+    // Filenames deliberately carry no before/after stem token, so a paired
+    // render can only come from the D1 path/state metadata rows below.
+    await bucket.put("acme/gh/acme-web/pull-1/one.png", "a", {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await bucket.put("acme/gh/acme-web/pull-1/two.png", "b", {
+      httpMetadata: { contentType: "image/png" },
+    });
+    db.fileMetadata.set(
+      "acme gh/acme-web/pull-1/one.png",
+      new Map([
+        ["path", "docs/hero.png"],
+        ["state", "before"],
+      ]),
+    );
+    db.fileMetadata.set(
+      "acme gh/acme-web/pull-1/two.png",
+      new Map([
+        ["path", "docs/hero.png"],
+        ["state", "after"],
+      ]),
+    );
+
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-preview",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { sample: string; body: string };
+    expect(body.sample).toBe("workspace");
+    expect(body.body).toContain("<strong>Before</strong>");
+    expect(body.body).toContain("<strong>After</strong>");
+    expect(body.body).toContain("docs/hero.png");
   });
 
   it("403s a non-admin member session", async () => {


### PR DESCRIPTION
## What

`GET /v1/workspaces/:workspace/comment-preview` (and its `/me` alias) built `AttachmentItem`s from `listObjects(prefix: "gh/")` without loading D1 metadata, so `attachmentsCommentBody` couldn't caption by `path` or pair before/after by `state`. The preview diverged from the production managed comment for workspaces whose attachments carry that metadata.

The handler now loads `path`/`state` via `getMetadataForKeys` for the sampled keys and attaches them as each item's `meta`, mirroring `gatherAttachments` in the real comment path: same narrow key set, same skip when `metaPath`/`metaState` both resolve false, fields set only when non-empty. Metadata is not loaded for the fixture fallback. The `video.*` keys are deliberately out of scope — poster rendering also needs `storageConfig`/`posterKeyFor` plumbing, and this finding was about caption/pairing divergence.

## Tests

- New test in `routes-workspace-settings.test.ts`: two workspace attachments whose filenames carry no before/after stem token, with D1 rows `path=docs/hero.png` + `state=before|after`. Asserts the preview body renders the paired `<strong>Before</strong>`/`<strong>After</strong>` table and the path caption — only possible via the metadata load (verified failing before the fix). The preview env record gains a `publicBaseUrl` so listed objects get embeddable URLs.
- `me.test.ts`'s sqlite-backed preview env now applies the `file_metadata` migration, since the handler legitimately queries that table.

Full `@uploads/api` suite (1805 tests), typecheck, and lint pass. No changeset: api-app-only change.

## Context

Raised by CodeRabbit on [PR #640](https://github.com/buildinternet/uploads/pull/640) (comment 3762819723); declined there because that PR moved the handler verbatim under the no-drift rule.
