### PR TITLE
docs: fix the preview delete invocation

### DIFF
--- a/docs/previews.md
+++ b/docs/previews.md
@@ -62,8 +62,9 @@ npx wrangler preview        # preview name defaults to the git branch
 
 The output prints two URLs: the Preview URL (tracks the latest deployment for
 that name) and an immutable per-deployment URL. Clean up with
-`wrangler preview delete <name>` — the account caps active previews per
-worker, evicting the least-recently deployed first.
+`wrangler preview delete --name <name> -y` (the name is a flag, not a
+positional — bare `delete <name>` prints help) — the account caps active
+previews per worker, evicting the least-recently deployed first.
 
 **Schema-changing branches.** The shared `uploads-preview` D1 serves every
 open preview, so applying a branch's migration migrates it for all of them.


### PR DESCRIPTION
Follow-up to #683. The playbook's cleanup command, `wrangler preview delete <name>`, just prints help — the name is a flag, not a positional. Verified on wrangler 4.110 while deleting the demo preview:

```
npx wrangler preview delete --name previews-adoption-test -y
✨ Preview "previews-adoption-test" deleted successfully.
```

One line changed in docs/previews.md.
