### PR TITLE
fix(mcp): advertise destructive metadata updates

### DIFF
--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -1069,12 +1069,12 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     {
       name: "set_metadata",
       title: "Set metadata",
-      annotations: mcpWritePublic,
+      annotations: mcpDestroyPublic,
       securitySchemes: mcpOAuthWrite,
       description:
         "Merge-set and/or delete an object's queryable custom metadata (D1 key-value pairs, not R2 provenance). `set` wins over `delete` for the same key. " +
         METADATA_DESCRIPTION +
-        " Requires at least one of `set` or `delete`. Same as `uploads meta set`.",
+        " Metadata on public objects appears on the unauthenticated public file page, so do not store secrets or sensitive data. Requires at least one of `set` or `delete`. Same as `uploads meta set`.",
       inputSchema: {
         type: "object",
         properties: {

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1509,6 +1509,11 @@ describe("modern-era (2026-07-28) requests", () => {
       destructiveHint: true,
       openWorldHint: true,
     });
+    expect(listed.find((tool) => tool.name === "set_metadata")?.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+    });
     expect(
       (listed.find((tool) => tool.name === "comment") as { outputSchema?: { properties?: object } })
         .outputSchema?.properties,


### PR DESCRIPTION
## In plain terms

ChatGPT app review reads each MCP tool's safety hints from the deployed server. The `set_metadata` tool can overwrite and delete public file metadata, so this PR advertises that destructive behavior accurately and tells callers not to store sensitive data there.

## What it does / what it is not

- Marks `set_metadata` as destructive while preserving its existing public-write classification.
- Explains that metadata on public objects appears on an unauthenticated public file page.
- Adds regression coverage for the exact annotation values in `tools/list`.
- Does not change metadata storage, authorization, or runtime mutation behavior.

## How to try it

Connect an MCP client to `https://agents.uploads.sh/mcp`, scan the tool catalog, and confirm that `set_metadata` reports `readOnlyHint: false`, `openWorldHint: true`, and `destructiveHint: true`.

## Technical notes

The submission import JSON remains a local form artifact and is not part of this PR. All hosted tools continue to declare output schemas.

## Test plan

- [x] `pnpm --filter @uploads/mcp test -- mcp.test.ts` (116 tests)
- [x] `pnpm --filter @uploads/mcp exec tsc --noEmit`
- [x] `pnpm exec oxfmt --check apps/mcp/src/tools.ts apps/mcp/test/mcp.test.ts`
- [x] Pre-commit `pnpm types` and lint-staged checks