### PR TITLE
fix(cli): zsh completion generated an _arguments call that could not complete

### DIFF
--- a/.changeset/spotty-crabs-repeat.md
+++ b/.changeset/spotty-crabs-repeat.md
@@ -1,0 +1,14 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Fix `uploads completion zsh` producing a script that could not complete anything.
+
+The generated `_arguments` call was missing line continuations between its
+option specs, so zsh ended the call after the first spec and tried to execute
+the remaining ones as commands — Tab printed a wall of `command not found`
+instead of completing. Short flags now also pair with their long form's
+summary, so the menu no longer reads `Show help (short)`.
+
+Regenerate an installed script after upgrading:
+`uploads completion zsh > ~/.zsh/completions/_uploads`

--- a/.changeset/spotty-crabs-repeat.md
+++ b/.changeset/spotty-crabs-repeat.md
@@ -10,5 +10,10 @@ the remaining ones as commands — Tab printed a wall of `command not found`
 instead of completing. Short flags now also pair with their long form's
 summary, so the menu no longer reads `Show help (short)`.
 
+`uploads completion --help` now also covers installation properly. Saving the
+script into an fpath directory does nothing when `compinit -C` reuses a cached
+dump, which is common under Oh My Zsh, so the help gives the `compdef` binding
+that works regardless of startup order.
+
 Regenerate an installed script after upgrading:
 `uploads completion zsh > ~/.zsh/completions/_uploads`

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -58,7 +58,12 @@ answers `did you mean: uploads meta set`. With `--json`, an unknown command
 returns `{ "error", "code": "USAGE", "didYouMean" }` on stdout.
 
 **Shell completion:** `uploads completion bash|zsh|fish` prints a script to
-stdout. Example (zsh): `uploads completion zsh > ~/.zsh/completions/_uploads`.
+stdout. Save it where your shell looks for completions, then start a new shell.
+For zsh, write the script to `~/.zsh/completions/_uploads`, then bind it at the
+end of `~/.zshrc` with `fpath=(~/.zsh/completions $fpath)` and
+`autoload -Uz _uploads && compdef _uploads uploads`. The `compdef` line matters:
+a cached `compinit -C` never rescans fpath, so the file alone can go unnoticed.
+`uploads completion --help` covers the rest.
 
 **Globals (before the command):** `--api-url`, `--token`, `--workspace` / `-w`,
 `--env-file`, `--json`, `--quiet`, `--version` / `-V`, `-h` / `--help`, `--all`

--- a/packages/uploads/src/commands/completion.ts
+++ b/packages/uploads/src/commands/completion.ts
@@ -14,8 +14,9 @@ import { writeCommandHelp } from "../cli-style.js";
 
 const HELP = `uploads completion <shell>
 
-Print a shell completion script to stdout. Source it or install it so Tab
-completes commands, subcommands, and common flags.
+Print a shell completion script to stdout. Save it where your shell looks for
+completions, then start a new shell. Tab then completes commands, subcommands,
+and common flags.
 
 Shells:
   bash   Bash (complete -F)
@@ -23,16 +24,36 @@ Shells:
   fish   Fish (complete -c)
 
 Examples:
-  # zsh (Oh My Zsh / fpath)
-  uploads completion zsh > ~/.zsh/completions/_uploads
-
-  # bash
-  uploads completion bash > ~/.local/share/bash-completion/completions/uploads
-  # or for the current session:
+  # bash — for the current session:
   eval "$(uploads completion bash)"
+  # or save it:
+  uploads completion bash > ~/.local/share/bash-completion/completions/uploads
 
   # fish
   uploads completion fish > ~/.config/fish/completions/uploads.fish
+
+  # zsh — save the script:
+  uploads completion zsh > ~/.zsh/completions/_uploads
+  # then add these two lines to the END of ~/.zshrc:
+  #   fpath=(~/.zsh/completions $fpath)
+  #   autoload -Uz _uploads && compdef _uploads uploads
+
+Zsh notes:
+  Saving the file into an fpath directory is often not enough. compinit caches
+  its scan in ~/.zcompdump, and \`compinit -C\` reuses that cache instead of
+  rescanning, so it never sees the new file. Oh My Zsh and several installers
+  call compinit that way. Some plugins also rewrite fpath as they load, which
+  drops entries added before them; zsh-autocomplete is one.
+
+  The \`compdef\` line avoids both problems, because it binds the function
+  directly instead of relying on a scan. Put it after any framework or plugin
+  setup. If completion still does nothing, delete ~/.zcompdump* and start a
+  new shell.
+
+  Check the result with: print $_comps[uploads] — it prints _uploads when the
+  completion is active, and nothing when it is not.
+
+After you upgrade the CLI, generate the script again so it lists new commands.
 `;
 
 function bashScript(): string {

--- a/packages/uploads/src/commands/completion.ts
+++ b/packages/uploads/src/commands/completion.ts
@@ -156,20 +156,24 @@ function zshScript(): string {
 
   const globalArgs = GLOBAL_FLAGS.map((g) => {
     const desc = g.summary.replace(/'/g, "'\\''");
-    // Short and long flags as separate specs when needed.
-    if (g.flag === "-w") return `    '(-w --workspace)'{-w,--workspace}'[${desc}]:workspace:'`;
-    if (g.flag === "--workspace") return null; // paired with -w
-    if (g.flag === "-V") return `    '(-V --version)'{-V,--version}'[${desc}]'`;
-    if (g.flag === "--version") return null;
-    if (g.flag === "-h") return `    '(-h --help)'{-h,--help}'[${desc}]'`;
-    if (g.flag === "--help") return null;
+    // Pair each short flag with its long form, keeping the long form's cleaner
+    // summary; the short entry then contributes nothing of its own.
+    if (g.flag === "--workspace")
+      return `    '(-w --workspace)'{-w,--workspace}'[${desc}]:workspace:'`;
+    if (g.flag === "-w") return null; // paired with --workspace
+    if (g.flag === "--version") return `    '(-V --version)'{-V,--version}'[${desc}]'`;
+    if (g.flag === "-V") return null;
+    if (g.flag === "--help") return `    '(-h --help)'{-h,--help}'[${desc}]'`;
+    if (g.flag === "-h") return null;
     if (g.flag === "--api-url") return `    '--api-url[${desc}]:url:'`;
     if (g.flag === "--token") return `    '--token[${desc}]:token:'`;
     if (g.flag === "--env-file") return `    '--env-file[${desc}]:file:_files'`;
     return `    '${g.flag}[${desc}]'`;
   })
     .filter(Boolean)
-    .join("\n");
+    // Every spec but the last needs a line continuation — without them zsh ends
+    // the `_arguments` call after the first spec and tries to *run* the rest.
+    .join(" \\\n");
 
   const subCases = ROOT_COMMANDS.filter((c) => c.subcommands?.length)
     .map((c) => {

--- a/packages/uploads/test/cli-completion.test.ts
+++ b/packages/uploads/test/cli-completion.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/cli.js";
 import { generateCompletionScript, runCompletion } from "../src/commands/completion.js";
-import { ROOT_COMMANDS } from "../src/cli-catalog.js";
+import { COMPLETION_SHELLS, ROOT_COMMANDS } from "../src/cli-catalog.js";
 
 function captureStdio() {
   const stdout: string[] = [];
@@ -134,6 +134,20 @@ describe("runCompletion", () => {
     const code = await runCompletion([], true);
     expect(code).toBe(0);
     expect(io.stderr()).toMatch(/uploads completion <shell>/);
+  });
+
+  it("help gives the zsh compdef binding, not fpath alone", async () => {
+    const io = captureStdio();
+    await runCompletion([], true);
+    const help = io.stderr();
+    // Writing the file into an fpath directory does nothing under a cached
+    // `compinit -C`, so the help has to show the direct binding as well.
+    expect(help).toMatch(/fpath=\(~\/\.zsh\/completions \$fpath\)/);
+    expect(help).toMatch(/autoload -Uz _uploads && compdef _uploads uploads/);
+    expect(help).toMatch(/compinit -C/);
+    for (const shell of COMPLETION_SHELLS) {
+      expect(help).toContain(`uploads completion ${shell}`);
+    }
   });
 
   it("exits 2 when shell is missing", async () => {

--- a/packages/uploads/test/cli-completion.test.ts
+++ b/packages/uploads/test/cli-completion.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/cli.js";
 import { generateCompletionScript, runCompletion } from "../src/commands/completion.js";
@@ -71,6 +75,45 @@ describe("generateCompletionScript", () => {
   it("includes the update command", () => {
     expect(ROOT_COMMANDS.map((c) => c.name)).toContain("update");
   });
+
+  it("continues every _arguments spec line so zsh keeps one command", () => {
+    const script = generateCompletionScript("zsh");
+    const block = /^ {2}_arguments -C -s -S \\\n((?: {4}.*\n)+)/m.exec(script);
+    expect(block).not.toBeNull();
+    const lines = block![1]!.trimEnd().split("\n");
+    // Every line but the last must end in a continuation; otherwise zsh ends the
+    // _arguments call early and tries to execute the remaining specs as commands.
+    for (const line of lines.slice(0, -1)) {
+      expect(line.endsWith(" \\")).toBe(true);
+    }
+    expect(lines.at(-1)).toMatch(/'\*::arg:->args'$/);
+    expect(lines.length).toBeGreaterThan(3);
+  });
+
+  it("pairs short flags with their long form, using the long summary", () => {
+    const script = generateCompletionScript("zsh");
+    expect(script).toContain("'(-w --workspace)'{-w,--workspace}'[Workspace name]:workspace:'");
+    expect(script).toContain("'(-h --help)'{-h,--help}'[Show help]'");
+    // The "(short)" catalog summaries are an artifact of the flag list, not copy
+    // a user should ever see in a completion menu.
+    expect(script).not.toMatch(/\(short\)/);
+  });
+
+  for (const [shell, bin, args] of [
+    ["zsh", "zsh", ["-n"]],
+    ["bash", "bash", ["-n"]],
+  ] as const) {
+    it(`${shell} script parses under ${bin} ${args.join(" ")}`, () => {
+      const which = spawnSync("command", ["-v", bin], { shell: true });
+      if (which.status !== 0) return; // shell not installed on this machine
+      const script = generateCompletionScript(shell);
+      const file = join(mkdtempSync(join(tmpdir(), "uploads-completion-")), `script.${shell}`);
+      writeFileSync(file, script);
+      const run = spawnSync(bin, [...args, file], { encoding: "utf8" });
+      expect(run.stderr.trim()).toBe("");
+      expect(run.status).toBe(0);
+    });
+  }
 });
 
 describe("runCompletion", () => {


### PR DESCRIPTION
## The bug

`uploads completion zsh` emitted an `_arguments` call whose option specs were joined with a bare newline instead of a line continuation:

```
  _arguments -C -s -S \
    '--api-url[API base URL]:url:'          <- no trailing backslash
    '--token[Bearer token]:token:'
    '(-w --workspace)'{-w,--workspace}'[Workspace name (short)]:workspace:'
    ...
```

zsh therefore ended the `_arguments` call after the first spec and tried to **execute** every remaining line. Pressing Tab on an installed script gave:

```
$ uploads <TAB>
_uploads:43: command not found: --token[Bearer token]:token:
_uploads:44: command not found: (-w --workspace)-w[Workspace name (short)]:workspace:
_uploads:45: command not found: --env-file[Load env from file]:file:_files
...
--api-url
```

`--api-url` was the only candidate ever offered. No command names, no subcommands.

After the fix:

```
$ uploads <TAB>
admin          -- Site-operator invitation management (ADMIN_TOKEN)
annotate       -- Bake hand-drawn boxes, arrows, labels, and redactions onto images
attach         -- Attach media to the current PR (stable URLs + managed comment)
...

$ uploads gallery <TAB>
add     -- Add objects to a gallery
create  -- Create a gallery
delete  -- Delete a gallery record
link    -- Link a gallery to a GitHub issue/PR
list    -- List galleries
show    -- Show a gallery
unlink  -- Unlink a gallery from GitHub
```

## Changes

- Join the `_arguments` specs with `" \\\n"` so the call stays one command.
- Build each short/long flag pair from the **long** flag, so its summary is used. The menu previously read `Show help (short)` and `Print package version (short)` — the `(short)` suffixes exist to disambiguate entries in `GLOBAL_FLAGS`, not as user-facing copy.

bash and fish output is unaffected; both were already correct.

## Why the existing tests missed it

The broken script is still *syntactically valid* zsh — it is just a different set of commands — so `zsh -n` parses it cleanly. The existing assertions only grep the output for substrings, all of which were present.

The new `continues every _arguments spec line` test asserts the continuation structure directly. I confirmed it fails against the previous generator and passes after. The added `zsh -n` / `bash -n` parse checks are a secondary net (they skip when the shell is absent); they do **not** catch this class of bug on their own.

## Verification

Driven through a real pty against a real interactive zsh, both before and after — the terminal output above is captured from those runs, not reconstructed.

- `vitest run` in `packages/uploads`: 1216 passed, 71 files.
- `pnpm lint`: unchanged from the `main` baseline (43 pre-existing warnings, none in the touched files).

## Upgrading

An already-installed script needs regenerating:

```bash
uploads completion zsh > ~/.zsh/completions/_uploads
```

## The install docs, which were also wrong

`uploads completion --help` said only "Source it or install it", and the README
gave a bare redirect into `~/.zsh/completions/`. That is not reliably enough to
install anything:

- `compinit` caches its fpath scan in `~/.zcompdump`. `compinit -C` reuses that
  cache instead of rescanning, so it never sees a newly written file. Oh My Zsh
  and several installer snippets call it that way.
- Some plugins rewrite `fpath` as they load, dropping entries added before them.
  `zsh-autocomplete` is one.

Either alone is enough for a correct script to look broken. The help now gives
the binding that survives both:

```zsh
fpath=(~/.zsh/completions $fpath)
autoload -Uz _uploads && compdef _uploads uploads
```

plus `print $_comps[uploads]` to check whether the completion is live, and a
note to regenerate after upgrading. The README carries a condensed version.

I verified both directions under a deliberately cached `compinit -C` whose dump
predates the script:

| setup | `$_comps[uploads]` |
| --- | --- |
| `fpath=(...)` alone | *(empty)* |
| `fpath=(...)` + `compdef` | `_uploads` |

A test asserts the help keeps the `compdef` line, the `fpath` line, and the
`compinit -C` explanation, so the guidance cannot quietly regress to the old
wording.
