### PR TITLE
fix: keep pre-PR hooks silent when the CLI is missing

### DIFF
--- a/.changeset/hook-missing-cli-noop.md
+++ b/.changeset/hook-missing-cli-noop.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Pre-PR screenshot hooks no-op silently when the `uploads` CLI is not on PATH.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -324,5 +324,6 @@ covers callouts and redaction (`uploads annotate` /
 The same install step also wires a fail-open pre-PR screenshot reminder for
 **Grok** and **Cursor** when those tools are present. **Claude Code** and
 **Codex** get that reminder from their plugins instead (both run
-`uploads hook pre-pr-screenshot`). Public walkthrough:
+`uploads hook pre-pr-screenshot` when the CLI is on `PATH`, and stay silent
+if it is not). Public walkthrough:
 [uploads.sh/docs/agents](https://uploads.sh/docs/agents).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uploads hook pre-pr-screenshot",
+            "command": "if command -v uploads >/dev/null 2>&1; then uploads hook pre-pr-screenshot; fi",
             "timeout": 15,
             "statusMessage": "Checking staged screenshots"
           }

--- a/packages/uploads/src/commands/hook.ts
+++ b/packages/uploads/src/commands/hook.ts
@@ -22,6 +22,7 @@ Usage:
   uploads hook pre-pr-screenshot
 
 Invoked by Claude Code / Codex / Grok / Cursor hooks. Never blocks.
+Harness manifests no-op (exit 0, no output) when this binary is not on PATH.
 
   pre-pr-screenshot
     If the shell command is \`gh pr create\`, the branch touches UI files, and

--- a/packages/uploads/src/commands/install.ts
+++ b/packages/uploads/src/commands/install.ts
@@ -8,7 +8,12 @@ import {
 import { resolveConfig } from "../config.js";
 import { execRunner, type CommandRunner } from "../github-gh.js";
 import { writeCommandHelp } from "../cli-style.js";
-import { HOOK_COMMAND, installHookManifests, type HookWriteResult } from "../hooks-install.js";
+import {
+  HOOK_COMMAND,
+  HOOK_INVOCATION,
+  installHookManifests,
+  type HookWriteResult,
+} from "../hooks-install.js";
 
 export const DEFAULT_MCP_URL = "https://agents.uploads.sh/mcp";
 const SKILL_SOURCE = "buildinternet/uploads";
@@ -23,7 +28,7 @@ hook for Grok / Cursor when those tools are present. The remote MCP endpoint
 infers your workspace from the bearer token, so only the token is needed.
 
 Claude Code and Codex ship the same reminder via their plugins (same command:
-\`${HOOK_COMMAND}\`) — install those plugins instead of relying on this step.
+\`${HOOK_INVOCATION}\`) — install those plugins instead of relying on this step.
 
 Safe to re-run. An MCP server already registered under this name is reported
 as \`already configured\` and left as-is — including the token it was created

--- a/packages/uploads/src/hooks-install.ts
+++ b/packages/uploads/src/hooks-install.ts
@@ -2,17 +2,26 @@
  * Install thin user-global hook manifests for Grok and Cursor.
  *
  * Claude and Codex ship the same PreToolUse hook via their plugins
- * (`hooks/hooks.json` → `uploads hook pre-pr-screenshot`). Do not also write
+ * (`hooks/hooks.json` → HOOK_COMMAND). Do not also write
  * ~/.codex/hooks.json here, or the reminder would fire twice.
  *
  * Idempotent: skip when our command string is already present.
+ * An older bare `uploads hook …` entry is upgraded in place.
  */
 
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-export const HOOK_COMMAND = "uploads hook pre-pr-screenshot";
+/** What the harness actually runs once `uploads` is on PATH. */
+export const HOOK_INVOCATION = "uploads hook pre-pr-screenshot";
+
+/**
+ * Fail-open shell used in every harness manifest.
+ * A missing `uploads` binary is a silent no-op (exit 0, no stderr) so plugin
+ * users without the CLI do not get a hook-failure annotation on every shell tool.
+ */
+export const HOOK_COMMAND = `if command -v uploads >/dev/null 2>&1; then ${HOOK_INVOCATION}; fi`;
 const TIMEOUT_SEC = 15;
 
 const GROK_PAYLOAD = {
@@ -47,6 +56,17 @@ function containsCommand(filePath: string): boolean {
   } catch {
     return false;
   }
+}
+
+function hookCommandOf(entry: unknown): string | undefined {
+  if (!entry || typeof entry !== "object") return undefined;
+  const command = (entry as { command?: unknown }).command;
+  return typeof command === "string" ? command : undefined;
+}
+
+function isOurHookEntry(entry: unknown): boolean {
+  const command = hookCommandOf(entry);
+  return Boolean(command?.includes(HOOK_INVOCATION));
 }
 
 function writeJson(filePath: string, value: unknown): void {
@@ -98,7 +118,16 @@ function mergeCursor(home: string, dryRun: boolean): HookWriteResult {
       ? ({ ...(existing.hooks as object) } as Record<string, unknown>)
       : {};
   const list = Array.isArray(hooks.beforeShellExecution) ? [...hooks.beforeShellExecution] : [];
-  list.push({ command: HOOK_COMMAND, timeout: TIMEOUT_SEC });
+  const ours = list.findIndex(isOurHookEntry);
+  const nextEntry = { command: HOOK_COMMAND, timeout: TIMEOUT_SEC };
+  if (ours >= 0) {
+    if (hookCommandOf(list[ours]) === HOOK_COMMAND) {
+      return { path: filePath, action: "skipped" };
+    }
+    list[ours] = { ...(list[ours] as object), ...nextEntry };
+  } else {
+    list.push(nextEntry);
+  }
   hooks.beforeShellExecution = list;
   existing.hooks = hooks;
   if (existing.version === undefined) existing.version = 1;

--- a/packages/uploads/test/hooks-install.test.ts
+++ b/packages/uploads/test/hooks-install.test.ts
@@ -1,8 +1,9 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { HOOK_COMMAND, installHookManifests } from "../src/hooks-install.js";
+import { HOOK_COMMAND, HOOK_INVOCATION, installHookManifests } from "../src/hooks-install.js";
 
 const temps: string[] = [];
 
@@ -70,5 +71,52 @@ describe("installHookManifests", () => {
     expect(fs.existsSync(path.join(home, ".grok", "hooks", "uploads-pre-pr-screenshot.json"))).toBe(
       false,
     );
+  });
+
+  it("upgrades a Grok file that still has the bare invocation", () => {
+    const home = tempHome();
+    const file = path.join(home, ".grok", "hooks", "uploads-pre-pr-screenshot.json");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({ command: HOOK_INVOCATION }), "utf8");
+    expect(installHookManifests({ home })[0]!.action).toBe("merged");
+    expect(fs.readFileSync(file, "utf8")).toContain(HOOK_COMMAND);
+    expect(installHookManifests({ home })[0]!.action).toBe("skipped");
+  });
+
+  it("replaces a Cursor bare invocation instead of adding a second hook", () => {
+    const home = tempHome();
+    const file = path.join(home, ".cursor", "hooks.json");
+    fs.mkdirSync(path.join(home, ".cursor"));
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        version: 1,
+        hooks: { beforeShellExecution: [{ command: HOOK_INVOCATION, timeout: 15 }] },
+      }),
+    );
+    expect(installHookManifests({ home, targets: ["cursor"] })[0]!.action).toBe("merged");
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as {
+      hooks: { beforeShellExecution: Array<{ command: string }> };
+    };
+    expect(parsed.hooks.beforeShellExecution).toHaveLength(1);
+    expect(parsed.hooks.beforeShellExecution[0]!.command).toBe(HOOK_COMMAND);
+  });
+
+  it("shared hooks.json uses the fail-open command", () => {
+    const file = path.join(import.meta.dirname, "../../../hooks/hooks.json");
+    expect(fs.readFileSync(file, "utf8")).toContain(HOOK_COMMAND);
+  });
+
+  it("is a silent no-op when uploads is not on PATH", () => {
+    const emptyPath = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-empty-path-"));
+    temps.push(emptyPath);
+    const result = spawnSync("/bin/sh", ["-c", HOOK_COMMAND], {
+      env: { ...process.env, PATH: emptyPath },
+      encoding: "utf8",
+      timeout: 5_000,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
   });
 });

--- a/plugins/claude/uploads/README.md
+++ b/plugins/claude/uploads/README.md
@@ -23,11 +23,10 @@ Plugin skills and commands are namespaced (`/uploads:…`).
 ## Pre-PR screenshot reminder
 
 Shared hook config: [`hooks/hooks.json`](../../../hooks/hooks.json). Runs
-`uploads hook pre-pr-screenshot` on shell `PreToolUse`. Fail-open; disable with
-`UPLOADS_HOOK_DISABLE=1`. Same file is used by the Codex plugin. Grok and Cursor
-get the same command via `uploads install hooks`.
-
-Requires the `uploads` CLI on `PATH`.
+`uploads hook pre-pr-screenshot` on shell `PreToolUse` when the CLI is on
+`PATH`. If `uploads` is missing, the hook exits 0 and stays silent. Fail-open;
+disable with `UPLOADS_HOOK_DISABLE=1`. Same file is used by the Codex plugin.
+Grok and Cursor get the same command via `uploads install hooks`.
 
 ## Install
 

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -8,7 +8,7 @@ Ships the checked-in skills, the hosted MCP server in
 pre-PR hook in [`hooks/hooks.json`](../../hooks/hooks.json)
 (`uploads hook pre-pr-screenshot`). Portal paste-ins (test cases, annotation
 justifications) live in [submission.md](submission.md).
-The hook requires the `uploads` CLI on `PATH`. After enabling the plugin, open
-`/hooks` once and trust the hook if Codex asks.
+If the `uploads` CLI is not on `PATH`, the hook exits 0 and stays silent.
+After enabling the plugin, open `/hooks` once and trust the hook if Codex asks.
 
 Disable the reminder with `UPLOADS_HOOK_DISABLE=1`.

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -951,7 +951,8 @@ uploads --api-url http://localhost:8787 doctor
   per-item results. `uploads install` sets up this skill + hosted MCP +
   Grok/Cursor hooks (short progress; `--verbose` / `--dry-run` available).
   Claude and Codex ship the same pre-PR reminder via their plugins
-  (`uploads hook pre-pr-screenshot`).
+  (`uploads hook pre-pr-screenshot`). The hook is a silent no-op when the
+  CLI is not on `PATH`.
 
   **Hosted MCP `put` comment parity.** The hosted `put` tool
   accepts `pr`/`issue` (mutually exclusive, mirroring the CLI's `--pr`/


### PR DESCRIPTION
## In plain terms

Installing the Claude or Codex plugin (or running `uploads install hooks`) registered a pre-PR screenshot reminder that shells out to `uploads`. If the CLI was not on `PATH`, every shell tool recorded a hook failure. The hook now checks for the binary first and stays silent when it is missing.

## What it does / what it is not

- Shared hook command is now `if command -v uploads >/dev/null 2>&1; then uploads hook pre-pr-screenshot; fi` (exit 0, no output when the CLI is absent).
- `uploads install hooks` upgrades an older bare command in place instead of adding a second hook.
- Not a change to the reminder itself. If the CLI is present, behavior is unchanged.
- Not a new install path. Claude/Codex still come from the plugin; Grok/Cursor still come from `uploads install hooks`.

## How to try it

Already installed the Grok or Cursor hook? Re-run install so the wrapper replaces the old command:

```bash
uploads install hooks
```

Claude and Codex pick up `hooks/hooks.json` from the plugin. Confirm a missing binary is silent:

```bash
PATH=/tmp/empty if command -v uploads >/dev/null 2>&1; then uploads hook pre-pr-screenshot; fi
echo $?
```

That should print `0` and nothing else.

## Technical notes

`HOOK_COMMAND` is the fail-open wrapper; `HOOK_INVOCATION` stays the inner `uploads hook pre-pr-screenshot` used in help text and upgrade detection.

## Test plan

- [x] `vitest run test/hooks-install.test.ts test/hook-pre-pr-screenshot.test.ts test/install.test.ts`
- [x] Wrapper exits 0 with empty stdout/stderr when `uploads` is not on `PATH`
- [x] Grok/Cursor manifests with the old bare command are upgraded, not duplicated
- [ ] CI lint + test