### PR TITLE
feat(ops): brand the origin 400 on the storage hosts

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -79,7 +79,7 @@ Two mechanisms, both driven from `scripts/cf-error-pages/`:
 | Mechanism          | Covers                                                                                    | Where it lives         |
 | ------------------ | ----------------------------------------------------------------------------------------- | ---------------------- |
 | Error Pages        | Errors Cloudflare generates: 5xx/1xxx classes, WAF and IP blocks, rate limits, challenges | `PAGES` in `pages.mjs` |
-| Custom Error Rules | Errors an **origin** returns — the R2 404 on the two storage hosts                        | `RULES` in `pages.mjs` |
+| Custom Error Rules | Errors an **origin** returns — R2 404 and 400 on the three storage hosts                  | `RULES` in `pages.mjs` |
 
 ```bash
 node scripts/cf-error-pages/build.mjs      # render dist/*.html (gitignored)
@@ -98,7 +98,7 @@ Notes:
 - HTML is stored at content-addressed `_internal/cf-error-pages/` keys, so a
   re-deploy of unchanged bytes is a no-op and Cloudflare never re-fetches a URL
   whose contents moved underneath it (same discipline as the email mark).
-- The custom error rule is scoped to `storage.` / `store.` / `embed.uploads.sh`
+- The custom error rules are scoped to `storage.` / `store.` / `embed.uploads.sh`
   on purpose: `uploads.sh` already serves its own branded 404, and the
   `api.` / `auth.` / `agents.` hosts must keep returning JSON error envelopes.
 - `waf_challenge` (the legacy WAF captcha) is not settable on the Pro plan.

--- a/scripts/cf-error-pages/pages.mjs
+++ b/scripts/cf-error-pages/pages.mjs
@@ -124,6 +124,17 @@ export const PAGES = [
  *   - api./auth./agents.uploads.sh answer with JSON error envelopes that
  *     clients parse (packages/errors), and must not be handed HTML.
  */
+/**
+ * The public storage hosts, in one place because more than one rule needs the
+ * same set and duplicating it is how `store.uploads.sh` got missed the first
+ * time. Keep in step with the "Dual public hosts" table in docs/ops.md.
+ */
+const STORAGE_HOSTS = ["storage.uploads.sh", "store.uploads.sh", "embed.uploads.sh"];
+
+/** Ruleset-engine host match over `STORAGE_HOSTS`, for a given response code. */
+const onStorageHosts = (code) =>
+  `(http.host in {${STORAGE_HOSTS.map((h) => `"${h}"`).join(" ")}} and http.response.code eq ${code})`;
+
 export const RULES = [
   {
     /** Asset name registered with Cloudflare, and the built file's basename. */
@@ -134,9 +145,31 @@ export const RULES = [
       "This link points at a file that isn’t on uploads.sh anymore. It may have been deleted, replaced by a newer upload, or the URL is wrong.",
     hint: "If this link used to work, the file or its workspace was removed.",
     token: null,
-    expression:
-      '(http.host in {"storage.uploads.sh" "store.uploads.sh" "embed.uploads.sh"} and http.response.code eq 404)',
+    expression: onStorageHosts(404),
     statusCode: 404,
     description: "Branded 404 for missing files on the R2 custom domains",
+  },
+  {
+    /*
+     * R2 rejects a malformed key (over-long, bad encoding) with a 400 before
+     * any lookup happens, which surfaced as a ~17 KB generic Cloudflare "Bad
+     * Request" page on a uploads.sh host (issue #658). Distinct copy from the
+     * 404 on purpose: nothing was deleted here, the URL itself is unusable, so
+     * "that file isn't here" would send people looking for the wrong problem.
+     *
+     * Deliberately not covered: 401 (needs a non-GET method, so a browser
+     * following an embedded image URL never sees it) and 416 (empty body —
+     * there is nothing to replace).
+     */
+    id: "bad_request",
+    label: "400",
+    title: "That link isn’t valid",
+    message:
+      "This URL isn’t a well-formed uploads.sh file link, so there’s no file to look up. It was most likely truncated or mangled on its way here.",
+    hint: "Check it against wherever you copied it from — the original may still work.",
+    token: null,
+    expression: onStorageHosts(400),
+    statusCode: 400,
+    description: "Branded 400 for malformed keys on the R2 custom domains",
   },
 ];


### PR DESCRIPTION
Closes #658.

R2 rejects a malformed key (over-long, bad encoding) with a 400 before any lookup happens. That surfaced as a ~17 KB generic Cloudflare "Bad Request" page served from a `uploads.sh` host — the same class of thing #656 set out to remove, just a code it didn't cover.


<img width="420" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/659/shot-400-after.webp">

## Verified in production

```
GET storage.uploads.sh/<1500-char key>   400  17949b → 5258b   "That link isn’t valid"
GET store.uploads.sh/<1500-char key>     400  17949b → 5258b   "That link isn’t valid"
GET embed.uploads.sh/<1500-char key>     400  17949b → 5258b   "That link isn’t valid"

GET store.uploads.sh/<missing key>       404  unchanged        "That file isn’t here"
GET uploads.sh/<missing>                 404  unchanged        "404 · Not found" (Astro)
GET api.uploads.sh/nope                  404  unchanged        JSON error envelope
```

Status code is preserved — these stay 400, they just get a body worth reading.

## Notes

- **Separate copy from the 404, on purpose.** Nothing was deleted here; the URL itself is unusable. Reusing "that file isn't here" would send people looking for a file that may well still exist under the correct link.
- **401 and 416 are deliberately not covered.** 401 needs a non-GET method, so a browser following an embedded image URL never sees it; 416 returns an empty body, so there's nothing to replace. Both are recorded in a comment next to the rule rather than left for someone to rediscover.
- **The host list moves into a shared `STORAGE_HOSTS` constant.** Two rules now need the same set, and duplicating it inline is exactly how `store.uploads.sh` got missed on the first pass. This is not a fix for #657 — the tokens are still hand-copied and `scripts/` still isn't in the test runner's project globs — but it removes one of the two copies that issue is about.
- Config is already live on the zone. `node scripts/cf-error-pages/deploy.mjs --revert` rolls back.

No changeset — scripts and docs only.
