### PR TITLE
docs: treat hosted MCP as the same put-and-promote loop

### DIFF
--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -176,7 +176,7 @@ branch stage) and `promote` for the same outcomes.
 
 ### Why there is no hosted `staged` tool
 
-**Intentional (issue #405).** Local `staged` defaults branch/repo from git.
+**Intentional.** Local `staged` defaults branch/repo from git.
 Hosted has no git context. Answer the same questions with:
 
 ```text

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -96,9 +96,11 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
       <code>attach</code>. The hosted MCP at <code>agents.uploads.sh</code> is for agents without a local
       checkout: it has <code>put</code>, <code>list</code>, <code>delete</code>, and more — not <code
         >attach</code
-      >, and no git defaults. Stage with <code>put</code> and pass the branch and repo. Hosted <code
-        >put</code
-      >/<code>comment</code> honor a repo's&#32;
+      >, and no git defaults. Stage with <code>put</code> plus <code>repo</code> and <code
+        >branch</code
+      >. Once a PR exists, <code>promote</code> with <code>repo</code>, <code>pr</code>, and <code
+        >branch</code
+      >. Hosted <code>put</code>/<code>comment</code> honor a repo's&#32;
       <a href="/docs/comment-config"><code>.uploads.yml</code></a> the same way the bot does. Register
       the local server with any MCP client, e.g.:
     </p>

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -151,7 +151,10 @@ const FAQ_JSON_LD = JSON.stringify({
         The local stdio <strong>MCP</strong> (<code>uploads mcp</code>) matches the CLI, including
         <code>attach</code>. Hosted MCP at <code>agents.uploads.sh</code> has <code>put</code>,
         <code>list</code>, <code>delete</code>, and more — not <code>attach</code>, and no git
-        defaults. Stage with <code>put</code> and pass the branch and repo.
+        defaults. Stage with <code>put</code> plus <code>repo</code> and <code>branch</code>. Once a
+        PR exists, <code>promote</code> with <code>repo</code>, <code>pr</code>, and <code
+          >branch</code
+        >.
       </li>
     </ul>
     <p>Or set up each piece yourself, for other agent runtimes:</p>

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -88,8 +88,7 @@ Two tiers, pick by whether a PR already exists:
   `uploads attach shot.png`, which infers the PR from the current branch) —
   one call, stable per-PR key, embed URLs back immediately, and the managed
   comment collects that PR's media as a side effect.
-- **Advanced — stage pre-PR, before there's anything to target.** `uploads
-attach shot.png --branch` (see below) — no PR/issue needed yet; promotion
+- **Advanced — stage pre-PR, before there's anything to target.** `uploads put shot.png` on a branch (see below) — no PR/issue needed yet; promotion
   and the comment happen automatically once the PR opens, **but only for a
   repo already bound to the workspace** (see the caveat below). Reach for the
   simple tier once the PR exists unless you're deliberately building up a
@@ -97,12 +96,11 @@ attach shot.png --branch` (see below) — no PR/issue needed yet; promotion
 
 **Default loop: stage as you go, from the first visual milestone.** Don't wait
 for a PR to exist. The moment you have something worth capturing — mid-task,
-still on a branch, no PR yet — attach it right then. As of issue #403, a
-**bare `uploads put`** already does this automatically whenever you're inside
+still on a branch, no PR yet — attach it right then. A **bare `uploads put`** already does this automatically whenever you're inside
 a git repo on a non-default branch with no `--pr`/`--issue`/`--key`/`--ref`/
 `--prefix` — it stages under the same branch-keyed path `attach --branch`
 would produce, so a plain `uploads put step1-before.png --meta path=/settings
---state before` is enough. As of issue #469, **`uploads screenshot`** (with no
+--state before` is enough. **`uploads screenshot`** (with no
 `--pr`/`--issue`/`--branch` target) stages the same way, so capturing directly
 from a URL before the PR exists carries every derived fact (path/url/env/
 viewport, plus `--state`) all the way through to the PR once it opens — no

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -331,7 +331,7 @@ clean leaf. Use `--dry-run` to preview the exact public URL before uploading.
 
 Default `put` is the fast path; you don't need `--key`, `--prefix`, or `--repo`.
 **Inside a git repo, on a non-default branch, a bare `put` now stages
-automatically (issue #403)** — same key/metadata as `attach --branch`
+automatically** — same key/metadata as `attach --branch`
 (`gh/<owner>/<repo>/branch/<branch>/<filename>`), so it auto-attaches to that
 branch's PR when one opens. This fires whenever none of
 `--pr`/`--issue`/`--key`/`--ref`/`--prefix`/`--destination` is set and
@@ -354,7 +354,7 @@ uploads put ./shot.png --format markdown   # just the ![]()/<img> snippet
 uploads put ./shot.png --json              # {workspace,key,url,size,markdown}
 ```
 
-**The bare-put staging note (issue #403).** Since a bare `put` on a
+**The bare-put staging note.** Since a bare `put` on a
 non-default branch now stages by default (see above), it prints a one-line
 note confirming that instead of nudging you to do it yourself — human mode
 writes it to stderr, `--format json` adds it as an additive optional `hint`
@@ -447,11 +447,11 @@ Key options (`uploads screenshot --help` for all):
 | `--no-sidecar`                                       | Don't write the `<file>.uploads.json` sidecar alongside `--out`.                                                                                                                                                                                                                                                                                      |
 | `--no-upload`                                        | Skip hosting; requires `--out` (local file only).                                                                                                                                                                                                                                                                                                     |
 | `--key` / `--pr` / `--issue` / `--comment`           | Same destination and attachment options as `put` (see above); `--pr`/`--issue` also give a stable, hash-free key.                                                                                                                                                                                                                                     |
-| `--branch [name]`                                    | Stage against a branch, pre-PR — same key as `attach --branch` (see below); this is also what a bare `screenshot` on a non-default branch does automatically (issue #469).                                                                                                                                                                            |
+| `--branch [name]`                                    | Stage against a branch, pre-PR — same key as `attach --branch` (see below); this is also what a bare `screenshot` on a non-default branch does automatically.                                                                                                                                                                                         |
 | `--frame` / `--no-optimize` / `--gallery` / `--meta` | Same as `put` — reused from the shared upload pipeline.                                                                                                                                                                                                                                                                                               |
 
 **Inside a git repo, on a non-default branch, a bare `screenshot` now stages
-automatically too (issue #469, mirroring `put`'s issue #403 default)** — same
+automatically too** — same
 key/metadata as `--branch`/`attach --branch`
 (`gh/<owner>/<repo>/branch/<branch>/<filename>`), carrying every derived fact
 (`path`/`url`/`env`/`viewport`, plus `--state`) through to the PR once it
@@ -548,7 +548,7 @@ already-existing file have nothing to derive `path` from, so pass it
 explicitly with `--meta path=/route` — and `attach`/`put --pr`/`put --issue`
 print a `tip: add --meta path=/route so this shot is findable by page` on
 stderr (plus a JSON `hint` field) when an image lands with no `path` meta, as
-a reminder (issue #469 lever 3; respects `--quiet`).
+a reminder (respects `--quiet`).
 
 ```bash
 uploads screenshot https://app.example/settings --state before
@@ -953,7 +953,7 @@ uploads --api-url http://localhost:8787 doctor
   Claude and Codex ship the same pre-PR reminder via their plugins
   (`uploads hook pre-pr-screenshot`).
 
-  **Hosted MCP `put` comment parity (issue #392).** The hosted `put` tool
+  **Hosted MCP `put` comment parity.** The hosted `put` tool
   accepts `pr`/`issue` (mutually exclusive, mirroring the CLI's `--pr`/
   `--issue`) plus a required `repo` (`owner/name` — the hosted server has no
   git context to infer it from) to get the same stable `gh/…` key the CLI
@@ -987,7 +987,7 @@ uploads --api-url http://localhost:8787 doctor
   (same as the bot path — no separate MCP config; see
   https://uploads.sh/docs/comment-config).
 
-  **Hosted MCP: branch staging + promote.** There is still no `attach` tool
+  **Hosted MCP: branch staging + promote.** There is no `attach` tool
   on the hosted server (no filesystem paths) — use `put` instead:
 
   ```text
@@ -1003,7 +1003,7 @@ uploads --api-url http://localhost:8787 doctor
   put  { contentBase64, filename, repo: "owner/name", pr: 123, branch: "feature/x" }
   ```
 
-  **Hosted MCP: checking what's staged (issue #405).** There's no dedicated
+  **Hosted MCP: checking what's staged.** There's no dedicated
   `staged` tool on the hosted server — it has no local git context to default
   `branch` from, so it always needs the caller's own `repo`/`branch`. Answer
   "what's staged?" with the existing tools instead:


### PR DESCRIPTION
Hosted MCP is the same product loop as the CLI: put with repo and branch to stage, promote once a PR exists. The site and skills now say that outright, and leftover issue-number asides are gone.