### PR TITLE
fix(api): keep D1 queries under the 100 bound-parameter cap

### DIFF
--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -451,8 +451,9 @@ export async function deleteFileMetadataForKeys(
   workspace: string,
   keys: string[],
 ): Promise<void> {
-  for (let i = 0; i < keys.length; i += METADATA_LOOKUP_CHUNK) {
-    const chunk = keys.slice(i, i + METADATA_LOOKUP_CHUNK);
+  const chunkSize = metadataLookupChunk(1); // the workspace bind
+  for (let i = 0; i < keys.length; i += chunkSize) {
+    const chunk = keys.slice(i, i + chunkSize);
     const placeholders = chunk.map(() => "?").join(", ");
     await db
       .prepare(`DELETE FROM file_metadata WHERE workspace = ? AND object_key IN (${placeholders})`)
@@ -805,8 +806,24 @@ export async function listFacets(
   return { key, values, truncated };
 }
 
-/** Max object keys bound into a single `object_key IN (...)` statement (SQLite's ~999 host-parameter limit, kept well under it). */
-const METADATA_LOOKUP_CHUNK = 100;
+/**
+ * D1's hard cap on bound parameters per query. Not SQLite's ~999 host-parameter
+ * limit — D1 rejects anything over 100 with "too many SQL variables", which is
+ * how the screenshots by-path route came to 500 in production once a workspace
+ * had enough path groups to send 100 keys plus the workspace and meta-key binds.
+ * The test fake (test/helpers/sqlite-d1.ts) enforces the same ceiling.
+ */
+const D1_MAX_BOUND_PARAMS = 100;
+
+/**
+ * Max object keys bound into one `object_key IN (...)` statement, given how
+ * many parameters the rest of the statement already spends. Always at least 1,
+ * so a caller with an outsized fixed prefix chunks slowly rather than looping
+ * forever on an empty slice.
+ */
+function metadataLookupChunk(reservedParams: number): number {
+  return Math.max(1, D1_MAX_BOUND_PARAMS - reservedParams);
+}
 
 /**
  * Batched, unfiltered lookup of D1 metadata for a set of object keys — e.g.
@@ -835,8 +852,10 @@ export async function getMetadataForKeys(
   const metaKeys = opts.metaKeys?.length ? opts.metaKeys : undefined;
   const metaFilter = metaKeys ? ` AND meta_key IN (${metaKeys.map(() => "?").join(", ")})` : "";
 
-  for (let i = 0; i < keys.length; i += METADATA_LOOKUP_CHUNK) {
-    const chunk = keys.slice(i, i + METADATA_LOOKUP_CHUNK);
+  // The workspace bind plus one per meta key ride along with every chunk.
+  const chunkSize = metadataLookupChunk(1 + (metaKeys?.length ?? 0));
+  for (let i = 0; i < keys.length; i += chunkSize) {
+    const chunk = keys.slice(i, i + chunkSize);
     const placeholders = chunk.map(() => "?").join(", ");
     const result = await db
       .prepare(

--- a/apps/api/src/galleries.ts
+++ b/apps/api/src/galleries.ts
@@ -4,6 +4,27 @@ export const MAX_GALLERY_ITEMS = 100;
 export const MAX_GALLERY_REFERENCES = 20;
 export const MAX_GALLERY_PAGE_SIZE = 100;
 
+/**
+ * D1 rejects any query binding more than 100 parameters ("too many SQL
+ * variables"). Every cap above is 100, so a full page of galleries or a
+ * full-size reorder overruns it the moment the workspace or version binds ride
+ * along — see `chunkIds` and `reorderGalleryItems` below.
+ */
+const D1_MAX_BOUND_PARAMS = 100;
+
+/**
+ * Split an id list so each statement stays under the cap, given how many
+ * parameters the rest of the statement already spends. Callers merge the
+ * per-chunk rows; these are read-only lookups, so splitting them changes
+ * nothing a caller can observe.
+ */
+function chunkIds(ids: string[], reservedParams: number): string[][] {
+  const size = Math.max(1, D1_MAX_BOUND_PARAMS - reservedParams);
+  const chunks: string[][] = [];
+  for (let i = 0; i < ids.length; i += size) chunks.push(ids.slice(i, i + size));
+  return chunks;
+}
+
 export function clampGalleryPageLimit(requestedLimit: number | undefined): number {
   const limit = requestedLimit ?? 50;
   return Number.isFinite(limit)
@@ -390,18 +411,20 @@ export async function countItemsForGalleries(
 ): Promise<Map<string, number>> {
   const counts = new Map<string, number>();
   if (!galleryIds.length) return counts;
-  const placeholders = galleryIds.map(() => "?").join(", ");
-  const result = await db
-    .prepare(
-      `SELECT i.gallery_id AS gallery_id, COUNT(*) AS n
+  for (const chunk of chunkIds(galleryIds, 1)) {
+    const placeholders = chunk.map(() => "?").join(", ");
+    const result = await db
+      .prepare(
+        `SELECT i.gallery_id AS gallery_id, COUNT(*) AS n
        FROM gallery_items i
        JOIN galleries g ON g.id = i.gallery_id
        WHERE g.workspace = ? AND g.deleted_at IS NULL AND i.gallery_id IN (${placeholders})
        GROUP BY i.gallery_id`,
-    )
-    .bind(workspace, ...galleryIds)
-    .all<{ gallery_id: string; n: number }>();
-  for (const row of result.results) counts.set(row.gallery_id, Number(row.n) || 0);
+      )
+      .bind(workspace, ...chunk)
+      .all<{ gallery_id: string; n: number }>();
+    for (const row of result.results) counts.set(row.gallery_id, Number(row.n) || 0);
+  }
   return counts;
 }
 
@@ -413,22 +436,26 @@ export async function listExternalReferencesForGalleries(
 ): Promise<Map<string, GalleryExternalReferenceRecord[]>> {
   const byGallery = new Map<string, GalleryExternalReferenceRecord[]>();
   if (!galleryIds.length) return byGallery;
-  const placeholders = galleryIds.map(() => "?").join(", ");
-  const result = await db
-    .prepare(
-      `SELECT r.id, r.gallery_id, r.provider, r.resource_type, r.normalized_key, r.locator_json,
+  // Each gallery id lands in exactly one chunk, so every gallery's references
+  // still come back from a single ORDER BY — per-gallery ordering is intact.
+  for (const chunk of chunkIds(galleryIds, 1)) {
+    const placeholders = chunk.map(() => "?").join(", ");
+    const result = await db
+      .prepare(
+        `SELECT r.id, r.gallery_id, r.provider, r.resource_type, r.normalized_key, r.locator_json,
               r.canonical_url, r.created_at, r.updated_at
        FROM gallery_external_references r
        JOIN galleries g ON g.id = r.gallery_id
        WHERE g.workspace = ? AND g.deleted_at IS NULL AND r.gallery_id IN (${placeholders})
        ORDER BY r.created_at, r.id`,
-    )
-    .bind(workspace, ...galleryIds)
-    .all<GalleryExternalReferenceRecord>();
-  for (const row of result.results) {
-    const list = byGallery.get(row.gallery_id) ?? [];
-    list.push(row);
-    byGallery.set(row.gallery_id, list);
+      )
+      .bind(workspace, ...chunk)
+      .all<GalleryExternalReferenceRecord>();
+    for (const row of result.results) {
+      const list = byGallery.get(row.gallery_id) ?? [];
+      list.push(row);
+      byGallery.set(row.gallery_id, list);
+    }
   }
   return byGallery;
 }
@@ -568,14 +595,19 @@ export async function reorderGalleryItems(
   if (existing.every((item, index) => item.id === orderedItemIds[index]))
     return { status: "unchanged", value: existing };
   const iso = now.toISOString();
-  const placeholders = orderedItemIds.map(() => "?").join(", ") || "NULL";
+  // The id list travels as ONE json_each parameter rather than one bind per
+  // id: at MAX_GALLERY_ITEMS the enumerated form bound 106 parameters and D1
+  // rejected the batch with "too many SQL variables". Chunking is not
+  // available here — this set-equality guard has to stay a single atomic
+  // statement — so the list is collapsed into a single bound value instead.
   const statements: D1PreparedStatement[] = [
     db
       .prepare(
         `UPDATE galleries SET version = version + 1, updated_at = ?
      WHERE id = ? AND workspace = ? AND deleted_at IS NULL AND version = ?
        AND (SELECT COUNT(*) FROM gallery_items i WHERE i.gallery_id = galleries.id) = ?
-       AND (SELECT COUNT(*) FROM gallery_items i WHERE i.gallery_id = galleries.id AND i.id IN (${placeholders})) = ?`,
+       AND (SELECT COUNT(*) FROM gallery_items i WHERE i.gallery_id = galleries.id
+              AND i.id IN (SELECT value FROM json_each(?))) = ?`,
       )
       .bind(
         iso,
@@ -583,7 +615,7 @@ export async function reorderGalleryItems(
         workspace,
         expectedVersion,
         orderedItemIds.length,
-        ...orderedItemIds,
+        JSON.stringify(orderedItemIds),
         orderedItemIds.length,
       ),
   ];

--- a/apps/api/src/observability-retention.ts
+++ b/apps/api/src/observability-retention.ts
@@ -30,6 +30,28 @@ function placeholders(n: number): string {
 }
 
 /**
+ * D1 rejects any query binding more than 100 parameters ("too many SQL
+ * variables"), so a 500-id batch cannot go out as one `IN (...)` delete. The
+ * batch size stays 500 — it governs cron throughput and the truncation
+ * lookahead — and only the DELETE is split.
+ */
+const D1_MAX_BOUND_PARAMS = 100;
+
+async function deleteByIdsChunked(
+  db: D1Database,
+  table: "uploads_telemetry_events" | "auth_enrollments",
+  ids: string[],
+): Promise<void> {
+  for (let i = 0; i < ids.length; i += D1_MAX_BOUND_PARAMS) {
+    const chunk = ids.slice(i, i + D1_MAX_BOUND_PARAMS);
+    await db
+      .prepare(`DELETE FROM ${table} WHERE id IN (${placeholders(chunk.length)})`)
+      .bind(...chunk)
+      .run();
+  }
+}
+
+/**
  * Fetch BATCH_SIZE + 1 ids so truncation is grounded in a leftover row, not
  * “the last batch happened to be full” (exact-cap runs must report truncated=false).
  */
@@ -79,10 +101,7 @@ async function purgeTelemetry(
       return (results ?? []).map((r) => r.id);
     },
     async (ids) => {
-      await db
-        .prepare(`DELETE FROM uploads_telemetry_events WHERE id IN (${placeholders(ids.length)})`)
-        .bind(...ids)
-        .run();
+      await deleteByIdsChunked(db, "uploads_telemetry_events", ids);
     },
   );
 }
@@ -111,10 +130,7 @@ async function purgeEnrollments(
       return (results ?? []).map((r) => r.id);
     },
     async (ids) => {
-      await db
-        .prepare(`DELETE FROM auth_enrollments WHERE id IN (${placeholders(ids.length)})`)
-        .bind(...ids)
-        .run();
+      await deleteByIdsChunked(db, "auth_enrollments", ids);
     },
   );
 }

--- a/apps/api/test/file-metadata-sqlite.test.ts
+++ b/apps/api/test/file-metadata-sqlite.test.ts
@@ -427,6 +427,27 @@ describe("file metadata persistence against SQLite", () => {
       }
     });
 
+    it("stays under D1's 100-parameter cap when a filter rides along (screenshots by-path 500)", async () => {
+      // The regression: chunking at a flat 100 keys, then binding the
+      // workspace and each metaKey on top, sent 102 variables and D1 replied
+      // "too many SQL variables" — a 500 on every screenshots page whose path
+      // groups yielded 100+ recent keys. The fake enforces the same cap.
+      const sqlite = new SqliteD1(MIGRATION);
+      try {
+        const keys = Array.from({ length: 100 }, (_, i) => `shots/${i}.png`);
+        for (const key of keys) {
+          await replaceFileMetadata(database(sqlite), "ws1", key, { path: "/settings" });
+        }
+
+        const out = await getMetadataForKeys(database(sqlite), "ws1", keys, {
+          metaKeys: ["state"],
+        });
+        expect(out.size).toBe(0); // no `state` rows, but the query must not throw
+      } finally {
+        sqlite.close();
+      }
+    });
+
     it("applies the filter across every chunk when keys exceed the chunk size", async () => {
       const sqlite = new SqliteD1(MIGRATION);
       try {

--- a/apps/api/test/galleries-sqlite.test.ts
+++ b/apps/api/test/galleries-sqlite.test.ts
@@ -4,12 +4,15 @@ import { describe, expect, it } from "vitest";
 import {
   MAX_GALLERIES_PER_WORKSPACE,
   MAX_GALLERY_ITEMS,
+  MAX_GALLERY_PAGE_SIZE,
   addExternalReference,
   addGalleryItem,
+  countItemsForGalleries,
   createGallery,
   deleteGalleriesForWorkspace,
   getGallery,
   listExternalReferences,
+  listExternalReferencesForGalleries,
   listGalleryItems,
   removeExternalReference,
   removeGalleryItem,
@@ -169,6 +172,108 @@ describe("gallery persistence against SQLite", () => {
       await expect(getGallery(database(sqlite), "alpha", created.id)).resolves.toMatchObject({
         version: 1,
       });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("reorders a full-size gallery without blowing D1's bound-parameter cap", async () => {
+    // The guard statement used to enumerate every item id as its own bound
+    // parameter, so a MAX_GALLERY_ITEMS reorder bound 106 and D1 rejected the
+    // whole batch with "too many SQL variables" (same defect class as the
+    // screenshots by-path 500). SqliteD1.bind() enforces the same 100 cap.
+    const sqlite = newSqliteD1();
+    try {
+      const created = await gallery(sqlite);
+      const insert = sqlite.db.prepare(
+        "INSERT INTO gallery_items (id, gallery_id, object_key, position, created_at) VALUES (?, ?, ?, ?, ?)",
+      );
+      const ids = Array.from({ length: MAX_GALLERY_ITEMS }, (_, index) => `item-${index}`);
+      ids.forEach((id, index) => {
+        insert.run(
+          id,
+          created.id,
+          `screenshots/${index}.png`,
+          (index + 1) * 1000,
+          created.created_at,
+        );
+      });
+
+      const reversed = [...ids].reverse();
+      await expect(
+        reorderGalleryItems(database(sqlite), "alpha", created.id, reversed, 1),
+      ).resolves.toMatchObject({ status: "ok" });
+      const items = await listGalleryItems(database(sqlite), "alpha", created.id);
+      expect(items.map((item) => item.id)).toEqual(reversed);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rejects a reorder whose ids are not the gallery's current set", async () => {
+    // Companion to the test above: the guard's set-equality check must keep
+    // working after the id list stopped being one-parameter-per-id.
+    const sqlite = newSqliteD1();
+    try {
+      const created = await gallery(sqlite);
+      const first = await addGalleryItem(database(sqlite), "alpha", created.id, {
+        expectedVersion: 1,
+        objectKey: "screenshots/one.png",
+      });
+      if (first.status !== "ok") throw new Error("add failed");
+
+      await expect(
+        reorderGalleryItems(database(sqlite), "alpha", created.id, ["not-an-item"], 2),
+      ).resolves.toMatchObject({ status: "invalid" });
+      await expect(listGalleryItems(database(sqlite), "alpha", created.id)).resolves.toMatchObject([
+        { id: first.value.id, position: 1000 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("counts items and external refs for a full page of galleries in one pass", async () => {
+    // countItemsForGalleries / listExternalReferencesForGalleries bind the
+    // workspace plus one parameter per gallery id, so a full
+    // MAX_GALLERY_PAGE_SIZE page bound 101 and 500ed on the account list.
+    const sqlite = newSqliteD1();
+    try {
+      const ids: string[] = [];
+      for (let index = 0; index < MAX_GALLERY_PAGE_SIZE; index++) {
+        const created = await createGallery(database(sqlite), {
+          workspace: "alpha",
+          title: `Gallery ${index}`,
+          now: new Date("2026-07-11T12:00:00Z"),
+        });
+        if (created.status !== "ok") throw new Error(`create failed: ${created.status}`);
+        ids.push(created.value.id);
+        const item = await addGalleryItem(database(sqlite), "alpha", created.value.id, {
+          expectedVersion: 1,
+          objectKey: `screenshots/${index}.png`,
+        });
+        if (item.status !== "ok") throw new Error("add failed");
+        const reference = await addExternalReference(database(sqlite), "alpha", created.value.id, {
+          expectedVersion: 2,
+          provider: "github",
+          resourceType: "item",
+          normalizedKey: `github:item:buildinternet/uploads#${index}`,
+          locator: { owner: "buildinternet", repository: "uploads", number: index },
+          canonicalUrl: `https://github.com/buildinternet/uploads/issues/${index}`,
+        });
+        if (reference.status !== "ok") throw new Error("reference failed");
+      }
+
+      const counts = await countItemsForGalleries(database(sqlite), "alpha", ids);
+      expect(counts.size).toBe(MAX_GALLERY_PAGE_SIZE);
+      expect(counts.get(ids[0])).toBe(1);
+      expect(counts.get(ids[MAX_GALLERY_PAGE_SIZE - 1])).toBe(1);
+
+      const refs = await listExternalReferencesForGalleries(database(sqlite), "alpha", ids);
+      expect(refs.size).toBe(MAX_GALLERY_PAGE_SIZE);
+      expect(refs.get(ids[MAX_GALLERY_PAGE_SIZE - 1])).toHaveLength(1);
+      // Another workspace must not see them, however the ids were chunked.
+      expect((await countItemsForGalleries(database(sqlite), "beta", ids)).size).toBe(0);
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/helpers/sqlite-d1.ts
+++ b/apps/api/test/helpers/sqlite-d1.ts
@@ -19,6 +19,9 @@ const API_ROOT = fileURLToPath(new NodeURL("../../", import.meta.url));
 
 type SqliteValue = string | number | bigint | null | Uint8Array;
 
+/** D1's hard cap on bound parameters per query, enforced by `bind()` below. */
+export const D1_MAX_BOUND_PARAMS = 100;
+
 export class SqliteStatement {
   private values: SqliteValue[] = [];
 
@@ -28,6 +31,12 @@ export class SqliteStatement {
   ) {}
 
   bind(...values: unknown[]) {
+    // node:sqlite allows 32k bound parameters; D1 allows 100 and rejects the
+    // query with "too many SQL variables". Without this the fake happily runs
+    // statements that 500 in production (issue: the screenshots by-path route).
+    if (values.length > D1_MAX_BOUND_PARAMS) {
+      throw new Error(`D1_ERROR: too many SQL variables at offset ${values.length}: SQLITE_ERROR`);
+    }
     this.values = values as SqliteValue[];
     return this;
   }


### PR DESCRIPTION
## The bug

The screenshots page 500ed on every load. From a production `wrangler tail`:

```
D1_ERROR: too many SQL variables at offset 404: SQLITE_ERROR
  at async getMetadataForKeys (index.js:32587)
```

**D1 rejects any query binding more than 100 parameters.** `getMetadataForKeys` chunked object keys at a flat 100, then bound `workspace` *plus* one parameter per `metaKeys` entry on top — 102 variables for the `files/by-path` call. Any workspace whose screenshots page yields 100+ recent keys (17+ path groups) hit it. `default` crossed that line.

The stale comment citing SQLite's "~999 host-parameter limit" is what hid this: that is SQLite's limit, not D1's.

## Why tests did not catch it

`test/helpers/sqlite-d1.ts` is backed by `node:sqlite`, which allows 32k bound parameters. Existing tests deliberately exercised 150 keys and passed while production failed.

The fake now enforces D1's 100-parameter cap in `bind()`. That immediately surfaced **three more live instances** of the same defect:

| Site | Bound | Fix |
| --- | --- | --- |
| `observability-retention` telemetry/enrollment purge | 500 | Chunk the DELETE. Batch size stays 500, so cron throughput and the truncation lookahead are unchanged. |
| `countItemsForGalleries` / `listExternalReferencesForGalleries` | 101 at a full 100-gallery page | Chunk the id list. |
| `reorderGalleryItems` | 106 on a 100-item reorder | Single `json_each(?)` parameter. |

The retention cron has been failing whenever 101+ rows were eligible.

## Notes on the two non-obvious fixes

**Gallery references ordering.** Each gallery id lands in exactly one chunk, so every gallery's references still come back from a single `ORDER BY` — per-gallery ordering is preserved, not merely reassembled.

**`reorderGalleryItems` could not be chunked.** That `IN (...)` is a set-equality guard which has to stay inside the one atomic `UPDATE`; splitting it would break the atomicity it exists to provide. The id list now travels as a single `json_each(?)` parameter instead — 106 binds down to 7, identical semantics. `json_each` is verified working under both `node:sqlite` and D1 (SQLite JSON1).

## Tests

Five added. Two are the reproducers (they fail on `main` with the exact production error at offsets 106 and 101); three pin behaviour that the fixes could have regressed:

- the `by-path` call shape: 100 keys plus a `metaKeys` filter
- a full-size (100-item) reorder round-trips in the requested order
- a reorder with a wrong id set is still rejected — this guards the `json_each` rewrite specifically, since set-equality is what changed shape
- a full 100-gallery page counts items and refs, and a second workspace sees none of them

`pnpm test`: 4345 passed across 295 files. `tsc --noEmit` clean, lint 0 errors.

No changeset — `@uploads/api` is in the changesets ignore list.

## Verification owed after deploy

The fix is proven at the unit level against the real failing query shape, but I could not exercise the deployed endpoint: it is session-gated. Worth reloading the screenshots page once this ships.
