### PR TITLE
feat(ops): branded Cloudflare error pages for the uploads.sh zone

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -98,7 +98,7 @@ Notes:
 - HTML is stored at content-addressed `_internal/cf-error-pages/` keys, so a
   re-deploy of unchanged bytes is a no-op and Cloudflare never re-fetches a URL
   whose contents moved underneath it (same discipline as the email mark).
-- The custom error rule is scoped to `storage.uploads.sh` / `embed.uploads.sh`
+- The custom error rule is scoped to `storage.` / `store.` / `embed.uploads.sh`
   on purpose: `uploads.sh` already serves its own branded 404, and the
   `api.` / `auth.` / `agents.` hosts must keep returning JSON error envelopes.
 - `waf_challenge` (the legacy WAF captcha) is not settable on the Pro plan.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -66,6 +66,48 @@ attachments comment prefer `embedUrl` for `<img src>`.
 
 No Worker proxies image bytes — dual host is DNS + zone rules only.
 
+## Cloudflare error pages
+
+Errors Cloudflare produces itself never reach `apps/web`, so the Astro
+`404.astro` / `500.astro` pages cannot cover them. Without configuration those
+render as generic Cloudflare pages — including a 27 KB "Not Found" with a
+cloudflare.com favicon for any dead link on `storage.uploads.sh` /
+`embed.uploads.sh`, which are exactly the URLs the CLI hands out.
+
+Two mechanisms, both driven from `scripts/cf-error-pages/`:
+
+| Mechanism          | Covers                                                                                    | Where it lives         |
+| ------------------ | ----------------------------------------------------------------------------------------- | ---------------------- |
+| Error Pages        | Errors Cloudflare generates: 5xx/1xxx classes, WAF and IP blocks, rate limits, challenges | `PAGES` in `pages.mjs` |
+| Custom Error Rules | Errors an **origin** returns — the R2 404 on the two storage hosts                        | `RULES` in `pages.mjs` |
+
+```bash
+node scripts/cf-error-pages/build.mjs      # render dist/*.html (gitignored)
+node scripts/cf-error-pages/deploy.mjs --dry-run
+node scripts/cf-error-pages/deploy.mjs     # upload to R2 + configure the zone
+node scripts/cf-error-pages/deploy.mjs --revert   # back to Cloudflare defaults
+```
+
+Notes:
+
+- Pages are **self-contained** — no font, image, or stylesheet fetches. The
+  "origin is unreachable" page cannot depend on the origin. Design tokens are
+  inlined from `packages/ui`; keep them in sync by hand.
+- Each page carries its Cloudflare token (`::CLOUDFLARE_ERROR_500S_BOX::`,
+  `::CAPTCHA_BOX::`, …) verbatim; Cloudflare rejects the upload without it.
+- HTML is stored at content-addressed `_internal/cf-error-pages/` keys, so a
+  re-deploy of unchanged bytes is a no-op and Cloudflare never re-fetches a URL
+  whose contents moved underneath it (same discipline as the email mark).
+- The custom error rule is scoped to `storage.uploads.sh` / `embed.uploads.sh`
+  on purpose: `uploads.sh` already serves its own branded 404, and the
+  `api.` / `auth.` / `agents.` hosts must keep returning JSON error envelopes.
+- `waf_challenge` (the legacy WAF captcha) is not settable on the Pro plan.
+  Cloudflare answers `success: true` and keeps the default; `deploy.mjs` reads
+  each page back and reports that as `SKIPPED` rather than a false success. The
+  challenge visitors actually get is `managed_challenge`, which is customized.
+- Token scopes: Zone → Custom Pages → Edit, Zone → Config Rules → Edit,
+  Account → Workers R2 Storage → Edit.
+
 ## Ledger + retention
 
 ```bash

--- a/scripts/cf-error-pages/build.mjs
+++ b/scripts/cf-error-pages/build.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Renders the branded HTML Cloudflare serves for errors it generates itself,
+ * before (or instead of) our origin — Worker exceptions, origin timeouts, WAF
+ * blocks, rate limits, challenges. Those never reach apps/web, so the Astro
+ * 404/500 pages (src/pages/404.astro, 500.astro) can't cover them and visitors
+ * get the generic Cloudflare page instead.
+ *
+ * Usage: node scripts/cf-error-pages/build.mjs   (from the repo root)
+ * Output: scripts/cf-error-pages/dist/<page-id>.html
+ *
+ * Deploying is two more steps, both in ./deploy.mjs:
+ *   1. upload each file to the server-owned `_internal/` R2 namespace, which is
+ *      publicly fetchable at storage.uploads.sh and hidden from listings
+ *      (same pattern as the email mark — see packages/email/src/card.ts);
+ *   2. point the zone's Error Pages at those URLs via the Cloudflare API.
+ *      Cloudflare fetches and caches the HTML at configuration time, so the
+ *      pages keep working even when the origin they're hosted on is the thing
+ *      that's down.
+ *
+ * Hard constraints these pages are built around:
+ *   - Fully self-contained. No stylesheet, font, image, or script fetches. A
+ *     page shown because uploads.sh is unreachable cannot depend on uploads.sh,
+ *     so the @uploads/ui tokens are inlined below and the brand faces degrade
+ *     to system stacks rather than loading the self-hosted woff2 files.
+ *   - Each page must contain its Cloudflare token verbatim (`required_tokens`
+ *     on GET /zones/:zone/custom_pages). Cloudflare rejects the upload without
+ *     it. That token is where Cloudflare injects the error detail box, the
+ *     Ray ID, or the challenge widget.
+ *   - Error Pages do not apply to 500/501/503/505 responses (Cloudflare
+ *     excludes them so API endpoints keep their own bodies), which is why our
+ *     JSON APIs on api./auth./agents. keep returning JSON errors untouched.
+ */
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { PAGES, RULES } from "./pages.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const outDir = path.join(here, "dist");
+
+/**
+ * Design tokens copied from packages/ui/dist/uploads-ui.css `:root`. Inlined
+ * rather than imported because the built page has to stand alone; keep the
+ * values in sync with the design system when they change there.
+ */
+const TOKENS = `
+  --bg: #0a0a0b;
+  --panel: #121214;
+  --line: #232327;
+  --fg: #ececea;
+  --body: #b3b3ad;
+  --muted: #8a8a83;
+  --accent: #c27eff;
+  /* Brand faces are self-hosted woff2; a standalone page can't fetch them. */
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+`;
+
+/**
+ * The chevron mark from apps/web/public/favicon.svg, inlined as markup so it
+ * costs no request. `crispEdges` keeps the pixel grid sharp at any size.
+ */
+const MARK = `<svg class="mark" viewBox="0 0 32 32" shape-rendering="crispEdges" aria-hidden="true" focusable="false"><path d="M4 0H28V4H32V28H28V32H4V28H0V4H4Z" fill="#121214"/><g fill="#c27eff"><path d="M14 4h4v4h-4z M10 6h4v4h-4z M18 6h4v4h-4z M6 8h4v4h-4z M22 8h4v4h-4z"/><path opacity=".55" d="M14 12h4v4h-4z M10 14h4v4h-4z M18 14h4v4h-4z M6 16h4v4h-4z M22 16h4v4h-4z"/><path opacity=".28" d="M14 20h4v4h-4z M10 22h4v4h-4z M18 22h4v4h-4z M6 24h4v4h-4z M22 24h4v4h-4z"/></g></svg>`;
+
+/** Minimal HTML escape for copy — the templates below interpolate plain text. */
+const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+function render(page) {
+  // The token is Cloudflare's injection point; it must survive verbatim, so it
+  // is written outside `esc()` and given its own styled container.
+  const box = page.token ? `\n          <div class="cf-box">${page.token}</div>` : "";
+  const hint = page.hint ? `\n          <p class="hint">${esc(page.hint)}</p>` : "";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow, noarchive" />
+    <meta name="theme-color" content="#121214" />
+    <title>${esc(page.title)} · uploads.sh</title>
+    <style>
+      :root {
+        color-scheme: dark;${TOKENS}      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        padding: 28px 24px;
+        background: var(--bg);
+        color: var(--fg);
+        font: 14.5px/1.65 var(--mono);
+        -webkit-font-smoothing: antialiased;
+        display: grid;
+        place-items: center;
+      }
+      .card-wrap {
+        width: min(480px, 100%);
+      }
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 8px 14px;
+        border-bottom: 1px solid var(--line);
+        color: var(--muted);
+        font-size: 11px;
+        letter-spacing: 0.05em;
+      }
+      .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--fg);
+        text-decoration: none;
+      }
+      .mark {
+        width: 16px;
+        height: 16px;
+        display: block;
+      }
+      .body {
+        padding: 26px 22px 24px;
+      }
+      h1 {
+        margin: 0 0 12px;
+        font: 600 1.15rem/1.35 var(--sans);
+        letter-spacing: -0.01em;
+        color: var(--fg);
+      }
+      p {
+        margin: 0;
+        color: var(--body);
+        font: 0.92rem/1.6 var(--sans);
+      }
+      .hint {
+        margin-top: 10px;
+        font-size: 0.85rem;
+        color: var(--muted);
+      }
+      /*
+       * Cloudflare injects its own markup here: the error detail block (an
+       * <h2> carrying the error code and Ray ID, then <p> diagnostics) or the
+       * challenge widget. We don't control that markup, so the rules below
+       * only neutralize user-agent defaults that would fight the card — an
+       * unstyled <h2> lands at 1.5em bold and shouts over the real headline.
+       * Nothing here assumes a Cloudflare class name.
+       */
+      .cf-box {
+        margin-top: 20px;
+        padding-top: 18px;
+        border-top: 1px solid var(--line);
+        color: var(--muted);
+        font: 12px/1.6 var(--mono);
+        overflow-wrap: anywhere;
+      }
+      .cf-box h1,
+      .cf-box h2,
+      .cf-box h3 {
+        margin: 0 0 8px;
+        font: 500 12px/1.6 var(--mono);
+        color: var(--body);
+        letter-spacing: 0;
+      }
+      .cf-box p {
+        margin: 0 0 6px;
+        font: 12px/1.6 var(--mono);
+        color: var(--muted);
+      }
+      .cf-box p:last-child {
+        margin-bottom: 0;
+      }
+      .cf-box a {
+        color: var(--muted);
+      }
+      .actions {
+        margin-top: 22px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .btn {
+        display: inline-block;
+        font: 12px var(--mono);
+        color: var(--muted);
+        background: var(--bg);
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        padding: 7px 12px;
+        text-decoration: none;
+      }
+      .btn:hover,
+      .btn:focus-visible {
+        color: var(--fg);
+        border-color: var(--accent);
+        outline: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card-wrap">
+      <section class="card" aria-labelledby="error-title">
+        <div class="titlebar">
+          <a class="brand" href="https://uploads.sh/">${MARK}<span>uploads.sh</span></a>
+          <span aria-hidden="true">${esc(page.label)}</span>
+        </div>
+        <div class="body">
+          <h1 id="error-title">${esc(page.title)}</h1>
+          <p>${esc(page.message)}</p>${hint}${box}
+          <div class="actions">
+            <a class="btn" href="https://uploads.sh/">← home</a>
+            <a class="btn" href="https://status.uploads.sh/">status</a>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>
+`;
+}
+
+await rm(outDir, { recursive: true, force: true });
+await mkdir(outDir, { recursive: true });
+
+// Custom Error Rule bodies render from the same template — they differ only in
+// how they reach visitors (a ruleset rule rather than an Error Page slot).
+for (const page of [...PAGES, ...RULES]) {
+  const html = render(page);
+  // Fail loudly here rather than at the Cloudflare API, which rejects a page
+  // missing its token with a generic validation error.
+  if (page.token && !html.includes(page.token)) {
+    throw new Error(`${page.id}: required token ${page.token} missing from rendered output`);
+  }
+  const file = path.join(outDir, `${page.id}.html`);
+  await writeFile(file, html);
+  console.log(`wrote ${path.relative(process.cwd(), file)}  ${html.length} bytes`);
+}

--- a/scripts/cf-error-pages/deploy.mjs
+++ b/scripts/cf-error-pages/deploy.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Publishes the pages built by ./build.mjs and wires them into the uploads.sh
+ * zone: the `PAGES` entries become Cloudflare Error Pages, the `RULES` entries
+ * become Custom Error Rules (see ./pages.mjs for why both are needed).
+ *
+ * Usage (from the repo root, with .env loaded):
+ *   node scripts/cf-error-pages/build.mjs
+ *   node scripts/cf-error-pages/deploy.mjs --dry-run
+ *   node scripts/cf-error-pages/deploy.mjs
+ *   node scripts/cf-error-pages/deploy.mjs --only 500_errors,waf_block
+ *   node scripts/cf-error-pages/deploy.mjs --revert          # back to Cloudflare defaults
+ *
+ * Two steps per page:
+ *   1. `wrangler r2 object put` into the server-owned `_internal/` namespace of
+ *      the uploads-default bucket. That prefix is filtered out of every listing
+ *      (apps/api/src/files-core.ts) but is publicly fetchable at
+ *      storage.uploads.sh — the same arrangement the transactional email mark
+ *      uses (packages/email/src/card.ts).
+ *   2. `PUT /zones/:zone/custom_pages/:id` with that URL. Cloudflare fetches the
+ *      HTML once, validates that the required token is present, and caches the
+ *      content itself. Nothing is fetched from storage.uploads.sh at error time,
+ *      which is what makes it safe to host the "origin is down" page on the
+ *      origin's own storage domain.
+ *
+ * Keys are content-addressed (`<page-id>-<sha256-8>.html`) so a re-deploy of
+ * unchanged HTML is a no-op and Cloudflare never re-fetches a URL whose bytes
+ * changed underneath it — the same immutable-key discipline as the email mark.
+ *
+ * Requires CLOUDFLARE_API_TOKEN with, on the uploads.sh zone:
+ *   - Zone → Custom Pages → Edit    (Error Pages, and the stored-asset endpoints)
+ *   - Zone → Config Rules → Edit    (the http_custom_errors ruleset)
+ *   - Account → Workers R2 Storage → Edit   (the wrangler r2 object put)
+ */
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { PAGES, RULES } from "./pages.mjs";
+
+const run = promisify(execFile);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "..", "..");
+
+const ZONE = "e6350abfdaa46c08b9597190ac0c5911"; // uploads.sh
+const BUCKET = "uploads-default";
+const PREFIX = "_internal/cf-error-pages";
+const PUBLIC_ORIGIN = "https://storage.uploads.sh";
+const API = "https://api.cloudflare.com/client/v4";
+
+const argv = process.argv.slice(2);
+const dryRun = argv.includes("--dry-run");
+const revert = argv.includes("--revert");
+const onlyArg = argv[argv.indexOf("--only") + 1];
+const only = argv.includes("--only") ? new Set(onlyArg.split(",").map((s) => s.trim())) : null;
+
+const token = process.env.CLOUDFLARE_API_TOKEN;
+if (!token) throw new Error("CLOUDFLARE_API_TOKEN is not set — source .env first");
+
+/** Cloudflare's envelope is uniform; unwrap it and surface `errors` verbatim. */
+async function cf(pathname, init = {}) {
+  const res = await fetch(`${API}${pathname}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      ...init.headers,
+    },
+  });
+  const body = await res.json();
+  if (!body.success) {
+    const detail = (body.errors ?? []).map((e) => `${e.code}: ${e.message}`).join("; ");
+    throw new Error(
+      `${init.method ?? "GET"} ${pathname} → ${res.status} ${detail || "unknown error"}`,
+    );
+  }
+  return body.result;
+}
+
+const targets = PAGES.filter((p) => !only || only.has(p.id));
+const ruleTargets = RULES.filter((r) => !only || only.has(r.id));
+if (only) {
+  const known = new Set([...PAGES, ...RULES].map((p) => p.id));
+  const unknown = [...only].filter((id) => !known.has(id));
+  if (unknown.length) throw new Error(`unknown page id(s): ${unknown.join(", ")}`);
+}
+
+if (revert) {
+  if (ruleTargets.length) {
+    // Custom error rules live in one entrypoint ruleset; clearing its `rules`
+    // array is the documented way to remove them.
+    if (dryRun) console.log("[dry-run] would clear the http_custom_errors ruleset");
+    else {
+      await cf(`/zones/${ZONE}/rulesets/phases/http_custom_errors/entrypoint`, {
+        method: "PUT",
+        body: JSON.stringify({ rules: [] }),
+      });
+      console.log("cleared http_custom_errors ruleset");
+    }
+  }
+  for (const page of targets) {
+    if (dryRun) {
+      console.log(`[dry-run] would reset ${page.id} to the Cloudflare default`);
+      continue;
+    }
+    // `state: "default"` is how the API clears a customized page; DELETE is not
+    // supported on this collection.
+    await cf(`/zones/${ZONE}/custom_pages/${page.id}`, {
+      method: "PUT",
+      body: JSON.stringify({ state: "default", url: null }),
+    });
+    console.log(`reset  ${page.id} → Cloudflare default`);
+  }
+  process.exit(0);
+}
+
+for (const page of targets) {
+  const file = path.join(here, "dist", `${page.id}.html`);
+  let html;
+  try {
+    html = await readFile(file, "utf8");
+  } catch {
+    throw new Error(`missing ${path.relative(root, file)} — run build.mjs first`);
+  }
+  if (page.token && !html.includes(page.token)) {
+    throw new Error(
+      `${page.id}: rendered HTML is missing ${page.token}; Cloudflare will reject it`,
+    );
+  }
+
+  const digest = createHash("sha256").update(html).digest("hex").slice(0, 8);
+  const key = `${PREFIX}/${page.id}-${digest}.html`;
+  const url = `${PUBLIC_ORIGIN}/${key}`;
+
+  if (dryRun) {
+    console.log(
+      `[dry-run] ${page.id}\n          put ${BUCKET}/${key}\n          point custom page at ${url}`,
+    );
+    continue;
+  }
+
+  await run(
+    "npx",
+    [
+      "wrangler",
+      "r2",
+      "object",
+      "put",
+      `${BUCKET}/${key}`,
+      "--file",
+      file,
+      "--content-type",
+      "text/html; charset=utf-8",
+      "--remote",
+    ],
+    { cwd: root },
+  );
+
+  // Cloudflare fetches this URL synchronously during the PUT, so a propagation
+  // lag on a brand-new R2 object surfaces here as a fetch failure rather than a
+  // silently-broken error page. Retry briefly before giving up.
+  let lastErr;
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    const probe = await fetch(url, { cache: "no-store" });
+    if (probe.ok) break;
+    lastErr = `${probe.status} from ${url}`;
+    await new Promise((r) => setTimeout(r, attempt * 1000));
+  }
+  if (lastErr) {
+    const final = await fetch(url, { cache: "no-store" });
+    if (!final.ok) throw new Error(`uploaded object not publicly readable: ${lastErr}`);
+  }
+
+  await cf(`/zones/${ZONE}/custom_pages/${page.id}`, {
+    method: "PUT",
+    body: JSON.stringify({ url, state: "customized" }),
+  });
+
+  // Cloudflare answers `success: true` for page types the zone's plan can't
+  // actually set (observed on `waf_challenge`, the legacy WAF captcha, on Pro)
+  // and then quietly leaves them at `state: "default"`. Read the page back so a
+  // silent no-op reports as one instead of looking like a successful deploy.
+  const saved = await cf(`/zones/${ZONE}/custom_pages/${page.id}`);
+  if (saved.state !== "customized") {
+    console.warn(
+      `SKIPPED  ${page.id.padEnd(18)} Cloudflare accepted the write but kept the default page (not available on this zone's plan)`,
+    );
+    continue;
+  }
+  console.log(`deployed ${page.id.padEnd(18)} → ${url}`);
+}
+
+/*
+ * Custom Error Rules. Unlike Error Pages (which take a URL and let Cloudflare
+ * re-fetch it), rules reference a *stored asset*: Cloudflare fetches the URL
+ * once at registration and keeps the bytes. Asset names are content-addressed
+ * for the same reason the R2 keys are — registering an existing name is an
+ * error, and silently reusing a stale one would ship the wrong copy.
+ */
+if (ruleTargets.length) {
+  const existing = await cf(`/zones/${ZONE}/custom_pages/assets`);
+  const known = new Set((existing ?? []).map((a) => a.name));
+  const rules = [];
+
+  for (const rule of ruleTargets) {
+    const file = path.join(here, "dist", `${rule.id}.html`);
+    let html;
+    try {
+      html = await readFile(file, "utf8");
+    } catch {
+      throw new Error(`missing ${path.relative(root, file)} — run build.mjs first`);
+    }
+
+    const digest = createHash("sha256").update(html).digest("hex").slice(0, 8);
+    const key = `${PREFIX}/${rule.id}-${digest}.html`;
+    const url = `${PUBLIC_ORIGIN}/${key}`;
+    const assetName = `${rule.id}_${digest}`;
+
+    if (dryRun) {
+      console.log(
+        `[dry-run] ${rule.id}\n          put ${BUCKET}/${key}\n          register asset ${assetName}\n          rule: ${rule.expression}`,
+      );
+      rules.push({ assetName, rule });
+      continue;
+    }
+
+    if (!known.has(assetName)) {
+      await run(
+        "npx",
+        [
+          "wrangler",
+          "r2",
+          "object",
+          "put",
+          `${BUCKET}/${key}`,
+          "--file",
+          file,
+          "--content-type",
+          "text/html; charset=utf-8",
+          "--remote",
+        ],
+        { cwd: root },
+      );
+      await cf(`/zones/${ZONE}/custom_pages/assets`, {
+        method: "POST",
+        body: JSON.stringify({ name: assetName, description: rule.description, url }),
+      });
+      console.log(`registered asset ${assetName} ← ${url}`);
+    } else {
+      console.log(`asset ${assetName} already registered (unchanged)`);
+    }
+    rules.push({ assetName, rule });
+  }
+
+  const body = {
+    rules: rules.map(({ assetName, rule }) => ({
+      action: "serve_error",
+      action_parameters: {
+        asset_name: assetName,
+        content_type: "text/html",
+        status_code: rule.statusCode,
+      },
+      expression: rule.expression,
+      description: rule.description,
+      enabled: true,
+    })),
+  };
+
+  if (dryRun) {
+    console.log(
+      `[dry-run] would PUT http_custom_errors ruleset:\n${JSON.stringify(body, null, 2)}`,
+    );
+  } else {
+    // The entrypoint ruleset is replaced wholesale, so `rules` must always
+    // carry every rule we want live — never just the changed one. That is why
+    // `--only` on a rule id still rewrites the full set from RULES.
+    const saved = await cf(`/zones/${ZONE}/rulesets/phases/http_custom_errors/entrypoint`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+    console.log(`deployed ${saved.rules.length} custom error rule(s) → ruleset ${saved.id}`);
+  }
+}

--- a/scripts/cf-error-pages/pages.mjs
+++ b/scripts/cf-error-pages/pages.mjs
@@ -1,0 +1,138 @@
+/**
+ * The Cloudflare Error Page types this repo customizes, shared by build.mjs
+ * (which renders them) and deploy.mjs (which uploads and wires them up).
+ *
+ * Error Pages only cover errors Cloudflare itself generates. Errors that come
+ * back from an origin need a Custom Error Rule instead — see `RULES` below.
+ */
+export const PAGES = [
+  {
+    id: "500_errors",
+    label: "5xx",
+    title: "uploads.sh is unreachable",
+    message:
+      "Cloudflare couldn’t get a response from the uploads.sh origin. This isn’t a missing URL — the server is down, timing out, or erroring before it can answer.",
+    hint: "Nothing you did caused this, and no upload was lost. Try again in a moment.",
+    token: "::CLOUDFLARE_ERROR_500S_BOX::",
+  },
+  {
+    id: "1000_errors",
+    label: "1xxx",
+    title: "This request couldn’t be completed",
+    message:
+      "A DNS or domain configuration problem stopped this request from reaching uploads.sh, so it never made it to the application.",
+    hint: "This is a configuration issue on our side, not a bad link.",
+    token: "::CLOUDFLARE_ERROR_1000S_BOX::",
+  },
+  {
+    id: "waf_block",
+    label: "403",
+    title: "Request blocked",
+    message:
+      "Our firewall blocked this request before it reached uploads.sh. Automated rules sometimes catch ordinary traffic — a large upload, an unusual client, a shared network.",
+    hint: "If you were doing something normal, this is a false positive worth reporting.",
+    token: null,
+  },
+  {
+    id: "ip_block",
+    label: "403",
+    title: "Access blocked",
+    message:
+      "Requests from your IP address or region are blocked on uploads.sh. This is an access rule on the zone, not a problem with the page you asked for.",
+    hint: "If you think this is wrong, open an issue and include the Ray ID below.",
+    token: null,
+  },
+  {
+    id: "ratelimit_block",
+    label: "429",
+    title: "Too many requests",
+    message:
+      "You’ve gone past the rate limit for uploads.sh. The limit is per-client and resets on its own — nothing is permanently blocked.",
+    hint: "Wait a moment and retry. If a script is looping, slow it down before retrying.",
+    token: null,
+  },
+  {
+    id: "basic_challenge",
+    label: "checking",
+    title: "Verifying your browser",
+    message:
+      "This takes a few seconds and happens once. You’ll continue automatically when it finishes.",
+    hint: null,
+    token: "::CAPTCHA_BOX::",
+  },
+  {
+    // Legacy WAF captcha. Cloudflare accepts a write here on the Pro plan but
+    // never persists it (deploy.mjs reads the page back and reports SKIPPED).
+    // Kept in the list so it picks itself up if the plan ever changes — the
+    // challenge visitors actually see today is `managed_challenge`.
+    id: "waf_challenge",
+    label: "checking",
+    title: "Verifying your browser",
+    message:
+      "A firewall rule asked for a quick check before this request continues. It takes a few seconds and you’ll go through automatically.",
+    hint: null,
+    token: "::CAPTCHA_BOX::",
+  },
+  {
+    id: "country_challenge",
+    label: "checking",
+    title: "Verifying your browser",
+    message:
+      "Requests from your region get a quick check first. It takes a few seconds, then you’ll continue automatically.",
+    hint: null,
+    token: "::CAPTCHA_BOX::",
+  },
+  {
+    id: "managed_challenge",
+    label: "checking",
+    title: "Verifying your browser",
+    message:
+      "This takes a few seconds and happens once. You’ll continue automatically when it finishes.",
+    hint: null,
+    token: "::CAPTCHA_BOX::",
+  },
+  {
+    id: "under_attack",
+    label: "checking",
+    title: "Checking your connection",
+    message:
+      "uploads.sh is under elevated protection right now, so every visitor gets a short automatic check before continuing. No action needed.",
+    hint: null,
+    token: "::IM_UNDER_ATTACK_BOX::",
+  },
+];
+
+/**
+ * Custom Error Rules (the `http_custom_errors` ruleset phase). These catch
+ * error responses that come back from an *origin*, which Error Pages above
+ * deliberately do not cover.
+ *
+ * The case that matters here: storage.uploads.sh and embed.uploads.sh are R2
+ * custom domains, so a link to a file that no longer exists is answered by R2
+ * itself with a 27 KB generic Cloudflare "Not Found" page — complete with a
+ * cloudflare.com favicon. Those are exactly the URLs the CLI hands out and
+ * that end up embedded in GitHub comments, so a deleted file currently makes
+ * uploads.sh look broken rather than empty.
+ *
+ * Scoped to those two hosts on purpose:
+ *   - uploads.sh already serves its own branded 404 from apps/web
+ *     (src/pages/404.astro), and a rule here would override it;
+ *   - api./auth./agents.uploads.sh answer with JSON error envelopes that
+ *     clients parse (packages/errors), and must not be handed HTML.
+ */
+export const RULES = [
+  {
+    /** Asset name registered with Cloudflare, and the built file's basename. */
+    id: "file_not_found",
+    label: "404",
+    title: "That file isn’t here",
+    message:
+      "This link points at a file that isn’t on uploads.sh anymore. It may have been deleted, replaced by a newer upload, or the URL is wrong.",
+    hint: "If this link used to work, the file or its workspace was removed.",
+    token: null,
+    expression:
+      '(http.host in {"storage.uploads.sh" "embed.uploads.sh"} and http.response.code eq 404)',
+    statusCode: 404,
+    description: "Branded 404 for missing files on the R2 custom domains",
+  },
+];

--- a/scripts/cf-error-pages/pages.mjs
+++ b/scripts/cf-error-pages/pages.mjs
@@ -107,14 +107,18 @@ export const PAGES = [
  * error responses that come back from an *origin*, which Error Pages above
  * deliberately do not cover.
  *
- * The case that matters here: storage.uploads.sh and embed.uploads.sh are R2
- * custom domains, so a link to a file that no longer exists is answered by R2
- * itself with a 27 KB generic Cloudflare "Not Found" page — complete with a
- * cloudflare.com favicon. Those are exactly the URLs the CLI hands out and
- * that end up embedded in GitHub comments, so a deleted file currently makes
- * uploads.sh look broken rather than empty.
+ * The case that matters here: the R2 custom domains answer a link to a file
+ * that no longer exists with a 27 KB generic Cloudflare "Not Found" page —
+ * complete with a cloudflare.com favicon. Those are exactly the URLs the CLI
+ * hands out and that end up embedded in GitHub comments, so a deleted file
+ * makes uploads.sh look broken rather than empty.
  *
- * Scoped to those two hosts on purpose:
+ * All three public storage hosts are listed. `store.uploads.sh` is the easy
+ * one to forget: docs/ops.md documents it as a durable public URL alongside
+ * `storage.uploads.sh`, and objects resolve on it identically. Keep this set
+ * in step with the "Dual public hosts" table in docs/ops.md.
+ *
+ * Scoped to those hosts on purpose:
  *   - uploads.sh already serves its own branded 404 from apps/web
  *     (src/pages/404.astro), and a rule here would override it;
  *   - api./auth./agents.uploads.sh answer with JSON error envelopes that
@@ -131,7 +135,7 @@ export const RULES = [
     hint: "If this link used to work, the file or its workspace was removed.",
     token: null,
     expression:
-      '(http.host in {"storage.uploads.sh" "embed.uploads.sh"} and http.response.code eq 404)',
+      '(http.host in {"storage.uploads.sh" "store.uploads.sh" "embed.uploads.sh"} and http.response.code eq 404)',
     statusCode: 404,
     description: "Branded 404 for missing files on the R2 custom domains",
   },


### PR DESCRIPTION
Errors Cloudflare generates itself never reach `apps/web`, so the Astro `404.astro` / `500.astro` pages can't cover them. All ten Error Page slots on the `uploads.sh` zone were at `state=default`, so those rendered as stock Cloudflare pages.

The visible symptom was on the R2 custom domains. A dead link on `storage.` / `store.` / `embed.uploads.sh` — the URLs the CLI hands out and that end up embedded in GitHub comments — returned a **27 KB generic Cloudflare "Not Found", complete with a cloudflare.com favicon**. A deleted file made uploads.sh look broken rather than empty.

That one is an *origin* 404, which Error Pages explicitly don't cover, so it needs a Custom Error Rule rather than an Error Page.

## Before / after

A missing file on `store.uploads.sh`:

| Before | After |
| --- | --- |
| <img width="420" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/656/shot-404-before.webp"> | <img width="420" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/656/shot-404-after.webp"> |

The Cloudflare-generated pages use the same card treatment, with Cloudflare's injected detail block styled to sit inside it:

<img width="420" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/656/shot-500.webp">

## What's here

`scripts/cf-error-pages/` — a build step and a deploy step, plus a runbook section in `docs/ops.md`.

- **`build.mjs`** renders standalone pages in the `ErrorLayout` card treatment. Fully self-contained by necessity: the "origin is unreachable" page cannot fetch from the origin, so design tokens are inlined from `packages/ui` and the brand woff2 faces fall back to system stacks.
- **`deploy.mjs`** uploads to content-addressed `_internal/cf-error-pages/` R2 keys and wires up both mechanisms — Error Pages for Cloudflare-generated errors, and the `http_custom_errors` ruleset for origin errors.
- **`pages.mjs`** is the manifest both share.

Rendered HTML lands in a gitignored `dist/`; it's regenerable and not committed.

## Notes for review

- **The rule is deliberately scoped to the three storage hosts.** Zone-wide would override the branded `uploads.sh` 404 and hand HTML to API clients parsing the JSON error envelopes on `api.` / `auth.` / `agents.`. Both were verified unchanged.
- **`deploy.mjs` reads each page back after writing.** Cloudflare answers `success: true` for page types the plan can't actually set and then quietly leaves them at `state: "default"` — `waf_challenge` (the legacy WAF captcha) does exactly this on Pro. It now reports `SKIPPED` instead of a false success. 9 of 10 Error Pages are customized; the challenge visitors actually get is `managed_challenge`, which is.
- **Content-addressed keys** mean a re-deploy of unchanged bytes is a no-op, and Cloudflare never re-fetches a URL whose contents moved underneath it — same discipline as the email mark.
- `store.uploads.sh` is the easy host to forget (second commit). It's documented in the "Dual public hosts" table as a durable public URL and resolves objects identically, but was missing from the first pass.

## Verified in production

```
store.uploads.sh/<missing>     404  27150b → 5239b   "That file isn’t here"
storage.uploads.sh/<missing>   404  27150b → 5239b   "That file isn’t here"
embed.uploads.sh/<missing>     404  27150b → 5239b   "That file isn’t here"
uploads.sh/<missing>           404  unchanged        "404 · Not found" (Astro)
api.uploads.sh/nope            404  unchanged        JSON error envelope
```

Config is already live on the zone. Roll back with `node scripts/cf-error-pages/deploy.mjs --revert`.

No changeset — scripts and docs only, no `@buildinternet/uploads` change.
