### PR TITLE
feat: Label context-less local-origin screenshot groups as "local dev"

### DIFF
--- a/.changeset/no-project-context-nudge.md
+++ b/.changeset/no-project-context-nudge.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`put` and `screenshot` print an advisory stderr note when a path-tagged upload has no repo/app context and only a local origin — it would land in the screenshots page's "local dev" bucket. Suggests running from the project repo or passing `--app`. Suppressed by `--quiet`, `--no-git`, and the no-nudge config.

--- a/apps/api/src/file-metadata-facets.test.ts
+++ b/apps/api/src/file-metadata-facets.test.ts
@@ -194,6 +194,27 @@ describe("groupObjectsByPath", () => {
     expect(result.projects).toEqual([{ label: "Other", count: 3, lastUpdated: at(3) }]);
   });
 
+  it("reads app metadata so local-origin shots group by app, not host (#692)", async () => {
+    const result = await groupObjectsByPath(
+      timedDb([
+        {
+          workspace: "acme",
+          key: "a.png",
+          meta: { path: "/x", url: "http://localhost:3000/x", app: "web" },
+          at: at(1),
+        },
+        {
+          workspace: "acme",
+          key: "b.png",
+          meta: { path: "/x", url: "http://localhost:3000/x" },
+          at: at(2),
+        },
+      ]),
+      "acme",
+    );
+    expect(result.groups.map((g) => g.project)).toEqual(["local dev", "web"]);
+  });
+
   it("caps recent keys per group at BY_PATH_RECENT_LIMIT but counts all", async () => {
     const rows = Array.from({ length: BY_PATH_RECENT_LIMIT + 2 }, (_, i) => ({
       workspace: "acme",
@@ -293,10 +314,22 @@ describe("projectLabelFromMeta", () => {
     );
   });
   it("falls back to the url host, keeping the port", () => {
-    expect(projectLabelFromMeta({ url: "https://uploads.localhost/settings" })).toBe(
-      "uploads.localhost",
+    expect(projectLabelFromMeta({ url: "https://staging.x.dev:8443/p" })).toBe(
+      "staging.x.dev:8443",
     );
-    expect(projectLabelFromMeta({ url: "http://localhost:3000/admin" })).toBe("localhost:3000");
+  });
+  it("labels context-less local origins 'local dev' instead of the raw host (#692)", () => {
+    expect(projectLabelFromMeta({ url: "http://localhost:3000/admin" })).toBe("local dev");
+    expect(projectLabelFromMeta({ url: "https://uploads.localhost/settings" })).toBe("local dev");
+    expect(projectLabelFromMeta({ url: "http://127.0.0.1:8788/x" })).toBe("local dev");
+    expect(projectLabelFromMeta({ url: "http://0.0.0.0:4321/" })).toBe("local dev");
+    expect(projectLabelFromMeta({ url: "http://[::1]:3000/" })).toBe("local dev");
+  });
+  it("app metadata names local-origin and url-less groups, but never outranks a real host", () => {
+    expect(projectLabelFromMeta({ url: "http://localhost:3000/admin", app: "web" })).toBe("web");
+    expect(projectLabelFromMeta({ app: "ios" })).toBe("ios");
+    expect(projectLabelFromMeta({ url: "https://x.dev/p", app: "web" })).toBe("x.dev");
+    expect(projectLabelFromMeta({ repo: "acme/web", app: "ios" })).toBe("acme/web");
   });
   it("returns Other for missing or unparseable url", () => {
     expect(projectLabelFromMeta({})).toBe("Other");

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -694,7 +694,8 @@ export async function groupObjectsByPath(
       `SELECT p.meta_value AS path, p.object_key AS object_key, p.updated_at AS updated_at,
               (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'repo') AS repo,
               (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'gh.repo') AS gh_repo,
-              (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'url') AS url
+              (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'url') AS url,
+              (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'app') AS app
        FROM file_metadata p
        WHERE p.workspace = ? AND p.meta_key = 'path'
        ORDER BY p.updated_at DESC, p.object_key ASC`,
@@ -707,13 +708,19 @@ export async function groupObjectsByPath(
       repo: string | null;
       gh_repo: string | null;
       url: string | null;
+      app: string | null;
     }>();
 
   const groups: PathGroup[] = [];
   const byKey = new Map<string, PathGroup>();
   let truncated = false;
   for (const row of result.results) {
-    const project = projectLabelFromMeta({ repo: row.repo, ghRepo: row.gh_repo, url: row.url });
+    const project = projectLabelFromMeta({
+      repo: row.repo,
+      ghRepo: row.gh_repo,
+      url: row.url,
+      app: row.app,
+    });
     const groupKey = `${project}\0${row.path}`;
     let group = byKey.get(groupKey);
     if (!group) {
@@ -752,7 +759,10 @@ export async function groupObjectsByPath(
 /**
  * Project label for the screenshots page (spec:
  * docs/superpowers/specs/2026-08-11-screenshots-project-grouping-design.md).
- * Coalesces repo → gh.repo → url origin → "Other". Display/grouping only —
+ * Coalesces repo → gh.repo → url origin → app → "Other". Local origins
+ * (localhost and friends) never label a group by host — the host says which
+ * dev server was up, not which app it was (#692) — so they fall through to
+ * `app` metadata, else a shared "local dev" bucket. Display/grouping only —
  * never stored. Mirrored (with identical cases) by
  * apps/web/src/lib/workspace-screenshots.ts.
  */
@@ -760,18 +770,34 @@ export function projectLabelFromMeta(meta: {
   repo?: string | null;
   ghRepo?: string | null;
   url?: string | null;
+  app?: string | null;
 }): string {
   if (meta.repo) return meta.repo;
   if (meta.ghRepo) return meta.ghRepo;
+  let localOrigin = false;
   if (meta.url) {
     try {
-      const host = new URL(meta.url).host;
-      if (host) return host;
+      const parsed = new URL(meta.url);
+      if (isLocalHostname(parsed.hostname)) localOrigin = true;
+      else if (parsed.host) return parsed.host;
     } catch {
       // fall through — an unparseable url is just "no url"
     }
   }
-  return "Other";
+  if (meta.app) return meta.app;
+  return localOrigin ? "local dev" : "Other";
+}
+
+/** Hosts that identify a dev machine, not an app: any port counts the same. */
+export function isLocalHostname(hostname: string): boolean {
+  const bare = hostname.toLowerCase();
+  return (
+    bare === "localhost" ||
+    bare.endsWith(".localhost") ||
+    bare === "127.0.0.1" ||
+    bare === "0.0.0.0" ||
+    bare === "[::1]"
+  );
 }
 
 export type FacetKeysResult = {

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -95,7 +95,26 @@ describe("projectLabelFromItemMeta", () => {
       projectLabelFromItemMeta({ repo: "acme/web", "gh.repo": "acme/api", url: "https://x.dev/p" }),
     ).toBe("acme/web");
     expect(projectLabelFromItemMeta({ "gh.repo": "acme/api" })).toBe("acme/api");
-    expect(projectLabelFromItemMeta({ url: "http://localhost:3000/admin" })).toBe("localhost:3000");
+    expect(projectLabelFromItemMeta({ url: "https://staging.x.dev:8443/p" })).toBe(
+      "staging.x.dev:8443",
+    );
+  });
+  it("labels context-less local origins 'local dev' instead of the raw host (#692)", () => {
+    expect(projectLabelFromItemMeta({ url: "http://localhost:3000/admin" })).toBe("local dev");
+    expect(projectLabelFromItemMeta({ url: "https://uploads.localhost/settings" })).toBe(
+      "local dev",
+    );
+    expect(projectLabelFromItemMeta({ url: "http://127.0.0.1:8788/x" })).toBe("local dev");
+    expect(projectLabelFromItemMeta({ url: "http://0.0.0.0:4321/" })).toBe("local dev");
+    expect(projectLabelFromItemMeta({ url: "http://[::1]:3000/" })).toBe("local dev");
+  });
+  it("app metadata names local-origin and url-less groups, but never outranks a real host", () => {
+    expect(projectLabelFromItemMeta({ url: "http://localhost:3000/admin", app: "web" })).toBe(
+      "web",
+    );
+    expect(projectLabelFromItemMeta({ app: "ios" })).toBe("ios");
+    expect(projectLabelFromItemMeta({ url: "https://x.dev/p", app: "web" })).toBe("x.dev");
+    expect(projectLabelFromItemMeta({ repo: "acme/web", app: "ios" })).toBe("acme/web");
   });
   it("returns Other for missing/unparseable", () => {
     expect(projectLabelFromItemMeta(undefined)).toBe("Other");

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -43,15 +43,30 @@ export function lastUpdatedLabel(iso: string, now: Date): string {
 export function projectLabelFromItemMeta(meta: Record<string, string> | undefined): string {
   if (meta?.repo) return meta.repo;
   if (meta?.["gh.repo"]) return meta["gh.repo"];
+  let localOrigin = false;
   if (meta?.url) {
     try {
-      const host = new URL(meta.url).host;
-      if (host) return host;
+      const parsed = new URL(meta.url);
+      if (isLocalHostname(parsed.hostname)) localOrigin = true;
+      else if (parsed.host) return parsed.host;
     } catch {
       // unparseable url is just "no url"
     }
   }
-  return "Other";
+  if (meta?.app) return meta.app;
+  return localOrigin ? "local dev" : "Other";
+}
+
+/** Hosts that identify a dev machine, not an app: any port counts the same. */
+function isLocalHostname(hostname: string): boolean {
+  const bare = hostname.toLowerCase();
+  return (
+    bare === "localhost" ||
+    bare.endsWith(".localhost") ||
+    bare === "127.0.0.1" ||
+    bare === "0.0.0.0" ||
+    bare === "[::1]"
+  );
 }
 
 /**

--- a/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
@@ -15,7 +15,7 @@ const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
 
 const tip = {
-  body: "groups come from metadata: <code>path</code> for pages, <code>repo</code> or the URL host for projects.",
+  body: "groups come from metadata: <code>path</code> for pages, <code>repo</code>, <code>app</code>, or the URL host for projects.",
   href: "/docs/attach-pull-request-images#put",
   linkLabel: "how grouping works",
 };

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -71,6 +71,7 @@ import {
   type CommandRunner,
 } from "./github-gh.js";
 import { deriveRepoFromGit, deriveRepoSlugFromGit } from "./keys.js";
+import { noProjectContextNudge } from "./project-context-nudge.js";
 import { resolvePutPrefix } from "./destinations.js";
 import {
   optimizeImageForUpload,
@@ -2403,6 +2404,13 @@ export async function runPut(
     if (slug) metadata = mergeDerivedMeta(metadata, { repo: slug });
   }
 
+  // #692 follow-up: a path-tagged upload with no repo/gh.repo/app context and
+  // no real (non-local) origin lands in the screenshots page's fallback
+  // buckets — one advisory line at the moment the context went missing.
+  // --no-git is an explicit choice, so it suppresses the nudge too.
+  const contextNudge =
+    !ctx.quiet && !defaults.noNudge && !noGit ? noProjectContextNudge(metadata) : undefined;
+
   // Bare-put nudge (issue #393): only relevant when staging didn't take over
   // — once `stagingTarget` resolves, staging IS the upgrade the nudge used to
   // point at, so this is skipped entirely rather than firing redundantly.
@@ -2493,7 +2501,7 @@ export async function runPut(
   // warning); stderr prints the nudge/staging-note and binding-warning lines
   // independently, below. pathHint only ever fires on the ghTarget path, so
   // it never competes with the other three.
-  const jsonHint = nudge ?? bindingWarning ?? stagingNote ?? pathHint;
+  const jsonHint = nudge ?? bindingWarning ?? stagingNote ?? pathHint ?? contextNudge;
 
   type GalleryOutcome = {
     id: string;
@@ -2591,6 +2599,7 @@ export async function runPut(
       if (stagingNote) process.stderr.write(`${stagingNote}\n`);
       if (bindingWarning) process.stderr.write(`${bindingWarning}\n`);
       if (pathHint) process.stderr.write(`${pathHint}\n`);
+      if (contextNudge) process.stderr.write(`${contextNudge}\n`);
     }
     return failures.length === 0 && !galleryHadError ? 0 : 1;
   }
@@ -2654,6 +2663,7 @@ export async function runPut(
   if (stagingNote && format !== "json") process.stderr.write(`${stagingNote}\n`);
   if (bindingWarning && format !== "json") process.stderr.write(`${bindingWarning}\n`);
   if (pathHint && format !== "json") process.stderr.write(`${pathHint}\n`);
+  if (contextNudge && format !== "json") process.stderr.write(`${contextNudge}\n`);
 
   return gallery?.error ? 1 : 0;
 }

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -41,6 +41,7 @@ import {
   type CommandRunner,
 } from "../github-gh.js";
 import { deriveRepoSlugFromGit } from "../keys.js";
+import { noProjectContextNudge } from "../project-context-nudge.js";
 import { safeCaptureFacts } from "../capture-facts.js";
 import { parseMetaFlags, validateMetaMap } from "../metadata.js";
 import { mergeDerivedMeta } from "../metadata-vocab.js";
@@ -464,6 +465,11 @@ export async function runScreenshot(
     validateMetaMap(withFacts);
   }
 
+  // #692 follow-up: same advisory as put — a capture with no repo/app context
+  // and only a local origin lands in the screenshots page's fallback buckets.
+  const contextNudge =
+    !ctx.quiet && !putDefaults.noNudge && !noGit ? noProjectContextNudge(metadata) : undefined;
+
   const logHuman = !ctx.quiet && format === "human";
   if (logHuman) process.stderr.write(`>> capturing ${target}\n`);
 
@@ -653,6 +659,7 @@ export async function runScreenshot(
       }
     }
     if (bindingWarning) process.stderr.write(`${bindingWarning}\n`);
+    if (contextNudge) process.stderr.write(`${contextNudge}\n`);
     process.stderr.write("\n");
   }
 
@@ -669,7 +676,7 @@ export async function runScreenshot(
     result.replaced && explicitMeta.state
       ? `re-capture replaced the previous state=${explicitMeta.state} object at ${result.key} — expected for repeat captures of the same URL + state`
       : undefined;
-  const jsonHint = clipHint ?? bindingWarning ?? stagingNote ?? replacedHint;
+  const jsonHint = clipHint ?? bindingWarning ?? stagingNote ?? replacedHint ?? contextNudge;
 
   switch (format) {
     case "json":

--- a/packages/uploads/src/project-context-nudge.ts
+++ b/packages/uploads/src/project-context-nudge.ts
@@ -1,0 +1,43 @@
+/**
+ * No-project-context nudge (issue #692 follow-up): a path-tagged upload with
+ * no repo/gh.repo/app metadata and no real (non-local) origin lands in the
+ * screenshots page's "local dev" / "Other" fallback buckets. One advisory
+ * stderr line teaches the fix at the moment the context went missing. The
+ * predicate mirrors apps/api's projectLabelFromMeta fallback rules exactly —
+ * a real URL host is a meaningful group, so it never fires there.
+ */
+
+/** Hosts that identify a dev machine, not an app — same set as the API's
+ * isLocalHostname (apps/api/src/file-metadata.ts). */
+function isLocalHostname(hostname: string): boolean {
+  const bare = hostname.toLowerCase();
+  return (
+    bare === "localhost" ||
+    bare.endsWith(".localhost") ||
+    bare === "127.0.0.1" ||
+    bare === "0.0.0.0" ||
+    bare === "[::1]"
+  );
+}
+
+export function noProjectContextNudge(
+  meta: Record<string, string> | undefined,
+): string | undefined {
+  // Only `path`-tagged uploads appear on the screenshots page at all.
+  if (!meta?.path) return undefined;
+  if (meta.repo || meta["gh.repo"] || meta.app) return undefined;
+  let bucket = "Other";
+  if (meta.url) {
+    try {
+      const parsed = new URL(meta.url);
+      if (!isLocalHostname(parsed.hostname)) return undefined; // real host = real group
+      bucket = "local dev";
+    } catch {
+      // unparseable url is just "no url"
+    }
+  }
+  return (
+    `note: no repo detected — the screenshots page will group this under "${bucket}". ` +
+    `Run from inside your project repo, or pass --app <name>.`
+  );
+}

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -1349,6 +1349,52 @@ async function captureStdout(fn: () => Promise<unknown>): Promise<string> {
   }
 }
 
+describe("runPut no-project-context nudge (#692 follow-up)", () => {
+  it("fires on stderr for a path-tagged localhost upload outside a git repo", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--meta", "path=/admin", "--meta", "url=http://localhost:3000/admin"],
+        false,
+        nudgeRunner({}), // every git/gh stage throws → no repo context
+      ),
+    );
+    expect(stderr).toContain(
+      'note: no repo detected — the screenshots page will group this under "local dev"',
+    );
+  });
+
+  it("stays silent without path meta, and under --no-git", async () => {
+    const { client } = fakeClient();
+    const noPath = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--meta", "url=http://localhost:3000/admin"],
+        false,
+        nudgeRunner({}),
+      ),
+    );
+    expect(noPath).not.toContain("no repo detected");
+    const noGit = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [
+          tmpFile(),
+          "--no-git",
+          "--meta",
+          "path=/admin",
+          "--meta",
+          "url=http://localhost:3000/admin",
+        ],
+        false,
+        nudgeRunner({}),
+      ),
+    );
+    expect(noGit).not.toContain("no repo detected");
+  });
+});
+
 describe("runPut bare-put nudge (issue #393)", () => {
   const allClear = {
     branch: "feature/thing",

--- a/packages/uploads/test/commands-screenshot.test.ts
+++ b/packages/uploads/test/commands-screenshot.test.ts
@@ -815,6 +815,59 @@ describe("runScreenshot auto branch staging (issue #469 lever 1)", () => {
     expect(puts[0]?.key).toBeUndefined();
   });
 
+  describe("no-project-context nudge (#692 follow-up)", () => {
+    it("fires on stderr for a localhost capture with no derivable repo", async () => {
+      const { client } = fakeClient();
+      const stderr = await captureStderr(() =>
+        runScreenshot(
+          { ...ctxWith(client), quiet: false },
+          ["http://localhost:3000/admin"],
+          false,
+          noRun, // git derive throws → no repo context
+          fakeCapture("remote"),
+        ),
+      );
+      expect(stderr).toContain(
+        'note: no repo detected — the screenshots page will group this under "local dev"',
+      );
+      expect(stderr).toContain("--app <name>");
+    });
+
+    it("stays silent when --app supplies context, under --no-git, and in quiet mode", async () => {
+      const { client } = fakeClient();
+      const withApp = await captureStderr(() =>
+        runScreenshot(
+          { ...ctxWith(client), quiet: false },
+          ["http://localhost:3000/admin", "--app", "web"],
+          false,
+          noRun,
+          fakeCapture("remote"),
+        ),
+      );
+      expect(withApp).not.toContain("no repo detected");
+      const noGit = await captureStderr(() =>
+        runScreenshot(
+          { ...ctxWith(client), quiet: false },
+          ["http://localhost:3000/admin", "--no-git"],
+          false,
+          noRun,
+          fakeCapture("remote"),
+        ),
+      );
+      expect(noGit).not.toContain("no repo detected");
+      const quiet = await captureStderr(() =>
+        runScreenshot(
+          ctxWith(client),
+          ["http://localhost:3000/admin"],
+          false,
+          noRun,
+          fakeCapture("remote"),
+        ),
+      );
+      expect(quiet).not.toContain("no repo detected");
+    });
+  });
+
   describe("staging note: wording, suppression, JSON hint", () => {
     it("fires the exact staging-note wording on stderr", async () => {
       const { client } = fakeClient();

--- a/packages/uploads/test/project-context-nudge.test.ts
+++ b/packages/uploads/test/project-context-nudge.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { noProjectContextNudge } from "../src/project-context-nudge.js";
+
+// Mirrors the grouping rules in apps/api projectLabelFromMeta (#692/#694):
+// the nudge fires exactly when a shot would land in the "local dev" or
+// "Other" fallback buckets on the screenshots page.
+describe("noProjectContextNudge", () => {
+  it("fires for a path-tagged shot whose only origin is a local host", () => {
+    const note = noProjectContextNudge({ path: "/admin", url: "http://localhost:3000/admin" });
+    expect(note).toContain('"local dev"');
+    expect(note).toContain("--app");
+  });
+
+  it("fires for a path-tagged shot with no url at all, naming the Other bucket", () => {
+    const note = noProjectContextNudge({ path: "/admin" });
+    expect(note).toContain('"Other"');
+  });
+
+  it("covers all local-origin spellings", () => {
+    for (const url of [
+      "https://uploads.localhost/x",
+      "http://127.0.0.1:8788/x",
+      "http://0.0.0.0:4321/x",
+      "http://[::1]:3000/x",
+    ]) {
+      expect(noProjectContextNudge({ path: "/x", url })).toBeDefined();
+    }
+  });
+
+  it("stays silent when any project context exists", () => {
+    expect(
+      noProjectContextNudge({ path: "/x", url: "http://localhost:3000/x", repo: "o/r" }),
+    ).toBeUndefined();
+    expect(
+      noProjectContextNudge({ path: "/x", url: "http://localhost:3000/x", "gh.repo": "o/r" }),
+    ).toBeUndefined();
+    expect(
+      noProjectContextNudge({ path: "/x", url: "http://localhost:3000/x", app: "web" }),
+    ).toBeUndefined();
+  });
+
+  it("stays silent for real hosts, non-page uploads, and undefined meta", () => {
+    expect(noProjectContextNudge({ path: "/x", url: "https://x.dev/x" })).toBeUndefined();
+    expect(noProjectContextNudge({ url: "http://localhost:3000/x" })).toBeUndefined();
+    expect(noProjectContextNudge(undefined)).toBeUndefined();
+    expect(noProjectContextNudge({})).toBeUndefined();
+  });
+
+  it("treats an unparseable url as no url", () => {
+    expect(noProjectContextNudge({ path: "/x", url: "not a url" })).toContain('"Other"');
+  });
+});


### PR DESCRIPTION
Fixes #692.

Project headings on `/account/workspaces/:name/screenshots` fell back to the raw URL host, so dev-server shots grouped under hosts like **localhost:3000** — two apps on the same port collapsed into one "project", the same app on two ports split in two.

## What changed

**Grouping (commit 1)**
- Local origins (`localhost`, `*.localhost`, `127.0.0.1`, `0.0.0.0`, `[::1]` — any port) never label a group by host anymore. They fall through to `app` metadata (the existing `--app` sugar), else a single clearly-marked **local dev** bucket.
- `app` also names url-less groups that previously landed in "Other". It never outranks a real (non-local) host, so grouping for deployed origins is unchanged.
- `repo`/`gh.repo` context still wins outright — localhost shots taken inside a repo keep grouping under the repo, since a localhost capture is often an accurate shot of the real app.
- Applied identically to the API's `projectLabelFromMeta` (the by-path query now reads `app` via a fourth correlated subselect) and the web mirror `projectLabelFromItemMeta`; test fixtures pinned to the same cases on both sides. Screenshots-page tip mentions `app`.

**CLI nudge (commit 2)**
- `put` and `screenshot` print one advisory stderr line when a path-tagged upload has no repo/gh.repo/app context and no real (non-local) origin — i.e. exactly when it would land in the fallback buckets: `note: no repo detected — the screenshots page will group this under "local dev". Run from inside your project repo, or pass --app <name>.`
- Fixes the data at the source (the moment context went missing) instead of only relabeling downstream. Never affects exit code/stdout; suppressed by `--quiet`, `--no-git`, and the existing no-nudge config; lowest-priority occupant of the JSON `hint` slot. Changeset included (minor).

Deliberately skipped (per discussion): cross-item fold-into-repo heuristics and host→project mapping config — can revisit if this isn't enough.

## Tests

Full suite: 300 files / 4427 tests green; typecheck clean.