### PR TITLE
fix(web): open file tiles and rows as real links

### DIFF
--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -19,8 +19,7 @@ import {
 import { loadWorkspaces } from "../lib/workspaces-nav";
 import { resolveWorkspaceInfo, type WorkspaceInfoStatus } from "../lib/workspace-file-row";
 import { onSession } from "../lib/account-shell";
-import { filePath } from "../lib/public-file";
-import { fetchWithTimeout } from "../lib/request";
+import { makeFileOpener, newTabLinkProps, type FileOpener } from "../lib/file-opener";
 import {
   lastUpdatedLabel,
   pairedShotKeys,
@@ -53,56 +52,6 @@ type DrillState =
   | { status: "loading" }
   | { status: "error" }
   | { status: "ready"; items: SearchFileItem[]; truncated: boolean };
-
-// ── URL-resolution helpers (open-file) ────────────────────────────────────
-// Same shape as WorkspaceFileTable's private module helpers (Task 6 brief:
-// reimplement rather than export) — prefer a public `/f/` URL, else a
-// short-lived signed URL for private/BYO workspaces.
-
-async function resolveSignedFileUrl(
-  apiOrigin: string,
-  workspace: string,
-  key: string,
-): Promise<string | null> {
-  const result = await fetchWithTimeout(
-    `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url?key=${encodeURIComponent(key)}`,
-    { credentials: "include", cache: "no-store" },
-  );
-  if (result.kind === "unavailable") return null;
-  const body = (await result.response.json().catch(() => ({}))) as { url?: string };
-  return result.response.ok && typeof body.url === "string" ? body.url : null;
-}
-
-function openInNewTab(url: string): void {
-  const tab = window.open(url, "_blank");
-  if (tab) tab.opener = null;
-}
-
-function openFile(
-  apiOrigin: string,
-  workspace: string,
-  hasPublicUrl: boolean,
-  file: { key: string; pageUrl?: string },
-): void {
-  if (file.pageUrl) {
-    openInNewTab(file.pageUrl);
-    return;
-  }
-  if (hasPublicUrl) {
-    openInNewTab(filePath(workspace, file.key));
-    return;
-  }
-  const tab = window.open("about:blank", "_blank");
-  if (tab) tab.opener = null;
-  void resolveSignedFileUrl(apiOrigin, workspace, file.key).then((url) => {
-    if (url) {
-      if (tab) tab.location.replace(url);
-      else window.location.assign(url);
-    } else {
-      tab?.close();
-    }
-  });
-}
 
 /** Leaf name for an aria-label / alt text — "a/b/c.png" → "c.png". */
 function leafName(key: string): string {
@@ -137,6 +86,7 @@ function ShotThumb({
   item,
   paired,
   contextLabel,
+  href,
   onOpen,
 }: {
   item: { key: string; url: string | null; embedUrl: string | null; state?: string };
@@ -144,6 +94,8 @@ function ShotThumb({
   paired?: boolean;
   /** Optional pill (GitHub "PR #7 · author" context) — not the state. */
   contextLabel?: string;
+  /** Known destination; when null the tile falls back to a button + `onOpen`. */
+  href: string | null;
   onOpen: () => void;
 }) {
   const name = leafName(item.key);
@@ -155,14 +107,13 @@ function ShotThumb({
   // visual signal, and only when a counterpart actually exists.
   const stateSuffix = item.state ? ` (${item.state})` : "";
 
-  return (
-    <button
-      type="button"
-      className="wsp-tile"
-      aria-label={`Open ${name}${stateSuffix}${paired ? " — has before/after pair" : ""}`}
-      title={item.state ? `${name}${stateSuffix}` : undefined}
-      onClick={onOpen}
-    >
+  const shared = {
+    className: "wsp-tile",
+    "aria-label": `Open ${name}${stateSuffix}${paired ? " — has before/after pair" : ""}`,
+    title: item.state ? `${name}${stateSuffix}` : undefined,
+  };
+  const body = (
+    <>
       {showImage ? (
         <span
           className="wsp-thumb"
@@ -191,6 +142,16 @@ function ShotThumb({
           </svg>
         </span>
       )}
+    </>
+  );
+
+  return href ? (
+    <a {...shared} {...newTabLinkProps} href={href}>
+      {body}
+    </a>
+  ) : (
+    <button {...shared} type="button" onClick={onOpen}>
+      {body}
     </button>
   );
 }
@@ -378,8 +339,7 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
     );
   }
 
-  const open = (file: { key: string; pageUrl?: string }) =>
-    openFile(apiOrigin, workspace, info.hasPublicUrl, file);
+  const opener = makeFileOpener(apiOrigin, workspace, info.hasPublicUrl);
   const onDrill = (group: { project: string; path: string }) =>
     setView({ project: group.project, path: group.path });
 
@@ -446,7 +406,8 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
                     key={item.key}
                     item={{ ...item, state }}
                     paired={paired.has(item.key)}
-                    onOpen={() => open(item)}
+                    href={opener.href(item)}
+                    onOpen={() => opener.activate(item)}
                   />
                 ));
               })()}
@@ -506,9 +467,9 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
         ) : (
           <>
             {projectGroups.map((group) => (
-              <PathGroupSection key={group.path} group={group} onDrill={onDrill} onOpen={open} />
+              <PathGroupSection key={group.path} group={group} onDrill={onDrill} opener={opener} />
             ))}
-            {projectGh && <GitHubSection items={projectGh} onOpen={open} />}
+            {projectGh && <GitHubSection items={projectGh} opener={opener} />}
           </>
         )}
       </div>
@@ -551,7 +512,7 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
                 ghItems={ghItems}
                 onViewProject={() => setView({ project: label, path: "" })}
                 onDrill={onDrill}
-                onOpen={open}
+                opener={opener}
               />
             );
           })}
@@ -571,7 +532,7 @@ function ProjectSection({
   ghItems,
   onViewProject,
   onDrill,
-  onOpen,
+  opener,
 }: {
   label: string;
   summary: ProjectSummary | undefined;
@@ -579,7 +540,7 @@ function ProjectSection({
   ghItems: SearchFileItem[] | undefined;
   onViewProject: () => void;
   onDrill: (group: { project: string; path: string }) => void;
-  onOpen: (file: PathGroupItem | SearchFileItem) => void;
+  opener: FileOpener;
 }) {
   // A GH-only label (no by-path groups) has no ProjectSummary — fall back to
   // the GitHub items' count so the header still reads sensibly.
@@ -599,20 +560,14 @@ function ProjectSection({
         </button>
       </div>
       {groups.map((group) => (
-        <PathGroupSection key={group.path} group={group} onDrill={onDrill} onOpen={onOpen} />
+        <PathGroupSection key={group.path} group={group} onDrill={onDrill} opener={opener} />
       ))}
-      {ghItems && <GitHubSection items={ghItems} onOpen={onOpen} />}
+      {ghItems && <GitHubSection items={ghItems} opener={opener} />}
     </div>
   );
 }
 
-function GitHubSection({
-  items,
-  onOpen,
-}: {
-  items: SearchFileItem[];
-  onOpen: (file: SearchFileItem) => void;
-}) {
+function GitHubSection({ items, opener }: { items: SearchFileItem[]; opener: FileOpener }) {
   return (
     <div className="wsp-group">
       <div className="wsp-group__head">
@@ -627,7 +582,8 @@ function GitHubSection({
             key={item.key}
             item={item}
             contextLabel={ghLabel(item)}
-            onOpen={() => onOpen(item)}
+            href={opener.href(item)}
+            onOpen={() => opener.activate(item)}
           />
         ))}
       </div>
@@ -638,11 +594,11 @@ function GitHubSection({
 function PathGroupSection({
   group,
   onDrill,
-  onOpen,
+  opener,
 }: {
   group: FilesPathGroup;
   onDrill: (group: { project: string; path: string }) => void;
-  onOpen: (file: PathGroupItem) => void;
+  opener: FileOpener;
 }) {
   return (
     <div className="wsp-group">
@@ -662,7 +618,8 @@ function PathGroupSection({
               key={item.key}
               item={item}
               paired={paired.has(item.key)}
-              onOpen={() => onOpen(item)}
+              href={opener.href(item)}
+              onOpen={() => opener.activate(item)}
             />
           ));
         })()}

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -37,7 +37,13 @@ import {
   type FileVisibility,
   type GithubTitleMap,
 } from "../lib/api-client";
-import { filePath, formatBytes } from "../lib/public-file";
+import { formatBytes } from "../lib/public-file";
+import {
+  makeFileOpener,
+  newTabLinkProps,
+  type FileOpener,
+  type OpenableFile,
+} from "../lib/file-opener";
 import {
   breadcrumbSegments,
   childName,
@@ -368,14 +374,47 @@ function FileActionsMenu({
   );
 }
 
+/**
+ * A control that opens one file. Renders a real anchor whenever the
+ * destination is known at render time, and falls back to a button for the
+ * private/BYO signed-URL path — see `lib/file-opener`.
+ */
+function FileOpenTrigger({
+  opener,
+  file,
+  className,
+  title,
+  children,
+  ...rest
+}: {
+  opener: FileOpener;
+  file: OpenableFile;
+  className: string;
+  title?: string;
+  children: ReactNode;
+  "aria-label"?: string;
+}) {
+  const href = opener.href(file);
+  const shared = { className, title, ...rest };
+  return href ? (
+    <a {...shared} {...newTabLinkProps} href={href}>
+      {children}
+    </a>
+  ) : (
+    <button {...shared} type="button" onClick={() => opener.activate(file)}>
+      {children}
+    </button>
+  );
+}
+
 function sizeLabel(size: number | undefined): string {
   return typeof size === "number" ? formatBytes(size) : "—";
 }
 
 // ── URL-resolution helpers (open-file / copy-link) ────────────────────────
-// Prefer API `pageUrl` (`/f/…` file page, issue #308), else same-origin
-// `/f/` when the workspace has a public domain (issue #135), else a
-// short-lived signed URL for private/BYO workspaces.
+// Open-file resolution lives in `lib/file-opener` (shared with
+// ScreenshotsByPath); copy-link keeps its own signed-URL call because it needs
+// the raw URL for the clipboard rather than a navigation.
 
 async function resolveSignedFileUrl(
   apiOrigin: string,
@@ -391,40 +430,9 @@ async function resolveSignedFileUrl(
   return result.response.ok && typeof body.url === "string" ? body.url : null;
 }
 
-function openInNewTab(url: string): void {
-  const tab = window.open(url, "_blank");
-  if (tab) tab.opener = null;
-}
-
 /** "1 file" / "2 files" — `plural` defaults to `${singular}s`, override for irregulars (e.g. "match" → "matches"). */
 function pluralCount(count: number, singular: string, plural = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`;
-}
-
-function openFile(
-  apiOrigin: string,
-  workspace: string,
-  hasPublicUrl: boolean,
-  file: Pick<FileTableRow, "key" | "pageUrl">,
-): void {
-  if (file.pageUrl) {
-    openInNewTab(file.pageUrl);
-    return;
-  }
-  if (hasPublicUrl) {
-    openInNewTab(filePath(workspace, file.key));
-    return;
-  }
-  const tab = window.open("about:blank", "_blank");
-  if (tab) tab.opener = null;
-  void resolveSignedFileUrl(apiOrigin, workspace, file.key).then((url) => {
-    if (url) {
-      if (tab) tab.location.replace(url);
-      else window.location.assign(url);
-    } else {
-      tab?.close();
-    }
-  });
 }
 
 // ── Loading skeleton ───────────────────────────────────────────────────
@@ -884,6 +892,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
     );
   }
 
+  const opener = makeFileOpener(apiOrigin, workspace, info.hasPublicUrl);
   const bareMatch: GhWorkItem | null = state.status === "ok" ? exactPrMatch(state.files) : null;
   const match = bareMatch && githubTitles ? applyGhTitles([bareMatch], githubTitles)[0] : bareMatch;
   // Folders only in browse mode (search has no prefix tree). Empty while loading/error.
@@ -1352,14 +1361,10 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
 
             return (
               <div className="wft-row" key={file.key}>
-                <button
-                  type="button"
-                  className="wft-name wft-name--btn"
-                  onClick={() => openFile(apiOrigin, workspace, info.hasPublicUrl, file)}
-                >
+                <FileOpenTrigger opener={opener} file={file} className="wft-name wft-name--btn">
                   {thumb.kind !== "none" && <FileThumb thumb={thumb} />}
                   <span className="wft-filename">{name}</span>
-                </button>
+                </FileOpenTrigger>
                 <span className="wft-size">{sizeLabel(file.size)}</span>
                 <span className="wft-type">{type}</span>
                 <VisibilityBadge private={priv} />
@@ -1403,14 +1408,12 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
             const thumb = pickThumbnail(file);
             const type = fileTypeLabel(file);
             const priv = isPrivateFile(file);
-            const open = () => openFile(apiOrigin, workspace, info.hasPublicUrl, file);
-
             return (
               <div className="wft-card" key={file.key}>
-                <button
-                  type="button"
+                <FileOpenTrigger
+                  opener={opener}
+                  file={file}
                   className="wft-card__media"
-                  onClick={open}
                   aria-label={`Open ${name}`}
                 >
                   {thumb.kind === "image" ? (
@@ -1426,12 +1429,17 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
                       {thumb.kind === "none" && <span className="wft-card__ext">{type}</span>}
                     </span>
                   )}
-                </button>
+                </FileOpenTrigger>
                 <div className="wft-card__body">
                   <div className="wft-card__title">
-                    <button type="button" className="wft-card__name" title={name} onClick={open}>
+                    <FileOpenTrigger
+                      opener={opener}
+                      file={file}
+                      className="wft-card__name"
+                      title={name}
+                    >
                       {name}
-                    </button>
+                    </FileOpenTrigger>
                     <FileActionsMenu
                       open={openMenuKey === file.key}
                       busy={togglingKeys.has(file.key)}

--- a/apps/web/src/lib/file-opener.ts
+++ b/apps/web/src/lib/file-opener.ts
@@ -1,0 +1,76 @@
+/**
+ * How a signed-in surface opens one of its files.
+ *
+ * Three destinations, in order: the API's own `pageUrl` (`/f/…` file page,
+ * issue #308), else the same-origin `/f/` path when the workspace has a public
+ * domain (issue #135), else a short-lived signed URL for private/BYO
+ * workspaces (issue #123).
+ *
+ * The first two are known at render time, so callers render a real anchor and
+ * get middle/cmd-click, hover preview, and no popup-blocker or blank-tab hop.
+ * Only the third needs `activate`, which opens a blank tab synchronously (so
+ * the blocker attributes it to the click) and redirects it once the URL lands.
+ */
+import { filePath } from "./public-file";
+import { fetchWithTimeout } from "./request";
+
+/** The subset of a file row these helpers need. */
+export interface OpenableFile {
+  key: string;
+  pageUrl?: string;
+}
+
+export interface FileOpener {
+  /** Destination when known at render time; null for private/BYO workspaces. */
+  href(file: OpenableFile): string | null;
+  /** Fallback open path — only meaningful when `href` returned null. */
+  activate(file: OpenableFile): void;
+}
+
+async function resolveSignedFileUrl(
+  apiOrigin: string,
+  workspace: string,
+  key: string,
+): Promise<string | null> {
+  const result = await fetchWithTimeout(
+    `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url?key=${encodeURIComponent(key)}`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable") return null;
+  const body = (await result.response.json().catch(() => ({}))) as { url?: string };
+  return result.response.ok && typeof body.url === "string" ? body.url : null;
+}
+
+export function fileHref(
+  workspace: string,
+  hasPublicUrl: boolean,
+  file: OpenableFile,
+): string | null {
+  if (file.pageUrl) return file.pageUrl;
+  return hasPublicUrl ? filePath(workspace, file.key) : null;
+}
+
+export function makeFileOpener(
+  apiOrigin: string,
+  workspace: string,
+  hasPublicUrl: boolean,
+): FileOpener {
+  return {
+    href: (file) => fileHref(workspace, hasPublicUrl, file),
+    activate: (file) => {
+      const tab = window.open("about:blank", "_blank");
+      if (tab) tab.opener = null;
+      void resolveSignedFileUrl(apiOrigin, workspace, file.key).then((url) => {
+        if (url) {
+          if (tab) tab.location.replace(url);
+          else window.location.assign(url);
+        } else {
+          tab?.close();
+        }
+      });
+    },
+  };
+}
+
+/** Props that turn an element into a new-tab link to `href`. */
+export const newTabLinkProps = { target: "_blank", rel: "noopener noreferrer" } as const;

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1335,13 +1335,16 @@ button.wft-row {
   gap: 10px;
   min-width: 0;
 }
-button.wft-name--btn {
+/* Renders as <a> when the file's destination is known at render time, else as
+   a <button> for the signed-URL fallback — reset both chromes. */
+.wft-name--btn {
   background: none;
   border: 0;
   padding: 0;
   color: inherit;
   font: inherit;
   text-align: left;
+  text-decoration: none;
   cursor: pointer;
   width: 100%;
 }
@@ -1529,6 +1532,7 @@ button.wft-card:focus-visible {
   background: var(--bg);
   cursor: pointer;
   color: inherit;
+  text-decoration: none;
   overflow: hidden;
 }
 .wft-card__media:focus-visible {
@@ -1583,8 +1587,13 @@ button.wft-card:focus-visible {
   border: 0;
   padding: 0;
   text-align: left;
+  text-decoration: none;
   cursor: pointer;
 }
+/* Interactive only on file cards — a folder card's name is a plain span
+   inside the card button, and must not pick up the accent hover. */
+a.wft-card__name:hover,
+a.wft-card__name:focus-visible,
 button.wft-card__name:hover,
 button.wft-card__name:focus-visible {
   color: var(--accent);
@@ -1870,6 +1879,9 @@ button.wft-card__name:focus-visible {
   gap: 12px;
 }
 
+/* Renders as an <a> when the destination is known at render time, and as a
+   <button> only for the private/BYO signed-URL fallback — so the reset has to
+   neutralise both the button chrome and the inherited link styling. */
 .wsp-tile {
   position: relative;
   display: block;
@@ -1878,6 +1890,8 @@ button.wft-card__name:focus-visible {
   border: 0;
   padding: 0;
   cursor: pointer;
+  color: inherit;
+  text-decoration: none;
 }
 .wsp-strip .wsp-tile {
   width: 168px;


### PR DESCRIPTION
Opening a file from the screenshots page or the workspace files tab went through `window.open` on a click handler, so it cost a blank tab and a redirect even when the destination was already known. The tiles and rows weren't links at all — no middle-click, no cmd-click, no hover preview, and a popup blocker could eat them.

## The three destinations

Only one of them is genuinely unknown at render time:

| Case | Destination | Known at render? |
|---|---|---|
| API supplied `pageUrl` | the `/f/…` file page (#308) | yes |
| Workspace has a public domain | same-origin `/f/` path (#135) | yes |
| Private / BYO workspace | short-lived signed URL (#123) | **no** — minted on demand |

So the first two now render a real `<a href target="_blank" rel="noopener noreferrer">`, and only the signed-URL case keeps the open-blank-tab-then-redirect hop (the blank tab is opened synchronously so the popup blocker attributes it to the click).

## Why not a redirect endpoint

The obvious way to make *every* tile an anchor is a server-side route that 302s to the signed URL. I decided against it: it adds an auth-gated GET that redirects to a capability URL — a route that has to be reasoned about in every future security pass — and it's cross-origin (`api.` → `uploads.sh`), so it leans on SameSite behaviour on top-level navigation. That's real surface area to buy anchors for the minority path, when public workspaces are the common case. Worth revisiting if private workspaces ever become the norm.

## What changed

- **New `apps/web/src/lib/file-opener.ts`** — the resolution logic was about to exist in three copies, so it's one module now: `fileHref`, `makeFileOpener` (`href` + `activate`), `newTabLinkProps`.
- **`ScreenshotsByPath.tsx`** — `ShotThumb` takes an `href` and switches element; the `onOpen` prop threaded through the section components became a single `opener`.
- **`WorkspaceFileTable.tsx`** — a local `FileOpenTrigger` does the switch at all three open points (list-view name cell, grid card media, grid card name). Its `resolveSignedFileUrl` stays, because copy-link needs the raw URL for the clipboard rather than a navigation.

## Reviewer notes

Two element-qualified CSS selectors needed care, and one of them would have shipped as a visual bug:

- `button.wft-name--btn` would have **stopped matching entirely** once the element became an anchor, dropping the whole button reset. De-qualified.
- `.wft-card__name`'s hover rule is now scoped to `a, button` rather than de-qualified — a *folder* card's name is a plain `<span>` inside the card button, and dropping the qualifier would have given folder names an accent hover they never had.

**`AccountFileBrowser` is deliberately untouched.** It doesn't own its row markup — it renders `FileBrowser` from `@uploads/ui`, whose only opening API is `onSelect?: (file) => void`. Anchors there mean adding an href-per-item concept to a DS component with other consumers; that deserves its own change.

No changeset: `apps/web` only, and changesets cover the `@buildinternet/uploads` package (AGENTS.md).

## Verification

Local stack with a signed-in session, seeded `path`-tagged files, all four states checked by reading the rendered markup:

| Surface | Public workspace | Private/BYO |
|---|---|---|
| Screenshots overview + drill-in tiles | `A` → `/f/dev-demo/screenshots/….png` | `BUTTON type="button"` |
| Files list-view name cell | `A` | `BUTTON` |
| Files grid card (media + name) | `A`, both triggers | `BUTTON`, both triggers |

Folder cards stay `SPAN` throughout, and I confirmed the hover rule matches file-name anchors and not folder spans. Computed `text-decoration: none` and inherited colour on every converted element, so there's no visual diff. 43 web test files / 611 tests pass.
