### PR TITLE
Fix 500 on private-prefix file pages; calmer before/after tile badges

### DIFF
--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -494,15 +494,15 @@ const FIND_MAX_LIMIT = 500;
 const FIND_PROBE_MAX_LIMIT = FIND_MAX_LIMIT + 1;
 
 /**
- * Escapes SQL LIKE metacharacters (`%`, `_`, and the escape character itself)
- * so a prefix like `my_app/` matches only literal underscores — paired with
- * `ESCAPE '\'` in the query. Without this, `_` and `%` in `opts.prefix` are
- * interpreted as single-char/any-run wildcards and over-match (e.g. `my_app/`
- * would also match `myXapp/`).
+ * Prefix filter as a plain substring equality, NOT `LIKE ? || '%'`: D1 caps
+ * LIKE/GLOB patterns at 50 bytes, and real prefixes exceed that — a
+ * `gh/private/<32-hex>/pull/<n>/` attachment prefix is ~54 bytes and made
+ * every counterpart lookup (and with it the whole public file page) throw
+ * `D1_ERROR: LIKE or GLOB pattern too complex`. substr has no such cap and
+ * needs no wildcard escaping (`_`/`%` in the prefix stay literal). Binds the
+ * prefix twice: once for `length(?)`, once for the comparison.
  */
-function escapeLikePattern(raw: string): string {
-  return raw.replace(/[\\%_]/g, (ch) => `\\${ch}`);
-}
+const PREFIX_FILTER_SQL = `substr(object_key, 1, length(?)) = ?`;
 
 /**
  * Finds objects whose metadata matches ALL `filters` (ANDed equality), with
@@ -539,14 +539,14 @@ export async function findObjectsByMetadata(
   if (entries.length === 1) {
     sql = legs[0]!;
     if (opts.prefix) {
-      sql += ` AND object_key LIKE ? || '%' ESCAPE '\\'`;
-      params.push(escapeLikePattern(opts.prefix));
+      sql += ` AND ${PREFIX_FILTER_SQL}`;
+      params.push(opts.prefix, opts.prefix);
     }
   } else {
     sql = `SELECT object_key FROM (${legs.join(" INTERSECT ")})`;
     if (opts.prefix) {
-      sql += ` WHERE object_key LIKE ? || '%' ESCAPE '\\'`;
-      params.push(escapeLikePattern(opts.prefix));
+      sql += ` WHERE ${PREFIX_FILTER_SQL}`;
+      params.push(opts.prefix, opts.prefix);
     }
   }
   sql += ` ORDER BY object_key LIMIT ?`;

--- a/apps/api/test/file-metadata-sqlite.test.ts
+++ b/apps/api/test/file-metadata-sqlite.test.ts
@@ -194,6 +194,73 @@ describe("file metadata persistence against SQLite", () => {
     }
   });
 
+  it("matches a prefix longer than D1's 50-byte LIKE pattern cap (gh/private keys)", async () => {
+    // D1 rejects LIKE/GLOB patterns over 50 bytes ("LIKE or GLOB pattern too
+    // complex") — a gh/private/<32-hex>/pull/<n>/ attachment prefix is ~54
+    // bytes, which 500'd every public file page for private-prefix keys
+    // until the prefix filter moved off LIKE. Guard the substr-based filter.
+    const prefix = "gh/private/81b63c925cbe4387b7ee8b565c733358/pull/1060/";
+    expect(prefix.length).toBeGreaterThan(50);
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await setFileMetadata(database(sqlite), "alpha", `${prefix}before-500.webp`, {
+        path: "/500",
+        state: "before",
+      });
+      await setFileMetadata(database(sqlite), "alpha", "gh/other/before.webp", {
+        path: "/500",
+        state: "before",
+      });
+
+      // Single-filter and multi-filter legs both carry the prefix.
+      await expect(
+        findObjectsByMetadata(database(sqlite), "alpha", { state: "before" }, { prefix }),
+      ).resolves.toEqual([
+        { key: `${prefix}before-500.webp`, metadata: { path: "/500", state: "before" } },
+      ]);
+      await expect(
+        findObjectsByMetadata(
+          database(sqlite),
+          "alpha",
+          { path: "/500", state: "before" },
+          { prefix },
+        ),
+      ).resolves.toEqual([
+        { key: `${prefix}before-500.webp`, metadata: { path: "/500", state: "before" } },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("never filters the key prefix with LIKE (D1's 50-byte pattern cap)", async () => {
+    // Local SQLite doesn't enforce D1's cap, so the behavior test above can't
+    // catch a regression back to `LIKE ? || '%'` — assert on the SQL itself.
+    const seen: string[] = [];
+    const probe = {
+      prepare(sql: string) {
+        seen.push(sql);
+        return {
+          bind() {
+            return this;
+          },
+          async all() {
+            return { success: true, results: [], meta: {} };
+          },
+        };
+      },
+    } as unknown as D1Database;
+    await findObjectsByMetadata(probe, "alpha", { state: "before" }, { prefix: "gh/" });
+    await findObjectsByMetadata(
+      probe,
+      "alpha",
+      { state: "before", path: "/500" },
+      { prefix: "gh/" },
+    );
+    expect(seen).toHaveLength(2);
+    for (const sql of seen) expect(sql).not.toMatch(/LIKE/i);
+  });
+
   it("respects a limit and returns an empty array for no filters or no matches", async () => {
     const sqlite = new SqliteD1(MIGRATION);
     try {

--- a/apps/api/test/helpers/fake-file-metadata-table.ts
+++ b/apps/api/test/helpers/fake-file-metadata-table.ts
@@ -114,13 +114,13 @@ export class FileMetadataTable {
       return { success: true, results: results as T[], meta: {} };
     }
     // findObjectsByMetadata: single equality, or multi-filter INTERSECT legs.
-    // Args: (workspace, key, value)×N, optional LIKE-escaped prefix, limit.
+    // Args: (workspace, key, value)×N, optional prefix (bound twice), limit.
     if (
       normalizedSql.startsWith("SELECT object_key FROM file_metadata WHERE workspace") ||
       normalizedSql.startsWith("SELECT object_key FROM (SELECT object_key FROM file_metadata")
     ) {
       const filterCount = (normalizedSql.match(/meta_key = \? AND meta_value = \?/g) ?? []).length;
-      const hasPrefix = normalizedSql.includes("object_key LIKE ? || '%'");
+      const hasPrefix = normalizedSql.includes("substr(object_key, 1, length(?)) = ?");
       const filters: Array<{ workspace: string; key: string; value: string }> = [];
       for (let i = 0; i < filterCount; i++) {
         const base = i * 3;
@@ -131,8 +131,9 @@ export class FileMetadataTable {
         });
       }
       let idx = filterCount * 3;
-      // Bound prefix is ESCAPE-quoted for SQL LIKE; strip escapes for startsWith.
-      const prefix = hasPrefix ? String(args[idx++]).replace(/\\([\\%_])/g, "$1") : undefined;
+      // substr prefix filter binds the raw prefix twice (length + comparison).
+      const prefix = hasPrefix ? String(args[idx]) : undefined;
+      if (hasPrefix) idx += 2;
       const limit = args[idx] as number;
       const workspace = filters[0]?.workspace;
       if (!workspace || filters.some((f) => f.workspace !== workspace)) {

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -176,7 +176,7 @@ function ShotThumb({
       )}
       {contextLabel && <span className="wsp-state">{contextLabel}</span>}
       {paired && (
-        <span className="wsp-pair" aria-hidden="true">
+        <span className="wsp-pair" aria-hidden="true" title="Has a before/after pair">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
             <rect x="1" y="1" width="4.5" height="10" rx="1" fill="currentColor" opacity="0.45" />
             <rect

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -23,6 +23,7 @@ import { filePath } from "../lib/public-file";
 import { fetchWithTimeout } from "../lib/request";
 import {
   lastUpdatedLabel,
+  pairedShotKeys,
   projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
@@ -134,18 +135,34 @@ function ghLabel(item: SearchFileItem): string {
 
 function ShotThumb({
   item,
+  paired,
+  contextLabel,
   onOpen,
 }: {
   item: { key: string; url: string | null; embedUrl: string | null; state?: string };
+  /** True when a before/after counterpart sits in the same strip/grid. */
+  paired?: boolean;
+  /** Optional pill (GitHub "PR #7 · author" context) — not the state. */
+  contextLabel?: string;
   onOpen: () => void;
 }) {
   const name = leafName(item.key);
   const kind = shotKindFromKey(item.key);
   const showLock = kind === "image" && item.url === null;
   const showImage = kind === "image" && !!item.embedUrl;
+  // The state stays in the accessible name (and hover title) even though the
+  // tile no longer wears a BEFORE/AFTER pill — the pair badge covers the
+  // visual signal, and only when a counterpart actually exists.
+  const stateSuffix = item.state ? ` (${item.state})` : "";
 
   return (
-    <button type="button" className="wsp-tile" aria-label={`Open ${name}`} onClick={onOpen}>
+    <button
+      type="button"
+      className="wsp-tile"
+      aria-label={`Open ${name}${stateSuffix}${paired ? " — has before/after pair" : ""}`}
+      title={item.state ? `${name}${stateSuffix}` : undefined}
+      onClick={onOpen}
+    >
       {showImage ? (
         <span
           className="wsp-thumb"
@@ -157,7 +174,23 @@ function ShotThumb({
           {showLock ? "🔒" : extLabel(item.key)}
         </span>
       )}
-      {item.state && <span className="wsp-state">{item.state}</span>}
+      {contextLabel && <span className="wsp-state">{contextLabel}</span>}
+      {paired && (
+        <span className="wsp-pair" aria-hidden="true">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <rect x="1" y="1" width="4.5" height="10" rx="1" fill="currentColor" opacity="0.45" />
+            <rect
+              x="6.5"
+              y="1"
+              width="4.5"
+              height="10"
+              rx="1"
+              stroke="currentColor"
+              strokeWidth="1.2"
+            />
+          </svg>
+        </span>
+      )}
     </button>
   );
 }
@@ -400,13 +433,23 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
         {drill.status === "ready" && (
           <>
             <div className="wsp-grid">
-              {drillItems.map((item) => (
-                <ShotThumb
-                  key={item.key}
-                  item={{ ...item, state: item.metadata?.state }}
-                  onOpen={() => open(item)}
-                />
-              ))}
+              {(() => {
+                const withState = drillItems.map((item) => ({
+                  item,
+                  state: item.metadata?.state,
+                }));
+                const paired = pairedShotKeys(
+                  withState.map(({ item, state }) => ({ key: item.key, state })),
+                );
+                return withState.map(({ item, state }) => (
+                  <ShotThumb
+                    key={item.key}
+                    item={{ ...item, state }}
+                    paired={paired.has(item.key)}
+                    onOpen={() => open(item)}
+                  />
+                ));
+              })()}
             </div>
             {/* The project scope is applied client-side AFTER the search's
                 100-item cap (the origin-labeled fallback can't be expressed
@@ -582,7 +625,8 @@ function GitHubSection({
         {items.map((item) => (
           <ShotThumb
             key={item.key}
-            item={{ ...item, state: ghLabel(item) }}
+            item={item}
+            contextLabel={ghLabel(item)}
             onOpen={() => onOpen(item)}
           />
         ))}
@@ -611,9 +655,17 @@ function PathGroupSection({
         <span className="wsp-group__viewall">view all →</span>
       </button>
       <div className="wsp-strip">
-        {group.recent.map((item) => (
-          <ShotThumb key={item.key} item={item} onOpen={() => onOpen(item)} />
-        ))}
+        {(() => {
+          const paired = pairedShotKeys(group.recent);
+          return group.recent.map((item) => (
+            <ShotThumb
+              key={item.key}
+              item={item}
+              paired={paired.has(item.key)}
+              onOpen={() => onOpen(item)}
+            />
+          ));
+        })()}
       </div>
     </div>
   );

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -1,11 +1,68 @@
 import { describe, expect, it } from "vitest";
 import {
   lastUpdatedLabel,
+  pairedShotKeys,
   projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
   shotKindFromKey,
 } from "./workspace-screenshots";
+
+describe("pairedShotKeys", () => {
+  it("marks a tile paired only when the opposite state exists in the same collection", () => {
+    const keys = pairedShotKeys([
+      { key: "p/1/after-500.webp", state: "after" },
+      { key: "p/1/before-500.webp", state: "before" },
+      { key: "p/1/after-404.webp", state: "after" },
+      { key: "p/1/plain.webp" },
+    ]);
+    expect(keys.has("p/1/after-500.webp")).toBe(true);
+    expect(keys.has("p/1/before-500.webp")).toBe(true);
+    // An after with no before still counts as paired at the collection level
+    // only when a before exists SOMEWHERE in the collection — pairing is
+    // stem-based so an unrelated before must not mark it.
+    expect(keys.has("p/1/after-404.webp")).toBe(false);
+    expect(keys.has("p/1/plain.webp")).toBe(false);
+  });
+
+  it("pairs by filename stem with the before/after token swapped", () => {
+    const keys = pairedShotKeys([
+      { key: "g/hero-after.png", state: "after" },
+      { key: "g/hero-before.png", state: "before" },
+      { key: "g/other-after.png", state: "after" },
+    ]);
+    expect(keys.has("g/hero-after.png")).toBe(true);
+    expect(keys.has("g/hero-before.png")).toBe(true);
+    expect(keys.has("g/other-after.png")).toBe(false);
+  });
+
+  it("falls back to lone-pair matching when stems don't carry the token", () => {
+    // Exactly one before and one after with token-less names: still a pair.
+    const keys = pairedShotKeys([
+      { key: "g/old.png", state: "before" },
+      { key: "g/new.png", state: "after" },
+    ]);
+    expect(keys.has("g/old.png")).toBe(true);
+    expect(keys.has("g/new.png")).toBe(true);
+    // Ambiguous (two afters, one before, no stems): no pairing claimed.
+    const ambiguous = pairedShotKeys([
+      { key: "g/a.png", state: "after" },
+      { key: "g/b.png", state: "after" },
+      { key: "g/c.png", state: "before" },
+    ]);
+    expect(ambiguous.size).toBe(0);
+  });
+
+  it("ignores non-before/after states and empty input", () => {
+    expect(pairedShotKeys([]).size).toBe(0);
+    expect(
+      pairedShotKeys([
+        { key: "a.png", state: "draft" },
+        { key: "b.png", state: "final" },
+      ]).size,
+    ).toBe(0);
+  });
+});
 
 describe("shotKindFromKey", () => {
   it("classifies by extension, case-insensitively", () => {

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -54,6 +54,61 @@ export function projectLabelFromItemMeta(meta: Record<string, string> | undefine
   return "Other";
 }
 
+/**
+ * Which tiles in a collection have a real before/after counterpart sitting
+ * next to them. Client mirror of the API's pairing rules (before-after.ts):
+ * primary rule swaps the before/after filename token and looks for that exact
+ * sibling; fallback pairs a LONE before with a LONE after (the state metadata
+ * declares the pairing even when filenames carry no token). Anything
+ * ambiguous stays unpaired — the indicator must never claim a pair that the
+ * file page won't actually show.
+ */
+const PAIR_TOKEN_RE = /(^|[-_.])(before|after)(?=[-_.]|$)/i;
+
+function swapPairToken(key: string): string | null {
+  // Token boundaries are -_. or the FILENAME edges (same as the API's rule) —
+  // run the swap on the leaf name so a preceding `/` counts as a start.
+  const slash = key.lastIndexOf("/");
+  const dir = key.slice(0, slash + 1);
+  const leaf = key.slice(slash + 1);
+  const match = PAIR_TOKEN_RE.exec(leaf);
+  if (!match) return null;
+  const found = match[2]!;
+  const swapped = found.toLowerCase() === "before" ? "after" : "before";
+  let cased: string;
+  if (found === found.toUpperCase()) cased = swapped.toUpperCase();
+  else if (found[0] === found[0]!.toUpperCase())
+    cased = swapped[0]!.toUpperCase() + swapped.slice(1);
+  else cased = swapped;
+  const start = match.index + match[1]!.length;
+  return dir + leaf.slice(0, start) + cased + leaf.slice(start + found.length);
+}
+
+export function pairedShotKeys(items: Array<{ key: string; state?: string }>): Set<string> {
+  const paired = new Set<string>();
+  const stated = items.filter((i) => i.state === "before" || i.state === "after");
+  const byKey = new Set(stated.map((i) => i.key));
+
+  for (const item of stated) {
+    const counterpartKey = swapPairToken(item.key);
+    if (counterpartKey && byKey.has(counterpartKey)) paired.add(item.key);
+  }
+
+  // Token-less fallback: exactly one before and one after (neither already
+  // token-paired) is an unambiguous pair.
+  const loneBefore = stated.filter((i) => i.state === "before" && !paired.has(i.key));
+  const loneAfter = stated.filter((i) => i.state === "after" && !paired.has(i.key));
+  if (loneBefore.length === 1 && loneAfter.length === 1) {
+    // Only when neither carries a token that failed to match — a token that
+    // points at a missing sibling is a declared non-pair, not an ambiguity.
+    if (swapPairToken(loneBefore[0]!.key) === null && swapPairToken(loneAfter[0]!.key) === null) {
+      paired.add(loneBefore[0]!.key);
+      paired.add(loneAfter[0]!.key);
+    }
+  }
+  return paired;
+}
+
 /** `?project=` / `?path=` view state, "" when absent. */
 export function readScreenshotsView(search: string): { project: string; path: string } {
   const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1918,3 +1918,23 @@ button.wft-card__name:focus-visible {
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
+
+/* Compact before/after pair indicator — shown only when the counterpart
+   actually sits in the same strip/grid (pairedShotKeys), replacing the old
+   full-width BEFORE/AFTER text pills that dominated 96px tiles. */
+.wsp-pair {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+.wsp-pair svg {
+  display: block;
+}

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1866,8 +1866,8 @@ button.wft-card__name:focus-visible {
 /* Responsive grid of a full path's items (drill-in). */
 .wsp-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
 }
 
 .wsp-tile {
@@ -1880,7 +1880,7 @@ button.wft-card__name:focus-visible {
   cursor: pointer;
 }
 .wsp-strip .wsp-tile {
-  width: 96px;
+  width: 168px;
 }
 
 .wsp-thumb {


### PR DESCRIPTION
## Summary

**Bug — broken links to `gh/private/...` files.** Every `/f/` page (and its backing `GET /public/files/...`) for a private-prefix attachment returned a 500. Root cause (confirmed via `wrangler tail`): D1 caps LIKE/GLOB patterns at **50 bytes**, and the before/after counterpart lookup filtered by attachment prefix with `object_key LIKE ? || '%'` — a `gh/private/<32-hex>/pull/<n>/` prefix is ~54 bytes, so the query threw `D1_ERROR: LIKE or GLOB pattern too complex` on every existing private-prefix object. Plain `gh/<owner>/<repo>/...` prefixes usually sit under 50 bytes, which is why only private keys broke. The prefix filter is now `substr(object_key, 1, length(?)) = ?` — no pattern cap, no wildcard escaping needed, same index behavior (the leg is already narrowed by `file_metadata_lookup_idx`).

**UX — before/after pills dominated the screenshots page.** Tiles no longer render full-width BEFORE/AFTER pills. Instead a compact split-square badge appears only when a tile's counterpart actually exists in the same strip/grid, using a client mirror of the API's pairing rules (filename stem with the token swapped; lone before + lone after as an unambiguous fallback). The state remains in the tile's accessible name and hover title. GitHub strips keep their "PR #n · author" context pill.

## Tests

- Real-SQLite regression test with a 54-byte `gh/private` prefix through both query legs, plus a SQL-shape guard that fails if the prefix filter ever regresses to LIKE (local SQLite doesn't enforce D1's cap, so behavior tests alone can't catch it).
- `pairedShotKeys` unit tests: stem pairing, unpaired afters, lone-pair fallback, ambiguity, non-b/a states.
- Full suite: 4357 passed. Verified in the local stack: pair badge renders only on `/login`'s before/after pair; lone-state and stateless tiles are clean.


## Screenshot

Pair badge on the `/login` before/after pair only; lone-state and stateless tiles stay clean:

<img src="https://storage.uploads.sh/default/gh/buildinternet/uploads/pull/660/pair-badges.webp" width="900" alt="Screenshots page with compact pair badges" />
