### PR TITLE
feat(mcp): advertise output schemas on hosted tools

### DIFF
--- a/.changeset/mcp-output-schemas.md
+++ b/.changeset/mcp-output-schemas.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Advertise an output schema on every hosted MCP tool (and matching stdio tools) so clients can validate structured results.

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -45,6 +45,8 @@ import {
   mcpRead,
   mcpWriteInternal,
   mcpWritePublic,
+  hostedOutputSchemas,
+  withOutputSchemas,
 } from "@buildinternet/uploads/mcp";
 import { AppError, NotFoundError } from "@uploads/errors";
 import { badKey } from "@uploads/api/files";
@@ -330,7 +332,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     );
   }
 
-  return [
+  const tools: McpTool[] = [
     {
       name: "gallery_create",
       title: "Create gallery",
@@ -1297,4 +1299,5 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       },
     },
   ];
+  return withOutputSchemas(tools, hostedOutputSchemas, { required: true });
 }

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1494,6 +1494,7 @@ describe("modern-era (2026-07-28) requests", () => {
         destructiveHint?: boolean;
         openWorldHint?: boolean;
       };
+      outputSchema?: { type?: string };
     }>;
     for (const tool of listed) {
       expect(tool.annotations).toEqual({
@@ -1501,12 +1502,22 @@ describe("modern-era (2026-07-28) requests", () => {
         destructiveHint: expect.any(Boolean),
         openWorldHint: expect.any(Boolean),
       });
+      expect(tool.outputSchema?.type, `${tool.name} outputSchema`).toBe("object");
     }
     expect(listed.find((tool) => tool.name === "delete")?.annotations).toEqual({
       readOnlyHint: false,
       destructiveHint: true,
       openWorldHint: true,
     });
+    expect(
+      (listed.find((tool) => tool.name === "comment") as { outputSchema?: { properties?: object } })
+        .outputSchema?.properties,
+    ).toEqual(
+      expect.objectContaining({
+        posted: expect.anything(),
+        reason: expect.anything(),
+      }),
+    );
     expect(
       (listed.find((tool) => tool.name === "delete") as { _meta?: { securitySchemes?: unknown } })
         ._meta?.securitySchemes,

--- a/packages/uploads/src/mcp/output-schemas.ts
+++ b/packages/uploads/src/mcp/output-schemas.ts
@@ -1,0 +1,411 @@
+/**
+ * JSON Schema for MCP tool `structuredContent`. The SDK validates successful
+ * results against the advertised `outputSchema`, so every property a handler
+ * actually returns must be listed. Roots are always `type: object` — a
+ * oneOf/anyOf root is treated as non-object by the 2025-era codec and wraps
+ * the result as `{ result: … }`.
+ */
+export type JsonSchema = Record<string, unknown>;
+
+function objectSchema(properties: Record<string, JsonSchema>, required: string[] = []): JsonSchema {
+  return {
+    type: "object",
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+    additionalProperties: false,
+  };
+}
+
+const stringMap: JsonSchema = {
+  type: "object",
+  additionalProperties: { type: "string" },
+};
+
+const nullableString: JsonSchema = { type: ["string", "null"] };
+const nullableNumber: JsonSchema = { type: ["number", "null"] };
+
+/** Hosted + stdio `comment` / `put.comment` — all PostCommentResult variants. */
+export const commentResultSchema: JsonSchema = objectSchema(
+  {
+    posted: { type: "boolean" },
+    reason: {
+      type: "string",
+      enum: [
+        "app_unconfigured",
+        "not_installed",
+        "not_authorized",
+        "actor_not_authorized",
+        "unavailable",
+        "forbidden",
+      ],
+    },
+    message: { type: "string" },
+    fixUrl: { type: "string" },
+    required: { type: "array", items: { type: "string" } },
+    action: { type: "string", enum: ["skipped", "created", "updated"] },
+    count: { type: "number" },
+    commentUrl: { type: "string" },
+  },
+  ["posted"],
+);
+
+const promoteResultSchema: JsonSchema = objectSchema(
+  {
+    promoted: { type: "array", items: { type: "string" } },
+    skipped: {
+      type: "array",
+      items: objectSchema({ key: { type: "string" }, reason: { type: "string" } }, [
+        "key",
+        "reason",
+      ]),
+    },
+  },
+  ["promoted", "skipped"],
+);
+
+const putObjectFields: Record<string, JsonSchema> = {
+  key: { type: "string" },
+  url: nullableString,
+  embedUrl: nullableString,
+  size: { type: "number" },
+  contentType: { type: "string" },
+  replaced: { type: "boolean" },
+  markdown: { type: "string" },
+  provenance: stringMap,
+  metadata: stringMap,
+  visibility: { type: "string" },
+};
+
+/** Hosted `PostCommentResult` or stdio `AttachmentsCommentResult` (`via`/`action`). */
+const putCommentSchema: JsonSchema = objectSchema({
+  posted: { type: "boolean" },
+  reason: {
+    type: "string",
+    enum: [
+      "app_unconfigured",
+      "not_installed",
+      "not_authorized",
+      "actor_not_authorized",
+      "unavailable",
+      "forbidden",
+    ],
+  },
+  message: { type: "string" },
+  fixUrl: { type: "string" },
+  required: { type: "array", items: { type: "string" } },
+  action: { type: "string", enum: ["skipped", "created", "updated"] },
+  count: { type: "number" },
+  commentUrl: { type: "string" },
+  via: { type: "string", enum: ["bot", "gh"] },
+});
+
+const putExtras: Record<string, JsonSchema> = {
+  comment: putCommentSchema,
+  commentError: { type: "string" },
+  promotion: promoteResultSchema,
+  promoteError: { type: "string" },
+};
+
+const putFailure: JsonSchema = objectSchema(
+  {
+    file: { type: "string" },
+    error: objectSchema(
+      {
+        message: { type: "string" },
+        code: { type: "string" },
+        status: { type: "number" },
+      },
+      ["message"],
+    ),
+  },
+  ["file", "error"],
+);
+
+/** Single-file put (flat) or multi-file `{ uploads, failures }`, plus optional comment/promote extras. */
+export const putResultSchema: JsonSchema = objectSchema({
+  workspace: { type: "string" },
+  ...putObjectFields,
+  file: { type: "string" },
+  uploads: {
+    type: "array",
+    items: {
+      type: "object",
+      properties: { file: { type: "string" }, ...putObjectFields },
+      additionalProperties: true,
+    },
+  },
+  failures: { type: "array", items: putFailure },
+  ...putExtras,
+  // stdio put adds client-side optimize/frame provenance and dry-run flags.
+  optimize: { type: "object", additionalProperties: true },
+  frame: { type: "object", additionalProperties: true },
+  dryRun: { type: "boolean" },
+  hint: { type: "string" },
+});
+
+export const listResultSchema: JsonSchema = objectSchema({
+  items: {
+    type: "array",
+    items: objectSchema({
+      key: { type: "string" },
+      url: nullableString,
+      embedUrl: nullableString,
+      size: { type: "number" },
+      contentType: { type: "string" },
+      uploaded: { type: "string" },
+      visibility: { type: "string" },
+      pageUrl: { type: "string" },
+    }),
+  },
+  cursor: nullableString,
+  prefixes: { type: "array", items: { type: "string" } },
+});
+
+export const deleteResultSchema: JsonSchema = objectSchema(
+  {
+    key: { type: "string" },
+    deleted: { type: "boolean" },
+    dryRun: { type: "boolean" },
+  },
+  ["key"],
+);
+
+export const metadataResultSchema: JsonSchema = objectSchema({ metadata: stringMap }, ["metadata"]);
+
+export const findFilesResultSchema: JsonSchema = objectSchema(
+  {
+    items: {
+      type: "array",
+      items: objectSchema(
+        {
+          key: { type: "string" },
+          url: nullableString,
+          metadata: stringMap,
+        },
+        ["key"],
+      ),
+    },
+    cursor: nullableString,
+    truncated: { type: "boolean" },
+  },
+  ["items"],
+);
+
+/** `meta keys` or `meta values <key>`. */
+export const metadataFacetsResultSchema: JsonSchema = objectSchema({
+  keys: {
+    type: "array",
+    items: objectSchema(
+      {
+        key: { type: "string" },
+        count: { type: "number" },
+        distinctValues: { type: "number" },
+      },
+      ["key", "count", "distinctValues"],
+    ),
+  },
+  truncated: { type: "boolean" },
+  key: { type: "string" },
+  values: {
+    type: "array",
+    items: objectSchema({ value: { type: "string" }, count: { type: "number" } }, [
+      "value",
+      "count",
+    ]),
+  },
+});
+
+export const repoLinkStatusResultSchema: JsonSchema = objectSchema(
+  { binding: { type: "string", enum: ["self", "other", "none"] } },
+  ["binding"],
+);
+
+export const usageResultSchema: JsonSchema = objectSchema({
+  workspace: { type: "string" },
+  bytes: { type: "number" },
+  objects: { type: "number" },
+  uploadsInPeriod: { type: "number" },
+  periodStart: { type: "string" },
+  updatedAt: { type: "string" },
+  maxStorageBytes: { type: "number" },
+  storageRemainingBytes: { type: "number" },
+  maxUploadsPerPeriod: { type: "number" },
+  uploadsRemaining: { type: "number" },
+});
+
+export const reconcileResultSchema: JsonSchema = objectSchema({
+  workspace: { type: "string" },
+  bytes: { type: "number" },
+  objects: { type: "number" },
+  previous: objectSchema({ bytes: { type: "number" }, objects: { type: "number" } }, [
+    "bytes",
+    "objects",
+  ]),
+  changed: { type: "boolean" },
+  usage: usageResultSchema,
+  unprefixedBucket: { type: "boolean" },
+});
+
+export const purgeExpiredResultSchema: JsonSchema = objectSchema({
+  skipped: { type: "boolean" },
+  reason: { type: "string" },
+  workspace: { type: "string" },
+  retentionDays: { type: "number" },
+  cutoff: { type: "string" },
+  deleted: { type: "number" },
+  freedBytes: { type: "number" },
+  keys: { type: "array", items: { type: "string" } },
+  keysTruncated: { type: "boolean" },
+  reconcile: reconcileResultSchema,
+});
+
+export const healthResultSchema: JsonSchema = objectSchema({
+  ok: { type: "boolean" },
+  apiUrl: { type: "string" },
+});
+
+export const promoteToolResultSchema: JsonSchema = objectSchema(
+  {
+    promotion: promoteResultSchema,
+    comment: commentResultSchema,
+    commentError: { type: "string" },
+  },
+  ["promotion"],
+);
+
+const galleryItemSchema: JsonSchema = objectSchema({
+  id: { type: "string" },
+  objectKey: { type: "string" },
+  filename: { type: "string" },
+  position: { type: "number" },
+  caption: nullableString,
+  altText: nullableString,
+  createdAt: { type: "string" },
+  status: { type: "string", enum: ["available", "missing", "withheld"] },
+  url: nullableString,
+  embedUrl: nullableString,
+  pageUrl: { type: "string" },
+  contentType: nullableString,
+  size: nullableNumber,
+  uploaded: nullableString,
+  modified: nullableString,
+  posterUrl: { type: "string" },
+  videoDimensions: {
+    type: "object",
+    additionalProperties: true,
+  },
+});
+
+const galleryReferenceSchema: JsonSchema = objectSchema({
+  id: { type: "string" },
+  provider: { type: "string" },
+  resourceType: { type: "string" },
+  coordinate: { type: "string" },
+  canonicalUrl: nullableString,
+  createdAt: { type: "string" },
+  title: { type: "string" },
+  kind: { type: "string", enum: ["pull", "issue"] },
+});
+
+export const galleryResultSchema: JsonSchema = objectSchema({
+  id: { type: "string" },
+  url: { type: "string" },
+  workspace: { type: "string" },
+  title: { type: "string" },
+  description: nullableString,
+  visibility: { type: "string" },
+  coverItemId: nullableString,
+  version: { type: "number" },
+  createdAt: { type: "string" },
+  updatedAt: { type: "string" },
+  items: { type: "array", items: galleryItemSchema },
+  itemCount: { type: "number" },
+  references: { type: "array", items: galleryReferenceSchema },
+});
+
+export const galleryFindResultSchema: JsonSchema = objectSchema({
+  galleries: { type: "array", items: galleryResultSchema },
+  nextCursor: nullableString,
+});
+
+/** Hosted catalog — every tool must have an entry. */
+export const hostedOutputSchemas: Record<string, JsonSchema> = {
+  gallery_create: galleryResultSchema,
+  gallery_get: galleryResultSchema,
+  gallery_add: galleryItemSchema,
+  gallery_link: galleryReferenceSchema,
+  gallery_find_by_reference: galleryFindResultSchema,
+  put: putResultSchema,
+  list: listResultSchema,
+  delete: deleteResultSchema,
+  comment: commentResultSchema,
+  promote: promoteToolResultSchema,
+  get_metadata: metadataResultSchema,
+  set_metadata: metadataResultSchema,
+  find_files: findFilesResultSchema,
+  list_metadata_keys: metadataFacetsResultSchema,
+  repo_link_status: repoLinkStatusResultSchema,
+  usage: usageResultSchema,
+  reconcile: reconcileResultSchema,
+  purge_expired: purgeExpiredResultSchema,
+  health: healthResultSchema,
+};
+
+/** Shared-shape stdio tools. Hosted-only tools (`promote`, `repo_link_status`) omitted. */
+export const stdioOutputSchemas: Record<string, JsonSchema> = {
+  gallery_create: galleryResultSchema,
+  gallery_get: galleryResultSchema,
+  gallery_add: galleryItemSchema,
+  gallery_link: galleryReferenceSchema,
+  gallery_find_by_reference: galleryFindResultSchema,
+  put: putResultSchema,
+  list: listResultSchema,
+  delete: deleteResultSchema,
+  comment: objectSchema({
+    posted: { type: "boolean" },
+    reason: { type: "string" },
+    message: { type: "string" },
+    fixUrl: { type: "string" },
+    required: { type: "array", items: { type: "string" } },
+    action: { type: "string", enum: ["skipped", "created", "updated"] },
+    count: { type: "number" },
+    commentUrl: { type: "string" },
+    repo: { type: "string" },
+    kind: { type: "string" },
+    num: { type: "number" },
+    via: { type: "string", enum: ["bot", "gh"] },
+  }),
+  get_metadata: metadataResultSchema,
+  set_metadata: metadataResultSchema,
+  find_files: findFilesResultSchema,
+  list_metadata_keys: metadataFacetsResultSchema,
+  usage: usageResultSchema,
+  reconcile: reconcileResultSchema,
+  purge_expired: purgeExpiredResultSchema,
+  health: healthResultSchema,
+  report: objectSchema(
+    {
+      ok: { type: "boolean" },
+      id: { type: "string" },
+      hasAttachment: { type: "boolean" },
+    },
+    ["ok"],
+  ),
+};
+
+export function withOutputSchemas<T extends { name: string }>(
+  tools: T[],
+  schemas: Record<string, JsonSchema>,
+  opts: { required: boolean },
+): Array<T & { outputSchema?: JsonSchema }> {
+  return tools.map((tool) => {
+    const outputSchema = schemas[tool.name];
+    if (!outputSchema) {
+      if (opts.required) {
+        throw new Error(`missing output schema for MCP tool ${tool.name}`);
+      }
+      return tool;
+    }
+    return { ...tool, outputSchema };
+  });
+}

--- a/packages/uploads/src/mcp/server.ts
+++ b/packages/uploads/src/mcp/server.ts
@@ -46,6 +46,26 @@ export {
 export { ToolBatchError, batchFailureMessage } from "./batch-error.js";
 export { mapBounded } from "../async.js";
 export { McpServer, type jsonSchemaValidator };
+export {
+  commentResultSchema,
+  deleteResultSchema,
+  findFilesResultSchema,
+  galleryFindResultSchema,
+  galleryResultSchema,
+  healthResultSchema,
+  hostedOutputSchemas,
+  listResultSchema,
+  metadataFacetsResultSchema,
+  metadataResultSchema,
+  promoteToolResultSchema,
+  purgeExpiredResultSchema,
+  putResultSchema,
+  reconcileResultSchema,
+  repoLinkStatusResultSchema,
+  stdioOutputSchemas,
+  usageResultSchema,
+  withOutputSchemas,
+} from "./output-schemas.js";
 
 /** MCP tool safety hints. Required so tools/list advertises them for review. */
 export interface McpToolAnnotations {
@@ -131,6 +151,11 @@ export interface McpTool {
   securitySchemes: McpSecurityScheme[];
   /** Hand-written JSON Schema for the tool's arguments. */
   inputSchema: Record<string, unknown>;
+  /**
+   * Hand-written JSON Schema for successful `structuredContent`. Required
+   * whenever the handler returns structured data (OpenAI Scan Tools).
+   */
+  outputSchema?: Record<string, unknown>;
   handler: (args: Record<string, unknown>) => Promise<unknown>;
 }
 
@@ -224,6 +249,9 @@ export function createMcpServer(opts: {
         ...(tool.title ? { title: tool.title } : {}),
         description: tool.description,
         inputSchema: fromJsonSchema<Record<string, unknown>>(tool.inputSchema, validator),
+        ...(tool.outputSchema
+          ? { outputSchema: fromJsonSchema<Record<string, unknown>>(tool.outputSchema, validator) }
+          : {}),
         annotations: tool.annotations,
         _meta: { securitySchemes: tool.securitySchemes },
       },

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -70,6 +70,8 @@ import {
   mcpRead,
   mcpWriteInternal,
   mcpWritePublic,
+  stdioOutputSchemas,
+  withOutputSchemas,
   ToolBatchError,
   type McpTool,
 } from "./server.js";
@@ -221,7 +223,7 @@ export function createUploadsMcpTools(opts: {
     return { comment, commentError };
   };
 
-  return [
+  const tools: McpTool[] = [
     {
       name: "gallery_create",
       title: "Create gallery",
@@ -1608,4 +1610,5 @@ export function createUploadsMcpTools(opts: {
       },
     },
   ];
+  return withOutputSchemas(tools, stdioOutputSchemas, { required: false });
 }

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -470,6 +470,9 @@ describe("tools/list", () => {
         destructiveHint: expect.any(Boolean),
         openWorldHint: expect.any(Boolean),
       });
+      if (tool.outputSchema) {
+        expect(tool.outputSchema.type, `${tool.name} outputSchema`).toBe("object");
+      }
       expect(tool._meta.securitySchemes).toEqual([
         expect.objectContaining({ type: expect.stringMatching(/^(oauth2|noauth)$/) }),
       ]);


### PR DESCRIPTION
## In plain terms

OpenAI's plugin scan expects every tool that returns structured data to advertise an `outputSchema`. We already return `structuredContent` on every hosted call; this PR names that shape so ChatGPT can validate results and reason about follow-up calls. Fixes #671.

## What it does / what it is not

- Registers an object-root `outputSchema` on every hosted MCP tool (`put`, `comment`, `list`, galleries, metadata, usage, …).
- Aligns stdio tools that share a result shape (`put`, `list`, `delete`, metadata, galleries, …). Stdio-only tools (`screenshot`, `attach`, `staged`, `doctor`) stay schema-less.
- `comment` documents `posted` / `reason` / `action` so honest declines (`not_installed`, `not_authorized`, `forbidden`) stay structured results, not thrown errors.
- Roots are `type: object` on purpose: a oneOf root would make the 2025-era codec wrap results as `{ result: … }`.
- Does **not** wait for the first portal scan. The existing tool tests are the source of truth for the live result shapes.
- Does **not** add new tools, CIMD, or a skill rewrite.

## How to try it

After deploy, `tools/list` on `https://agents.uploads.sh/mcp` includes `outputSchema` on each tool. A `comment` decline is still `{ posted: false, reason: "not_installed" }` (or similar), not a protocol error.

## Test plan

- [x] `pnpm --filter @uploads/mcp test` (116)
- [x] `pnpm --filter @buildinternet/uploads exec vitest run test/mcp.test.ts test/mcp-screenshot.test.ts` (88)
- [x] `pnpm --filter @uploads/mcp typecheck` and `pnpm --filter @buildinternet/uploads typecheck`
- [ ] Portal Scan Tools after #670 identity + secret