### PR TITLE
docs(web): lead the public docs with put, not attach

### DIFF
--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -24,7 +24,38 @@ const REPO = "https://github.com/buildinternet/uploads";
       script, there is no drag-and-drop. uploads.sh fills that gap: it hosts your file at a stable
       public URL and posts it to the right place on GitHub for you.
     </p>
-    <p>The everyday flow is two commands:</p>
+    <p>
+      The everyday flow is one command, on the branch you are already on. No pull request required:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads put ./after.png</span>
+      <button type="button" data-copy="uploads put ./after.png" aria-live="polite">copy</button>
+    </div>
+    <div class="block" aria-label="Example output">
+      <pre>&gt;&gt; uploading ./after.png
+note: staged for branch feat/nav — auto-comments to pull request when opened
+(or run: uploads attach --promote once it exists)</pre>
+    </div>
+    <p>
+      Keep doing that as you work. When the PR opens, staged files land in one managed comment — via
+      the GitHub App, or the next <code>uploads attach --promote</code>. Tag a pair with&#32;
+      <code>--state before</code> and <code>--state after</code> and they render side by side. See&#32;
+      <a href="/docs/attach-pull-request-images#staging">Attach &amp; share</a> for what is queued.
+    </p>
+  </section>
+
+  <section id="before-the-pr">
+    <h2>
+      Already have a PR open? <a
+        class="anchor"
+        href="#before-the-pr"
+        aria-label="Link to this section">#</a
+      >
+    </h2>
+    <p>
+      <code>attach</code> is the direct path. The CLI finds the pull request, uploads the files, and keeps
+      one comment up to date:
+    </p>
     <div class="cmd">
       <span class="text">uploads attach ./before.png ./after.png</span>
       <button type="button" data-copy="uploads attach ./before.png ./after.png" aria-live="polite"
@@ -38,36 +69,9 @@ const REPO = "https://github.com/buildinternet/uploads";
 <span class="ok">&gt;&gt; attachments comment updated</span></pre>
     </div>
     <p>
-      That's it. The CLI figures out which repo and pull request you're on, uploads the files, and
-      keeps one managed comment on the PR up to date. Tag a pair with&#32;
-      <code>--state before</code> and <code>--state after</code> and they render side by side in that
-      comment — see&#32;
+      Same pairing works here: <code>--state before</code> and <code>--state after</code> render side
+      by side — see&#32;
       <a href="/docs/attach-pull-request-images#before-after">pair a before and after</a>.
-    </p>
-  </section>
-
-  <section id="before-the-pr">
-    <h2>
-      Start before the PR exists <a
-        class="anchor"
-        href="#before-the-pr"
-        aria-label="Link to this section">#</a
-      >
-    </h2>
-    <p>You don't need a PR open to start uploading — on a branch, it stages automatically:</p>
-    <div class="cmd">
-      <span class="text">uploads put ./after.png</span>
-      <button type="button" data-copy="uploads put ./after.png" aria-live="polite">copy</button>
-    </div>
-    <div class="block" aria-label="Example output">
-      <pre>&gt;&gt; uploading ./after.png
-note: staged for branch feat/nav — auto-comments to pull request when opened
-(or run: uploads attach --promote once it exists)</pre>
-    </div>
-    <p>
-      Keep doing that as you work and the PR opens with screenshots already attached — see&#32;
-      <a href="/docs/attach-pull-request-images#staging">Attach &amp; share</a> for the staged view that
-      shows what's queued.
     </p>
   </section>
 
@@ -95,10 +99,10 @@ note: staged for branch feat/nav — auto-comments to pull request when opened
     </p>
     <p>Prefer not to install anything? Every command works as a one-off with <code>npx</code>:</p>
     <div class="cmd">
-      <span class="text">npx @buildinternet/uploads attach ./after.png</span>
+      <span class="text">npx @buildinternet/uploads put ./after.png</span>
       <button
         type="button"
-        data-copy="npx @buildinternet/uploads attach ./after.png"
+        data-copy="npx @buildinternet/uploads put ./after.png"
         aria-live="polite">copy</button
       >
     </div>

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -89,16 +89,18 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
       Skill vs. MCP <a class="anchor" href="#skill-vs-mcp" aria-label="Link to this section">#</a>
     </h2>
     <p>
-      The <strong>skills</strong> teach the agent when and how to use the CLI — for example attaching
-      before/after screenshots to the PR it just opened, or baking callouts onto a capture with <code
+      The <strong>skills</strong> teach the agent when and how to use the CLI — for example staging a
+      before/after with <code>uploads put</code> as it works, or baking callouts onto a capture with <code
         >uploads screenshot --annotate</code
-      >. The&#32;
-      <strong>MCP server</strong> gives agents the same tools (<code>put</code>,&#32;
-      <code>attach</code>, <code>list</code>, <code>delete</code>, and more) over HTTP, using the
-      same token as the CLI. Hosted <code>put</code>/<code>comment</code> honor a repo's&#32;
-      <a href="/docs/comment-config"><code>.uploads.yml</code></a> the same way the bot does. There's
-      also a local stdio variant — register&#32;
-      <code>uploads mcp</code> with any MCP client, e.g.:
+      >. The local stdio MCP (<code>uploads mcp</code>) gives the same tools as the CLI, including
+      <code>attach</code>. The hosted MCP at <code>agents.uploads.sh</code> is for agents without a local
+      checkout: it has <code>put</code>, <code>list</code>, <code>delete</code>, and more — not <code
+        >attach</code
+      >, and no git defaults. Stage with <code>put</code> and pass the branch and repo. Hosted <code
+        >put</code
+      >/<code>comment</code> honor a repo's&#32;
+      <a href="/docs/comment-config"><code>.uploads.yml</code></a> the same way the bot does. Register
+      the local server with any MCP client, e.g.:
     </p>
     <div class="cmd">
       <span class="text">claude mcp add uploads -- uploads mcp</span>
@@ -108,7 +110,7 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
     </div>
     <div class="note">
       Want the guided version? The <a href="/github-screenshots">agent walkthrough</a> takes a coding
-      agent from install to a first before/after attachment on a PR.
+      agent from install to a first staged before/after.
     </div>
   </section>
 
@@ -123,8 +125,7 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
     <p>
       Any agent that can run a shell command can capture at each visual milestone and run a bare <code
         >uploads put ./shot.png --state before|after</code
-      > — on a branch it stages automatically (issue #403), no <code>--branch</code> flag required. A
-      bare&#32;
+      > — on a branch it stages automatically, no <code>--branch</code> flag required. A bare&#32;
       <code>uploads screenshot</code> stages the same way, carrying its derived&#32;
       <code>path</code>/<code>url</code>/<code>env</code>/<code>viewport</code> metadata through promotion.
       <code>--state</code> is still worth keeping as a habit; it's the one thing no tool can infer from

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -19,7 +19,7 @@ const TOC = [
   description="Attach screenshots and video to GitHub PRs and issues, get a public URL for any file, capture a screenshot, and bake callouts or redactions onto it with the uploads CLI."
   path="/docs/attach-pull-request-images"
   heading="Attach & share"
-  tagline="The commands that get media onto a PR, an issue, or a plain URL — capture, annotate, and attach."
+  tagline="Stage as you work with put. Attach when a PR is already open. Capture, annotate, and share a URL."
   active="attach"
   toc={TOC}
 >
@@ -28,8 +28,8 @@ const TOC = [
       Attach files to a PR <a class="anchor" href="#attach" aria-label="Link to this section">#</a>
     </h2>
     <p>
-      <code>attach</code> is the command you'll use most. From a checked-out branch with an open pull
-      request, it needs no arguments beyond the files:
+      When a pull request is already open, <code>attach</code> is the direct command. From a checked-out
+      branch it needs no arguments beyond the files:
     </p>
     <div class="cmd">
       <span class="text">uploads attach ./screenshot.png</span>
@@ -143,8 +143,8 @@ const TOC = [
       >
     </h2>
     <p>
-      Don't wait for a PR to capture something. As of issue #403, a bare <code>put</code> on a non-default
-      git branch already stages by default — no <code>--branch</code> flag needed:
+      Don't wait for a PR to capture something. A bare <code>put</code> on a non-default git branch already
+      stages by default — no <code>--branch</code> flag needed:
     </p>
     <div class="cmd">
       <span class="text">uploads put ./after.png</span>

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -14,7 +14,8 @@ const TOC = [
   { id: "problem", label: "The problem" },
   { id: "setup", label: "Install & sign in" },
   { id: "agents", label: "Teach your agent" },
-  { id: "attach", label: "Attach media" },
+  { id: "stage", label: "Stage as you go" },
+  { id: "attach", label: "PR already open" },
   { id: "video", label: "Video & everything else" },
   { id: "faq", label: "FAQ" },
 ];
@@ -34,7 +35,7 @@ const FAQ = [
   },
   {
     q: "How do I set up Claude Code to attach screenshots to its pull requests?",
-    a: "Run `uploads install` once. It installs the agent skills (attach workflow, CLI reference, and annotations) and registers the hosted MCP server with Claude Code. After that, the agent runs `uploads attach <files>` on its own when it changes something visual.",
+    a: "Run `uploads install` once. It installs the agent skills (stage-as-you-go workflow, CLI reference, and annotations) and registers the hosted MCP server with Claude Code. After that, the agent runs `uploads put <file>` on the branch as it works. When the PR opens, staged files land in one attachments comment.",
   },
   {
     q: "Can I mark up a screenshot before attaching it?",
@@ -42,7 +43,7 @@ const FAQ = [
   },
   {
     q: "Are uploaded files private?",
-    a: "No. Files are public to anyone with the URL, even media attached to private repos. Don't upload secrets or sensitive UI — use a solid redaction (`uploads annotate` / `screenshot --annotate`) when a capture shows credentials. Uploading itself requires an invite-issued workspace token.",
+    a: "No. Files are public to anyone with the URL, even media attached to private repos. Don't upload secrets or sensitive UI — use a solid redaction (`uploads annotate` / `screenshot --annotate`) when a capture shows credentials. Create your own workspace (GitHub-linked) or accept an invite from a workspace admin.",
   },
 ];
 
@@ -143,12 +144,14 @@ const FAQ_JSON_LD = JSON.stringify({
     </div>
     <ul>
       <li>
-        The <strong>agent skills</strong> teach when to attach screenshots (and when to annotate them
-        with callouts or redactions), plus the full CLI reference.
+        The <strong>agent skills</strong> teach when to capture as you go (and when to annotate with callouts
+        or redactions), plus the full CLI reference.
       </li>
       <li>
-        The <strong>MCP server</strong> offers the same tools (<code>put</code>, <code>attach</code
-        >, <code>list</code>, <code>delete</code>, …) for runtimes that prefer MCP.
+        The local stdio <strong>MCP</strong> (<code>uploads mcp</code>) matches the CLI, including
+        <code>attach</code>. Hosted MCP at <code>agents.uploads.sh</code> has <code>put</code>,
+        <code>list</code>, <code>delete</code>, and more — not <code>attach</code>, and no git
+        defaults. Stage with <code>put</code> and pass the branch and repo.
       </li>
     </ul>
     <p>Or set up each piece yourself, for other agent runtimes:</p>
@@ -172,29 +175,59 @@ const FAQ_JSON_LD = JSON.stringify({
     </div>
   </section>
 
-  <section id="attach">
+  <section id="stage">
     <h2>
-      Step 3: the agent attaches media with one command <a
+      Step 3: the agent stages screenshots as it works <a
         class="anchor"
-        href="#attach"
+        href="#stage"
         aria-label="Link to this section">#</a
       >
     </h2>
     <p>
-      From a branch with an open pull request, <code>attach</code> only needs the files. It finds the
-      PR through <code>gh</code>, uploads each file to a stable URL, and keeps one managed comment:
+      No pull request required. On a branch, a bare <code>put</code> stages the file automatically:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads put ./after.png --state after</span>
+      <button type="button" data-copy="uploads put ./after.png --state after" aria-live="polite"
+        >copy</button
+      >
+    </div>
+    <div class="block" aria-label="Example output">
+      <pre>&gt;&gt; uploading ./after.png
+note: staged for branch feat/nav — auto-comments to pull request when opened
+(or run: uploads attach --promote once it exists)</pre>
+    </div>
+    <p>
+      Keep doing that at each visual milestone. Check the queue with <code>uploads staged</code>.
+      When the PR opens, staged files promote into one managed comment — via the GitHub App, or
+      <code>uploads attach --promote</code> without the App.
+    </p>
+    <p>
+      <code>uploads screenshot</code> captures and stages the same way. Tag a pair with&#32;
+      <code>--state before</code> and <code>--state after</code> and they render side by side.
+    </p>
+    <h3>Why the URLs matter</h3>
+    <p>
+      Keys are hash-free. Upload the same filename again and every embed shows the new image at the
+      same URL within a minute. No stale screenshots.
+    </p>
+  </section>
+
+  <section id="attach">
+    <h2>
+      Already have a PR open? <a class="anchor" href="#attach" aria-label="Link to this section"
+        >#</a
+      >
+    </h2>
+    <p>
+      <code>attach</code> is the direct path. It finds the PR through <code>gh</code>, uploads each
+      file, and keeps one managed comment:
     </p>
     <div class="cmd">
       <span class="text">uploads attach ./before.png ./after.png</span>
       <button type="button" data-copy="uploads attach ./before.png ./after.png" aria-live="polite"
         >copy</button
       >
-    </div>
-    <div class="block" aria-label="Example output">
-      <pre># optimizes each image, then keeps one comment on the PR up to date
-&gt;&gt; uploading ./before.png
-&gt;&gt; uploading ./after.png
-<span class="ok">&gt;&gt; attachments comment updated</span></pre>
     </div>
     <p>Not on a PR branch? Point it somewhere:</p>
     <div class="cmd">
@@ -213,14 +246,7 @@ const FAQ_JSON_LD = JSON.stringify({
     </div>
     <p>
       Want to place the image yourself, in a PR description or README?&#32;
-      <code>--no-comment</code> prints the URL and Markdown without posting anything.&#32;
-      <code>uploads put</code> gives full control over naming and output.
-    </p>
-    <h3>Why the URLs matter</h3>
-    <p>
-      Attachments get <strong>stable keys</strong>, like&#32;
-      <code>gh/owner/repo/pull/123/shot.webp</code>. Upload the same filename again and the PR shows
-      the new image at the same URL within a minute. No stale screenshots.
+      <code>--no-comment</code> prints the URL and Markdown without posting anything.
     </p>
   </section>
 
@@ -235,10 +261,9 @@ const FAQ_JSON_LD = JSON.stringify({
       logs all upload as-is:
     </p>
     <div class="cmd">
-      <span class="text"
-        >uploads attach ./demo.mp4 <span class="cm"># linked from the comment</span></span
+      <span class="text">uploads put ./demo.mp4 <span class="cm"># stages on the branch</span></span
       >
-      <button type="button" data-copy="uploads attach ./demo.mp4" aria-live="polite">copy</button>
+      <button type="button" data-copy="uploads put ./demo.mp4" aria-live="polite">copy</button>
     </div>
     <p>
       One caveat: GitHub only plays videos it hosts itself. Outside video shows up as a&#32;


### PR DESCRIPTION
The homepage already teaches stage-as-you-go with uploads put. The docs hub and agent walkthrough still opened with attach from an open PR. This flips those pages so put on a branch is the everyday loop, attach is the PR-already-open path, and hosted MCP is no longer described as if it had attach. Copy only.