### PR TITLE
feat(web): redesign the workspace GitHub comment settings page

### DIFF
--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -13,6 +13,7 @@
  * moves it into the right rail, above Tip and Quick actions.
  */
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
+import { GITHUB_APP_INSTALL_URL } from "../../../../lib/github-app";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
 
 export const prerender = false;
@@ -31,12 +32,22 @@ const tip = {
 <WorkspaceLayout workspace={workspace} tip={tip} wideRail>
   <section class="card settings-page">
     <div class="settings-section" id="cs-section" hidden>
-      <h2>GitHub comment</h2>
+      <h2>GitHub</h2>
       <p class="settings-note muted">
-        Defaults every linked repo's managed comment uses. Commit&#32;
-        <a href="/docs/comment-config"><code>.uploads.yml</code></a> in a repo to override them — see
-        the&#32;<a href="/docs/comment-config">comment config docs</a> for keys, file locations, and precedence.
+        Control how uploads appear in comments on issues and pull requests.
       </p>
+
+      <div class="cs-install" id="cs-install" hidden>
+        <p class="cs-install__body">
+          The GitHub App posts and updates these comments — install it on your repos to get started.
+        </p>
+        <a
+          class="cs-install__cta"
+          href={GITHUB_APP_INSTALL_URL}
+          target="_blank"
+          rel="noopener noreferrer">Install GitHub App →</a
+        >
+      </div>
 
       <div id="cs-repo-banner" class="ul-callout cs-repo-banner" hidden></div>
 
@@ -46,7 +57,7 @@ const tip = {
         <div class="cs-row" id="cs-row-width">
           <div class="cs-row__info">
             <div class="cs-row__label-line">
-              <span class="cs-row__label">image width</span>
+              <span class="cs-row__label">Image width</span>
               <span class="cs-row__chip-slot" id="cs-row-width-chip"></span>
             </div>
             <p class="cs-row__desc">How wide inline screenshots render in the comment.</p>
@@ -94,7 +105,7 @@ const tip = {
         <div class="cs-row" id="cs-row-max-inline">
           <div class="cs-row__info">
             <div class="cs-row__label-line">
-              <span class="cs-row__label">max inline images</span>
+              <span class="cs-row__label">Max inline images</span>
               <span class="cs-row__chip-slot" id="cs-row-max-inline-chip"></span>
             </div>
             <p class="cs-row__desc">Attachments beyond this collapse into a "more files" link.</p>
@@ -115,142 +126,80 @@ const tip = {
         <div class="cs-row" id="cs-row-meta">
           <div class="cs-row__info">
             <div class="cs-row__label-line">
-              <span class="cs-row__label">metadata captions</span>
+              <span class="cs-row__label">Metadata captions</span>
               <span class="cs-row__chip-slot" id="cs-row-meta-chip"></span>
             </div>
-            <p class="cs-row__desc">Filename, dimensions, and size under each image.</p>
+            <p class="cs-row__desc">
+              Show extra details like filename, dimensions, and size under each image.
+            </p>
           </div>
           <div class="cs-row__control">
-            <div
-              class="cs-seg"
-              role="radiogroup"
-              aria-label="Metadata captions"
+            <button
+              type="button"
+              class="cs-toggle"
+              role="switch"
               id="cs-show-metadata"
+              aria-checked="false"
+              aria-label="Metadata captions"
             >
-              <button
-                type="button"
-                class="cs-seg__btn"
-                role="radio"
-                aria-checked="true"
-                tabindex="0"
-                data-value="">auto (on)</button
-              >
-              <button
-                type="button"
-                class="cs-seg__btn"
-                role="radio"
-                aria-checked="false"
-                tabindex="-1"
-                data-value="true">on</button
-              >
-              <button
-                type="button"
-                class="cs-seg__btn"
-                role="radio"
-                aria-checked="false"
-                tabindex="-1"
-                data-value="false">off</button
-              >
-            </div>
+              <span class="cs-toggle__knob" aria-hidden="true"></span>
+            </button>
           </div>
         </div>
 
         <div class="cs-row" id="cs-row-link">
           <div class="cs-row__info">
             <div class="cs-row__label-line">
-              <span class="cs-row__label">link to file pages</span>
+              <span class="cs-row__label">Link items to file pages</span>
               <span class="cs-row__chip-slot" id="cs-row-link-chip"></span>
             </div>
-            <p class="cs-row__desc">Filenames link to the hosted file page on uploads.sh.</p>
+            <p class="cs-row__desc">Each item links to a hosted file page for larger previews.</p>
           </div>
           <div class="cs-row__control">
-            <div
-              class="cs-seg"
-              role="radiogroup"
-              aria-label="Link to file pages"
+            <button
+              type="button"
+              class="cs-toggle"
+              role="switch"
               id="cs-link-to-file-page"
+              aria-checked="false"
+              aria-label="Link items to file pages"
             >
-              <button
-                type="button"
-                class="cs-seg__btn"
-                role="radio"
-                aria-checked="true"
-                tabindex="0"
-                data-value="">auto (on)</button
-              >
-              <button
-                type="button"
-                class="cs-seg__btn"
-                role="radio"
-                aria-checked="false"
-                tabindex="-1"
-                data-value="true">on</button
-              >
-              <button
-                type="button"
-                class="cs-seg__btn"
-                role="radio"
-                aria-checked="false"
-                tabindex="-1"
-                data-value="false">off</button
-              >
-            </div>
+              <span class="cs-toggle__knob" aria-hidden="true"></span>
+            </button>
           </div>
         </div>
 
         <div class="cs-row" id="cs-row-ingest">
           <div class="cs-row__info">
             <div class="cs-row__label-line">
-              <span class="cs-row__label">ingest github attachments</span>
+              <span class="cs-row__label">Import GitHub attachments</span>
             </div>
             <p class="cs-row__desc">
-              Mirror images and video dragged into PR/issue bodies and comments on linked repos into
-              this workspace. Repos can override with <code>ingestGithubAttachments</code> in&#32;
-              <code>.uploads.yml</code>.
+              Mirror manually added images and video on pull requests and issues into this
+              workspace.
             </p>
           </div>
           <div class="cs-row__control">
-            <div
-              class="cs-seg"
-              role="radiogroup"
-              aria-label="Ingest GitHub attachments"
+            <button
+              type="button"
+              class="cs-toggle"
+              role="switch"
               id="cs-ingest-github-attachments"
+              aria-checked="false"
+              aria-label="Import GitHub attachments"
             >
-              <button
-                type="button"
-                class="cs-seg__btn"
-                role="radio"
-                aria-checked="true"
-                tabindex="0"
-                data-value="">auto (off)</button
-              >
-              <button
-                type="button"
-                class="cs-seg__btn"
-                role="radio"
-                aria-checked="false"
-                tabindex="-1"
-                data-value="true">on</button
-              >
-              <button
-                type="button"
-                class="cs-seg__btn"
-                role="radio"
-                aria-checked="false"
-                tabindex="-1"
-                data-value="false">off</button
-              >
-            </div>
+              <span class="cs-toggle__knob" aria-hidden="true"></span>
+            </button>
           </div>
         </div>
 
         <div class="cs-row cs-row--note" id="cs-row-note">
           <div class="cs-row__note-head">
-            <span class="cs-row__label">note</span>
+            <span class="cs-row__label">Note (optional)</span>
             <span class="cs-row__chip-slot" id="cs-row-note-chip"></span>
             <span class="cs-row__note-count"><span id="cs-note-count">0</span>/500</span>
           </div>
-          <p class="cs-row__desc">Optional line appended to every managed comment.</p>
+          <p class="cs-row__desc">Included with every managed comment.</p>
           <textarea
             id="cs-note"
             class="ul-input cs-note"
@@ -259,9 +208,19 @@ const tip = {
             placeholder="e.g. Screenshots update on every push."></textarea>
         </div>
 
-        <div class="cs-actions">
-          <button type="submit" class="ul-btn" id="cs-save-btn" disabled>Save</button>
-          <span class="muted" id="cs-save-status" role="status"></span>
+        {
+          /* Floating save bar (issue #365 redesign): pinned to the viewport,
+             not the form flow, so it stays reachable past a long form. It lives
+             inside `<form>` so its `type="submit"` button posts normally — the
+             `position:fixed` means DOM location doesn't affect layout. It
+             reveals only when dirty (or briefly on the post-save flash). */
+        }
+        <div class="cs-savebar" id="cs-savebar" role="status" hidden>
+          <span class="cs-savebar__msg" id="cs-savebar-msg"></span>
+          <button type="button" class="cs-savebar__reset" id="cs-reset-btn">Reset</button>
+          <button type="submit" class="ul-btn ul-btn--solid cs-savebar__save" id="cs-save-btn"
+            >Save changes</button
+          >
         </div>
       </form>
     </div>
@@ -269,21 +228,21 @@ const tip = {
 
   <Fragment slot="preview">
     <section class="ws-rail__section cs-preview-section" id="cs-preview-section" hidden>
-      <div class="cs-preview-head">
-        <h2 class="cs-preview-title">Preview</h2>
+      <div class="ws-rail__head">
+        <span class="ws-rail__label">preview</span>
+        <span class="ws-rail__rule"></span>
         <span
           class="ul-badge ul-badge--accent cs-preview-chip"
           id="cs-preview-chip-dirty"
           title="The preview still shows your saved settings — save to update it."
           hidden>unsaved edits</span
         >
-        <span class="ul-badge cs-preview-chip" id="cs-preview-chip-live">live</span>
       </div>
 
       <div class="cs-preview-repo-field">
-        <label for="cs-preview-repo" class="sr-only">Repo</label>
+        <label for="cs-preview-repo" class="sr-only">Previewing with config from</label>
         <select id="cs-preview-repo" class="ul-select cs-preview-repo-select">
-          <option value="">No repo config</option>
+          <option value="">Workspace defaults</option>
         </select>
       </div>
 
@@ -319,7 +278,7 @@ const tip = {
       </div>
 
       <p class="settings-note muted cs-preview-footnote">
-        Rendered from your saved settings — GitHub's own styling may differ slightly.
+        Rendered from your saved settings — GitHub's own styling may differ from preview.
       </p>
     </section>
   </Fragment>
@@ -330,21 +289,100 @@ const tip = {
       margin: 0 0 16px;
       font-size: 12.5px;
     }
+
+    /* Install-App prompt: shown only when the workspace has no GitHub App
+       installed (JS reveals it), since the App is what posts these comments. */
+    .cs-install {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      margin: 16px 0 4px;
+      padding: 12px 14px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: var(--panel);
+    }
+    .cs-install__body {
+      margin: 0;
+      max-width: 44ch;
+      font: 12.5px/1.55 var(--sans);
+      color: var(--body);
+      text-wrap: pretty;
+    }
+    .cs-install__cta {
+      flex: none;
+      padding: 7px 13px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: var(--bg);
+      color: var(--fg);
+      font: 600 12.5px var(--sans);
+      text-decoration: none;
+      white-space: nowrap;
+    }
+    .cs-install__cta:hover,
+    .cs-install__cta:focus-visible {
+      border-color: var(--accent);
+      color: var(--accent);
+      outline: none;
+    }
+
+    /* Toggle switch (role=switch button). Replaces the tri-state segmented
+       control for the boolean rows — the workspace value is the default, so a
+       plain on/off reads cleaner than auto/on/off (issue #365). */
+    .cs-toggle {
+      position: relative;
+      width: 38px;
+      height: 21px;
+      flex: none;
+      padding: 0;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      cursor: pointer;
+      transition:
+        background 0.15s ease,
+        border-color 0.15s ease;
+    }
+    .cs-toggle__knob {
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      width: 15px;
+      height: 15px;
+      border-radius: 999px;
+      background: var(--muted);
+      transition:
+        left 0.15s ease,
+        background 0.15s ease;
+    }
+    .cs-toggle[aria-checked="true"] {
+      background: color-mix(in srgb, var(--accent) 28%, transparent);
+      border-color: var(--accent);
+    }
+    .cs-toggle[aria-checked="true"] .cs-toggle__knob {
+      left: 19px;
+      background: var(--accent);
+    }
+    .cs-toggle:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
     /* Rows are label-left / control-right, so they want the full content
        column — not `.ws-form`'s 28rem single-column measure. */
     #cs-form {
       max-width: none;
+      margin-top: 8px;
     }
     .cs-row {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
-      gap: 10px 28px;
+      gap: 8px 28px;
       align-items: center;
-      padding: 16px 0;
+      padding: 20px 0;
       border-bottom: 1px solid var(--line);
-    }
-    #cs-form .cs-row:first-child {
-      padding-top: 4px;
     }
     /* Dimmed when a linked repo's `.uploads.yml` pins this row — its
        workspace-default control still shows the value, just de-emphasized,
@@ -362,9 +400,7 @@ const tip = {
       flex-wrap: wrap;
     }
     .cs-row__label {
-      font-size: 11px;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
+      font: 600 13px var(--sans);
       color: var(--fg);
     }
     .cs-row__desc {
@@ -422,9 +458,8 @@ const tip = {
       overflow: hidden;
     }
     .cs-seg__btn {
-      font: 12px var(--mono);
-      letter-spacing: 0.02em;
-      padding: 6px 12px;
+      font: 12.5px var(--sans);
+      padding: 7px 13px;
       background: transparent;
       color: var(--muted);
       border: 0;
@@ -457,39 +492,60 @@ const tip = {
       }
     }
 
-    .cs-actions {
+    /* Floating save bar — pinned bottom-center, revealed only when dirty. */
+    .cs-savebar {
+      position: fixed;
+      bottom: 24px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 40;
       display: flex;
       align-items: center;
-      gap: 12px;
-      margin-top: 14px;
-      padding-top: 16px;
-      border-top: 1px solid var(--line);
+      gap: 16px;
+      max-width: calc(100vw - 32px);
+      padding: 10px 10px 10px 18px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius-md);
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+      white-space: nowrap;
     }
-    #cs-save-status[data-state="error"] {
+    .cs-savebar__msg {
+      font: 13px var(--sans);
+      color: var(--fg);
+    }
+    .cs-savebar__msg[data-state="ok"] {
+      color: var(--green);
+    }
+    .cs-savebar__msg[data-state="error"] {
       color: var(--red);
     }
-    #cs-save-status[data-state="ok"] {
-      color: var(--green);
+    .cs-savebar__reset {
+      padding: 6px 4px;
+      border: 0;
+      background: none;
+      color: var(--muted);
+      font: 12.5px var(--sans);
+      cursor: pointer;
+    }
+    .cs-savebar__reset:hover,
+    .cs-savebar__reset:focus-visible {
+      color: var(--red);
+      outline: none;
+    }
+    /* Off the dirty state (the brief post-save "Saved." flash) only the
+       message shows — Reset / Save changes collapse away. */
+    .cs-savebar:not([data-mode="dirty"]) .cs-savebar__reset,
+    .cs-savebar:not([data-mode="dirty"]) .cs-savebar__save {
+      display: none;
     }
 
     /* ---------- Preview (rail slot) ---------- */
     /* No `display` on `.cs-preview-section` itself: it starts `hidden` until
        the settings GET succeeds, and any class-level `display` would outrank
-       the UA `[hidden]` rule (same trap as `.ws-rail__cta[hidden]`). */
-    .cs-preview-head {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      margin: 0 0 12px;
-    }
-    .cs-preview-title {
-      margin: 0;
-      font: 600 15px/1.4 var(--sans);
-      color: var(--fg);
-    }
-    .cs-preview-chip {
-      margin-left: auto;
-    }
+       the UA `[hidden]` rule (same trap as `.ws-rail__cta[hidden]`). The head
+       reuses the rail's own `.ws-rail__head` divider so it matches the usage /
+       tip sections below it — the "unsaved edits" chip sits after the rule. */
     .cs-preview-repo-field {
       margin-bottom: 14px;
     }
@@ -582,6 +638,7 @@ const tip = {
       requireElement,
     } from "../../../../lib/account-shell";
     import {
+      getGithubInstalled,
       getWorkspaceCommentPreview,
       getWorkspaceCommentSettings,
       getWorkspaceRepoLinks,
@@ -634,19 +691,22 @@ const tip = {
       );
 
       const csPreviewSection = requireElement<HTMLElement>("#cs-preview-section", page);
+      const installEl = requireElement<HTMLElement>("#cs-install", page);
       const errorEl = requireElement<HTMLElement>("#cs-error", page);
       const repoBannerEl = requireElement<HTMLElement>("#cs-repo-banner", page);
       const form = requireElement<HTMLFormElement>("#cs-form", page);
       const widthSeg = requireElement<HTMLElement>("#cs-image-width", page);
       const widthPxInput = requireElement<HTMLInputElement>("#cs-image-width-px", page);
       const maxInlineInput = requireElement<HTMLInputElement>("#cs-max-inline", page);
-      const metaSeg = requireElement<HTMLElement>("#cs-show-metadata", page);
-      const linkSeg = requireElement<HTMLElement>("#cs-link-to-file-page", page);
-      const ingestSeg = requireElement<HTMLElement>("#cs-ingest-github-attachments", page);
+      const metaToggle = requireElement<HTMLButtonElement>("#cs-show-metadata", page);
+      const linkToggle = requireElement<HTMLButtonElement>("#cs-link-to-file-page", page);
+      const ingestToggle = requireElement<HTMLButtonElement>("#cs-ingest-github-attachments", page);
       const noteInput = requireElement<HTMLTextAreaElement>("#cs-note", page);
       const noteCount = requireElement<HTMLElement>("#cs-note-count", page);
       const saveBtn = requireElement<HTMLButtonElement>("#cs-save-btn", page);
-      const saveStatus = requireElement<HTMLElement>("#cs-save-status", page);
+      const resetBtn = requireElement<HTMLButtonElement>("#cs-reset-btn", page);
+      const savebar = requireElement<HTMLElement>("#cs-savebar", page);
+      const savebarMsg = requireElement<HTMLElement>("#cs-savebar-msg", page);
       // worker-configuration.d.ts's HTMLRewriter ambient `Element` redeclares
       // `remove()`, which makes HTMLSelectElement fail requireElement's
       // `T extends Element` constraint (same workaround as people.astro's
@@ -657,7 +717,6 @@ const tip = {
       ) as unknown as HTMLSelectElement;
       const previewBodyEl = requireElement<HTMLElement>("#cs-preview-body", page);
       const previewChipDirty = requireElement<HTMLElement>("#cs-preview-chip-dirty", page);
-      const previewChipLive = requireElement<HTMLElement>("#cs-preview-chip-live", page);
 
       /** One entry per settings row. `source` reads the row's badge state out
        * of a preview — the metadata row is the only one backed by two keys,
@@ -678,17 +737,22 @@ const tip = {
         chip: requireElement<HTMLElement>(`#cs-row-${target.id}-chip`, page),
       }));
 
-      /** `null` -> "" (Auto), `true` -> "true", `false` -> "false" — for the tri-state segments. */
-      function triStateToSelectValue(value: boolean | null): string {
-        if (value === true) return "true";
-        if (value === false) return "false";
-        return "";
+      // ---------- role=switch toggles (metadata / link / import rows) ----------
+      // These read/write a plain boolean. The stored value can still be `null`
+      // ("auto") on older workspaces; `applySettingsToForm` folds that into the
+      // effective default when painting, so a toggle never has to show a third
+      // state (issue #365 dropped the auto/on/off segment for these rows).
+      function toggleOn(btn: HTMLButtonElement): boolean {
+        return btn.getAttribute("aria-checked") === "true";
       }
-      /** Inverse of `triStateToSelectValue`, for reading a tri-state segment back into a patch. */
-      function selectValueToTriState(value: string): boolean | null {
-        if (value === "true") return true;
-        if (value === "false") return false;
-        return null;
+      function paintToggle(btn: HTMLButtonElement, on: boolean): void {
+        btn.setAttribute("aria-checked", on ? "true" : "false");
+      }
+      function bindToggle(btn: HTMLButtonElement, onChange: () => void): void {
+        btn.addEventListener("click", () => {
+          paintToggle(btn, !toggleOn(btn));
+          onChange();
+        });
       }
 
       /** Current selection of a `.cs-seg` radiogroup — `""` if somehow none is checked. */
@@ -773,9 +837,10 @@ const tip = {
           `<code>.uploads.yml</code> and ignore the workspace default.`;
       }
 
-      // ---------- Dirty-state tracking (drives the Save button + preview chip) ----------
+      // ---------- Dirty-state tracking (drives the save bar + preview chip) ----------
       let savedSettings: CommentSettings | null = null;
       let savedFlash = false;
+      let flashTimer: ReturnType<typeof setTimeout> | undefined;
 
       function currentFormAsSettings(): CommentSettings {
         const widthMode = segValue(widthSeg);
@@ -793,10 +858,14 @@ const tip = {
         return {
           imageWidth,
           maxInlineImages: rawMaxInline === "" ? null : Number(rawMaxInline),
-          showMetadata: selectValueToTriState(segValue(metaSeg)),
-          linkToFilePage: selectValueToTriState(segValue(linkSeg)),
+          // Toggles always write an explicit boolean — a previously-`null`
+          // ("auto") row therefore gets pinned to its effective value on the
+          // next save. That value equals the former auto default, so behaviour
+          // is unchanged (issue #365 traded the auto state for a plain toggle).
+          showMetadata: toggleOn(metaToggle),
+          linkToFilePage: toggleOn(linkToggle),
           note: noteInput.value.trim() === "" ? null : noteInput.value,
-          ingestGithubAttachments: selectValueToTriState(segValue(ingestSeg)),
+          ingestGithubAttachments: toggleOn(ingestToggle),
         };
       }
 
@@ -807,31 +876,33 @@ const tip = {
 
       function updatePreviewDirtyChip(dirty: boolean): void {
         previewChipDirty.hidden = !dirty;
-        previewChipLive.hidden = dirty;
       }
 
       function renderSaveState(): void {
         const dirty = isDirty();
         saveBtn.disabled = !dirty;
-        saveBtn.classList.toggle("ul-btn--solid", dirty);
         if (savedFlash) {
-          saveStatus.textContent = "Saved.";
-          saveStatus.dataset.state = "ok";
+          savebar.hidden = false;
+          savebar.dataset.mode = "saved";
+          savebarMsg.textContent = "Saved.";
+          savebarMsg.dataset.state = "ok";
         } else if (dirty) {
-          // The mock computed its preview client-side and could claim the
-          // preview was already showing the edits; ours is server-rendered
-          // from saved settings, so it only refreshes after a save.
-          saveStatus.textContent = "Unsaved changes — save to update the preview.";
-          saveStatus.removeAttribute("data-state");
+          savebar.hidden = false;
+          savebar.dataset.mode = "dirty";
+          savebarMsg.textContent = "You have unsaved changes";
+          savebarMsg.removeAttribute("data-state");
         } else {
-          saveStatus.textContent = "";
-          saveStatus.removeAttribute("data-state");
+          savebar.hidden = true;
+          savebar.removeAttribute("data-mode");
+          savebarMsg.textContent = "";
+          savebarMsg.removeAttribute("data-state");
         }
         updatePreviewDirtyChip(dirty);
       }
 
       function markEdited(): void {
         savedFlash = false;
+        clearTimeout(flashTimer);
         renderSaveState();
       }
 
@@ -853,13 +924,19 @@ const tip = {
         paintSegmented(widthSeg, widthValue);
         maxInlineInput.value =
           settings.maxInlineImages === null ? "" : String(settings.maxInlineImages);
-        paintSegmented(metaSeg, triStateToSelectValue(settings.showMetadata));
-        paintSegmented(linkSeg, triStateToSelectValue(settings.linkToFilePage));
-        paintSegmented(ingestSeg, triStateToSelectValue(settings.ingestGithubAttachments));
+        // `null` ("auto") folds into the effective default: metadata + links
+        // default on, import defaults off.
+        paintToggle(metaToggle, settings.showMetadata ?? true);
+        paintToggle(linkToggle, settings.linkToFilePage ?? true);
+        paintToggle(ingestToggle, settings.ingestGithubAttachments ?? false);
         noteInput.value = settings.note ?? "";
         noteCount.textContent = String(noteInput.value.length);
-        savedSettings = { ...settings };
+        // Baseline off the painted form, not `settings`: the toggles normalise
+        // `null` to a boolean above, so reading the form back keeps the dirty
+        // check from firing on load for an "auto" row.
+        savedSettings = currentFormAsSettings();
         savedFlash = false;
+        clearTimeout(flashTimer);
         renderSaveState();
       }
 
@@ -867,14 +944,20 @@ const tip = {
         widthPxInput.hidden = value !== "custom";
         markEdited();
       });
-      bindSegmented(metaSeg, () => markEdited());
-      bindSegmented(linkSeg, () => markEdited());
-      bindSegmented(ingestSeg, () => markEdited());
+      bindToggle(metaToggle, () => markEdited());
+      bindToggle(linkToggle, () => markEdited());
+      bindToggle(ingestToggle, () => markEdited());
       widthPxInput.addEventListener("input", () => markEdited());
       maxInlineInput.addEventListener("input", () => markEdited());
       noteInput.addEventListener("input", () => {
         noteCount.textContent = String(noteInput.value.length);
         markEdited();
+      });
+
+      // Reset discards the in-progress edits by repainting the last-saved
+      // snapshot — that clears the dirty state, which hides the save bar.
+      resetBtn.addEventListener("click", () => {
+        if (savedSettings) applySettingsToForm(savedSettings);
       });
 
       // Monotonic token guarding against out-of-order responses: each
@@ -909,7 +992,7 @@ const tip = {
         const options = repos
           .map((repo) => `<option value="${escapeHtml(repo)}">${escapeHtml(repo)}</option>`)
           .join("");
-        repoSelect.innerHTML = `<option value="">No repo config</option>${options}`;
+        repoSelect.innerHTML = `<option value="">Workspace defaults</option>${options}`;
       }
 
       function showFormError(message: string | null): void {
@@ -936,6 +1019,17 @@ const tip = {
         applySettingsToForm(result.settings);
         void loadRepoPicker();
         void loadPreview();
+        void revealInstallPrompt();
+      }
+
+      // The install prompt only makes sense until the App is on. `getGithubInstalled`
+      // returns `true` only on an explicit `installed: true`, so any outage
+      // leaves the prompt up (nagging an installed workspace is cheaper than
+      // hiding it from one that never installed) — same call the rail uses.
+      async function revealInstallPrompt(): Promise<void> {
+        const installed = await getGithubInstalled(apiOrigin, workspaceName);
+        if (!stillHere()) return;
+        installEl.hidden = installed;
       }
 
       repoSelect.addEventListener("change", () => {
@@ -946,8 +1040,10 @@ const tip = {
         event.preventDefault();
         void (async () => {
           showFormError(null);
-          saveStatus.textContent = "Saving…";
-          saveStatus.removeAttribute("data-state");
+          savebar.hidden = false;
+          savebar.dataset.mode = "dirty";
+          savebarMsg.textContent = "Saving…";
+          savebarMsg.removeAttribute("data-state");
           saveBtn.disabled = true;
 
           const patch = currentFormAsSettings();
@@ -958,6 +1054,14 @@ const tip = {
             applySettingsToForm(result.settings);
             savedFlash = true;
             renderSaveState();
+            // The "Saved." confirmation is transient — drop it after a beat so
+            // the bar clears itself rather than lingering over the form.
+            clearTimeout(flashTimer);
+            flashTimer = setTimeout(() => {
+              if (!stillHere()) return;
+              savedFlash = false;
+              renderSaveState();
+            }, 1800);
             void loadPreview();
             return;
           }
@@ -966,9 +1070,13 @@ const tip = {
             renderSaveState();
             return;
           }
-          saveStatus.textContent = "Couldn’t save. Try again.";
-          saveStatus.dataset.state = "error";
-          saveBtn.disabled = !isDirty();
+          // Save failed (network / server): keep the dirty bar up with an error
+          // message so the edits and the retry affordance stay in place.
+          savebar.hidden = false;
+          savebar.dataset.mode = "dirty";
+          savebarMsg.textContent = "Couldn’t save. Try again.";
+          savebarMsg.dataset.state = "error";
+          saveBtn.disabled = false;
         })();
       });
 


### PR DESCRIPTION
## Before / after

| Before | After |
| --- | --- |
| <img width="400" alt="GitHub comment settings, before the redesign" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/666/localhost-account-workspaces-testws-settings-before.webp"> | <img width="400" alt="GitHub comment settings, after the redesign" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/666/localhost-account-workspaces-testws-settings-after.webp"> |

<sub>Captured against the local dev server with the admin-gated section force-revealed; the Install GitHub App callout is conditional (shown only when the App isn't installed) so it doesn't appear in this unauthenticated capture.</sub>

Ports the Claude Design **workspace-settings** redesign onto the GitHub-comment settings tab (`/account/workspaces/<name>/settings`). The app shell, sidebar, and rail already come from `WorkspaceLayout`, so this touches only the content section and the preview rail slot.

## What changed
- **Copy** — heading `GitHub comment` → **GitHub**; new one-line intro; reworded row descriptions; `note` → **Note (optional)**, `ingest github attachments` → **Import GitHub attachments**, `link to file pages` → **Link items to file pages**.
- **Style** — row labels moved from uppercase-mono to **sentence-case sans (600/13px)**; segmented control uses sans; roomier hairline rows. Mock values translated to the app's design tokens (kept DS `--radius-sm/md` over the mock's 2px).
- **Install GitHub App callout** — shown only when the workspace has no App installed (`getGithubInstalled`, fail-open, same call the rail uses).
- **Toggles** — Metadata captions / Link items / Import became `role="switch"` toggles. Per product decision they write an explicit boolean and drop the `null`/"auto" tri-state: a previously-`null` row is painted at its effective default and pinned to that boolean on the next save, so behaviour is unchanged.
- **Floating save bar** — pinned bottom-center with **Reset** + **Save changes**, revealed only when dirty, with a transient "Saved." flash and an inline error on failure. Replaces the old inline Save button.
- **Preview rail head** — now reuses the rail's own `preview ——` divider (matching usage / tip below it) with the "unsaved edits" chip.

## ⚠️ Save-bar consistency note
The floating save bar is currently a **one-off**. The sibling **Storage** tab in this same Settings view (`settings/storage.astro`) and the admin OAuth editor (`admin/oauth/[clientId].astro`) still use inline Save buttons — the pattern this page had before. If we want the Settings tabs to feel uniform, a follow-up should migrate those to the same floating bar (happy to do it in a separate PR).

## Verification
- `astro check` + `tsc`: 0 errors, 0 warnings
- Web tests: 611 passed
- Lint/prettier clean
- Rendered in the real app cascade — toggle on-state uses the accent (28% bg + accent border), labels compute to `600 13px Geist Variable`, save bar renders with the solid-accent button

Web-only change (`@uploads/web` is changeset-ignored) — no changeset.
