### PR TITLE
fix(web): keep the comment-settings save bar a compact centered pill

### DIFF
--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -502,13 +502,16 @@ const tip = {
       display: flex;
       align-items: center;
       gap: 16px;
+      /* Sized to its contents — a compact centered pill, never the full
+         viewport width. The max-width only reins it in on very small screens,
+         where the row wraps instead of overflowing. */
+      width: max-content;
       max-width: calc(100vw - 32px);
       padding: 10px 10px 10px 18px;
       background: var(--panel);
       border: 1px solid var(--line);
       border-radius: var(--radius-md);
       box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
-      white-space: nowrap;
     }
     .cs-savebar__msg {
       font: 13px var(--sans);


### PR DESCRIPTION
Follow-up to #666. Two things: a width fix on the floating save bar, and the result of auditing whether that bar belongs on the other settings-style pages.

## Save-bar width
The floating save bar was sized by shrink-to-fit plus `white-space: nowrap`. That reads as a compact pill on desktop, but on a narrow viewport the nowrap content overflowed the `max-width: calc(100vw - 32px)` cap. This sizes it **explicitly to its content** (`width: max-content`) and drops the nowrap, so it stays a compact centered pill on desktop and **wraps within the cap on mobile** instead of overflowing. Width only — no behaviour change.

Measured in the real signed-in shell:

| Viewport | Save-bar width | Result |
| --- | --- | --- |
| 1200px | 382px, centered (409px gutters each side) | compact pill, not full-width |
| 375px | 343px (= viewport − 32), 16px gutters | wraps cleanly, no overflow |

## Audit: does the floating bar belong on other settings pages?
Checked every settings-style / save-button surface. **It only fits the GitHub comment page**, and I did not migrate the others — on inspection they're a different interaction model, where a "you have unsaved changes → Save / Reset" bar would be worse, not more consistent:

- **Storage tab** (`settings/storage.astro`) — a connect → **verify → save wizard** plus contextual action buttons (Re-run verification, Rotate credentials, Disconnect). "Save" is step 3 of the wizard, gated on a verification checklist. There's no persistent editable-settings state to be "unsaved".
- **Admin OAuth editor** (`admin/oauth/[clientId].astro`) — a read-only detail view with an **Edit** toggle that opens a modal-style form (Save changes / Cancel), on the `AdminLayout` shell.

The GitHub comment page is the one surface that's a flat list of persistent settings edited in place, which is exactly what the floating bar is for. Leaving Storage/OAuth on their inline controls is the right call; happy to revisit if you'd rather force uniformity.

## Screenshots

| Desktop (1200px) | Mobile (390px) |
| --- | --- |
| <img width="420" alt="Save bar as a compact centered pill on desktop" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/667/savebar-desktop.webp"> | <img width="230" alt="Save bar wrapping within the viewport on mobile" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/667/savebar-mobile.webp"> |

<sub>Local dev server with the admin-gated section force-revealed and the bar pinned dirty; the auth banner up top is just the unauthenticated dev shell.</sub>
