### PR TITLE
perf: Server-render signed-in page data to remove layout jump

### DIFF
--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -3,6 +3,8 @@ import {
   deleteWorkspaceFile,
   deleteWorkspaceStorage,
   getGithubInstalled,
+  getMyWorkspaceFiles,
+  getMyWorkspaceGalleries,
   getMyWorkspaces,
   getSuggestedWorkspaceName,
   parseIssuedWorkspaceTokens,
@@ -12,7 +14,9 @@ import {
   getWorkspaceFilesByPath,
   getWorkspaceInvites,
   getWorkspaceMembers,
+  getWorkspacePeople,
   getWorkspaceStorageStatus,
+  getWorkspaceSummary,
   inviteToWorkspace,
   listWorkspaceFolder,
   putWorkspaceStorage,
@@ -171,6 +175,180 @@ describe("getMyWorkspaces", () => {
       ["acme", "pro"],
       ["byo", undefined],
     ]);
+  });
+
+  it("forwards an opts.cookie as the outgoing cookie header (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json({ workspaces: [] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getMyWorkspaces("http://127.0.0.1:8787", { cookie: "better-auth.session=abc" });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect((seenInit?.headers as Record<string, string> | undefined)?.cookie).toBe(
+      "better-auth.session=abc",
+    );
+  });
+
+  it("sends no cookie header without opts (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json({ workspaces: [] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getMyWorkspaces("http://127.0.0.1:8787");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(seenInit?.headers).toBeUndefined();
+  });
+});
+
+describe("getWorkspaceSummary opts.cookie", () => {
+  const BODY = {
+    workspace: "acme",
+    role: "owner",
+    organization: { id: "org1", slug: "acme", name: "Acme Inc" },
+  };
+
+  it("forwards an opts.cookie as the outgoing cookie header (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json(BODY);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getWorkspaceSummary("http://127.0.0.1:8787", "acme", {
+      cookie: "better-auth.session=abc",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect((seenInit?.headers as Record<string, string> | undefined)?.cookie).toBe(
+      "better-auth.session=abc",
+    );
+  });
+
+  it("sends no cookie header without opts (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json(BODY);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getWorkspaceSummary("http://127.0.0.1:8787", "acme");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(seenInit?.headers).toBeUndefined();
+  });
+});
+
+describe("getWorkspacePeople opts.cookie", () => {
+  const BODY = { role: "owner", members: [] };
+
+  it("forwards an opts.cookie as the outgoing cookie header (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json(BODY);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getWorkspacePeople("http://127.0.0.1:8787", "acme", {
+      cookie: "better-auth.session=abc",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect((seenInit?.headers as Record<string, string> | undefined)?.cookie).toBe(
+      "better-auth.session=abc",
+    );
+  });
+
+  it("sends no cookie header without opts (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json(BODY);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getWorkspacePeople("http://127.0.0.1:8787", "acme");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(seenInit?.headers).toBeUndefined();
+  });
+});
+
+describe("getMyWorkspaceGalleries opts.cookie", () => {
+  it("forwards an opts.cookie as the outgoing cookie header (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json({ galleries: [] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getMyWorkspaceGalleries("http://127.0.0.1:8787", "acme", {
+      cookie: "better-auth.session=abc",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect((seenInit?.headers as Record<string, string> | undefined)?.cookie).toBe(
+      "better-auth.session=abc",
+    );
+  });
+
+  it("sends no cookie header without opts (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json({ galleries: [] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getMyWorkspaceGalleries("http://127.0.0.1:8787", "acme");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(seenInit?.headers).toBeUndefined();
+  });
+});
+
+describe("getMyWorkspaceFiles opts.cookie", () => {
+  it("forwards an opts.cookie as the outgoing cookie header (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json({ files: [] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getMyWorkspaceFiles("http://127.0.0.1:8787", "acme", {
+      cookie: "better-auth.session=abc",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect((seenInit?.headers as Record<string, string> | undefined)?.cookie).toBe(
+      "better-auth.session=abc",
+    );
+  });
+
+  it("sends no cookie header without opts (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json({ files: [] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getMyWorkspaceFiles("http://127.0.0.1:8787", "acme");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(seenInit?.headers).toBeUndefined();
   });
 });
 
@@ -378,6 +556,38 @@ describe("getWorkspaceFilesByPath", () => {
     );
     const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
     expect(result.kind).toBe("unavailable");
+  });
+
+  it("forwards an opts.cookie as the outgoing cookie header (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json({ groups: [], projects: [], truncated: false });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getWorkspaceFilesByPath("https://api.uploads.sh", "acme", {
+      cookie: "better-auth.session=abc",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect((seenInit?.headers as Record<string, string> | undefined)?.cookie).toBe(
+      "better-auth.session=abc",
+    );
+  });
+
+  it("sends no cookie header without opts (issue #365 follow-up)", async () => {
+    let seenInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit = init;
+      return Response.json({ groups: [], projects: [], truncated: false });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(seenInit?.headers).toBeUndefined();
   });
 });
 

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -110,11 +110,14 @@ export function parseWorkspaceCreateQuota(value: unknown): WorkspaceCreateQuota 
 }
 
 /** GET /me/workspaces, preserving an outage rather than rendering it as an empty account. */
-export async function getMyWorkspaces(apiOrigin: string): Promise<WorkspacesResult> {
-  const result = await fetchWithTimeout(`${trimOrigin(apiOrigin)}/me/workspaces`, {
-    credentials: "include",
-    cache: "no-store",
-  });
+export async function getMyWorkspaces(
+  apiOrigin: string,
+  opts?: { cookie?: string },
+): Promise<WorkspacesResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces`,
+    sessionFetchInit(opts?.cookie),
+  );
   if (result.kind === "unavailable") return result;
   const { response } = result;
   if (!response.ok) return { kind: "unavailable", reason: "server" };
@@ -183,10 +186,11 @@ export type WorkspaceSummaryResult =
 export async function getWorkspaceSummary(
   apiOrigin: string,
   name: string,
+  opts?: { cookie?: string },
 ): Promise<WorkspaceSummaryResult> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/summary`,
-    { credentials: "include", cache: "no-store" },
+    sessionFetchInit(opts?.cookie),
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -213,10 +217,11 @@ async function fetchWorkspaceList<T>(
   segment: string,
   key: string,
   isValid: (value: unknown) => value is T,
+  opts?: { cookie?: string },
 ): Promise<T[]> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/${segment}`,
-    { credentials: "include", cache: "no-store" },
+    sessionFetchInit(opts?.cookie),
   );
   if (result.kind === "unavailable" || !result.response.ok) return [];
   const body = (await result.response.json().catch(() => null)) as Record<string, unknown> | null;
@@ -274,8 +279,9 @@ function isGallerySummary(value: unknown): value is GallerySummary {
 export function getMyWorkspaceGalleries(
   apiOrigin: string,
   name: string,
+  opts?: { cookie?: string },
 ): Promise<GallerySummary[]> {
-  return fetchWorkspaceList(apiOrigin, name, "galleries", "galleries", isGallerySummary);
+  return fetchWorkspaceList(apiOrigin, name, "galleries", "galleries", isGallerySummary, opts);
 }
 
 export interface WorkspaceFile {
@@ -303,10 +309,11 @@ function isWorkspaceFile(value: unknown): value is WorkspaceFile {
 export async function getMyWorkspaceFiles(
   apiOrigin: string,
   name: string,
+  opts?: { cookie?: string },
 ): Promise<WorkspaceFile[]> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files`,
-    { credentials: "include", cache: "no-store" },
+    sessionFetchInit(opts?.cookie),
   );
   if (result.kind === "unavailable" || !result.response.ok) return [];
   const body = (await result.response.json().catch(() => null)) as Record<string, unknown> | null;
@@ -464,10 +471,11 @@ export type WorkspacePeopleResult =
 export async function getWorkspacePeople(
   apiOrigin: string,
   name: string,
+  opts?: { cookie?: string },
 ): Promise<WorkspacePeopleResult> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/people`,
-    { credentials: "include", cache: "no-store" },
+    sessionFetchInit(opts?.cookie),
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -903,9 +911,10 @@ function isProjectSummary(value: unknown): value is ProjectSummary {
 export async function getWorkspaceFilesByPath(
   apiOrigin: string,
   name: string,
+  opts?: { cookie?: string },
 ): Promise<FilesByPathResult> {
   const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/by-path`;
-  const result = await fetchWithTimeout(url, { credentials: "include", cache: "no-store" });
+  const result = await fetchWithTimeout(url, sessionFetchInit(opts?.cookie));
   if (result.kind === "unavailable") return result;
   const { response } = result;
   if (!response.ok) return { kind: "unavailable", reason: "server" };

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -5,7 +5,10 @@
  * Auto-opens a workspace (last-used, else first owned) so a signed-in user
  * lands somewhere; `?manage=1` asks for the list itself instead.
  */
+import { env } from "cloudflare:workers";
 import AccountLayout from "../../layouts/AccountLayout.astro";
+import { getMyWorkspaces } from "../../lib/api-client";
+import { resolveSignedInOrigins } from "../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../lib/workspace-browse-url";
 import { renderWorkspacesPlaceholderHtml } from "../../lib/workspace-ui";
 
@@ -21,6 +24,25 @@ if (isBrowseWorkspace(legacyWs)) {
     if (key !== "ws" && key !== "to") dest.searchParams.append(key, value);
   }
   return Astro.redirect(`${dest.pathname}${dest.search}${dest.hash}`);
+}
+
+// Server-side auto-open: for a single-workspace user (the common case),
+// 302 straight to their workspace so login reaches content without a client
+// fetch + redirect hop. Multi-workspace (last-used lives client-side),
+// ?manage=1, empty, and unavailable all fall through to the client script.
+const managing = new URLSearchParams(Astro.url.search).get("manage") === "1";
+if (!managing) {
+  const { apiOrigin } = resolveSignedInOrigins(env);
+  const cookie = Astro.request.headers.get("cookie") ?? "";
+  if (cookie.trim()) {
+    const result = await getMyWorkspaces(apiOrigin, { cookie });
+    if (result.kind === "success" && result.workspaces.length === 1) {
+      const only = result.workspaces[0].workspace;
+      const to = new URLSearchParams(Astro.url.search).get("to");
+      const suffix = to === "screenshots" ? "/screenshots" : "";
+      return Astro.redirect(`/account/workspaces/${encodeURIComponent(only)}${suffix}`);
+    }
+  }
 }
 ---
 

--- a/apps/web/src/pages/account/workspaces/[name]/galleries.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/galleries.astro
@@ -3,9 +3,15 @@
  * Workspace galleries tab: explainer, create command, and table (name, items,
  * linked PR/issues, updated) from GET /me/workspaces/:name/galleries.
  */
+import { env } from "cloudflare:workers";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
+import { getMyWorkspaceGalleries, getWorkspaceSummary } from "../../../../lib/api-client";
+import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
-import { renderGalleriesPlaceholderHtml } from "../../../../lib/workspace-ui";
+import {
+  renderGalleriesPlaceholderHtml,
+  renderGalleriesTableHtml,
+} from "../../../../lib/workspace-ui";
 
 export const prerender = false;
 
@@ -18,6 +24,24 @@ const createCmd = 'uploads gallery create --title "Release screenshots"';
 const tip = {
   body: "link a gallery to a PR and the public link stays current as you add shots.",
 };
+
+// SSR-first: when the request carries a session and the workspace resolves,
+// fetch galleries server-side so first paint has real rows. Only render the
+// table when there IS data — getMyWorkspaceGalleries conflates empty and error,
+// so an empty/failed result falls back to the placeholder and the client script
+// paints the correct empty-state or error.
+const { apiOrigin } = resolveSignedInOrigins(env);
+const cookie = Astro.request.headers.get("cookie") ?? "";
+let ssrGalleriesHtml: string | null = null;
+if (cookie.trim()) {
+  const [summary, galleries] = await Promise.all([
+    getWorkspaceSummary(apiOrigin, workspace, { cookie }),
+    getMyWorkspaceGalleries(apiOrigin, workspace, { cookie }),
+  ]);
+  if (summary.kind === "success" && galleries.length > 0) {
+    ssrGalleriesHtml = renderGalleriesTableHtml(galleries);
+  }
+}
 ---
 
 <WorkspaceLayout workspace={workspace} tip={tip}>
@@ -35,7 +59,7 @@ const tip = {
         </div>
       </div>
 
-      <div id="ws-galleries" set:html={renderGalleriesPlaceholderHtml()} />
+      <div id="ws-galleries" set:html={ssrGalleriesHtml ?? renderGalleriesPlaceholderHtml()} />
 
       {
         /* Hidden while the empty-state CTA is up — it repeats the create

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -4,9 +4,12 @@
  * Pending invites render in the same people list (not a separate section).
  * Operator ADMIN_TOKEN enrollment lives under /admin, not here.
  */
+import { env } from "cloudflare:workers";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
+import { getWorkspacePeople } from "../../../../lib/api-client";
+import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
-import { renderMembersPlaceholderHtml } from "../../../../lib/workspace-ui";
+import { renderMembersHtml, renderMembersPlaceholderHtml } from "../../../../lib/workspace-ui";
 
 export const prerender = false;
 
@@ -17,6 +20,23 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 const tip = {
   body: "invites are workspace-scoped — teammates see every file, not just their own.",
 };
+
+// SSR-first: render the member rows read-only on the server so first paint has
+// real teammates. Controls, the "you" badge, and pending invites are added by
+// the client re-render (they need viewer identity, which the server gate does
+// not expose). Rows are identical between the two renders → no layout jump.
+const { apiOrigin } = resolveSignedInOrigins(env);
+const cookie = Astro.request.headers.get("cookie") ?? "";
+let ssrMembersHtml: string | null = null;
+if (cookie.trim()) {
+  const people = await getWorkspacePeople(apiOrigin, workspace, { cookie });
+  if (people.kind === "ok" && people.members.length > 0) {
+    ssrMembersHtml = renderMembersHtml(people.members, {
+      canManage: false,
+      viewerRole: people.role,
+    });
+  }
+}
 ---
 
 <WorkspaceLayout workspace={workspace} tip={tip}>
@@ -35,8 +55,8 @@ const tip = {
       <div
         id="ws-members"
         class="member-list"
-        aria-busy="true"
-        set:html={renderMembersPlaceholderHtml()}
+        aria-busy={ssrMembersHtml ? "false" : "true"}
+        set:html={ssrMembersHtml ?? renderMembersPlaceholderHtml()}
       />
     </div>
 


### PR DESCRIPTION
## What & why

Signed-in pages under `/account/*` are already on-demand rendered (`prerender = false`), but until now only `account/developers.astro` fetched its data *during* the server render. The rest painted a placeholder skeleton and fetched their primary data **client-side** after the session gate — the source of the skeleton→content jump and the slower-feeling load on those pages.

This PR propagates the proven `developers.astro` pattern (fetch with the request cookie in the frontmatter, render real content, let the client script revalidate) to the highest-value pages, and moves the post-login workspace resolution server-side.

## Changes

- **Cookie forwarding** (`api-client.ts`): optional `{ cookie }` on the `/me/*` helpers (`getMyWorkspaces`, `getWorkspaceSummary`, `getWorkspacePeople`, `getMyWorkspaceFiles`, `getWorkspaceFilesByPath`, and the shared `fetchWorkspaceList` behind `getMyWorkspaceGalleries`), routed through the existing `sessionFetchInit`. Enables server-side authenticated fetches. No change for existing browser callers — the option is optional.
- **Galleries tab**: server-renders the real table when the viewer is a member with ≥1 gallery; placeholder fallback otherwise. Also collapses the client summary→galleries waterfall on the server.
- **People tab**: server-renders the member rows read-only (`canManage: false`); the client re-render adds identity, per-row controls, and invites. Rows are identical across the two renders, so there is no layout jump.
- **Post-login landing**: `/account/workspaces` now 302s a single-workspace user straight to their workspace server-side (honoring `?to=screenshots`), removing a client fetch + JS boot + redirect hop before reaching content. Multi-workspace, `?manage=1`, empty, and unavailable states all fall through to the existing client script unchanged.

## Verification

- `pnpm --filter @uploads/web typecheck` — 0 errors
- `pnpm --filter @uploads/web test` — 644/644, including 12 new cookie-forwarding tests. They are load-bearing: reverting the source fails exactly the 6 "forwards" cases (assertions run outside the `fetch` mock so `fetchWithTimeout`'s catch can't swallow them).
- `pnpm lint` — clean
- Runtime (local raw stack, signed-in demo session):
  - **Galleries / People**: real content is present in the **server** HTML only with a valid session cookie; without one, the safe placeholder renders (no data leak).
  - **Landing**: `302 → /account/workspaces/<ws>` for a single-workspace user; `?to=screenshots` → `.../screenshots`; `?manage=1` and signed-out both render `200` with no redirect loop.

## Notes

- **No changeset** — `@uploads/web` is private; a changeset naming it would yield an empty version PR and block the next CLI publish.
- **Warm vs cold**: the SSR content paints immediately on warm SPA navigations (the common case). Cold first loads still wait behind the client session gate; removing that is a deeper change, tracked as a follow-up.
- Part of a broader SSR-first audit. The workspace **files** and **screenshots** tabs (React islands) are the remaining, higher-effort candidates and are intentionally out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace pages now load summaries, galleries, and member information on the server when possible, reducing empty states and improving initial page display.
  * Signed-in users with one workspace are redirected directly to it, while preserving the selected screenshots tab.
  * Workspace member listings initially include read-only role information before interactive controls load.

* **Bug Fixes**
  * Improved handling of authenticated workspace requests so session information is consistently retained across workspace views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->