### PR TITLE
feat(web): changelog page + Atom feed for releases.sh ingestion

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -19,6 +19,8 @@ From the repo root: `pnpm dev:web` / `pnpm run deploy:web`.
 ```
 src/layouts/                         Shared shells (error pages)
 src/pages/                           Astro pages; g/[id].astro is the on-demand public gallery
+src/pages/changelog.astro            /changelog — platform updates + CLI releases, newest first
+src/pages/changelog.xml.ts           Atom twin of /changelog, served at /changelog.xml
 src/pages/oembed.ts                  oEmbed 1.0 JSON endpoint for shareable /f and /g pages
 src/lib/                             Public gallery/file fetch + oEmbed resolution
 public/_headers                      Per-path response headers (Link, robots, types)
@@ -44,15 +46,16 @@ wrangler.jsonc                       Hybrid Worker, static assets, skills index,
 The landing page, `/docs`, and the `/github-screenshots` use-case guide are meant
 for search engines. Agent discovery docs are public but not listed in the sitemap.
 
-| Path                                                        | Indexable | Notes                                                      |
-| ----------------------------------------------------------- | --------- | ---------------------------------------------------------- |
-| `/`                                                         | yes       | Listed in `sitemap.xml`; Link headers advertise catalogs   |
-| `/docs`                                                     | yes       | Plain-language setup guide; in `sitemap.xml`               |
-| `/github-screenshots`                                       | yes       | SEO landing: agents uploading media to GitHub; FAQ JSON-LD |
-| `/invite`                                                   | **no**    | Magic-link enrollment; robots + meta + `X-Robots-Tag`      |
-| `/console`                                                  | **no**    | Operator scaffold; same triple coverage                    |
-| `/404`,`/500`                                               | **no**    | Status pages                                               |
-| `/auth.md`, `/llms.txt`, `/llms-full.txt`, `/.well-known/*` | n/a       | Machine-readable; not in sitemap                           |
+| Path                                                        | Indexable | Notes                                                                      |
+| ----------------------------------------------------------- | --------- | -------------------------------------------------------------------------- |
+| `/`                                                         | yes       | Listed in `sitemap.xml`; Link headers advertise catalogs                   |
+| `/docs`                                                     | yes       | Plain-language setup guide; in `sitemap.xml`                               |
+| `/github-screenshots`                                       | yes       | SEO landing: agents uploading media to GitHub; FAQ JSON-LD                 |
+| `/changelog`                                                | yes       | Product updates + CLI releases; in `sitemap.xml`; Atom at `/changelog.xml` |
+| `/invite`                                                   | **no**    | Magic-link enrollment; robots + meta + `X-Robots-Tag`                      |
+| `/console`                                                  | **no**    | Operator scaffold; same triple coverage                                    |
+| `/404`,`/500`                                               | **no**    | Status pages                                                               |
+| `/auth.md`, `/llms.txt`, `/llms-full.txt`, `/.well-known/*` | n/a       | Machine-readable; not in sitemap                                           |
 
 `robots.txt` includes explicit `User-agent` blocks for common AI crawlers and
 `Content-Signal` preferences (`search=yes`, `ai-input=yes`, `ai-train=no`).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "files-sdk": "^2.2.3",
     "img-comparison-slider": "^8.0.7",
     "markdown-for-agents": "^1.3.4",
+    "marked": "^18.0.9",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/apps/web/public/.well-known/releases.json
+++ b/apps/web/public/.well-known/releases.json
@@ -8,9 +8,14 @@
   "social": { "github": "buildinternet" },
   "releases": [
     {
-      "title": "@buildinternet/uploads",
-      "github": "buildinternet/uploads",
+      "title": "Changelog",
+      "url": "https://uploads.sh/changelog",
+      "feed": "https://uploads.sh/changelog.xml",
       "canonical": true
+    },
+    {
+      "title": "@buildinternet/uploads",
+      "github": "buildinternet/uploads"
     }
   ]
 }

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -96,3 +96,9 @@
   Content-Type: application/json; charset=utf-8
   Cache-Control: public, max-age=300
   Access-Control-Allow-Origin: *
+
+# Atom feed for /changelog — the machine locator declared in releases.json.
+/changelog.xml
+  Content-Type: application/atom+xml; charset=utf-8
+  Cache-Control: public, max-age=300
+  Access-Control-Allow-Origin: *

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -246,6 +246,7 @@ staged files are promoted into the PR's attachments comment automatically.
 
 - Home: https://uploads.sh/
 - Docs hub: https://uploads.sh/docs
+- Changelog: https://uploads.sh/changelog (Atom feed at https://uploads.sh/changelog.xml)
 - Attach & share: https://uploads.sh/docs/attach-pull-request-images
 - GitHub App: https://uploads.sh/docs/github-app
 - Comment config (`.uploads.yml`): https://uploads.sh/docs/comment-config

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -12,6 +12,7 @@ Landed on the GitHub monorepo instead? Start at [repo llms.txt](https://github.c
 - [Home](https://uploads.sh/): product overview and copyable install commands
 - [Full agent guide (llms-full.txt)](https://uploads.sh/llms-full.txt): install, auth, stage/attach loops, hosted MCP contracts, cautions
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
+- [Changelog](https://uploads.sh/changelog): platform updates and CLI releases, newest first (Atom feed at https://uploads.sh/changelog.xml)
 - [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, pair a before/after with --state, get a URL for any file, capture a screenshot, annotate with callouts/redactions
 - [Docs: annotate a screenshot](https://uploads.sh/docs/attach-pull-request-images#annotate): bake boxes, arrows, labels, freeform strokes, and solid redactions into a capture (`uploads screenshot --annotate` or `uploads annotate`)
 - [Docs: GitHub App](https://uploads.sh/docs/github-app): recommended install for bot-posted attachment comments, private-repo PR/issue titles, and zero-CLI promotion of branch-staged screenshots when a PR opens

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -11,6 +11,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://uploads.sh/changelog</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://uploads.sh/docs/attach-pull-request-images</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -37,6 +37,7 @@ const COLUMNS: FooterColumn[] = [
     title: "Product",
     links: [
       { label: "Docs", href: "/docs" },
+      { label: "Changelog", href: "/changelog" },
       { label: "GitHub App", href: "/docs/github-app" },
       { label: "Agent guide", href: "/github-screenshots" },
       { label: "Sign in", href: "/login" },

--- a/apps/web/src/content.config.ts
+++ b/apps/web/src/content.config.ts
@@ -1,0 +1,26 @@
+import { glob } from "astro/loaders";
+import { defineCollection, z } from "astro:content";
+
+/**
+ * Platform updates for /changelog. One .md per update; slug = filename.
+ * Screenshots are NEVER committed — upload to the buildinternet workspace
+ * (changelog/ prefix) and reference the absolute storage.uploads.sh URL.
+ * See src/content/changelog/README.md for the publishing workflow.
+ */
+const changelog = defineCollection({
+  // README.md is the authoring guide, not an entry — exclude it.
+  loader: glob({ pattern: ["*.md", "!README.md"], base: "./src/content/changelog" }),
+  schema: z.object({
+    title: z.string().min(1),
+    date: z.coerce.date(),
+    tags: z.array(z.string()).default([]),
+    image: z
+      .object({
+        url: z.string().url().startsWith("https://"),
+        alt: z.string().min(1),
+      })
+      .optional(),
+  }),
+});
+
+export const collections = { changelog };

--- a/apps/web/src/content/changelog/README.md
+++ b/apps/web/src/content/changelog/README.md
@@ -7,8 +7,11 @@ automatically from `packages/uploads/CHANGELOG.md` — never write those here.
 2. Upload it — never commit images to the repo:
 
    ```bash
-   uploads put shot.png --workspace buildinternet --key changelog/<slug>.png
+   uploads put shot.png --key screenshots/changelog/<slug>.png
    ```
+
+   (The workspace key policy only allows the `f/`, `gh/`, and `screenshots/`
+   prefixes, so changelog images live under `screenshots/changelog/`.)
 
    Copy the public `storage.uploads.sh` URL from the output.
 
@@ -20,7 +23,7 @@ automatically from `packages/uploads/CHANGELOG.md` — never write those here.
    date: 2026-08-12
    tags: [platform]
    image:
-     url: https://storage.uploads.sh/changelog/<slug>.png
+     url: https://storage.uploads.sh/default/screenshots/changelog/<slug>.png
      alt: "What the screenshot shows"
    ---
 

--- a/apps/web/src/content/changelog/README.md
+++ b/apps/web/src/content/changelog/README.md
@@ -1,0 +1,35 @@
+# Publishing a changelog entry
+
+One markdown file per platform update. CLI releases are merged in
+automatically from `packages/uploads/CHANGELOG.md` — never write those here.
+
+1. Capture the screenshot (if any).
+2. Upload it — never commit images to the repo:
+
+   ```bash
+   uploads put shot.png --workspace buildinternet --key changelog/<slug>.png
+   ```
+
+   Copy the public `storage.uploads.sh` URL from the output.
+
+3. Create `<slug>.md` in this directory (slug becomes the page anchor):
+
+   ```md
+   ---
+   title: "Human-readable title"
+   date: 2026-08-12
+   tags: [platform]
+   image:
+     url: https://storage.uploads.sh/changelog/<slug>.png
+     alt: "What the screenshot shows"
+   ---
+
+   Body in plain markdown. Inline images work too, absolute https URLs only.
+   ```
+
+4. Open a PR. Merge deploys /changelog and /changelog.xml; releases.sh picks
+   up the new entry on its normal feed sweep.
+
+Image rules: absolute `https://` URLs, 1 KB–8 MB, png/jpeg/gif/webp/avif —
+that's what releases.sh mirrors into its own storage. `date` supports full
+ISO timestamps (`2026-08-12T15:00:00Z`) when same-day ordering matters.

--- a/apps/web/src/content/changelog/screenshots-page.md
+++ b/apps/web/src/content/changelog/screenshots-page.md
@@ -1,0 +1,14 @@
+---
+title: "A home for your screenshots"
+date: 2026-08-11
+tags: [platform, web]
+---
+
+Every screenshot the CLI captures now has a page of its own. **Screenshots**
+in your workspace groups captures by the page they came from — grouped by
+project, with before/after pairs kept together — so you can find last week's
+capture without scrolling a flat file list.
+
+The CLI pitches in too: `uploads screenshot` derives a stable name from the
+URL (plus `--state` for before/after variants), so re-capturing the same page
+replaces the old shot instead of piling up near-duplicates.

--- a/apps/web/src/content/changelog/screenshots-page.md
+++ b/apps/web/src/content/changelog/screenshots-page.md
@@ -2,6 +2,9 @@
 title: "A home for your screenshots"
 date: 2026-08-11
 tags: [platform, web]
+image:
+  url: https://storage.uploads.sh/default/screenshots/changelog/screenshots-page.webp
+  alt: "The Screenshots page grouping captures by project and page path"
 ---
 
 Every screenshot the CLI captures now has a page of its own. **Screenshots**

--- a/apps/web/src/lib/changelog-collection.ts
+++ b/apps/web/src/lib/changelog-collection.ts
@@ -4,27 +4,12 @@
  * Kept in its own module so `changelog.ts`'s pure functions stay importable
  * from vitest without a top-level `astro:content` import, which vitest
  * cannot resolve outside an Astro build.
- *
- * The `"changelog" as never` / return cast below are load-bearing until a
- * later task registers the `changelog` collection in `content.config.ts`:
- * without that config, `astro:content`'s generated types don't know about
- * any collection name, so `getCollection` types its argument as `never`.
- * Once the collection is registered, `getCollection("changelog")` and this
- * shape will typecheck for real; the casts can be dropped then.
  */
+import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
 
-export type ChangelogPost = {
-  id: string;
-  body?: string;
-  data: {
-    title: string;
-    date: Date;
-    tags: string[];
-    image?: { url: string; alt: string };
-  };
-};
+export type ChangelogPost = CollectionEntry<"changelog">;
 
 export function getChangelogCollection(): Promise<ChangelogPost[]> {
-  return getCollection("changelog" as never) as unknown as Promise<ChangelogPost[]>;
+  return getCollection("changelog");
 }

--- a/apps/web/src/lib/changelog-collection.ts
+++ b/apps/web/src/lib/changelog-collection.ts
@@ -1,0 +1,30 @@
+/**
+ * Isolated `astro:content` access for the `changelog` collection.
+ *
+ * Kept in its own module so `changelog.ts`'s pure functions stay importable
+ * from vitest without a top-level `astro:content` import, which vitest
+ * cannot resolve outside an Astro build.
+ *
+ * The `"changelog" as never` / return cast below are load-bearing until a
+ * later task registers the `changelog` collection in `content.config.ts`:
+ * without that config, `astro:content`'s generated types don't know about
+ * any collection name, so `getCollection` types its argument as `never`.
+ * Once the collection is registered, `getCollection("changelog")` and this
+ * shape will typecheck for real; the casts can be dropped then.
+ */
+import { getCollection } from "astro:content";
+
+export type ChangelogPost = {
+  id: string;
+  body?: string;
+  data: {
+    title: string;
+    date: Date;
+    tags: string[];
+    image?: { url: string; alt: string };
+  };
+};
+
+export function getChangelogCollection(): Promise<ChangelogPost[]> {
+  return getCollection("changelog" as never) as unknown as Promise<ChangelogPost[]>;
+}

--- a/apps/web/src/lib/changelog-feed.test.ts
+++ b/apps/web/src/lib/changelog-feed.test.ts
@@ -10,6 +10,10 @@ const entries: ChangelogEntry[] = [
     date: "2026-08-11T00:00:00.000Z",
     html: '<p>Now with <img src="https://storage.uploads.sh/changelog/x.png" alt="x"></p>',
     tags: ["platform"],
+    image: {
+      url: "https://storage.uploads.sh/default/screenshots/changelog/lead.webp",
+      alt: 'The "lead" image',
+    },
   },
   {
     kind: "cli",
@@ -44,6 +48,12 @@ describe("renderAtomFeed", () => {
     expect(xml).toContain('<content type="html">');
     expect(xml).toContain("https://storage.uploads.sh/changelog/x.png");
     expect(xml).toContain("&lt;img src=");
+  });
+
+  it("inlines the frontmatter lead image into the entry content", () => {
+    // Escaped once for the HTML attribute, then again for XML.
+    expect(xml).toContain("https://storage.uploads.sh/default/screenshots/changelog/lead.webp");
+    expect(xml).toContain("alt=&quot;The &amp;quot;lead&amp;quot; image&quot;");
   });
 
   it("throws on an empty entry list rather than publishing an empty feed", () => {

--- a/apps/web/src/lib/changelog-feed.test.ts
+++ b/apps/web/src/lib/changelog-feed.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { ChangelogEntry } from "./changelog";
+import { renderAtomFeed } from "./changelog-feed";
+
+const entries: ChangelogEntry[] = [
+  {
+    kind: "platform",
+    id: "screenshots-page",
+    title: "A home for <your> screenshots",
+    date: "2026-08-11T00:00:00.000Z",
+    html: '<p>Now with <img src="https://storage.uploads.sh/changelog/x.png" alt="x"></p>',
+    tags: ["platform"],
+  },
+  {
+    kind: "cli",
+    id: "cli-0-41-1",
+    title: "CLI 0.41.1",
+    date: "2026-08-09T18:00:00.000Z",
+    html: "<p>Fixes</p>",
+    tags: ["cli"],
+  },
+];
+
+describe("renderAtomFeed", () => {
+  const xml = renderAtomFeed(entries);
+
+  it("is an atom feed with feed-level metadata", () => {
+    expect(xml).toContain('<?xml version="1.0" encoding="utf-8"?>');
+    expect(xml).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(xml).toContain("<id>https://uploads.sh/changelog</id>");
+    // Feed updated = newest entry date.
+    expect(xml).toContain("<updated>2026-08-11T00:00:00.000Z</updated>");
+    expect(xml).toContain('href="https://uploads.sh/changelog.xml" rel="self"');
+  });
+
+  it("emits one entry per item with anchored ids and escaped titles", () => {
+    expect(xml).toContain("<id>https://uploads.sh/changelog#screenshots-page</id>");
+    expect(xml).toContain("<id>https://uploads.sh/changelog#cli-0-41-1</id>");
+    expect(xml).toContain("A home for &lt;your&gt; screenshots");
+    expect(xml).not.toContain("A home for <your>");
+  });
+
+  it("carries full HTML content with absolute image URLs, escaped", () => {
+    expect(xml).toContain('<content type="html">');
+    expect(xml).toContain("https://storage.uploads.sh/changelog/x.png");
+    expect(xml).toContain("&lt;img src=");
+  });
+
+  it("throws on an empty entry list rather than publishing an empty feed", () => {
+    expect(() => renderAtomFeed([])).toThrow(/empty/i);
+  });
+});

--- a/apps/web/src/lib/changelog-feed.ts
+++ b/apps/web/src/lib/changelog-feed.ts
@@ -1,0 +1,53 @@
+/**
+ * Atom serializer for /changelog.xml. Entries carry full HTML content with
+ * absolute image URLs so releases.sh mirrors the media at ingest.
+ */
+import type { ChangelogEntry } from "./changelog";
+
+const SITE = "https://uploads.sh";
+const PAGE = `${SITE}/changelog`;
+const FEED = `${SITE}/changelog.xml`;
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function renderAtomFeed(entries: ChangelogEntry[]): string {
+  if (entries.length === 0) {
+    throw new Error("renderAtomFeed: refusing to publish an empty feed");
+  }
+  const updated = entries
+    .map((e) => e.date)
+    .sort()
+    .at(-1)!;
+
+  const items = entries
+    .map(
+      (entry) => `  <entry>
+    <id>${PAGE}#${entry.id}</id>
+    <title>${escapeXml(entry.title)}</title>
+    <link href="${PAGE}#${entry.id}"/>
+    <updated>${entry.date}</updated>
+${entry.tags.map((tag) => `    <category term="${escapeXml(tag)}"/>`).join("\n")}
+    <content type="html">${escapeXml(entry.html)}</content>
+  </entry>`,
+    )
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>${PAGE}</id>
+  <title>uploads.sh changelog</title>
+  <subtitle>Platform updates and CLI releases</subtitle>
+  <link href="${PAGE}"/>
+  <link href="${FEED}" rel="self"/>
+  <updated>${updated}</updated>
+  <author><name>uploads.sh</name></author>
+${items}
+</feed>
+`;
+}

--- a/apps/web/src/lib/changelog-feed.ts
+++ b/apps/web/src/lib/changelog-feed.ts
@@ -16,6 +16,16 @@ function escapeXml(value: string): string {
     .replaceAll('"', "&quot;");
 }
 
+/**
+ * The lead image lives in frontmatter, not the body — inline it into the
+ * feed content so releases.sh sees (and mirrors) it at ingest.
+ */
+function entryContentHtml(entry: ChangelogEntry): string {
+  if (!entry.image) return entry.html;
+  const escapeAttr = (v: string) => v.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
+  return `<p><img src="${escapeAttr(entry.image.url)}" alt="${escapeAttr(entry.image.alt)}"></p>${entry.html}`;
+}
+
 export function renderAtomFeed(entries: ChangelogEntry[]): string {
   if (entries.length === 0) {
     throw new Error("renderAtomFeed: refusing to publish an empty feed");
@@ -33,7 +43,7 @@ export function renderAtomFeed(entries: ChangelogEntry[]): string {
     <link href="${PAGE}#${entry.id}"/>
     <updated>${entry.date}</updated>
 ${entry.tags.map((tag) => `    <category term="${escapeXml(tag)}"/>`).join("\n")}
-    <content type="html">${escapeXml(entry.html)}</content>
+    <content type="html">${escapeXml(entryContentHtml(entry))}</content>
   </entry>`,
     )
     .join("\n");

--- a/apps/web/src/lib/changelog-source.ts
+++ b/apps/web/src/lib/changelog-source.ts
@@ -1,0 +1,11 @@
+/**
+ * Isolated raw import of the CLI package's changeset-generated CHANGELOG.md.
+ *
+ * Kept in its own module so `changelog.ts`'s pure functions stay importable
+ * from vitest without pulling in a Vite-only `?raw` import that vitest may
+ * fail to resolve alongside the `astro:content` import.
+ */
+// Vite raw import — the monorepo checkout is present at build time.
+import cliChangelogRaw from "../../../../packages/uploads/CHANGELOG.md?raw";
+
+export { cliChangelogRaw };

--- a/apps/web/src/lib/changelog.test.ts
+++ b/apps/web/src/lib/changelog.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type ChangelogEntry,
+  cliAnchorId,
+  fetchCliReleaseDates,
+  mergeEntries,
+  parseCliChangelog,
+  renderMarkdown,
+} from "./changelog";
+
+const SAMPLE = `# @buildinternet/uploads
+
+## 0.41.1
+
+### Patch Changes
+
+- 2697e69: Fix \`uploads completion zsh\` producing a script that could not complete anything.
+
+  The generated \`_arguments\` call was missing line continuations.
+
+## 0.41.0
+
+### Minor Changes
+
+- 085da59: Per-key file operations now use the canonical paths (#613).
+`;
+
+describe("parseCliChangelog", () => {
+  it("splits ## <version> sections newest-first with bodies intact", () => {
+    const sections = parseCliChangelog(SAMPLE);
+    expect(sections.map((s) => s.version)).toEqual(["0.41.1", "0.41.0"]);
+    expect(sections[0].body).toContain("### Patch Changes");
+    expect(sections[0].body).toContain("line continuations");
+    expect(sections[0].body).not.toContain("## 0.41.0");
+  });
+
+  it("throws when no version sections are found", () => {
+    expect(() => parseCliChangelog("# nothing here")).toThrow(/no version sections/i);
+  });
+});
+
+describe("cliAnchorId", () => {
+  it("dasherizes the version", () => {
+    expect(cliAnchorId("0.41.1")).toBe("cli-0-41-1");
+  });
+});
+
+describe("fetchCliReleaseDates", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the npm time map minus created/modified", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          time: {
+            created: "2026-01-01T00:00:00.000Z",
+            modified: "2026-08-01T00:00:00.000Z",
+            "0.41.1": "2026-08-09T18:00:00.000Z",
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    const dates = await fetchCliReleaseDates(fetchImpl as unknown as typeof fetch);
+    expect(dates).toEqual({ "0.41.1": "2026-08-09T18:00:00.000Z" });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/@buildinternet/uploads",
+      expect.anything(),
+    );
+  });
+
+  it("throws on a non-200 response", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("nope", { status: 503 }));
+    await expect(fetchCliReleaseDates(fetchImpl as unknown as typeof fetch)).rejects.toThrow(
+      /npm registry/i,
+    );
+  });
+});
+
+describe("renderMarkdown", () => {
+  it("renders markdown to HTML", () => {
+    expect(renderMarkdown("some `code` here")).toContain("<code>code</code>");
+  });
+});
+
+describe("mergeEntries", () => {
+  const entry = (over: Partial<ChangelogEntry>): ChangelogEntry => ({
+    kind: "platform",
+    id: "x",
+    title: "x",
+    date: "2026-08-01T00:00:00.000Z",
+    html: "",
+    tags: [],
+    ...over,
+  });
+
+  it("sorts newest first", () => {
+    const sorted = mergeEntries([
+      entry({ id: "old", date: "2026-07-01T00:00:00.000Z" }),
+      entry({ id: "new", date: "2026-08-10T00:00:00.000Z" }),
+    ]);
+    expect(sorted.map((e) => e.id)).toEqual(["new", "old"]);
+  });
+
+  it("puts platform entries before cli entries on the same date", () => {
+    const sorted = mergeEntries([
+      entry({ id: "cli", kind: "cli" }),
+      entry({ id: "post", kind: "platform" }),
+    ]);
+    expect(sorted.map((e) => e.id)).toEqual(["post", "cli"]);
+  });
+});

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -77,7 +77,20 @@ export function mergeEntries(entries: ChangelogEntry[]): ChangelogEntry[] {
   });
 }
 
-export async function loadChangelogEntries(): Promise<ChangelogEntry[]> {
+let cached: Promise<ChangelogEntry[]> | null = null;
+
+/**
+ * Both /changelog and /changelog.xml call this during the same build; cache
+ * the promise so the npm registry fetch (and content-collection load) only
+ * happens once per build instead of once per route. A rejected build-time
+ * promise still rejects every caller, so failures still fail the build.
+ */
+export function loadChangelogEntries(): Promise<ChangelogEntry[]> {
+  cached ??= buildChangelogEntries();
+  return cached;
+}
+
+async function buildChangelogEntries(): Promise<ChangelogEntry[]> {
   const [{ cliChangelogRaw }, { getChangelogCollection }] = await Promise.all([
     import("./changelog-source"),
     import("./changelog-collection"),

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -1,0 +1,110 @@
+/**
+ * Build-time data source for /changelog and /changelog.xml.
+ *
+ * Merges two streams into one newest-first list:
+ *  - platform updates: the `changelog` content collection (hand-written .md)
+ *  - CLI releases: `packages/uploads/CHANGELOG.md` (changesets output),
+ *    dated via the npm registry's `time` map, since changesets carry no dates.
+ *
+ * Everything here runs at build time only. Failures throw so a bad build
+ * never ships an incomplete changelog.
+ */
+import { marked } from "marked";
+
+export type ChangelogImage = { url: string; alt: string };
+
+export type ChangelogEntry = {
+  kind: "platform" | "cli";
+  /** Stable anchor id, e.g. "screenshots-page" or "cli-0-41-1". */
+  id: string;
+  title: string;
+  /** ISO 8601 UTC timestamp. */
+  date: string;
+  /** Rendered HTML body. */
+  html: string;
+  tags: string[];
+  image?: ChangelogImage;
+};
+
+const NPM_PACKAGE_URL = "https://registry.npmjs.org/@buildinternet/uploads";
+
+export function parseCliChangelog(md: string): { version: string; body: string }[] {
+  const sections: { version: string; body: string }[] = [];
+  const matches = [...md.matchAll(/^## (\d+\.\d+\.\d+(?:-[\w.]+)?)\s*$/gm)];
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    const start = (match.index ?? 0) + match[0].length;
+    const end = i + 1 < matches.length ? matches[i + 1].index : md.length;
+    sections.push({ version: match[1], body: md.slice(start, end).trim() });
+  }
+  if (sections.length === 0) {
+    throw new Error("parseCliChangelog: no version sections found in CHANGELOG.md");
+  }
+  return sections;
+}
+
+export function cliAnchorId(version: string): string {
+  return `cli-${version.replaceAll(".", "-")}`;
+}
+
+export async function fetchCliReleaseDates(
+  fetchImpl: typeof fetch = fetch,
+): Promise<Record<string, string>> {
+  const res = await fetchImpl(NPM_PACKAGE_URL, {
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`npm registry responded ${res.status} for @buildinternet/uploads`);
+  }
+  const data = (await res.json()) as { time?: Record<string, string> };
+  if (!data.time) {
+    throw new Error("npm registry response has no time map");
+  }
+  const { created: _created, modified: _modified, ...versions } = data.time;
+  return versions;
+}
+
+export function renderMarkdown(md: string): string {
+  return marked.parse(md, { async: false }) as string;
+}
+
+export function mergeEntries(entries: ChangelogEntry[]): ChangelogEntry[] {
+  return [...entries].sort((a, b) => {
+    const byDate = Date.parse(b.date) - Date.parse(a.date);
+    if (byDate !== 0) return byDate;
+    if (a.kind === b.kind) return 0;
+    return a.kind === "platform" ? -1 : 1;
+  });
+}
+
+export async function loadChangelogEntries(): Promise<ChangelogEntry[]> {
+  const [{ cliChangelogRaw }, { getChangelogCollection }] = await Promise.all([
+    import("./changelog-source"),
+    import("./changelog-collection"),
+  ]);
+  const [posts, dates] = await Promise.all([getChangelogCollection(), fetchCliReleaseDates()]);
+
+  const platform: ChangelogEntry[] = posts.map((post) => ({
+    kind: "platform",
+    id: post.id,
+    title: post.data.title,
+    date: post.data.date.toISOString(),
+    html: renderMarkdown(post.body ?? ""),
+    tags: post.data.tags,
+    image: post.data.image,
+  }));
+
+  const cli: ChangelogEntry[] = parseCliChangelog(cliChangelogRaw)
+    // Versions missing from npm (e.g. the skipped 0.20.0) are dropped.
+    .filter((section) => dates[section.version] !== undefined)
+    .map((section) => ({
+      kind: "cli" as const,
+      id: cliAnchorId(section.version),
+      title: `CLI ${section.version}`,
+      date: dates[section.version],
+      html: renderMarkdown(section.body),
+      tags: ["cli"],
+    }));
+
+  return mergeEntries([...platform, ...cli]);
+}

--- a/apps/web/src/pages-reachability.test.ts
+++ b/apps/web/src/pages-reachability.test.ts
@@ -56,6 +56,7 @@ describe.each([
   { path: "/account/developers", title: "Developers · uploads.sh" },
   { path: "/console", title: "uploads.sh console" },
   { path: "/f/acme/screenshots/shot.png", title: "shot.png · uploads.sh" },
+  { path: "/changelog", title: "Changelog" },
 ])("route reachability: $path", ({ path, title }) => {
   it("reaches the page handler (not a static 404) on a browser navigation request", async () => {
     let handlerCalled = false;

--- a/apps/web/src/pages/changelog.astro
+++ b/apps/web/src/pages/changelog.astro
@@ -6,6 +6,7 @@ import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
 import SiteHeader from "../components/SiteHeader.astro";
 import { loadChangelogEntries } from "../lib/changelog";
+import { OG_DEFAULT_IMAGE, OG_SITE_NAME } from "../lib/og";
 
 const entries = await loadChangelogEntries();
 
@@ -37,6 +38,20 @@ const formatDate = (iso: string) =>
       title="uploads.sh changelog"
       href="/changelog.xml"
     />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://uploads.sh/changelog" />
+    <meta property="og:site_name" content={OG_SITE_NAME} />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:title" content={pageTitle} />
+    <meta property="og:description" content={pageDescription} />
+    <meta property="og:image" content={OG_DEFAULT_IMAGE} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content={pageTitle} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={pageTitle} />
+    <meta name="twitter:description" content={pageDescription} />
+    <meta name="twitter:image" content={OG_DEFAULT_IMAGE} />
     <style>
       * {
         box-sizing: border-box;

--- a/apps/web/src/pages/changelog.astro
+++ b/apps/web/src/pages/changelog.astro
@@ -1,0 +1,190 @@
+---
+// /changelog — merged product stream: hand-written platform updates
+// (src/content/changelog) interleaved with CLI releases from changesets.
+// Fully prerendered, zero client JS. Machine twin: /changelog.xml (Atom).
+import BaseHead from "../components/BaseHead.astro";
+import Footer from "../components/Footer.astro";
+import SiteHeader from "../components/SiteHeader.astro";
+import { loadChangelogEntries } from "../lib/changelog";
+
+const entries = await loadChangelogEntries();
+
+const pageTitle = "Changelog";
+const pageDescription =
+  "What's new in uploads.sh — platform updates and CLI releases, newest first.";
+
+// Static page — auth origin is baked at build time (see src/lib/auth-client.ts).
+const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+---
+
+<html lang="en">
+  <head>
+    <BaseHead preloadSans />
+    <title>{pageTitle} · uploads.sh</title>
+    <meta name="description" content={pageDescription} />
+    <link rel="canonical" href="https://uploads.sh/changelog" />
+    <link
+      rel="alternate"
+      type="application/atom+xml"
+      title="uploads.sh changelog"
+      href="/changelog.xml"
+    />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        background: var(--bg);
+        color: var(--fg);
+        font: 15.5px/1.7 var(--sans);
+        display: flex;
+        flex-direction: column;
+      }
+      main {
+        width: min(var(--width-content, 720px), 100%);
+        margin: 0 auto;
+        padding: 32px 24px 64px;
+        flex: 1;
+      }
+      h1 {
+        font-size: clamp(26px, 5vw, 34px);
+        font-weight: 600;
+        letter-spacing: -0.015em;
+        line-height: 1.25;
+        margin: 8px 0 4px;
+      }
+      .lede {
+        color: var(--muted);
+        font-size: 14px;
+        margin: 0 0 12px;
+      }
+      .feed-link {
+        color: var(--muted);
+        font-size: 13px;
+        text-decoration: underline;
+        text-underline-offset: 3px;
+      }
+      .entry {
+        border-top: 1px solid var(--line);
+        padding: 32px 0 8px;
+        margin-top: 24px;
+      }
+      .entry time {
+        display: block;
+        color: var(--muted);
+        font: 12px var(--mono);
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        margin-bottom: 6px;
+      }
+      .entry h2 {
+        font-size: 20px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        margin: 0 0 12px;
+      }
+      .entry h2 a {
+        color: inherit;
+        text-decoration: none;
+      }
+      .entry h2 a:hover {
+        text-decoration: underline;
+        text-underline-offset: 3px;
+      }
+      .entry--cli h2 {
+        font-size: 16px;
+        color: var(--body);
+      }
+      .entry--cli .body {
+        color: var(--muted);
+      }
+      .lead-image {
+        max-width: 100%;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        margin: 0 0 14px;
+      }
+      .body :global(p),
+      .body :global(li) {
+        color: var(--body);
+      }
+      .body :global(img) {
+        max-width: 100%;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+      }
+      .body :global(h3) {
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--muted);
+        margin: 18px 0 6px;
+      }
+      .body :global(a) {
+        color: var(--fg);
+        text-decoration: underline;
+        text-decoration-color: color-mix(in srgb, var(--accent) 55%, transparent);
+        text-underline-offset: 3px;
+      }
+      .body :global(code) {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 5px;
+        padding: 1px 6px;
+        font: 0.88em var(--mono);
+        font-variant-ligatures: none;
+      }
+      .body :global(pre) {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 12px 14px;
+        overflow-x: auto;
+      }
+      .body :global(pre code) {
+        background: none;
+        border: none;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <SiteHeader authOrigin={authOrigin} />
+    <main>
+      <h1>Changelog</h1>
+      <p class="lede">{pageDescription}</p>
+      <a class="feed-link" href="/changelog.xml">Atom feed</a>
+      {
+        entries.map((entry) => (
+          <article class:list={["entry", { "entry--cli": entry.kind === "cli" }]} id={entry.id}>
+            <time datetime={entry.date}>{formatDate(entry.date)}</time>
+            <h2>
+              <a href={`#${entry.id}`}>{entry.title}</a>
+            </h2>
+            {entry.image && (
+              <img
+                class="lead-image"
+                src={entry.image.url}
+                alt={entry.image.alt}
+                loading="lazy"
+                decoding="async"
+              />
+            )}
+            <div class="body" set:html={entry.html} />
+          </article>
+        ))
+      }
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/apps/web/src/pages/changelog.xml.ts
+++ b/apps/web/src/pages/changelog.xml.ts
@@ -1,0 +1,17 @@
+/**
+ * /changelog.xml — Atom twin of /changelog. Prerendered at build time and
+ * served off the ASSETS binding; headers come from public/_headers. This is
+ * the Tier-1 machine locator declared in .well-known/releases.json.
+ */
+import type { APIRoute } from "astro";
+import { loadChangelogEntries } from "../lib/changelog";
+import { renderAtomFeed } from "../lib/changelog-feed";
+
+export const prerender = true;
+
+export const GET: APIRoute = async () => {
+  const entries = await loadChangelogEntries();
+  return new Response(renderAtomFeed(entries), {
+    headers: { "content-type": "application/atom+xml; charset=utf-8" },
+  });
+};

--- a/docs/superpowers/plans/2026-08-12-changelog-page.md
+++ b/docs/superpowers/plans/2026-08-12-changelog-page.md
@@ -1,0 +1,987 @@
+# Changelog Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A prerendered `/changelog` page + `/changelog.xml` Atom feed on uploads.sh merging hand-written platform updates (Astro content collection) with CLI releases parsed from `packages/uploads/CHANGELOG.md`, declared canonical in `.well-known/releases.json` for releases.sh ingestion.
+
+**Architecture:** A build-time data module (`apps/web/src/lib/changelog.ts`) parses the changesets CHANGELOG, fetches per-version publish dates from the npm registry `time` map, and merges with content-collection entries into one sorted list consumed by both the page and the feed. Everything is prerendered; zero client JS.
+
+**Tech Stack:** Astro 7 (content layer + prerendered endpoint), zod (via `astro:content`), `marked` (new dep, build-time markdown→HTML), vitest (colocated `src/**/*.test.ts`).
+
+**Spec:** `docs/superpowers/specs/2026-08-12-changelog-page-design.md`
+
+## Global Constraints
+
+- Public pages ship **zero framework/client JS**; `/changelog` and `/changelog.xml` are prerendered (no `prerender = false`).
+- `trailingSlash: "never"`, `build.format: "file"` — page file is `src/pages/changelog.astro`, endpoint is `src/pages/changelog.xml.ts`.
+- All image URLs in entries must be absolute `https://` (releases.sh mirrors 1 KB–8 MB png/jpeg/gif/webp/avif only).
+- Build must **fail loudly** if: the npm `time` fetch fails, the CHANGELOG parse yields zero versions, or frontmatter validation fails.
+- No `:root` tokens or `@font-face` in pages — BaseHead imports `@uploads/ui/styles.css`; use existing tokens (`--bg --fg --body --muted --line --panel --accent --sans --mono --width-content`).
+- apps/web is in the changesets `ignore` list — **no changeset file needed** for this work.
+- Husky pre-commit runs oxfmt on staged files; commit output may show reformatting — that's normal.
+- Run web tests with `pnpm --filter @uploads/web test`; typecheck with `pnpm --filter @uploads/web typecheck`.
+
+---
+
+### Task 1: Changelog data module (parser, dates, merge)
+
+**Files:**
+
+- Create: `apps/web/src/lib/changelog.ts`
+- Test: `apps/web/src/lib/changelog.test.ts`
+- Modify: `apps/web/package.json` (add `marked` dependency)
+
+**Interfaces:**
+
+- Produces (later tasks import these from `../lib/changelog` / `./changelog`):
+
+```ts
+export type ChangelogImage = { url: string; alt: string };
+
+export type ChangelogEntry = {
+  kind: "platform" | "cli";
+  /** Stable anchor id, e.g. "screenshots-page" or "cli-0-41-1" */
+  id: string;
+  title: string;
+  /** ISO 8601 UTC timestamp */
+  date: string;
+  /** Rendered HTML body (marked output) */
+  html: string;
+  tags: string[];
+  image?: ChangelogImage;
+};
+
+export function parseCliChangelog(md: string): { version: string; body: string }[];
+export function cliAnchorId(version: string): string; // "0.41.1" -> "cli-0-41-1"
+export function fetchCliReleaseDates(fetchImpl?: typeof fetch): Promise<Record<string, string>>;
+export function renderMarkdown(md: string): string; // marked, async: false
+export function mergeEntries(entries: ChangelogEntry[]): ChangelogEntry[]; // newest-first, date desc then kind (platform before cli on same date)
+export function loadChangelogEntries(): Promise<ChangelogEntry[]>; // page/feed entry point
+```
+
+- [ ] **Step 1: Add the `marked` dependency**
+
+```bash
+pnpm --filter @uploads/web add marked
+```
+
+Expected: lockfile updates cleanly (supply-chain policy check runs on install).
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `apps/web/src/lib/changelog.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type ChangelogEntry,
+  cliAnchorId,
+  fetchCliReleaseDates,
+  mergeEntries,
+  parseCliChangelog,
+  renderMarkdown,
+} from "./changelog";
+
+const SAMPLE = `# @buildinternet/uploads
+
+## 0.41.1
+
+### Patch Changes
+
+- 2697e69: Fix \`uploads completion zsh\` producing a script that could not complete anything.
+
+  The generated \`_arguments\` call was missing line continuations.
+
+## 0.41.0
+
+### Minor Changes
+
+- 085da59: Per-key file operations now use the canonical paths (#613).
+`;
+
+describe("parseCliChangelog", () => {
+  it("splits ## <version> sections newest-first with bodies intact", () => {
+    const sections = parseCliChangelog(SAMPLE);
+    expect(sections.map((s) => s.version)).toEqual(["0.41.1", "0.41.0"]);
+    expect(sections[0].body).toContain("### Patch Changes");
+    expect(sections[0].body).toContain("line continuations");
+    expect(sections[0].body).not.toContain("## 0.41.0");
+  });
+
+  it("throws when no version sections are found", () => {
+    expect(() => parseCliChangelog("# nothing here")).toThrow(/no version sections/i);
+  });
+});
+
+describe("cliAnchorId", () => {
+  it("dasherizes the version", () => {
+    expect(cliAnchorId("0.41.1")).toBe("cli-0-41-1");
+  });
+});
+
+describe("fetchCliReleaseDates", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the npm time map minus created/modified", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          time: {
+            created: "2026-01-01T00:00:00.000Z",
+            modified: "2026-08-01T00:00:00.000Z",
+            "0.41.1": "2026-08-09T18:00:00.000Z",
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    const dates = await fetchCliReleaseDates(fetchImpl as unknown as typeof fetch);
+    expect(dates).toEqual({ "0.41.1": "2026-08-09T18:00:00.000Z" });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/@buildinternet/uploads",
+      expect.anything(),
+    );
+  });
+
+  it("throws on a non-200 response", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("nope", { status: 503 }));
+    await expect(fetchCliReleaseDates(fetchImpl as unknown as typeof fetch)).rejects.toThrow(
+      /npm registry/i,
+    );
+  });
+});
+
+describe("renderMarkdown", () => {
+  it("renders markdown to HTML", () => {
+    expect(renderMarkdown("some `code` here")).toContain("<code>code</code>");
+  });
+});
+
+describe("mergeEntries", () => {
+  const entry = (over: Partial<ChangelogEntry>): ChangelogEntry => ({
+    kind: "platform",
+    id: "x",
+    title: "x",
+    date: "2026-08-01T00:00:00.000Z",
+    html: "",
+    tags: [],
+    ...over,
+  });
+
+  it("sorts newest first", () => {
+    const sorted = mergeEntries([
+      entry({ id: "old", date: "2026-07-01T00:00:00.000Z" }),
+      entry({ id: "new", date: "2026-08-10T00:00:00.000Z" }),
+    ]);
+    expect(sorted.map((e) => e.id)).toEqual(["new", "old"]);
+  });
+
+  it("puts platform entries before cli entries on the same date", () => {
+    const sorted = mergeEntries([
+      entry({ id: "cli", kind: "cli" }),
+      entry({ id: "post", kind: "platform" }),
+    ]);
+    expect(sorted.map((e) => e.id)).toEqual(["post", "cli"]);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm --filter @uploads/web exec vitest run src/lib/changelog.test.ts`
+Expected: FAIL — module `./changelog` not found.
+
+- [ ] **Step 4: Implement `apps/web/src/lib/changelog.ts`**
+
+```ts
+/**
+ * Build-time data source for /changelog and /changelog.xml.
+ *
+ * Merges two streams into one newest-first list:
+ *  - platform updates: the `changelog` content collection (hand-written .md)
+ *  - CLI releases: `packages/uploads/CHANGELOG.md` (changesets output),
+ *    dated via the npm registry's `time` map, since changesets carry no dates.
+ *
+ * Everything here runs at build time only. Failures throw so a bad build
+ * never ships an incomplete changelog.
+ */
+import { getCollection } from "astro:content";
+import { marked } from "marked";
+// Vite raw import — the monorepo checkout is present at build time.
+import cliChangelogRaw from "../../../../packages/uploads/CHANGELOG.md?raw";
+
+export type ChangelogImage = { url: string; alt: string };
+
+export type ChangelogEntry = {
+  kind: "platform" | "cli";
+  /** Stable anchor id, e.g. "screenshots-page" or "cli-0-41-1". */
+  id: string;
+  title: string;
+  /** ISO 8601 UTC timestamp. */
+  date: string;
+  /** Rendered HTML body. */
+  html: string;
+  tags: string[];
+  image?: ChangelogImage;
+};
+
+const NPM_PACKAGE_URL = "https://registry.npmjs.org/@buildinternet/uploads";
+
+export function parseCliChangelog(md: string): { version: string; body: string }[] {
+  const sections: { version: string; body: string }[] = [];
+  const matches = [...md.matchAll(/^## (\d+\.\d+\.\d+(?:-[\w.]+)?)\s*$/gm)];
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    const start = (match.index ?? 0) + match[0].length;
+    const end = i + 1 < matches.length ? matches[i + 1].index : md.length;
+    sections.push({ version: match[1], body: md.slice(start, end).trim() });
+  }
+  if (sections.length === 0) {
+    throw new Error("parseCliChangelog: no version sections found in CHANGELOG.md");
+  }
+  return sections;
+}
+
+export function cliAnchorId(version: string): string {
+  return `cli-${version.replaceAll(".", "-")}`;
+}
+
+export async function fetchCliReleaseDates(
+  fetchImpl: typeof fetch = fetch,
+): Promise<Record<string, string>> {
+  const res = await fetchImpl(NPM_PACKAGE_URL, {
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`npm registry responded ${res.status} for @buildinternet/uploads`);
+  }
+  const data = (await res.json()) as { time?: Record<string, string> };
+  if (!data.time) {
+    throw new Error("npm registry response has no time map");
+  }
+  const { created: _created, modified: _modified, ...versions } = data.time;
+  return versions;
+}
+
+export function renderMarkdown(md: string): string {
+  return marked.parse(md, { async: false }) as string;
+}
+
+export function mergeEntries(entries: ChangelogEntry[]): ChangelogEntry[] {
+  return [...entries].sort((a, b) => {
+    const byDate = Date.parse(b.date) - Date.parse(a.date);
+    if (byDate !== 0) return byDate;
+    if (a.kind === b.kind) return 0;
+    return a.kind === "platform" ? -1 : 1;
+  });
+}
+
+export async function loadChangelogEntries(): Promise<ChangelogEntry[]> {
+  const [posts, dates] = await Promise.all([getCollection("changelog"), fetchCliReleaseDates()]);
+
+  const platform: ChangelogEntry[] = posts.map((post) => ({
+    kind: "platform",
+    id: post.id,
+    title: post.data.title,
+    date: post.data.date.toISOString(),
+    html: renderMarkdown(post.body ?? ""),
+    tags: post.data.tags,
+    image: post.data.image,
+  }));
+
+  const cli: ChangelogEntry[] = parseCliChangelog(cliChangelogRaw)
+    // Versions missing from npm (e.g. the skipped 0.20.0) are dropped.
+    .filter((section) => dates[section.version] !== undefined)
+    .map((section) => ({
+      kind: "cli" as const,
+      id: cliAnchorId(section.version),
+      title: `CLI ${section.version}`,
+      date: dates[section.version],
+      html: renderMarkdown(section.body),
+      tags: ["cli"],
+    }));
+
+  return mergeEntries([...platform, ...cli]);
+}
+```
+
+Note: `loadChangelogEntries` imports `astro:content`, which vitest cannot resolve — that is why the tests only exercise the pure functions. Keep it that way.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @uploads/web exec vitest run src/lib/changelog.test.ts`
+Expected: PASS (all describes). If the `?raw` import breaks vitest module resolution, move the raw import into `loadChangelogEntries` via `import.meta.glob` eagerly — but try the plain `?raw` first; vitest supports it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/lib/changelog.ts apps/web/src/lib/changelog.test.ts apps/web/package.json pnpm-lock.yaml
+git commit -m "feat(web): changelog data module — changeset parser, npm dates, merged stream"
+```
+
+---
+
+### Task 2: Content collection + first entry + authoring README
+
+**Files:**
+
+- Create: `apps/web/src/content.config.ts`
+- Create: `apps/web/src/content/changelog/screenshots-page.md`
+- Create: `apps/web/src/content/changelog/README.md`
+
+**Interfaces:**
+
+- Consumes: nothing from other tasks.
+- Produces: the `changelog` collection consumed by `loadChangelogEntries()` (Task 1) with data shape `{ title: string; date: Date; tags: string[]; image?: { url; alt } }`.
+
+- [ ] **Step 1: Create `apps/web/src/content.config.ts`**
+
+```ts
+import { glob } from "astro/loaders";
+import { defineCollection, z } from "astro:content";
+
+/**
+ * Platform updates for /changelog. One .md per update; slug = filename.
+ * Screenshots are NEVER committed — upload to the buildinternet workspace
+ * (changelog/ prefix) and reference the absolute storage.uploads.sh URL.
+ * See src/content/changelog/README.md for the publishing workflow.
+ */
+const changelog = defineCollection({
+  // README.md is the authoring guide, not an entry — exclude it.
+  loader: glob({ pattern: ["*.md", "!README.md"], base: "./src/content/changelog" }),
+  schema: z.object({
+    title: z.string().min(1),
+    date: z.coerce.date(),
+    tags: z.array(z.string()).default([]),
+    image: z
+      .object({
+        url: z.string().url().startsWith("https://"),
+        alt: z.string().min(1),
+      })
+      .optional(),
+  }),
+});
+
+export const collections = { changelog };
+```
+
+- [ ] **Step 2: Create the first entry `apps/web/src/content/changelog/screenshots-page.md`**
+
+```md
+---
+title: "A home for your screenshots"
+date: 2026-08-11
+tags: [platform, web]
+---
+
+Every screenshot the CLI captures now has a page of its own. **Screenshots**
+in your workspace groups captures by the page they came from — grouped by
+project, with before/after pairs kept together — so you can find last week's
+capture without scrolling a flat file list.
+
+The CLI pitches in too: `uploads screenshot` derives a stable name from the
+URL (plus `--state` for before/after variants), so re-capturing the same page
+replaces the old shot instead of piling up near-duplicates.
+```
+
+(The lead screenshot is added at integration time — the image is uploaded to the buildinternet workspace first, then an `image:` block plus an inline image are added to this file. The entry is valid without it; `image` is optional.)
+
+- [ ] **Step 3: Create `apps/web/src/content/changelog/README.md`**
+
+````md
+# Publishing a changelog entry
+
+One markdown file per platform update. CLI releases are merged in
+automatically from `packages/uploads/CHANGELOG.md` — never write those here.
+
+1. Capture the screenshot (if any).
+2. Upload it — never commit images to the repo:
+
+   ```bash
+   uploads put shot.png --workspace buildinternet --key changelog/<slug>.png
+   ```
+````
+
+Copy the public `storage.uploads.sh` URL from the output. 3. Create `<slug>.md` in this directory (slug becomes the page anchor):
+
+```md
+---
+title: "Human-readable title"
+date: 2026-08-12
+tags: [platform]
+image:
+  url: https://storage.uploads.sh/changelog/<slug>.png
+  alt: "What the screenshot shows"
+---
+
+Body in plain markdown. Inline images work too, absolute https URLs only.
+```
+
+4. Open a PR. Merge deploys /changelog and /changelog.xml; releases.sh picks
+   up the new entry on its normal feed sweep.
+
+Image rules: absolute `https://` URLs, 1 KB–8 MB, png/jpeg/gif/webp/avif —
+that's what releases.sh mirrors into its own storage. `date` supports full
+ISO timestamps (`2026-08-12T15:00:00Z`) when same-day ordering matters.
+
+````
+
+- [ ] **Step 4: Verify the collection loads**
+
+Run: `pnpm --filter @uploads/web exec astro sync`
+Expected: exits 0 and generates `.astro/` types including the `changelog` collection. (If `astro sync` complains the content dir README matched, fix the glob exclusion from Step 1.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/content.config.ts apps/web/src/content/changelog/
+git commit -m "feat(web): changelog content collection with first entry and authoring guide"
+````
+
+---
+
+### Task 3: `/changelog` page
+
+**Files:**
+
+- Create: `apps/web/src/pages/changelog.astro`
+- Modify: `apps/web/src/components/Footer.astro` (add Changelog link to the Product column)
+- Modify: `apps/web/src/pages-reachability.test.ts` (add `/changelog` to the route table)
+
+**Interfaces:**
+
+- Consumes: `loadChangelogEntries()`, `ChangelogEntry` from `../lib/changelog` (Task 1).
+
+- [ ] **Step 1: Add `/changelog` to the reachability test**
+
+Open `apps/web/src/pages-reachability.test.ts`, find the `describe.each` route table, and add an entry following the exact shape of the existing rows (they carry at least `path` and an expected marker/title):
+
+```ts
+{ path: "/changelog", title: "Changelog" },
+```
+
+Match the row shape actually present in the file — copy an existing static-page row (e.g. the `/terms` one) and adjust.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @uploads/web exec vitest run src/pages-reachability.test.ts`
+Expected: FAIL on the new `/changelog` row (page doesn't exist yet).
+
+- [ ] **Step 3: Create `apps/web/src/pages/changelog.astro`**
+
+```astro
+---
+// /changelog — merged product stream: hand-written platform updates
+// (src/content/changelog) interleaved with CLI releases from changesets.
+// Fully prerendered, zero client JS. Machine twin: /changelog.xml (Atom).
+import BaseHead from "../components/BaseHead.astro";
+import Footer from "../components/Footer.astro";
+import SiteHeader from "../components/SiteHeader.astro";
+import { loadChangelogEntries } from "../lib/changelog";
+
+const entries = await loadChangelogEntries();
+
+const pageTitle = "Changelog";
+const pageDescription =
+  "What's new in uploads.sh — platform updates and CLI releases, newest first.";
+
+// Static page — auth origin is baked at build time (see src/lib/auth-client.ts).
+const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+---
+
+<html lang="en">
+  <head>
+    <BaseHead preloadSans />
+    <title>{pageTitle} · uploads.sh</title>
+    <meta name="description" content={pageDescription} />
+    <link rel="canonical" href="https://uploads.sh/changelog" />
+    <link
+      rel="alternate"
+      type="application/atom+xml"
+      title="uploads.sh changelog"
+      href="/changelog.xml"
+    />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        background: var(--bg);
+        color: var(--fg);
+        font: 15.5px/1.7 var(--sans);
+        display: flex;
+        flex-direction: column;
+      }
+      main {
+        width: min(var(--width-content, 720px), 100%);
+        margin: 0 auto;
+        padding: 32px 24px 64px;
+        flex: 1;
+      }
+      h1 {
+        font-size: clamp(26px, 5vw, 34px);
+        font-weight: 600;
+        letter-spacing: -0.015em;
+        line-height: 1.25;
+        margin: 8px 0 4px;
+      }
+      .lede {
+        color: var(--muted);
+        font-size: 14px;
+        margin: 0 0 12px;
+      }
+      .feed-link {
+        color: var(--muted);
+        font-size: 13px;
+        text-decoration: underline;
+        text-underline-offset: 3px;
+      }
+      .entry {
+        border-top: 1px solid var(--line);
+        padding: 32px 0 8px;
+        margin-top: 24px;
+      }
+      .entry time {
+        display: block;
+        color: var(--muted);
+        font: 12px var(--mono);
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        margin-bottom: 6px;
+      }
+      .entry h2 {
+        font-size: 20px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        margin: 0 0 12px;
+      }
+      .entry h2 a {
+        color: inherit;
+        text-decoration: none;
+      }
+      .entry h2 a:hover {
+        text-decoration: underline;
+        text-underline-offset: 3px;
+      }
+      .entry--cli h2 {
+        font-size: 16px;
+        color: var(--body);
+      }
+      .entry--cli .body {
+        color: var(--muted);
+      }
+      .lead-image {
+        max-width: 100%;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        margin: 0 0 14px;
+      }
+      .body :global(p),
+      .body :global(li) {
+        color: var(--body);
+      }
+      .body :global(img) {
+        max-width: 100%;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+      }
+      .body :global(h3) {
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--muted);
+        margin: 18px 0 6px;
+      }
+      .body :global(a) {
+        color: var(--fg);
+        text-decoration: underline;
+        text-decoration-color: color-mix(in srgb, var(--accent) 55%, transparent);
+        text-underline-offset: 3px;
+      }
+      .body :global(code) {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 5px;
+        padding: 1px 6px;
+        font: 0.88em var(--mono);
+        font-variant-ligatures: none;
+      }
+      .body :global(pre) {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 12px 14px;
+        overflow-x: auto;
+      }
+      .body :global(pre code) {
+        background: none;
+        border: none;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <SiteHeader authOrigin={authOrigin} />
+    <main>
+      <h1>Changelog</h1>
+      <p class="lede">{pageDescription}</p>
+      <a class="feed-link" href="/changelog.xml">Atom feed</a>
+      {
+        entries.map((entry) => (
+          <article class:list={["entry", { "entry--cli": entry.kind === "cli" }]} id={entry.id}>
+            <time datetime={entry.date}>{formatDate(entry.date)}</time>
+            <h2>
+              <a href={`#${entry.id}`}>{entry.title}</a>
+            </h2>
+            {entry.image && (
+              <img
+                class="lead-image"
+                src={entry.image.url}
+                alt={entry.image.alt}
+                loading="lazy"
+                decoding="async"
+              />
+            )}
+            <div class="body" set:html={entry.html} />
+          </article>
+        ))
+      }
+    </main>
+    <Footer />
+  </body>
+</html>
+```
+
+- [ ] **Step 4: Add the footer link**
+
+In `apps/web/src/components/Footer.astro`, in the `COLUMNS` constant's Product column, add one line after the Docs link:
+
+```ts
+{ label: "Changelog", href: "/changelog" },
+```
+
+- [ ] **Step 5: Verify — tests and build**
+
+Run: `pnpm --filter @uploads/web exec vitest run src/pages-reachability.test.ts`
+Expected: PASS.
+
+Run: `pnpm --filter @uploads/web build`
+Expected: build succeeds; `apps/web/dist/changelog.html` exists and contains `id="cli-` anchors and the first platform entry's title. (The build performs the real npm fetch — network is required.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/pages/changelog.astro apps/web/src/components/Footer.astro apps/web/src/pages-reachability.test.ts
+git commit -m "feat(web): /changelog page — merged platform + CLI release stream"
+```
+
+---
+
+### Task 4: `/changelog.xml` Atom feed
+
+**Files:**
+
+- Create: `apps/web/src/pages/changelog.xml.ts`
+- Create: `apps/web/src/lib/changelog-feed.ts`
+- Test: `apps/web/src/lib/changelog-feed.test.ts`
+- Modify: `apps/web/public/_headers` (content-type + cache for `/changelog.xml`)
+
+**Interfaces:**
+
+- Consumes: `ChangelogEntry`, `loadChangelogEntries()` from `./changelog` (Task 1).
+- Produces: `renderAtomFeed(entries: ChangelogEntry[]): string` in `changelog-feed.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/lib/changelog-feed.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { ChangelogEntry } from "./changelog";
+import { renderAtomFeed } from "./changelog-feed";
+
+const entries: ChangelogEntry[] = [
+  {
+    kind: "platform",
+    id: "screenshots-page",
+    title: "A home for <your> screenshots",
+    date: "2026-08-11T00:00:00.000Z",
+    html: '<p>Now with <img src="https://storage.uploads.sh/changelog/x.png" alt="x"></p>',
+    tags: ["platform"],
+  },
+  {
+    kind: "cli",
+    id: "cli-0-41-1",
+    title: "CLI 0.41.1",
+    date: "2026-08-09T18:00:00.000Z",
+    html: "<p>Fixes</p>",
+    tags: ["cli"],
+  },
+];
+
+describe("renderAtomFeed", () => {
+  const xml = renderAtomFeed(entries);
+
+  it("is an atom feed with feed-level metadata", () => {
+    expect(xml).toContain('<?xml version="1.0" encoding="utf-8"?>');
+    expect(xml).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(xml).toContain("<id>https://uploads.sh/changelog</id>");
+    // Feed updated = newest entry date.
+    expect(xml).toContain("<updated>2026-08-11T00:00:00.000Z</updated>");
+    expect(xml).toContain('href="https://uploads.sh/changelog.xml" rel="self"');
+  });
+
+  it("emits one entry per item with anchored ids and escaped titles", () => {
+    expect(xml).toContain("<id>https://uploads.sh/changelog#screenshots-page</id>");
+    expect(xml).toContain("<id>https://uploads.sh/changelog#cli-0-41-1</id>");
+    expect(xml).toContain("A home for &lt;your&gt; screenshots");
+    expect(xml).not.toContain("A home for <your>");
+  });
+
+  it("carries full HTML content with absolute image URLs, escaped", () => {
+    expect(xml).toContain('<content type="html">');
+    expect(xml).toContain("https://storage.uploads.sh/changelog/x.png");
+    expect(xml).toContain("&lt;img src=");
+  });
+
+  it("throws on an empty entry list rather than publishing an empty feed", () => {
+    expect(() => renderAtomFeed([])).toThrow(/empty/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @uploads/web exec vitest run src/lib/changelog-feed.test.ts`
+Expected: FAIL — module `./changelog-feed` not found.
+
+- [ ] **Step 3: Implement `apps/web/src/lib/changelog-feed.ts`**
+
+```ts
+/**
+ * Atom serializer for /changelog.xml. Entries carry full HTML content with
+ * absolute image URLs so releases.sh mirrors the media at ingest.
+ */
+import type { ChangelogEntry } from "./changelog";
+
+const SITE = "https://uploads.sh";
+const PAGE = `${SITE}/changelog`;
+const FEED = `${SITE}/changelog.xml`;
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function renderAtomFeed(entries: ChangelogEntry[]): string {
+  if (entries.length === 0) {
+    throw new Error("renderAtomFeed: refusing to publish an empty feed");
+  }
+  const updated = entries
+    .map((e) => e.date)
+    .sort()
+    .at(-1)!;
+
+  const items = entries
+    .map(
+      (entry) => `  <entry>
+    <id>${PAGE}#${entry.id}</id>
+    <title>${escapeXml(entry.title)}</title>
+    <link href="${PAGE}#${entry.id}"/>
+    <updated>${entry.date}</updated>
+${entry.tags.map((tag) => `    <category term="${escapeXml(tag)}"/>`).join("\n")}
+    <content type="html">${escapeXml(entry.html)}</content>
+  </entry>`,
+    )
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>${PAGE}</id>
+  <title>uploads.sh changelog</title>
+  <subtitle>Platform updates and CLI releases</subtitle>
+  <link href="${PAGE}"/>
+  <link href="${FEED}" rel="self"/>
+  <updated>${updated}</updated>
+  <author><name>uploads.sh</name></author>
+${items}
+</feed>
+`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @uploads/web exec vitest run src/lib/changelog-feed.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Create the endpoint `apps/web/src/pages/changelog.xml.ts`**
+
+```ts
+/**
+ * /changelog.xml — Atom twin of /changelog. Prerendered at build time and
+ * served off the ASSETS binding; headers come from public/_headers. This is
+ * the Tier-1 machine locator declared in .well-known/releases.json.
+ */
+import type { APIRoute } from "astro";
+import { loadChangelogEntries } from "../lib/changelog";
+import { renderAtomFeed } from "../lib/changelog-feed";
+
+export const prerender = true;
+
+export const GET: APIRoute = async () => {
+  const entries = await loadChangelogEntries();
+  return new Response(renderAtomFeed(entries), {
+    headers: { "content-type": "application/atom+xml; charset=utf-8" },
+  });
+};
+```
+
+- [ ] **Step 6: Add headers for the feed**
+
+In `apps/web/public/_headers`, following the existing per-path block style (see the `/.well-known/releases.json` block there), add:
+
+```
+# Atom feed for /changelog — the machine locator declared in releases.json.
+/changelog.xml
+  Content-Type: application/atom+xml; charset=utf-8
+  Cache-Control: public, max-age=300
+  Access-Control-Allow-Origin: *
+```
+
+- [ ] **Step 7: Verify with a build**
+
+Run: `pnpm --filter @uploads/web build`
+Expected: succeeds; `apps/web/dist/changelog.xml` exists, starts with `<?xml`, and contains `<entry>` elements for both streams.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/pages/changelog.xml.ts apps/web/src/lib/changelog-feed.ts apps/web/src/lib/changelog-feed.test.ts apps/web/public/_headers
+git commit -m "feat(web): /changelog.xml Atom feed for releases.sh ingestion"
+```
+
+---
+
+### Task 5: Manifest, sitemap, llms.txt, crawl policy
+
+**Files:**
+
+- Modify: `apps/web/public/.well-known/releases.json`
+- Modify: `apps/web/public/sitemap.xml`
+- Modify: `apps/web/public/llms.txt`
+- Modify: `apps/web/public/llms-full.txt`
+- Modify: `apps/web/README.md`
+
+**Interfaces:**
+
+- Consumes: the live URLs `/changelog` and `/changelog.xml` (Tasks 3–4).
+
+- [ ] **Step 1: Update the domain manifest**
+
+Replace the `releases` array in `apps/web/public/.well-known/releases.json` with (everything else unchanged):
+
+```json
+"releases": [
+  {
+    "title": "Changelog",
+    "url": "https://uploads.sh/changelog",
+    "feed": "https://uploads.sh/changelog.xml",
+    "canonical": true
+  },
+  {
+    "title": "@buildinternet/uploads",
+    "github": "buildinternet/uploads"
+  }
+]
+```
+
+The repo-root `releases.json` is intentionally unchanged (repo scope, own canonical).
+
+- [ ] **Step 2: Validate the manifest**
+
+Run:
+
+```bash
+node "/Users/zachdunn/Library/Application Support/Claude/local-agent-mode-sessions/skills-plugin/a305a85e-806a-4eb0-ac31-8c5f1d63838d/96fb1803-793e-4756-8aff-2ea947c9df92/skills/creating-releases-json/scripts/validate.mjs" apps/web/public/.well-known/releases.json
+```
+
+Expected: `✓` exit 0. (Fallback if that path has moved: `node /Users/zachdunn/Code/releases/skills/creating-releases-json/scripts/validate.mjs …` — same script.)
+
+- [ ] **Step 3: Sitemap**
+
+In `apps/web/public/sitemap.xml`, add after the `/docs` entry:
+
+```xml
+  <url>
+    <loc>https://uploads.sh/changelog</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+```
+
+(The feed is a machine endpoint — deliberately not in the sitemap.)
+
+- [ ] **Step 4: llms.txt + llms-full.txt**
+
+In `apps/web/public/llms.txt`, in the "Start here" list after the Docs line, add:
+
+```
+- [Changelog](https://uploads.sh/changelog): platform updates and CLI releases, newest first (Atom feed at https://uploads.sh/changelog.xml)
+```
+
+In `apps/web/public/llms-full.txt`, add the same link wherever the site's page inventory is listed (match the file's existing style — read it first).
+
+- [ ] **Step 5: README crawl-policy table**
+
+In `apps/web/README.md`, add a row to the crawl-policy table after `/github-screenshots`:
+
+```md
+| `/changelog` | yes | Product updates + CLI releases; in `sitemap.xml`; Atom at `/changelog.xml` |
+```
+
+Also add `src/pages/changelog.astro` / `changelog.xml.ts` to the README's file map if other pages are listed there (match existing style).
+
+- [ ] **Step 6: Full verification sweep**
+
+```bash
+pnpm --filter @uploads/web test
+pnpm --filter @uploads/web typecheck
+pnpm --filter @uploads/web build
+```
+
+Expected: all pass. Then confirm `apps/web/dist/.well-known/releases.json` carries the new entries.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/public/.well-known/releases.json apps/web/public/sitemap.xml apps/web/public/llms.txt apps/web/public/llms-full.txt apps/web/README.md
+git commit -m "feat(web): declare changelog url+feed canonical in releases.json; discovery plumbing"
+```
+
+---
+
+### Task 6 (integration, main session — not delegated): first-entry screenshot + browser verification + PR
+
+This task runs in the main session because it needs the browser panel, the uploads MCP, and PR credentials.
+
+- [ ] **Step 1:** Capture a screenshot of the Screenshots page (signed-in surface — use the local stack-raw recipe or an existing capture) and upload it: `uploads put screenshots-page.png` to the buildinternet workspace at key `changelog/screenshots-page.png`.
+- [ ] **Step 2:** Add the `image:` block (url + alt) to `apps/web/src/content/changelog/screenshots-page.md` frontmatter; rebuild; confirm the image renders on `/changelog` and appears escaped in `/changelog.xml`.
+- [ ] **Step 3:** Verify in the browser panel: `/changelog` renders the merged stream (platform post first by date, CLI entries quieter), anchors work, footer link present, feed link resolves.
+- [ ] **Step 4:** `git push` and open a PR to `main` titled `feat(web): changelog page + Atom feed (#…)`, description covering the page, feed, manifest change, and publishing workflow; embed the page screenshot via the github-screenshots skill.
+- [ ] **Step 5:** After merge/deploy, confirm `https://uploads.sh/changelog.xml` serves Atom with the right content type, re-validate the live manifest (`POST https://api.releases.sh/v1/listing/validate` with `{"domain":"uploads.sh"}`), and optionally trigger `POST /v1/orgs/uploads/sync-well-known` so releases.sh picks up the feed without waiting for the daily sweep.

--- a/docs/superpowers/specs/2026-08-12-changelog-page-design.md
+++ b/docs/superpowers/specs/2026-08-12-changelog-page-design.md
@@ -1,0 +1,158 @@
+# Changelog page for uploads.sh — design
+
+Date: 2026-08-12
+Status: approved (brainstorm 2026-08-12)
+
+## Goal
+
+A public `/changelog` page on uploads.sh that tells the product story in one
+merged stream: hand-written platform updates (e.g. "Screenshots page") plus CLI
+releases from changesets. The page must be ingest-friendly for releases.sh,
+which means shipping a real Atom feed (Tier 1 ingestion) and updating the
+`.well-known/releases.json` manifest to declare it. Screenshots in updates are
+hosted on R2 via the uploads platform itself, never committed to the repo.
+
+## Background facts (verified 2026-08-12)
+
+- `releases.json` (v2) is a pointer manifest — it declares _where_ release
+  notes live, not the entries themselves. uploads.sh already serves a valid
+  domain-scope manifest at `apps/web/public/.well-known/releases.json`
+  (canonical: `github: buildinternet/uploads`) and a repo-scope `releases.json`
+  at the repo root (`github: "self"`, canonical).
+- releases.sh ingestion tiers: `feed`/`github`/`appstore` locators are Tier 1
+  (deterministic, auto-created, self-serve). A bare `url` is Tier 2 — billable
+  AI scrape, curator-gated. So the feed is what makes the page ingest-friendly.
+- releases.sh mirrors entry images into its own R2 when they are absolute
+  `https://` URLs between 1 KB and 8 MB (png/jpeg/gif/webp/avif; GIF→MP4).
+  Relative paths and auth-walled URLs are not mirrored.
+- Non-versioned entries are first-class in releases.sh (`version` is nullable;
+  only `title` + `content` are required). Platform notes need no semver.
+- The uploads org exists in the releases.sh registry as a stub (source
+  auto-created from the declared GitHub locator, zero releases indexed yet).
+- `packages/uploads/CHANGELOG.md` is the changesets output for
+  `@buildinternet/uploads`: `## <version>` sections with prose bodies. It
+  carries **no dates**. GitHub releases are tagged `uploads-v<version>`.
+- apps/web is Astro 7 on Cloudflare Workers; pages are prerendered by default;
+  public pages ship no framework JS; sitemap.xml and llms.txt are
+  hand-maintained; the web worker has no R2 binding.
+
+## Decisions (made with Zach, 2026-08-12)
+
+1. **Publishing model:** git-committed markdown. One file per platform update
+   in an Astro content collection. Publish = PR + merge (Workers Builds
+   deploys). No admin UI, no D1, no scaffold script.
+2. **Page scope:** merged stream — platform updates interleaved with CLI
+   releases parsed from `packages/uploads/CHANGELOG.md` at build time.
+3. **Screenshot hosting:** dogfood the product. Upload via the uploads CLI to
+   the buildinternet workspace under a `changelog/` prefix; reference the
+   absolute `storage.uploads.sh` URL from the markdown. Accepted risk:
+   workspace files are deletable like any other file.
+4. **Canonical source:** the changelog `url`+`feed` pair becomes the canonical
+   entry in the domain manifest; the GitHub locator stays as a secondary
+   source. The repo-scope manifest is unchanged.
+
+## Components
+
+### 1. Content collection — `apps/web/src/content/changelog/`
+
+- One `.md` file per platform update, slug = filename.
+- Frontmatter schema (zod, via Astro content config):
+  - `title: string` (required)
+  - `date: ISO date` (required)
+  - `tags?: string[]` (e.g. `platform`, `web`, `cli`)
+  - `image?: { url: https URL, alt: string }` — lead image; more images may
+    appear inline in the body as standard markdown.
+- Body: plain markdown. Image URLs must be absolute `https://`.
+
+### 2. CLI release parser — build-time module
+
+- Parses `packages/uploads/CHANGELOG.md` into `{ version, body }[]` from
+  `## <version>` sections.
+- Dates come from one build-time fetch of
+  `https://registry.npmjs.org/@buildinternet/uploads` — its `time` map has an
+  exact publish timestamp per version. If the fetch fails, the build fails
+  loudly (no undated entries). Versions absent from npm (e.g. the known-skipped
+  0.20.0) are dropped.
+- Trade-off accepted: a network dependency in the site build. Fallback option
+  if it flakes: commit a version→date JSON maintained by the release workflow.
+
+### 3. Page — `/changelog`
+
+- Prerendered Astro page, zero client JS. SiteHeader + Footer + BaseHead (not
+  DocsLayout — it is a top-level page like the homepage).
+- Newest-first merged stream. Each entry gets a stable anchor id: platform
+  entries use their slug (`#screenshots-page`), CLI entries use
+  `#cli-<version-with-dashes>` (`#cli-0-41-0`).
+- Platform entries render prominently (title, date, lead image, body). CLI
+  entries render the full changeset body but visually quieter.
+- `<link rel="alternate" type="application/atom+xml" href="/changelog.xml">`
+  in the head.
+
+### 4. Feed — `/changelog.xml`
+
+- Prerendered Astro endpoint emitting Atom. Same merged entries as the page.
+- Each entry: `id` (page URL + anchor), `title`, `updated` (entry date),
+  `link` to the anchor, `content type="html"` with the rendered body including
+  absolute image URLs (so releases.sh mirrors media).
+- Feed-level `updated` = newest entry date. Not listed in sitemap.xml
+  (machine endpoint convention).
+
+### 5. Manifest + discovery updates
+
+- `apps/web/public/.well-known/releases.json`: add top-level entry
+  `{ "title": "Changelog", "url": "https://uploads.sh/changelog",
+"feed": "https://uploads.sh/changelog.xml", "canonical": true }`; remove
+  `canonical` from the GitHub entry (keep the entry itself).
+- Validate with the creating-releases-json skill's `validate.mjs` before
+  shipping.
+- Repo-root `releases.json`: unchanged.
+
+### 6. Site plumbing
+
+- `public/sitemap.xml`: add `/changelog`.
+- `public/llms.txt` and `public/llms-full.txt`: add the changelog link.
+- `apps/web/README.md` crawl-policy table: `/changelog` is indexable.
+- No `_headers` change needed for the feed (served prerendered via ASSETS with
+  the correct content type by extension); confirm during implementation.
+
+### 7. Publishing workflow doc
+
+- `apps/web/src/content/changelog/README.md` (or a docs page section):
+  1. Capture the screenshot.
+  2. `uploads put shot.png` to the buildinternet workspace with key prefix
+     `changelog/` → copy the public URL.
+  3. Create `apps/web/src/content/changelog/<slug>.md` with frontmatter + body.
+  4. Open a PR; merge deploys the site and the feed; releases.sh picks the new
+     entry up on its normal sweep.
+- Image constraints to note in the doc: absolute https URLs, 1 KB–8 MB, so
+  releases.sh mirrors them.
+
+## Error handling
+
+- Build fails if: npm `time` fetch fails, CHANGELOG.md parse yields zero
+  versions, a content entry fails frontmatter validation, or an entry `image.url`
+  is not `https://`.
+- Feed omits nothing silently — every merged entry appears on both the page and
+  the feed.
+
+## Testing
+
+- Unit tests: CHANGELOG.md parser (section splitting, version extraction,
+  skipped-version handling), merge/sort ordering, anchor id generation.
+- Feed test: output is well-formed XML with required Atom elements
+  (`id`, `title`, `updated`, `entry` fields) and absolute URLs.
+- Existing web build in CI validates the Astro pages end-to-end.
+
+## Out of scope (YAGNI)
+
+- Pagination (single page until it hurts).
+- Admin UI / DB-backed entries.
+- Scaffold/helper command for authoring.
+- Per-entry pages (`/changelog/<slug>`) — anchors suffice for now.
+- RSS in addition to Atom.
+
+## First entry
+
+Seed the collection with a post about the Screenshots page (shipped 2026-08-11,
+PR #614/#629), including a screenshot uploaded to the buildinternet workspace —
+this exercises the whole pipeline end to end.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       markdown-for-agents:
         specifier: ^1.3.4
         version: 1.3.4
+      marked:
+        specifier: ^18.0.9
+        version: 18.0.9
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -4430,6 +4433,11 @@ packages:
   markdown-for-agents@1.3.4:
     resolution: {integrity: sha512-kyXaAd/A+6SrZdaEbzeKL1wyJck5lckIXeTa1w04SCqxpzV0vxAQDT7FlJfXsYdm426L/TB39p7HKMpM4uFVsA==}
     engines: {node: '>=22'}
+
+  marked@18.0.9:
+    resolution: {integrity: sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -9669,6 +9677,8 @@ snapshots:
     dependencies:
       domhandler: 5.0.3
       htmlparser2: 10.1.0
+
+  marked@18.0.9: {}
 
   math-intrinsics@1.1.0:
     optional: true


### PR DESCRIPTION
Adds a public changelog to uploads.sh: a prerendered `/changelog` page and its Atom twin at `/changelog.xml`, merging two streams newest-first:

- **Platform updates** — a new Astro content collection at `apps/web/src/content/changelog/` (one markdown file per post; screenshots are uploaded to R2 via the product itself, never committed — see the authoring README in that directory).
- **CLI releases** — parsed at build time from `packages/uploads/CHANGELOG.md` (changesets output), dated via the npm registry `time` map since changesets carry no dates. The build fails loudly if the fetch fails or the parse yields nothing.

![/changelog rendered](https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/claude-changelog-page-r2-assets-f63a0e/localhost-changelog.webp)

### releases.sh ingestion

`releases.json` v2 is a pointer manifest, so the ingest-friendly part is the feed: the domain manifest now declares `{url: /changelog, feed: /changelog.xml}` as the canonical location (Tier 1, deterministic ingest — no curator-gated scrape lane), keeping the GitHub locator as a secondary source. The repo-root manifest is unchanged. Validated against the releases.sh schema validator. Feed entries carry full HTML with absolute `storage.uploads.sh` image URLs (frontmatter lead images are inlined into feed content) so releases.sh mirrors media at ingest.

### Also

- Footer gets a Changelog link; `/changelog` added to `sitemap.xml`, `llms.txt`, `llms-full.txt`, and the README crawl-policy table; `_headers` serves the feed as `application/atom+xml` with `max-age=300`.
- Zero client JS on both routes; OG/Twitter meta matches the site convention; one shared npm fetch per build (memoized).
- First entry seeds the pipeline end to end: the Screenshots page post, with its image re-hosted at a durable `screenshots/changelog/` key (the workspace key policy disallows a bare `changelog/` prefix; the authoring README documents this).

Publishing workflow from here: write a markdown file, `uploads put` the screenshot, open a PR — merge deploys the page and feed, and releases.sh picks new entries up on its normal sweep.

Design spec: `docs/superpowers/specs/2026-08-12-changelog-page-design.md` · Plan: `docs/superpowers/plans/2026-08-12-changelog-page.md`
