### PR TITLE
feat: read-only API tokens, last-used, and less layout jump

### DIFF
--- a/.changeset/api-token-read-only-last-used.md
+++ b/.changeset/api-token-read-only-last-used.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads config` help no longer mentions a separate API key. Workspace tokens are `up_<workspace>_…`.

--- a/apps/api/migrations/20260817180000_token_last_used.sql
+++ b/apps/api/migrations/20260817180000_token_last_used.sql
@@ -1,0 +1,4 @@
+-- Last-used stamp for issued tokens on /account/developers. Nullable: unused
+-- tokens and rows minted before this migration stay NULL. Touched on a
+-- successful auth, at most once an hour (see touchTokenLastUsed).
+ALTER TABLE auth_tokens ADD COLUMN last_used_at TEXT;

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -1,6 +1,6 @@
 import { ForbiddenError, UnauthorizedError } from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
-import { findActiveToken, isOperatorScope } from "./auth-db";
+import { findActiveToken, isOperatorScope, touchTokenLastUsed } from "./auth-db";
 import { hexToBytes, sha256Hex, workspaceNameFromToken } from "./workspace";
 
 const READ_METHODS = new Set(["GET", "HEAD"]);
@@ -41,6 +41,7 @@ export const adminAuth: MiddlewareHandler<{
 
   const record = await findActiveToken(c.env.DB, workspace, token);
   if (!record) throw new UnauthorizedError();
+  await touchTokenLastUsed(c.env.DB, record.id);
 
   // record.scopes is operator-token-or-file-token JSON; parseScopes (auth-db.ts)
   // is file-scope-only, so parse directly here and keep just the operator ones.

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -34,6 +34,11 @@ export function isWorkspaceScope(value: unknown): value is WorkspaceScope {
 export const DEFAULT_ENROLLMENT_SECONDS = 2 * 60 * 60;
 export const DEFAULT_TOKEN_SECONDS = 90 * 24 * 60 * 60;
 export const MAX_TOKEN_SECONDS = 365 * 24 * 60 * 60;
+/** How stale last_used_at must be before a successful auth rewrites it. */
+export const LAST_USED_TOUCH_SECONDS = 60 * 60;
+
+const TOKEN_COLUMNS = `id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
+              minting_user_id, last_used_at`;
 
 export interface AuthTokenRecord {
   id: string;
@@ -47,6 +52,7 @@ export interface AuthTokenRecord {
   // Better Auth user id that minted this token (POST /v1/tokens), or null for
   // enrollment-code tokens and rows created before the Phase 4 migration.
   minting_user_id: string | null;
+  last_used_at: string | null;
 }
 
 interface EnrollmentRecord {
@@ -118,8 +124,7 @@ export async function findActiveToken(
   const hash = await sha256Hex(rawToken);
   return db
     .prepare(
-      `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
-              minting_user_id
+      `SELECT ${TOKEN_COLUMNS}
        FROM auth_tokens
        WHERE workspace = ? AND token_hash = ? AND revoked_at IS NULL
          AND (expires_at IS NULL OR expires_at > ?)
@@ -155,6 +160,7 @@ export async function createToken(
     expires_at: input.expiresAt?.toISOString() ?? null,
     revoked_at: null,
     minting_user_id: input.mintedByUserId ?? null,
+    last_used_at: null,
   };
   await db
     .prepare(
@@ -311,11 +317,9 @@ export async function listTokens(
   const result = await db
     .prepare(
       includeRevoked
-        ? `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
-                  minting_user_id
+        ? `SELECT ${TOKEN_COLUMNS}
            FROM auth_tokens WHERE workspace = ? ORDER BY created_at ASC`
-        : `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
-                  minting_user_id
+        : `SELECT ${TOKEN_COLUMNS}
            FROM auth_tokens WHERE workspace = ? AND revoked_at IS NULL ORDER BY created_at ASC`,
     )
     .bind(workspace)
@@ -380,8 +384,7 @@ export async function listTokensForMintingUser(
   if (!userId) return [];
   const result = await db
     .prepare(
-      `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
-              minting_user_id
+      `SELECT ${TOKEN_COLUMNS}
        FROM auth_tokens
        WHERE minting_user_id = ? AND revoked_at IS NULL
          AND (expires_at IS NULL OR expires_at > ?)
@@ -406,8 +409,7 @@ export async function findTokenForMintingUser(
   const iso = now.toISOString();
   const match = await db
     .prepare(
-      `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
-              minting_user_id
+      `SELECT ${TOKEN_COLUMNS}
        FROM auth_tokens
        WHERE id = ? AND minting_user_id = ? AND revoked_at IS NULL
        LIMIT 1`,
@@ -436,4 +438,26 @@ export async function revokeTokenForMintingUser(
     .bind(now.toISOString(), match.id, userId)
     .run();
   return match;
+}
+
+/**
+ * Stamp last_used_at on a successful auth. No-ops when the column was
+ * written in the last hour so a busy token does not pay a D1 write per request.
+ */
+export async function touchTokenLastUsed(
+  db: D1Database,
+  tokenId: string,
+  now = new Date(),
+): Promise<void> {
+  if (!tokenId) return;
+  const iso = now.toISOString();
+  const staleBefore = new Date(now.getTime() - LAST_USED_TOUCH_SECONDS * 1000).toISOString();
+  await db
+    .prepare(
+      `UPDATE auth_tokens SET last_used_at = ?
+       WHERE id = ? AND revoked_at IS NULL
+         AND (last_used_at IS NULL OR last_used_at < ?)`,
+    )
+    .bind(iso, tokenId, staleBefore)
+    .run();
 }

--- a/apps/api/src/routes/admin-scoped-token.test.ts
+++ b/apps/api/src/routes/admin-scoped-token.test.ts
@@ -9,6 +9,7 @@ const ADMIN_TOKEN = "test-admin-token";
 const MIGRATIONS = [
   "migrations/20260710120000_auth.sql",
   "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
 ];
 
 const RECORD = {

--- a/apps/api/src/routes/admin-ui-metrics.test.ts
+++ b/apps/api/src/routes/admin-ui-metrics.test.ts
@@ -11,6 +11,7 @@ const MIGRATIONS = [
   "migrations/20260710120000_auth.sql",
   "migrations/20260710140000_workspace_usage.sql",
   "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
   "migrations/20260728120000_daily_metrics.sql",
 ];
 const ADMIN_USER = { id: "u-admin", email: "admin@b.com", name: "Admin", role: "admin" };

--- a/apps/api/src/routes/admin-workspace-required.test.ts
+++ b/apps/api/src/routes/admin-workspace-required.test.ts
@@ -22,6 +22,7 @@ const ADMIN_TOKEN = "test-admin-token";
 const MIGRATIONS = [
   "migrations/20260710120000_auth.sql",
   "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
 ];
 
 const RECORD = {

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -495,6 +495,7 @@ const OWN_TOKEN: {
   expires_at: string;
   revoked_at: string | null;
   minting_user_id: string;
+  last_used_at: string | null;
 } = {
   id: "tok-1",
   workspace: "acme",
@@ -505,6 +506,7 @@ const OWN_TOKEN: {
   expires_at: "2026-11-01T00:00:00.000Z",
   revoked_at: null,
   minting_user_id: USER.id,
+  last_used_at: "2026-08-17T12:00:00.000Z",
 };
 
 function issuedDb(tokens: (typeof OWN_TOKEN)[]) {
@@ -581,6 +583,7 @@ describe("GET /v1/tokens/issued", () => {
           scopes: ["files:read", "files:write"],
           createdAt: OWN_TOKEN.created_at,
           expiresAt: OWN_TOKEN.expires_at,
+          lastUsedAt: OWN_TOKEN.last_used_at,
         },
       ],
     });

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -270,6 +270,7 @@ export const tokens = new Hono<SessionVars>()
       scopes: parseIssuedScopes(token.scopes),
       createdAt: token.created_at,
       expiresAt: token.expires_at,
+      lastUsedAt: token.last_used_at,
     }));
     return c.json({ tokens: issued });
   })

--- a/apps/api/src/routes/workspace-governance-invite.test.ts
+++ b/apps/api/src/routes/workspace-governance-invite.test.ts
@@ -14,6 +14,7 @@ import { workspaces } from "./workspaces";
 const MIGRATIONS = [
   "migrations/20260710120000_auth.sql",
   "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
 ];
 
 const MINTER_ID = "user-minter-1";

--- a/apps/api/src/routes/workspace-governance-tokens.test.ts
+++ b/apps/api/src/routes/workspace-governance-tokens.test.ts
@@ -15,6 +15,7 @@ import { workspaces } from "./workspaces";
 const MIGRATIONS = [
   "migrations/20260710120000_auth.sql",
   "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
 ];
 
 const USER = { id: "u1", email: "z@x.com", name: "Zach" };

--- a/apps/api/src/routes/workspaces.test.ts
+++ b/apps/api/src/routes/workspaces.test.ts
@@ -11,6 +11,7 @@ const USER = { id: "u1", email: "z@x.com", name: "Zach" };
 const MIGRATIONS = [
   "migrations/20260710120000_auth.sql",
   "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
 ];
 
 interface EnvOpts {

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -6,6 +6,7 @@ import {
   findActiveToken,
   isWorkspaceScope,
   parseScopes,
+  touchTokenLastUsed,
   type FileScope,
   type WorkspaceScope,
 } from "./auth-db";
@@ -423,6 +424,7 @@ function workspaceAuthWith(
     c.set("authSource", d1Token ? "d1" : "legacy");
     // Uploader attribution (issue #340) — null for legacy/enrollment tokens.
     c.set("mintingUserId", d1Token?.minting_user_id ?? null);
+    if (d1Token) await touchTokenLastUsed(c.env.DB, d1Token.id);
     await next();
   };
 }
@@ -530,6 +532,7 @@ export function workspaceGovernanceAuth(scope: WorkspaceScope): MiddlewareHandle
     if (!scopes.has(scope)) throw new ForbiddenError();
 
     c.set("governanceMintingUserId", record.minting_user_id);
+    await touchTokenLastUsed(c.env.DB, record.id);
     await next();
   };
 }

--- a/apps/api/test/auth-db.test.ts
+++ b/apps/api/test/auth-db.test.ts
@@ -7,6 +7,7 @@ import {
   findActiveToken,
   findEnrollmentPage,
   parseScopes,
+  touchTokenLastUsed,
 } from "../src/auth-db";
 
 type Row = Record<string, unknown>;
@@ -258,5 +259,30 @@ describe("D1 enrollment exchange", () => {
 
     expect(await exchangeEnrollment(database(fake), enrollment.code, later)).toBeNull();
     expect(await exchangeEnrollment(database(fake), "upe_unknown", later)).toBeNull();
+  });
+});
+
+describe("touchTokenLastUsed", () => {
+  it("stamps last_used_at when the row is stale or unused", async () => {
+    const updates: unknown[][] = [];
+    const db = {
+      prepare() {
+        return {
+          bind(...values: unknown[]) {
+            return {
+              run: async () => {
+                updates.push(values);
+                return { meta: { changes: 1 } };
+              },
+            };
+          },
+        };
+      },
+    } as unknown as D1Database;
+    const now = new Date("2026-08-17T12:00:00.000Z");
+    await touchTokenLastUsed(db, "tok-1", now);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.[0]).toBe(now.toISOString());
+    expect(updates[0]?.[1]).toBe("tok-1");
   });
 });

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -121,6 +121,14 @@ beforeEach(async () => {
       "utf8",
     ),
   );
+  db.exec(
+    readFileSync(
+      fileURLToPath(
+        new NodeURL("../migrations/20260817180000_token_last_used.sql", import.meta.url),
+      ),
+      "utf8",
+    ),
+  );
   // Task 2: putObject/deleteObject (exercised via fileRequest below) now
   // read/write `file_metadata` on every put/delete.
   db.exec(

--- a/apps/api/test/routes-workspace-galleries.test.ts
+++ b/apps/api/test/routes-workspace-galleries.test.ts
@@ -143,6 +143,7 @@ beforeEach(async () => {
   db.exec(migration("20260710140000_workspace_usage.sql"));
   db.exec(migration("20260711180000_galleries.sql"));
   db.exec(migration("20260712230000_token_minting_user.sql"));
+  db.exec(migration("20260817180000_token_last_used.sql"));
   db.exec(migration("20260713210559_file_metadata.sql"));
   db.exec(migration("20260728120000_daily_metrics.sql"));
   bucket = new FakeR2Bucket();

--- a/apps/api/test/routes-workspace-members.test.ts
+++ b/apps/api/test/routes-workspace-members.test.ts
@@ -19,6 +19,7 @@ import { SqliteD1, database } from "./helpers/sqlite-d1";
 const MIGRATIONS = [
   "migrations/20260710120000_auth.sql",
   "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
 ];
 
 const ADMIN = { id: "u-admin", email: "admin@example.com", name: "Admin" };

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -281,6 +281,9 @@ export class UsageFakeD1 {
           });
           return { success: true as const, meta: { changes: 1 }, results: [] };
         }
+        if (normalized.startsWith("UPDATE auth_tokens SET last_used_at")) {
+          return { success: true as const, meta: { changes: 1 }, results: [] };
+        }
         throw new Error(`unsupported run: ${normalized}`);
       },
     };

--- a/apps/mcp/test/mcp-repo-link-status.test.ts
+++ b/apps/mcp/test/mcp-repo-link-status.test.ts
@@ -93,6 +93,9 @@ function makeDb(links: RepoLinksTable, scopedToken?: { tokenHash: string; scopes
           }
           return null as T;
         },
+        async run() {
+          return { success: true, meta: { changes: 1 }, results: [] };
+        },
       };
       return stmt;
     },

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -999,10 +999,18 @@ describe("parseIssuedWorkspaceTokens", () => {
     scopes: ["files:read", "files:write"],
     createdAt: "2026-08-01T00:00:00.000Z",
     expiresAt: "2026-11-01T00:00:00.000Z",
+    lastUsedAt: "2026-08-17T12:00:00.000Z",
   };
 
   it("reads the GET /v1/tokens/issued envelope", () => {
     expect(parseIssuedWorkspaceTokens({ tokens: [row] })).toEqual([row]);
+  });
+
+  it("treats a missing lastUsedAt as null", () => {
+    const { lastUsedAt: _dropped, ...withoutUsed } = row;
+    expect(parseIssuedWorkspaceTokens({ tokens: [withoutUsed] })).toEqual([
+      { ...withoutUsed, lastUsedAt: null },
+    ]);
   });
 
   it("returns null for a malformed payload", () => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1110,6 +1110,7 @@ export interface IssuedWorkspaceToken {
   scopes: string[];
   createdAt: string;
   expiresAt: string | null;
+  lastUsedAt: string | null;
 }
 
 export type MintWorkspaceTokenResult =
@@ -1145,6 +1146,7 @@ function asIssuedWorkspaceToken(value: unknown): IssuedWorkspaceToken | null {
     scopes: row.scopes,
     createdAt: row.createdAt,
     expiresAt: row.expiresAt ?? null,
+    lastUsedAt: typeof row.lastUsedAt === "string" ? row.lastUsedAt : null,
   };
 }
 
@@ -1176,14 +1178,23 @@ export function parseIssuedWorkspaceTokens(body: unknown): IssuedWorkspaceToken[
   return out;
 }
 
+function sessionFetchInit(cookie?: string): RequestInit {
+  return {
+    credentials: "include",
+    cache: "no-store",
+    ...(cookie ? { headers: { cookie } } : {}),
+  };
+}
+
 /** GET /v1/tokens — workspaces the signed-in user can mint a token for. */
 export async function listMintableWorkspaces(
   apiOrigin: string,
+  opts?: { cookie?: string },
 ): Promise<MintableWorkspace[] | null> {
-  const result = await fetchWithTimeout(`${trimOrigin(apiOrigin)}/v1/tokens`, {
-    credentials: "include",
-    cache: "no-store",
-  });
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/v1/tokens`,
+    sessionFetchInit(opts?.cookie),
+  );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = await result.response.json().catch(() => undefined);
   return parseMintableWorkspaces(body);
@@ -1192,11 +1203,12 @@ export async function listMintableWorkspaces(
 /** GET /v1/tokens/issued — tokens this session user minted. */
 export async function listIssuedWorkspaceTokens(
   apiOrigin: string,
+  opts?: { cookie?: string },
 ): Promise<IssuedWorkspaceToken[] | null> {
-  const result = await fetchWithTimeout(`${trimOrigin(apiOrigin)}/v1/tokens/issued`, {
-    credentials: "include",
-    cache: "no-store",
-  });
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/v1/tokens/issued`,
+    sessionFetchInit(opts?.cookie),
+  );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = await result.response.json().catch(() => undefined);
   return parseIssuedWorkspaceTokens(body);
@@ -1205,7 +1217,12 @@ export async function listIssuedWorkspaceTokens(
 /** POST /v1/tokens — mint a `up_<workspace>_` token. Secret is returned once. */
 export async function mintWorkspaceToken(
   apiOrigin: string,
-  input: { workspace: string; label?: string; ttlSeconds?: number | null },
+  input: {
+    workspace: string;
+    label?: string;
+    ttlSeconds?: number | null;
+    scopes?: string[];
+  },
 ): Promise<MintWorkspaceTokenResult> {
   const result = await fetchWithTimeout(`${trimOrigin(apiOrigin)}/v1/tokens`, {
     method: "POST",
@@ -1213,7 +1230,12 @@ export async function mintWorkspaceToken(
     cache: "no-store",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      grants: [{ workspace: input.workspace }],
+      grants: [
+        {
+          workspace: input.workspace,
+          ...(input.scopes ? { scopes: input.scopes } : {}),
+        },
+      ],
       ...(input.label ? { label: input.label } : {}),
       ...(input.ttlSeconds !== undefined ? { ttlSeconds: input.ttlSeconds } : {}),
     }),

--- a/apps/web/src/lib/developers-ui.test.ts
+++ b/apps/web/src/lib/developers-ui.test.ts
@@ -26,5 +26,7 @@ describe("renderIssuedTokenListHtml", () => {
     expect(html).toMatch(/no expiry/);
     expect(html).toMatch(/last used 2026-08-17/);
     expect(html).toMatch(/data-token-id="tok-1"/);
+    expect(html).toMatch(/data-revoke-label="ci"/);
+    expect(html).toMatch(/data-revoke-workspace="acme"/);
   });
 });

--- a/apps/web/src/lib/developers-ui.test.ts
+++ b/apps/web/src/lib/developers-ui.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { renderIssuedTokenListHtml, tokenAccessLabel } from "./developers-ui";
+
+describe("tokenAccessLabel", () => {
+  it("calls out read-only and stays quiet for the default read+write grant", () => {
+    expect(tokenAccessLabel(["files:read"])).toBe("read-only");
+    expect(tokenAccessLabel(["files:read", "files:write"])).toBe("");
+  });
+});
+
+describe("renderIssuedTokenListHtml", () => {
+  it("renders the empty state and a used read-only row", () => {
+    expect(renderIssuedTokenListHtml([])).toMatch(/No tokens yet/);
+    const html = renderIssuedTokenListHtml([
+      {
+        id: "tok-1",
+        workspace: "acme",
+        label: "ci",
+        scopes: ["files:read"],
+        createdAt: "2026-08-01T00:00:00.000Z",
+        expiresAt: null,
+        lastUsedAt: "2026-08-17T12:00:00.000Z",
+      },
+    ]);
+    expect(html).toMatch(/read-only/);
+    expect(html).toMatch(/no expiry/);
+    expect(html).toMatch(/last used 2026-08-17/);
+    expect(html).toMatch(/data-token-id="tok-1"/);
+  });
+});

--- a/apps/web/src/lib/developers-ui.ts
+++ b/apps/web/src/lib/developers-ui.ts
@@ -57,7 +57,7 @@ export function renderIssuedTokenListHtml(tokens: IssuedWorkspaceToken[]): strin
       ]
         .filter(Boolean)
         .join(" · ");
-      return `<li data-token-id="${escapeHtml(token.id)}"><div class="detail-main"><div class="detail-title">${title}</div><div class="detail-meta">${meta}</div></div><button type="button" class="text-btn" data-revoke="${escapeHtml(token.id)}">Revoke</button></li>`;
+      return `<li data-token-id="${escapeHtml(token.id)}"><div class="detail-main"><div class="detail-title">${title}</div><div class="detail-meta">${meta}</div></div><button type="button" class="text-btn" data-revoke="${escapeHtml(token.id)}" data-revoke-label="${title}" data-revoke-workspace="${workspace}">Revoke</button></li>`;
     })
     .join("");
 }

--- a/apps/web/src/lib/developers-ui.ts
+++ b/apps/web/src/lib/developers-ui.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared markup for /account/developers so SSR and the client swap the same
+ * token-list rows. Keep this next to any placeholder that occupies the list.
+ */
+import {
+  listIssuedWorkspaceTokens,
+  listMintableWorkspaces,
+  type IssuedWorkspaceToken,
+  type MintableWorkspace,
+} from "./api-client";
+import { escapeHtml } from "./workspace-ui";
+
+export async function loadDevelopersPageData(
+  apiOrigin: string,
+  cookie: string,
+): Promise<{ workspaces: MintableWorkspace[] | null; tokens: IssuedWorkspaceToken[] | null }> {
+  if (!cookie.trim()) return { workspaces: null, tokens: null };
+  const [workspaces, tokens] = await Promise.all([
+    listMintableWorkspaces(apiOrigin, { cookie }),
+    listIssuedWorkspaceTokens(apiOrigin, { cookie }),
+  ]);
+  return { workspaces, tokens };
+}
+
+export function formatTokenWhen(value: string | null | undefined): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "";
+  return date.toISOString().slice(0, 10);
+}
+
+/** Short access label. Default read+write stays quiet; read-only is called out. */
+export function tokenAccessLabel(scopes: string[]): string {
+  const files = scopes.filter((scope) => scope.startsWith("files:"));
+  if (files.length === 1 && files[0] === "files:read") return "read-only";
+  return "";
+}
+
+export function renderIssuedTokenListHtml(tokens: IssuedWorkspaceToken[]): string {
+  if (tokens.length === 0) {
+    return `<li><div class="detail-main"><div class="detail-title">No tokens yet</div><div class="detail-meta">Create one above to start.</div></div></li>`;
+  }
+  return tokens
+    .map((token) => {
+      const title = escapeHtml(token.label || "Untitled");
+      const workspace = escapeHtml(token.workspace);
+      const created = formatTokenWhen(token.createdAt);
+      const expires = formatTokenWhen(token.expiresAt);
+      const used = formatTokenWhen(token.lastUsedAt);
+      const access = tokenAccessLabel(token.scopes);
+      const meta = [
+        workspace,
+        access,
+        created ? `created ${created}` : "",
+        expires ? `expires ${expires}` : "no expiry",
+        used ? `last used ${used}` : "never used",
+      ]
+        .filter(Boolean)
+        .join(" · ");
+      return `<li data-token-id="${escapeHtml(token.id)}"><div class="detail-main"><div class="detail-title">${title}</div><div class="detail-meta">${meta}</div></div><button type="button" class="text-btn" data-revoke="${escapeHtml(token.id)}">Revoke</button></li>`;
+    })
+    .join("");
+}
+
+export function renderWorkspaceOptionsHtml(names: string[]): string {
+  return names
+    .map((name) => `<option value="${escapeHtml(name)}">${escapeHtml(name)}</option>`)
+    .join("");
+}

--- a/apps/web/src/pages/account/developers.astro
+++ b/apps/web/src/pages/account/developers.astro
@@ -1,8 +1,22 @@
 ---
+import { env } from "cloudflare:workers";
 import AccountLayout from "../../layouts/AccountLayout.astro";
+import {
+  loadDevelopersPageData,
+  renderIssuedTokenListHtml,
+  renderWorkspaceOptionsHtml,
+} from "../../lib/developers-ui";
+import { resolveSignedInOrigins } from "../../lib/signed-in-page";
 import { renderDetailListPlaceholderHtml } from "../../lib/workspace-ui";
 
 export const prerender = false;
+
+const { apiOrigin } = resolveSignedInOrigins(env);
+const initial = await loadDevelopersPageData(apiOrigin, Astro.request.headers.get("cookie") ?? "");
+const workspaceNames = initial.workspaces?.map((row) => row.workspace) ?? [];
+const hasWorkspaces = workspaceNames.length > 0;
+const knownEmpty = initial.workspaces !== null && !hasWorkspaces;
+const tokensReady = initial.tokens !== null;
 ---
 
 <AccountLayout section="developers">
@@ -30,7 +44,7 @@ export const prerender = false;
         <button type="button" class="text-btn" id="cli-upgrade-dismiss">Dismiss</button>
       </div>
     </div>
-    <div class="cli-steps" id="cli-steps">
+    <div class="cli-steps" id="cli-steps" hidden>
       <div class="command" id="cli-install-cmd">
         <code>npm install -g @buildinternet/uploads</code>
         <button type="button" data-copy="npm install -g @buildinternet/uploads" aria-live="polite"
@@ -42,11 +56,11 @@ export const prerender = false;
         <button type="button" data-copy="uploads login" aria-live="polite">copy</button>
       </div>
     </div>
-    <p class="muted cli-note" id="cli-setup-note">
+    <p class="muted cli-note" id="cli-setup-note" hidden>
       Or <code>npx @buildinternet/uploads login</code> —
       <a href="/docs#install">docs</a>.
     </p>
-    <div id="cli-agents">
+    <div id="cli-agents" hidden>
       <p class="muted cli-note">Agents (skill + MCP for Claude Code):</p>
       <div class="cli-steps cli-steps--solo">
         <div class="command">
@@ -65,14 +79,24 @@ export const prerender = false;
         1 year, or until you revoke them. The CLI reads the workspace from the token.
       </p>
 
-      <p class="muted cli-note" id="token-empty" hidden>
+      <p class="muted cli-note" id="token-empty" hidden={knownEmpty ? undefined : true}>
         Create a <a href="/account/workspaces/new">workspace</a> first, then mint a token for it.
       </p>
 
-      <form class="ws-form" id="token-form" hidden>
-        <label class="token-field" id="token-workspace-field">
+      <form class="ws-form" id="token-form" hidden={knownEmpty ? true : undefined}>
+        <label
+          class="token-field"
+          id="token-workspace-field"
+          hidden={hasWorkspaces && workspaceNames.length === 1 ? true : undefined}
+        >
           <span class="sr-only">Workspace</span>
-          <select name="workspace" class="ul-select" id="token-workspace" required></select>
+          <select
+            name="workspace"
+            class="ul-select"
+            id="token-workspace"
+            required
+            set:html={renderWorkspaceOptionsHtml(workspaceNames)}
+          />
         </label>
         <div class="input-group">
           <label class="input-group__field">
@@ -86,6 +110,13 @@ export const prerender = false;
               autocomplete="off"
               spellcheck="false"
             />
+          </label>
+          <label class="token-access">
+            <span class="sr-only">Access</span>
+            <select name="access" class="ul-select" id="token-access">
+              <option value="readwrite">Read &amp; write</option>
+              <option value="readonly">Read only</option>
+            </select>
           </label>
           <label class="token-ttl">
             <span class="sr-only">Expires</span>
@@ -117,8 +148,10 @@ export const prerender = false;
       <ul
         class="detail-list"
         id="token-list"
-        aria-busy="true"
-        set:html={renderDetailListPlaceholderHtml()}
+        aria-busy={tokensReady ? "false" : "true"}
+        set:html={tokensReady
+          ? renderIssuedTokenListHtml(initial.tokens ?? [])
+          : renderDetailListPlaceholderHtml()}
       />
     </div>
   </section>
@@ -155,11 +188,13 @@ export const prerender = false;
       display: block;
       margin: 0 0 10px;
     }
-    .token-ttl {
+    .token-ttl,
+    .token-access {
       display: flex;
       align-items: stretch;
     }
-    .token-ttl .ul-select {
+    .token-ttl .ul-select,
+    .token-access .ul-select {
       width: auto;
     }
   </style>
@@ -264,10 +299,13 @@ export const prerender = false;
         else delete status.dataset.state;
         status.textContent = statusText;
 
-        // ready: hide commands; reconnect: login only; setup/checking: full install.
-        steps.hidden = kind === "ready";
+        // Checking/ready stay compact (steps hidden). Setup reveals install;
+        // reconnect reveals login only. Expanding is better than collapsing.
+        const agents = requireElement<HTMLElement>("#cli-agents", "developers");
+        steps.hidden = kind === "ready" || kind === "checking";
         installCmd.hidden = kind === "reconnect";
-        note.hidden = kind === "ready" || kind === "reconnect";
+        note.hidden = kind !== "setup";
+        agents.hidden = kind !== "setup";
 
         if (loaded) void maybeShowCliUpgrade(sessions);
       }
@@ -292,14 +330,8 @@ export const prerender = false;
       revokeIssuedWorkspaceToken,
       type IssuedWorkspaceToken,
     } from "../../lib/api-client";
-    import { bindCopyButtons, escapeHtml } from "../../lib/workspace-ui";
-
-    function formatWhen(value: string | null | undefined): string {
-      if (!value) return "";
-      const date = new Date(value);
-      if (!Number.isFinite(date.getTime())) return "";
-      return date.toISOString().slice(0, 10);
-    }
+    import { renderIssuedTokenListHtml, renderWorkspaceOptionsHtml } from "../../lib/developers-ui";
+    import { bindCopyButtons } from "../../lib/workspace-ui";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("workspace-tokens")) return;
@@ -328,26 +360,7 @@ export const prerender = false;
           return;
         }
         status.hidden = true;
-        if (tokens.length === 0) {
-          list.innerHTML = `<li><div class="detail-main"><div class="detail-title">No tokens yet</div><div class="detail-meta">Create one above to start.</div></div></li>`;
-          return;
-        }
-        list.innerHTML = tokens
-          .map((token) => {
-            const title = escapeHtml(token.label || "Untitled");
-            const workspace = escapeHtml(token.workspace);
-            const created = formatWhen(token.createdAt);
-            const expires = formatWhen(token.expiresAt);
-            const meta = [
-              workspace,
-              created ? `created ${created}` : "",
-              expires ? `expires ${expires}` : "no expiry",
-            ]
-              .filter(Boolean)
-              .join(" · ");
-            return `<li data-token-id="${escapeHtml(token.id)}"><div class="detail-main"><div class="detail-title">${title}</div><div class="detail-meta">${meta}</div></div><button type="button" class="text-btn" data-revoke="${escapeHtml(token.id)}">Revoke</button></li>`;
-          })
-          .join("");
+        list.innerHTML = renderIssuedTokenListHtml(tokens);
       }
 
       async function refreshTokens(): Promise<void> {
@@ -362,17 +375,19 @@ export const prerender = false;
           "#token-workspace",
           "developers",
         ) as unknown as HTMLSelectElement;
-        if (names === null || names.length === 0) {
+        if (names === null) {
+          // Keep whatever SSR painted. A fetch miss is not "no workspaces".
+          return;
+        }
+        if (names.length === 0) {
           form.hidden = true;
-          empty.hidden = names === null;
+          empty.hidden = false;
           select.replaceChildren();
           return;
         }
         empty.hidden = true;
         form.hidden = false;
-        select.innerHTML = names
-          .map((name) => `<option value="${escapeHtml(name)}">${escapeHtml(name)}</option>`)
-          .join("");
+        select.innerHTML = renderWorkspaceOptionsHtml(names);
         field.hidden = names.length === 1;
       }
 
@@ -389,38 +404,43 @@ export const prerender = false;
           const label = labelInput instanceof HTMLInputElement ? labelInput.value.trim() : "";
           const ttlRaw = ttlInput instanceof HTMLSelectElement ? ttlInput.value : "";
           const ttlSeconds = ttlRaw === "never" ? null : ttlRaw ? Number(ttlRaw) : undefined;
+          const accessInput = form.elements.namedItem("access");
+          const access = accessInput instanceof HTMLSelectElement ? accessInput.value : "readwrite";
+          const scopes = access === "readonly" ? ["files:read"] : undefined;
           if (!workspace || !label) return;
           const button = requireElement<HTMLButtonElement>("#token-create", "developers");
           const error = requireElement<HTMLElement>("#token-error", "developers");
           const created = requireElement<HTMLElement>("#token-created", "developers");
           button.disabled = true;
           error.hidden = true;
-          void mintWorkspaceToken(apiOrigin, { workspace, label, ttlSeconds }).then((result) => {
-            button.disabled = false;
-            if (!result.ok) {
-              error.hidden = false;
-              error.textContent = result.message;
-              return;
-            }
-            if (labelInput instanceof HTMLInputElement) labelInput.value = "";
-            const secret = requireElement<HTMLElement>("#token-secret", "developers");
-            const secretCopy = requireElement<HTMLButtonElement>(
-              "#token-secret-copy",
-              "developers",
-            );
-            const exportsEl = requireElement<HTMLElement>("#token-exports", "developers");
-            const exportsCopy = requireElement<HTMLButtonElement>(
-              "#token-exports-copy",
-              "developers",
-            );
-            secret.textContent = result.token;
-            secretCopy.dataset.copy = result.token;
-            const snippet = `export UPLOADS_TOKEN=${result.token}`;
-            exportsEl.textContent = snippet;
-            exportsCopy.dataset.copy = snippet;
-            created.hidden = false;
-            void refreshTokens();
-          });
+          void mintWorkspaceToken(apiOrigin, { workspace, label, ttlSeconds, scopes }).then(
+            (result) => {
+              button.disabled = false;
+              if (!result.ok) {
+                error.hidden = false;
+                error.textContent = result.message;
+                return;
+              }
+              if (labelInput instanceof HTMLInputElement) labelInput.value = "";
+              const secret = requireElement<HTMLElement>("#token-secret", "developers");
+              const secretCopy = requireElement<HTMLButtonElement>(
+                "#token-secret-copy",
+                "developers",
+              );
+              const exportsEl = requireElement<HTMLElement>("#token-exports", "developers");
+              const exportsCopy = requireElement<HTMLButtonElement>(
+                "#token-exports-copy",
+                "developers",
+              );
+              secret.textContent = result.token;
+              secretCopy.dataset.copy = result.token;
+              const snippet = `export UPLOADS_TOKEN=${result.token}`;
+              exportsEl.textContent = snippet;
+              exportsCopy.dataset.copy = snippet;
+              created.hidden = false;
+              void refreshTokens();
+            },
+          );
         },
       );
 

--- a/apps/web/src/pages/account/developers.astro
+++ b/apps/web/src/pages/account/developers.astro
@@ -452,6 +452,11 @@ const tokensReady = initial.tokens !== null;
           if (!revoke) return;
           const id = revoke.dataset.revoke;
           if (!id) return;
+          const label = revoke.dataset.revokeLabel || "this token";
+          const workspace = revoke.dataset.revokeWorkspace || "this workspace";
+          if (!confirm(`Revoke “${label}” on ${workspace}? It will stop working immediately.`)) {
+            return;
+          }
           revoke.disabled = true;
           const ok = await revokeIssuedWorkspaceToken(apiOrigin, id);
           if (!ok) {

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -8,10 +8,10 @@ Nobody needs the API's `ADMIN_TOKEN` to sign in.
 ## Workspace tokens (no device login)
 
 `/account/developers` mints the same `up_<workspace>_` token `uploads login`
-does. Pick a workspace, a label, and 90 days, 1 year, or no expiry. The
-secret is shown once. A token with no expiry lives until you revoke it. The
-CLI reads the workspace from the token. Curl still puts the workspace in the
-path (`/v1/:workspace/…`).
+does. Pick a workspace, a label, read-and-write or read-only, and 90 days, 1
+year, or no expiry. The secret is shown once. A token with no expiry lives
+until you revoke it. The CLI reads the workspace from the token. Curl still
+puts the workspace in the path (`/v1/:workspace/…`).
 
 ## Everyday login (device flow)
 

--- a/packages/uploads/src/commands/config.ts
+++ b/packages/uploads/src/commands/config.ts
@@ -30,7 +30,7 @@ Subcommands:
 Keys:
   UPLOADS_API_URL           API base URL (default: ${DEFAULT_API_URL})
   UPLOADS_WORKSPACE         Workspace / bucket tenant (default: ${DEFAULT_WORKSPACE})
-  UPLOADS_TOKEN             Bearer token (up_<workspace>_… or an API key)
+  UPLOADS_TOKEN             Bearer token (up_<workspace>_…)
   UPLOADS_SESSION_TOKEN     Device-flow session (CLI version on account sessions)
   UPLOADS_DEFAULT_PREFIX    Default key prefix for put/list
   UPLOADS_DEFAULT_REPO      Default repo segment for put


### PR DESCRIPTION
## In plain terms

API tokens on `/account/developers` can be read-only, show when they were last used, and the page no longer hides the form and list until JavaScript finishes. CLI help no longer talks about a separate API key.

## What it does / what it is not

- Create offers **Read & write** (default) or **Read only** (`files:read`).
- Successful token auth stamps `last_used_at` at most once an hour. The list shows last used or never used.
- The developers page loads workspaces and issued tokens on the server when a session cookie is present, and keeps the CLI setup card compact until it knows whether to show install steps.
- `uploads config` help is `up_<workspace>_…` only.
- Login still defaults to 90-day read+write. Admin enrollment is unchanged.

## How to try it

After API (with the D1 migration) + web deploy:

1. Open `/account/developers`. The token form and list should be there on first paint.
2. Create a **Read only** token and confirm the row says `read-only`.
3. Use a token once, wait for the hourly stamp, refresh — **last used** should appear.

```bash
export UPLOADS_TOKEN=up_<workspace>_...
uploads put ./shot.png
```

A read-only token will refuse the put.

## Technical notes

Migration `apps/api/migrations/20260817180000_token_last_used.sql` adds `auth_tokens.last_used_at`. `deploy:api` applies it. Touch is a conditional UPDATE so busy tokens do not write D1 on every request.

## Test plan

- [x] Token mint / issued-list tests including `lastUsedAt`
- [x] `touchTokenLastUsed` unit test
- [x] GitHub link/comment/promote auth tests after the touch write
- [x] Web parse + list HTML tests
- [x] `astro check` (0 errors)
- [x] Direct PUT to prod with `UPLOADS_TOKEN_DEFAULT` — 201 on `buildinternet`
- [ ] Click through `/account/developers` after deploy