### PR TITLE
fix(web): show a preview-failed state when an image won't load

### DIFF
--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -10,8 +10,13 @@
  * view switch between this image alone and a draggable before/after slider
  * (`img-comparison-slider`, a custom element — the public file page ships no
  * framework runtime and must keep it that way).
+ *
+ * A failed load (404, corrupt bytes, decode error) hides the browser's
+ * broken-image chrome and reveals MediaFallback instead.
  */
 import { compareImages, type BeforeAfterState } from "../lib/before-after-view";
+import { mediaPreviewFailedBody, MEDIA_PREVIEW_FAILED_TITLE } from "../lib/media-load";
+import MediaFallback from "./MediaFallback.astro";
 /** Vendor FOUC guard (the `rendered` class + slot-hiding rules) — imported
  * rather than hand-copied so a future minor version can't silently drift out
  * from under a stale local copy (see Task 1's read of v8.0.7's dist/styles.css). */
@@ -48,6 +53,12 @@ const counterpartUrl = compare?.src ?? null;
     <button type="button" data-size="full" aria-pressed="false">Full width</button>
   </div>
   <img class="single-image" src={src} alt={alt} decoding="async" />
+  <MediaFallback
+    pending
+    title={MEDIA_PREVIEW_FAILED_TITLE}
+    body={mediaPreviewFailedBody("image")}
+    href={src}
+  />
   {
     pair && (
       <div class="compare-wrap">
@@ -90,6 +101,7 @@ const counterpartUrl = compare?.src ?? null;
 
 <script>
   import { resolvePreviewMode, type ImagePreviewMode } from "../lib/image-preview-mode";
+  import { bindMediaLoadError } from "../lib/media-load";
 
   type CompareView = "single" | "compare";
 
@@ -208,13 +220,17 @@ const counterpartUrl = compare?.src ?? null;
 
     void initCompare(root);
 
-    const img = root.querySelector("img");
+    const img = root.querySelector<HTMLImageElement>("img.single-image");
     if (!(img instanceof HTMLImageElement)) return;
+
+    bindMediaLoadError(root, img, () => applyView(root, "single"));
+    if (root.dataset.failed === "1") return;
 
     // Page-view only — no storage, so the next tall shot still auto-picks full.
     let override: ImagePreviewMode | null = null;
 
     const sync = () => {
+      if (root.dataset.failed === "1") return;
       applyMode(
         root,
         resolvePreviewMode({
@@ -237,6 +253,7 @@ const counterpartUrl = compare?.src ?? null;
     // Imgur-style click-to-zoom: the image itself is a supplementary toggle:
     // the pill buttons above remain the visible + accessible affordance.
     img.addEventListener("click", () => {
+      if (root.dataset.failed === "1") return;
       if (root.dataset.view === "compare") return;
       override = root.dataset.mode === "full" ? "fit" : "full";
       applyMode(root, override);
@@ -263,6 +280,18 @@ const counterpartUrl = compare?.src ?? null;
     display: grid;
     place-items: center;
     overflow: hidden;
+  }
+
+  .image-preview[data-failed="1"] > .size-toggle,
+  .image-preview[data-failed="1"] > .view-toggle,
+  .image-preview[data-failed="1"] > .single-image,
+  .image-preview[data-failed="1"] > .compare-wrap {
+    display: none;
+  }
+
+  .image-preview[data-failed="1"] {
+    max-height: var(--preview-max-h);
+    cursor: default;
   }
 
   .size-toggle,

--- a/apps/web/src/components/IslandErrorBoundary.tsx
+++ b/apps/web/src/components/IslandErrorBoundary.tsx
@@ -1,0 +1,57 @@
+/**
+ * Catch a render crash inside a signed-in React island so the rest of the
+ * Astro shell (header, nav, rail) stays up. Retry remounts the child; a
+ * deterministic throw will just land here again.
+ */
+import { Component, createElement, type ErrorInfo, type ReactElement, type ReactNode } from "react";
+import { Callout } from "@uploads/ui";
+import "@uploads/ui/styles.css";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class IslandErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(
+      JSON.stringify({
+        event: "island_render_failed",
+        message: error.message,
+        component: info.componentStack?.slice(0, 500) ?? "",
+      }),
+    );
+  }
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+    return (
+      <div className="wft-status-block">
+        <Callout tone="error">
+          This panel failed to load. The rest of the page is still usable.{" "}
+          <button
+            type="button"
+            className="text-btn"
+            onClick={() => this.setState({ hasError: false })}
+          >
+            Try again
+          </button>
+        </Callout>
+      </div>
+    );
+  }
+}
+
+/** Wrap an island element so a throw paints the recovery Callout, not a blank mount. */
+export function withIslandBoundary(element: ReactElement): ReactElement {
+  return createElement(IslandErrorBoundary, null, element);
+}

--- a/apps/web/src/components/MediaFallback.astro
+++ b/apps/web/src/components/MediaFallback.astro
@@ -1,0 +1,70 @@
+---
+/**
+ * Shared empty/error shell for a media stage (public file page, gallery
+ * item, gallery grid). Used both for known non-previewable kinds and as
+ * the hidden target ImagePreview / video reveal when a load fails.
+ */
+interface Props {
+  title: string;
+  body?: string;
+  href?: string | null;
+  filename?: string;
+  /** Start hidden until `applyMediaFailure` unhides it. */
+  pending?: boolean;
+  /** Tighter padding for gallery-grid tiles. */
+  compact?: boolean;
+}
+
+const { title, body, href = null, filename, pending = false, compact = false } = Astro.props;
+---
+
+<div
+  class:list={["media-fallback", compact && "media-fallback--compact"]}
+  data-media-fallback
+  hidden={pending || undefined}
+  role="status"
+>
+  <strong>{title}</strong>
+  {body ? <span class="media-fallback__body">{body}</span> : null}
+  {
+    href ? (
+      <a href={href} rel="noopener noreferrer">
+        {filename ? `Open ${filename}` : "Open original"}
+      </a>
+    ) : null
+  }
+</div>
+
+<style>
+  .media-fallback {
+    padding: 60px 30px;
+    text-align: center;
+    color: var(--muted);
+    font: 13px/1.6 var(--mono);
+    max-width: 28rem;
+    line-height: 1.6;
+  }
+  .media-fallback--compact {
+    padding: 30px 20px;
+  }
+  .media-fallback strong {
+    display: block;
+    color: var(--fg);
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
+  .media-fallback__body {
+    display: block;
+    margin: 0 0 12px;
+    color: var(--body);
+    font: 0.92rem/1.55 var(--sans);
+    text-wrap: pretty;
+  }
+  .media-fallback a {
+    color: var(--fg);
+    overflow-wrap: anywhere;
+  }
+  .media-fallback[hidden] {
+    display: none;
+  }
+</style>

--- a/apps/web/src/components/MediaStage.astro
+++ b/apps/web/src/components/MediaStage.astro
@@ -12,7 +12,9 @@
  * (issue #299) so the stage doesn't reflow when metadata loads.
  */
 import ImagePreview from "./ImagePreview.astro";
+import MediaFallback from "./MediaFallback.astro";
 import type { BeforeAfterState } from "../lib/before-after-view";
+import { mediaPreviewFailedBody, MEDIA_PREVIEW_FAILED_TITLE } from "../lib/media-load";
 import type { MediaKind } from "../lib/public-gallery";
 
 interface Props {
@@ -43,19 +45,6 @@ const {
   compare = null,
   railId,
 } = Astro.props;
-
-// Non-video, non-image states share one fallback shell.
-const fallback =
-  kind === "file" && url
-    ? { title: "Preview unavailable" }
-    : kind === "unsupported"
-      ? { title: "Unsupported media type", body: "This file cannot be previewed inline." }
-      : kind === "missing"
-        ? {
-            title: "Removed or expired",
-            body: "This item remains in the gallery to preserve its place.",
-          }
-        : null;
 ---
 
 <figure class="stage" style="margin:0" data-media-stage>
@@ -89,19 +78,28 @@ const fallback =
             >
               Your browser cannot play this video.
             </video>
+            <MediaFallback
+              pending
+              title={MEDIA_PREVIEW_FAILED_TITLE}
+              body={mediaPreviewFailedBody("video")}
+              href={url}
+            />
           </div>
         )}
-        {fallback && (
-          <div class="fallback">
-            <strong>{fallback.title}</strong>
-            {kind === "file" && url ? (
-              <a href={url} rel="noopener noreferrer">
-                Open {filename}
-              </a>
-            ) : (
-              <span>{fallback.body}</span>
-            )}
-          </div>
+        {kind === "file" && url && (
+          <MediaFallback title="Preview unavailable" href={url} filename={filename} />
+        )}
+        {kind === "unsupported" && (
+          <MediaFallback
+            title="Unsupported media type"
+            body="This file cannot be previewed inline."
+          />
+        )}
+        {kind === "missing" && (
+          <MediaFallback
+            title="Removed or expired"
+            body="This item remains in the gallery to preserve its place."
+          />
         )}
       </div>
     )
@@ -178,20 +176,15 @@ const fallback =
   .seek-toggle button:focus-visible {
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 55%, transparent);
   }
-  .fallback {
-    padding: 60px 30px;
-    text-align: center;
-    color: var(--muted);
-    font: 13px/1.6 var(--mono);
+  .video-wrap[data-failed="1"] {
+    width: 100%;
+    line-height: normal;
+    display: grid;
+    place-items: center;
   }
-  .fallback strong {
-    display: block;
-    color: var(--fg);
-    margin-bottom: 8px;
-  }
-  .fallback a {
-    color: var(--fg);
-    overflow-wrap: anywhere;
+  .video-wrap[data-failed="1"] video,
+  .video-wrap[data-failed="1"] .seek-toggle {
+    display: none;
   }
   /* Right rail: account-shell-like section gap; content is slotted (page-scoped). */
   .details {
@@ -228,6 +221,8 @@ const fallback =
 </style>
 
 <script>
+  import { bindMediaLoadError } from "../lib/media-load";
+
   // Skip ±10s for the native player. Progressive enhancement only — without
   // JS the buttons are inert and the native controls still work.
   function bootVideoStages() {
@@ -236,6 +231,7 @@ const fallback =
       wrap.dataset.bound = "1";
       const video = wrap.querySelector("video");
       if (!video) continue;
+      bindMediaLoadError(wrap, video);
       for (const button of wrap.querySelectorAll<HTMLButtonElement>("button[data-seek]")) {
         button.addEventListener("click", () => {
           const delta = Number(button.dataset.seek);

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -100,8 +100,9 @@ function ShotThumb({
 }) {
   const name = leafName(item.key);
   const kind = shotKindFromKey(item.key);
+  const [broken, setBroken] = useState(false);
   const showLock = kind === "image" && item.url === null;
-  const showImage = kind === "image" && !!item.embedUrl;
+  const showImage = kind === "image" && !!item.embedUrl && !broken;
   // The state stays in the accessible name (and hover title) even though the
   // tile no longer wears a BEFORE/AFTER pill — the pair badge covers the
   // visual signal, and only when a counterpart actually exists.
@@ -115,11 +116,15 @@ function ShotThumb({
   const body = (
     <>
       {showImage ? (
-        <span
-          className="wsp-thumb"
-          style={{ backgroundImage: `url(${item.embedUrl})` }}
-          aria-hidden="true"
-        />
+        <span className="wsp-thumb" aria-hidden="true">
+          <img
+            src={item.embedUrl!}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            onError={() => setBroken(true)}
+          />
+        </span>
       ) : (
         <span className="wsp-thumb wsp-thumb--tile" aria-hidden="true">
           {showLock ? "🔒" : extLabel(item.key)}

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -214,13 +214,20 @@ function GridViewIcon({ className }: { className?: string }) {
 }
 
 function FileThumb({ thumb }: { thumb: ReturnType<typeof pickThumbnail> }) {
+  const [broken, setBroken] = useState(false);
   if (thumb.kind === "image") {
+    if (broken) return null;
     return (
-      <span
-        className="wft-thumb"
-        style={{ backgroundImage: `url(${thumb.src})` }}
-        aria-hidden="true"
-      />
+      <span className="wft-thumb" aria-hidden="true">
+        <img
+          className="wft-thumb__img"
+          src={thumb.src}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          onError={() => setBroken(true)}
+        />
+      </span>
     );
   }
   return (

--- a/apps/web/src/entry.ts
+++ b/apps/web/src/entry.ts
@@ -6,9 +6,16 @@
  */
 import { handle } from "@astrojs/cloudflare/handler";
 import { withMarkdownNegotiation } from "./markdown-negotiation";
+import { respondWebFetchFailure } from "./lib/web-fetch-error";
 
 export default {
   async fetch(request, env, ctx) {
-    return withMarkdownNegotiation(request, (req) => handle(req, env, ctx));
+    try {
+      return await withMarkdownNegotiation(request, (req) => handle(req, env, ctx));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(JSON.stringify({ event: "web_fetch_failed", message }));
+      return respondWebFetchFailure(request, env.ASSETS);
+    }
   },
 } satisfies ExportedHandler<Env>;

--- a/apps/web/src/lib/media-load.test.ts
+++ b/apps/web/src/lib/media-load.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyMediaFailure,
+  imageLoadFailed,
+  mediaPreviewFailedBody,
+  MEDIA_PREVIEW_FAILED_TITLE,
+} from "./media-load";
+
+describe("imageLoadFailed", () => {
+  it("is false while the image is still loading", () => {
+    expect(imageLoadFailed({ complete: false, naturalWidth: 0 })).toBe(false);
+  });
+
+  it("is false for a decoded bitmap", () => {
+    expect(imageLoadFailed({ complete: true, naturalWidth: 800 })).toBe(false);
+  });
+
+  it("is true when loading finished with no bitmap", () => {
+    expect(imageLoadFailed({ complete: true, naturalWidth: 0 })).toBe(true);
+  });
+});
+
+describe("mediaPreviewFailedBody", () => {
+  it("names the media kind in the recovery copy", () => {
+    expect(MEDIA_PREVIEW_FAILED_TITLE).toBe("Preview failed");
+    expect(mediaPreviewFailedBody("image")).toMatch(/image/);
+    expect(mediaPreviewFailedBody("video")).toMatch(/video/);
+  });
+});
+
+describe("applyMediaFailure", () => {
+  it("marks the root, unhides the fallback, and is idempotent", () => {
+    const fallback = { hidden: true };
+    const root = {
+      dataset: {} as Record<string, string>,
+      querySelector: () => fallback,
+    };
+    const asRoot = root as unknown as HTMLElement;
+    expect(applyMediaFailure(asRoot)).toBe(true);
+    expect(root.dataset.failed).toBe("1");
+    expect(fallback.hidden).toBe(false);
+    expect(applyMediaFailure(asRoot)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/media-load.ts
+++ b/apps/web/src/lib/media-load.ts
@@ -1,0 +1,66 @@
+/**
+ * Detect and surface a failed <img> / <video> load on the public media
+ * stages. The file record can be fine while the bytes 404, fail to decode,
+ * or never arrive — the browser's broken-image icon is not a UI.
+ *
+ * Direct binders (ImagePreview, MediaStage) call `bindMediaLoadError`.
+ * Gallery grid roots opt in with `data-media-load` + a hidden
+ * `[data-media-fallback]` sibling and are wired by `bindMediaFallbacks`.
+ */
+
+export const MEDIA_PREVIEW_FAILED_TITLE = "Preview failed";
+
+export function mediaPreviewFailedBody(kind: "image" | "video"): string {
+  return kind === "video"
+    ? "The file is stored, but this video could not be played."
+    : "The file is stored, but this image could not be displayed.";
+}
+
+/** True when the image has finished and produced no bitmap (error or empty). */
+export function imageLoadFailed(img: { complete: boolean; naturalWidth: number }): boolean {
+  return img.complete && img.naturalWidth === 0;
+}
+
+/** Mark the stage failed and reveal its fallback. Returns false if already marked. */
+export function applyMediaFailure(root: HTMLElement): boolean {
+  if (root.dataset.failed === "1") return false;
+  root.dataset.failed = "1";
+  const fallback = root.querySelector<HTMLElement>("[data-media-fallback]");
+  if (fallback) fallback.hidden = false;
+  return true;
+}
+
+export function bindMediaLoadError(
+  root: HTMLElement,
+  media: HTMLImageElement | HTMLVideoElement,
+  onFailed?: () => void,
+): void {
+  const fail = () => {
+    if (!applyMediaFailure(root)) return;
+    onFailed?.();
+  };
+  if (media instanceof HTMLImageElement) {
+    if (media.complete) {
+      if (imageLoadFailed(media)) fail();
+      return;
+    }
+    media.addEventListener("error", fail, { once: true });
+    return;
+  }
+  if (media.error) {
+    fail();
+    return;
+  }
+  media.addEventListener("error", fail, { once: true });
+}
+
+/** Bind every `[data-media-load]` root under `scope` that hasn't been bound yet. */
+export function bindMediaFallbacks(scope: ParentNode = document): void {
+  for (const root of scope.querySelectorAll<HTMLElement>("[data-media-load]")) {
+    if (root.dataset.mediaBound === "1") continue;
+    root.dataset.mediaBound = "1";
+    const media = root.querySelector<HTMLImageElement | HTMLVideoElement>("img, video");
+    if (!media) continue;
+    bindMediaLoadError(root, media);
+  }
+}

--- a/apps/web/src/lib/web-fetch-error.test.ts
+++ b/apps/web/src/lib/web-fetch-error.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { respondWebFetchFailure } from "./web-fetch-error";
+
+describe("respondWebFetchFailure", () => {
+  it("returns the branded 500 page for HTML navigations", async () => {
+    const assets = {
+      fetch: vi.fn(async () => new Response("<html>500</html>", { status: 200 })),
+    };
+    const res = await respondWebFetchFailure(
+      new Request("https://uploads.sh/account", {
+        headers: { accept: "text/html,application/xhtml+xml" },
+      }),
+      assets,
+    );
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe("<html>500</html>");
+    expect(assets.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("does not recurse when /500 itself fails", async () => {
+    const assets = {
+      fetch: vi.fn(async () => {
+        throw new Error("assets down");
+      }),
+    };
+    const res = await respondWebFetchFailure(
+      new Request("https://uploads.sh/500", { headers: { accept: "text/html" } }),
+      assets,
+    );
+    expect(assets.fetch).not.toHaveBeenCalled();
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe("Internal Server Error");
+  });
+
+  it("returns plain text when the client is not asking for HTML", async () => {
+    const assets = { fetch: vi.fn() };
+    const res = await respondWebFetchFailure(
+      new Request("https://uploads.sh/openapi.json", {
+        headers: { accept: "application/json" },
+      }),
+      assets,
+    );
+    expect(assets.fetch).not.toHaveBeenCalled();
+    expect(res.headers.get("content-type")).toContain("text/plain");
+  });
+});

--- a/apps/web/src/lib/web-fetch-error.ts
+++ b/apps/web/src/lib/web-fetch-error.ts
@@ -1,0 +1,30 @@
+/**
+ * Last-resort Worker error boundary for the web origin. Astro already maps
+ * page throws to 500.astro; this covers unexpected throws in the markdown
+ * wrapper or the adapter itself so a crash still returns the branded page
+ * instead of a Cloudflare 1101.
+ */
+
+export async function respondWebFetchFailure(
+  request: Request,
+  assets: { fetch: (input: RequestInfo | URL) => Promise<Response> } | undefined,
+): Promise<Response> {
+  const path = new URL(request.url).pathname;
+  const accept = request.headers.get("accept") ?? "";
+  if (path !== "/500" && accept.includes("text/html") && assets) {
+    try {
+      const page = await assets.fetch(new URL("/500", request.url));
+      return new Response(page.body, {
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: page.headers,
+      });
+    } catch {
+      // Fall through to the plain-text body.
+    }
+  }
+  return new Response("Internal Server Error", {
+    status: 500,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}

--- a/apps/web/src/pages/500.astro
+++ b/apps/web/src/pages/500.astro
@@ -2,11 +2,10 @@
 /**
  * Application error page — distinct from 404 (missing route).
  *
- * Astro builds this to dist/500.html. Today the site is fully static, so this is
- * a branded page at /500 (and a ready target if we ever map app failures here).
- * When pages move to on-demand rendering (admin dashboard, etc.), Astro will use
- * this file for SSR render failures and can pass an `error` prop — see
- * https://docs.astro.build/en/basics/astro-pages/#custom-500-error-page
+ * Astro builds this to dist/500.html (Workers ASSETS + `not_found_handling`
+ * still serve it at /500). SSR pages (`prerender = false`) also land here
+ * on a page throw. Copy stays generic — never interpolate the thrown error.
+ * @see https://docs.astro.build/en/basics/astro-pages/#custom-500-error-page
  */
 import ErrorLayout from "../layouts/ErrorLayout.astro";
 ---

--- a/apps/web/src/pages/account/workspaces/[name].astro
+++ b/apps/web/src/pages/account/workspaces/[name].astro
@@ -31,6 +31,7 @@ const tip = {
     import { resolveActiveWorkspace } from "../../../lib/workspace-browse-url";
     import { createElement } from "react";
     import { createRoot, type Root } from "react-dom/client";
+    import { withIslandBoundary } from "../../../components/IslandErrorBoundary";
 
     let filesTableRoot: Root | null = null;
 
@@ -69,7 +70,9 @@ const tip = {
       if (!document.contains(mount)) return;
       teardown();
       filesTableRoot = createRoot(mount);
-      filesTableRoot.render(createElement(WorkspaceFileTable, { apiOrigin, workspace }));
+      filesTableRoot.render(
+        withIslandBoundary(createElement(WorkspaceFileTable, { apiOrigin, workspace })),
+      );
     }
 
     // astro:page-load fires on the initial load too (same as every sibling

--- a/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
@@ -32,6 +32,7 @@ const tip = {
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
     import { createElement } from "react";
     import { createRoot, type Root } from "react-dom/client";
+    import { withIslandBoundary } from "../../../../components/IslandErrorBoundary";
 
     let screenshotsRoot: Root | null = null;
 
@@ -70,7 +71,9 @@ const tip = {
       if (!document.contains(mount)) return;
       teardown();
       screenshotsRoot = createRoot(mount);
-      screenshotsRoot.render(createElement(ScreenshotsByPath, { apiOrigin, workspace }));
+      screenshotsRoot.render(
+        withIslandBoundary(createElement(ScreenshotsByPath, { apiOrigin, workspace })),
+      );
     }
 
     // astro:page-load fires on the initial load too (same as every sibling

--- a/apps/web/src/pages/g/[id].astro
+++ b/apps/web/src/pages/g/[id].astro
@@ -3,6 +3,8 @@ import BaseHead from "../../components/BaseHead.astro";
 import GalleryReferences from "../../components/GalleryReferences.astro";
 import Brand from "../../components/Brand.astro";
 import Footer from "../../components/Footer.astro";
+import MediaFallback from "../../components/MediaFallback.astro";
+import { mediaPreviewFailedBody, MEDIA_PREVIEW_FAILED_TITLE } from "../../lib/media-load";
 import {
   applyPublicGalleryHeaders,
   fetchPublicGallery,
@@ -166,20 +168,10 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
         object-fit: contain;
         display: block;
       }
-      .fallback {
-        padding: 30px;
-        text-align: center;
-        color: var(--muted);
-        font: 13px/1.6 var(--mono);
-      }
-      .fallback strong {
-        display: block;
-        color: var(--red);
-        margin-bottom: 8px;
-      }
-      .fallback a {
-        color: var(--fg);
-        overflow-wrap: anywhere;
+      .media[data-failed="1"] img,
+      .media[data-failed="1"] video,
+      .media[data-failed="1"] .media-link {
+        display: none;
       }
       figcaption {
         padding: 14px 16px 16px;
@@ -285,70 +277,85 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
               </section>
             ) : (
               <section class="grid">
-                {gallery.items.map((item) => (
-                  <figure>
-                    <div class="media">
-                      {kind(item) === "image" && (
-                        <a
-                          class="media-link"
-                          href={itemPage(item)}
-                          aria-label={`View ${item.filename}`}
-                        >
-                          <img
-                            src={item.url!}
-                            alt={item.altText ?? item.caption ?? item.filename}
-                            loading="lazy"
-                            decoding="async"
-                          />
-                        </a>
-                      )}
-                      {kind(item) === "video" && (
-                        <video
-                          src={item.url!}
-                          poster={item.posterUrl ?? undefined}
-                          controls
-                          playsinline
-                          preload={item.posterUrl ? "none" : "metadata"}
-                          aria-describedby={`caption-${item.id}`}
-                        >
-                          Your browser cannot play this video.
-                        </video>
-                      )}
-                      {kind(item) === "file" && (
-                        <div class="fallback">
-                          <strong>Preview unavailable</strong>
-                          <a href={item.url!} rel="noopener noreferrer">
-                            Open {item.filename}
+                {gallery.items.map((item) => {
+                  const mediaKind = kind(item);
+                  const previewable = mediaKind === "image" || mediaKind === "video";
+                  return (
+                    <figure>
+                      <div class="media" data-media-load={previewable ? "" : undefined}>
+                        {mediaKind === "image" && (
+                          <a
+                            class="media-link"
+                            href={itemPage(item)}
+                            aria-label={`View ${item.filename}`}
+                          >
+                            <img
+                              src={item.url!}
+                              alt={item.altText ?? item.caption ?? item.filename}
+                              loading="lazy"
+                              decoding="async"
+                            />
                           </a>
-                        </div>
-                      )}
-                      {kind(item) === "unsupported" && (
-                        <div class="fallback">
-                          <strong>Unsupported media type</strong>
-                          <span>This item cannot be opened inline.</span>
-                        </div>
-                      )}
-                      {kind(item) === "missing" && (
-                        <div class="fallback">
-                          <strong>Removed or expired</strong>
-                          <span>This item remains in the gallery to preserve its place.</span>
-                        </div>
-                      )}
-                    </div>
-                    <figcaption id={`caption-${item.id}`}>
-                      <div class="filename">{item.filename}</div>
-                      {item.caption && <div class="caption">{item.caption}</div>}
-                      <a class="original" href={itemPage(item)}>
-                        View page
-                      </a>
-                      {item.status === "available" && kind(item) !== "unsupported" && (
-                        <a class="original" href={item.url!} rel="noopener noreferrer">
-                          Open original
+                        )}
+                        {mediaKind === "video" && (
+                          <video
+                            src={item.url!}
+                            poster={item.posterUrl ?? undefined}
+                            controls
+                            playsinline
+                            preload={item.posterUrl ? "none" : "metadata"}
+                            aria-describedby={`caption-${item.id}`}
+                          >
+                            Your browser cannot play this video.
+                          </video>
+                        )}
+                        {previewable && (
+                          <MediaFallback
+                            pending
+                            compact
+                            title={MEDIA_PREVIEW_FAILED_TITLE}
+                            body={mediaPreviewFailedBody(mediaKind === "video" ? "video" : "image")}
+                            href={item.url}
+                          />
+                        )}
+                        {mediaKind === "file" && (
+                          <MediaFallback
+                            compact
+                            title="Preview unavailable"
+                            href={item.url}
+                            filename={item.filename}
+                          />
+                        )}
+                        {mediaKind === "unsupported" && (
+                          <MediaFallback
+                            compact
+                            title="Unsupported media type"
+                            body="This item cannot be opened inline."
+                          />
+                        )}
+                        {mediaKind === "missing" && (
+                          <MediaFallback
+                            compact
+                            title="Removed or expired"
+                            body="This item remains in the gallery to preserve its place."
+                          />
+                        )}
+                      </div>
+                      <figcaption id={`caption-${item.id}`}>
+                        <div class="filename">{item.filename}</div>
+                        {item.caption && <div class="caption">{item.caption}</div>}
+                        <a class="original" href={itemPage(item)}>
+                          View page
                         </a>
-                      )}
-                    </figcaption>
-                  </figure>
-                ))}
+                        {item.status === "available" && mediaKind !== "unsupported" && (
+                          <a class="original" href={item.url!} rel="noopener noreferrer">
+                            Open original
+                          </a>
+                        )}
+                      </figcaption>
+                    </figure>
+                  );
+                })}
               </section>
             )}
             <GalleryReferences references={gallery.references} />
@@ -375,5 +382,13 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
       }
     </main>
     <Footer />
+    <script>
+      import { bindMediaFallbacks } from "../../lib/media-load";
+      function boot(): void {
+        bindMediaFallbacks(document);
+      }
+      boot();
+      document.addEventListener("astro:page-load", boot);
+    </script>
   </body>
 </html>

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1354,8 +1354,15 @@ button.wft-row {
   border-radius: 2px;
   border: 1px solid var(--line);
   flex: none;
+  overflow: hidden;
   background-size: cover;
   background-position: center;
+}
+.wft-thumb__img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 .wft-thumb--tile {
   display: grid;
@@ -1903,8 +1910,15 @@ button.wft-card__name:focus-visible {
   aspect-ratio: 4 / 3;
   border-radius: 2px;
   border: 1px solid var(--line);
+  overflow: hidden;
   background-size: cover;
   background-position: center;
+}
+.wsp-thumb img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 .wsp-thumb--tile {
   display: grid;

--- a/packages/ui/src/GalleryTile.tsx
+++ b/packages/ui/src/GalleryTile.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { useState, type ComponentPropsWithoutRef, type ReactNode } from "react";
 
 export interface GalleryTileProps extends Omit<ComponentPropsWithoutRef<"a">, "title"> {
   /** File / screenshot name shown under the thumbnail. */
@@ -34,14 +34,25 @@ export function GalleryTile({
   href = "#",
   ...rest
 }: GalleryTileProps) {
+  const [broken, setBroken] = useState(false);
+  const showImg = Boolean(src) && !broken;
   return (
     <a className={["ul-tile", className].filter(Boolean).join(" ")} href={href} {...rest}>
       <span
-        className={src ? "ul-tile__thumb" : "ul-tile__thumb ul-tile__thumb--empty"}
+        className={showImg ? "ul-tile__thumb" : "ul-tile__thumb ul-tile__thumb--empty"}
         aria-hidden="true"
       >
-        {src && <img className="ul-tile__img" src={src} alt="" loading="lazy" decoding="async" />}
-        {!src && (
+        {showImg && (
+          <img
+            className="ul-tile__img"
+            src={src}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            onError={() => setBroken(true)}
+          />
+        )}
+        {!showImg && (
           <svg viewBox="0 0 32 32" fill="none" aria-hidden="true">
             <g stroke="currentColor" strokeWidth="3.2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M8 12.5 L16 5 L24 12.5" />


### PR DESCRIPTION
## In plain terms

A corrupt or unreachable image on the public file page used to show the browser’s broken-image icon. That looks like a dead page even when the file record is fine. The stage now swaps to a preview-failed state, and a render crash in the signed-in React islands no longer blanks the rest of the shell.

![Preview failed state](https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/fix-web-broken-preview-error-state/file-preview-failed-desktop.webp)

## What it does / what it is not

- **Does:** if an image or video fails to load, hide the native chrome and show “Preview failed” with a short reason and an Open original link. Fit / Full width hide because they don’t apply.
- **Does:** use the same fallback shell for known non-previewable kinds (file / unsupported / missing) on the file page, gallery item, and gallery grid.
- **Does:** wrap the files table and screenshots islands so a render throw keeps the header, nav, and rail up.
- **Does:** serve the branded `/500` page if the Worker itself throws, instead of a Cloudflare 1101.
- **Does not:** diagnose *why* the bytes failed (corrupt upload vs CDN vs decode). The copy stays generic on purpose.
- **Does not:** change 404 / unlisted / deleted file pages. Those already had their own states.

## How to try it

The 25-byte cache probe from the original report is still live:

https://uploads.sh/f/default/gh/_cachetest/probe-1783465136.png

Locally, `pnpm dev:web` and open the same path on `http://localhost:4321` — the page talks to the production API, so the broken file is the same one.

## Technical notes

- Load failures are a client `error` (or `complete && naturalWidth === 0`) on `<img>` / `<video>`. The file record can be fine while the object 404s, fails to decode, or never arrives.
- Shared helpers live in `media-load.ts`; the visible shell is `MediaFallback.astro`. ImagePreview and MediaStage bind directly. The gallery grid uses `data-media-load` + `bindMediaFallbacks`.
- The two signed-in React mounts (`WorkspaceFileTable`, `ScreenshotsByPath`) wrap in `IslandErrorBoundary`. Other account/admin pages are vanilla JS and already have per-flow error copy.
- Thumbnail cells use `<img onError>` instead of a silent empty `background-image`.

## Test plan

- [x] `pnpm --filter @uploads/web test` (619 passing)
- [x] Opened the original 25-byte probe in a local browser: stage shows Preview failed, Fit/Full width gone, rail still works
- [x] Mobile viewport of the same page
- [x] Missing file (`/f/default/does-not-exist.png`) still shows `file.not_found`
- [x] `/500` still renders the branded application-error card
- [ ] CI lint + typecheck + test on this PR
