### PR TITLE
perf(web): server-render the workspace files table first paint

### DIFF
--- a/apps/web/src/components/WorkspaceFileTable.test.ts
+++ b/apps/web/src/components/WorkspaceFileTable.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { readBrowseLocation } from "../lib/workspace-browse-url";
+import { readSearchFilters, readSearchName } from "../lib/workspace-search-url";
+import { resolveFilesView } from "../lib/workspace-files-view";
+
+/**
+ * Plan 005: seed-prop contract for `WorkspaceFileTable`'s `initialSearch`
+ * (prefix/filters/nameTerm/view) derivation.
+ *
+ * This package's `vitest run` cannot import `WorkspaceFileTable.tsx` (or any
+ * `.tsx` file) directly: `tsc --showConfig` resolves `jsx: "preserve"` from
+ * `astro/tsconfigs/strict`, and plain Vitest never loads `@astrojs/react`'s
+ * Vite plugin (only the full `astro dev`/`astro build` pipeline does) — so
+ * the raw JSX in the component reaches Rollup's import-analysis unparsed and
+ * the import throws. No `.test.tsx` exists anywhere in this package today;
+ * standing one up needs a `vitest.config.ts` wiring in a JSX-capable Vite
+ * plugin, which is out of this plan's file scope.
+ *
+ * So this pins the *inputs* to the component's seeding, not the component's
+ * render output: `WorkspaceFileTable`'s `useState` initializers do exactly
+ * `readBrowseLocation(seedSearch, seedPathname).path`,
+ * `readSearchFilters(seedSearch)`, `readSearchName(seedSearch) ?? ""`, and
+ * `resolveFilesView(seedSearch)`, where `seedSearch` is `initialSearch` when
+ * provided, else `window.location.search` when `window` exists, else `""` —
+ * see `WorkspaceFileTable.tsx`'s `seedSearch`/`seedPathname` consts. These
+ * are the same library functions the component calls, unmodified and
+ * already independently covered elsewhere (`workspace-browse-url.test.ts`,
+ * `workspace-search-url.test.ts`, `workspace-files-view.test.ts`) — what's
+ * new here is asserting the exact seed values `[name].astro`'s
+ * `initialSearch={Astro.url.search}` and a props-less (window-only) mount
+ * resolve to, which is the part plan 005 actually changed.
+ */
+
+describe("WorkspaceFileTable seed contract — initialSearch provided", () => {
+  it("a default root browse (empty search) seeds an empty prefix, no filters, no name, list view", () => {
+    const seedSearch = "";
+    const seedPathname = "/account/workspaces/acme";
+    expect(readBrowseLocation(seedSearch, seedPathname).path).toBe("");
+    expect(readSearchFilters(seedSearch)).toEqual([]);
+    expect(readSearchName(seedSearch) ?? "").toBe("");
+    expect(resolveFilesView(seedSearch, null)).toBe("list");
+  });
+
+  it("a deep-linked folder path seeds that prefix", () => {
+    const seedSearch = "?path=screenshots%2Freleases%2F";
+    const seedPathname = "/account/workspaces/acme";
+    expect(readBrowseLocation(seedSearch, seedPathname).path).toBe("screenshots/releases/");
+  });
+
+  it("a deep-linked search (name + meta filters) seeds filters and name, ignoring path", () => {
+    const seedSearch = "?name=logo&meta.gh.repo=acme%2Frepo";
+    expect(readSearchName(seedSearch)).toBe("logo");
+    expect(readSearchFilters(seedSearch)).toEqual([{ key: "gh.repo", value: "acme/repo" }]);
+  });
+
+  it("?view=grid in the URL wins over stored/default", () => {
+    expect(resolveFilesView("?view=grid", "list")).toBe("grid");
+  });
+});
+
+describe("WorkspaceFileTable view hydration-parity contract", () => {
+  // Regression guard for the view/localStorage hydration mismatch: the
+  // server has no localStorage, so its render of `view` is always
+  // "URL-param-or-list". `WorkspaceFileTableInner`'s `view` initializer
+  // calls `resolveFilesView(seedSearch, null)` — passing `null` explicitly
+  // rather than relying on `resolveFilesView`'s own localStorage-reading
+  // default arg — so the client's first render (before the mount-once
+  // effect that applies the *real* stored preference) matches the server
+  // bit-for-bit regardless of what's in the visiting browser's
+  // localStorage. If this ever regresses back to a bare
+  // `resolveFilesView(seedSearch)` call, a user with `"grid"` stored would
+  // hydrate onto server-rendered list markup and React would discard +
+  // regenerate the whole tree client-side (a visible flash plus a
+  // hydration-mismatch console error) on every load and warm nav.
+  it("with no stored preference and no URL param, resolves list — storage plays no part", () => {
+    expect(resolveFilesView("", null)).toBe("list");
+  });
+
+  it("a ?view= URL param still wins over the (ignored) stored preference", () => {
+    expect(resolveFilesView("?view=grid", null)).toBe("grid");
+  });
+});
+
+describe("WorkspaceFileTable seed contract — no initialSearch prop (props-less mount)", () => {
+  // Mirrors the component's own fallback: `initialSearch ?? (typeof window
+  // !== "undefined" ? window.location.search : "")`. This Vitest run has no
+  // `window` (Node environment, no jsdom), so the fallback resolves to `""`
+  // exactly as it would during a server render with no seed prop passed —
+  // the same empty-string floor the component's own guard produces.
+  const seedSearch = typeof window !== "undefined" ? (window as Window).location.search : "";
+
+  it("resolves to the same defaults today's props-less behavior always had", () => {
+    expect(seedSearch).toBe("");
+    expect(readBrowseLocation(seedSearch, "").path).toBe("");
+    expect(readSearchFilters(seedSearch)).toEqual([]);
+    expect(readSearchName(seedSearch)).toBeUndefined();
+    expect(resolveFilesView(seedSearch, null)).toBe("list");
+  });
+});

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -20,6 +20,7 @@
 import { Callout } from "@uploads/ui";
 import "@uploads/ui/styles.css";
 import { Fragment, useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { IslandErrorBoundary } from "./IslandErrorBoundary";
 import type { ConnectedWorkSetter } from "../lib/workspace-rail";
 import { applyGhTitles, connectedWork, exactPrMatch, type GhWorkItem } from "../lib/gh-context";
 import {
@@ -84,10 +85,22 @@ import { onSession } from "../lib/account-shell";
 interface WorkspaceFileTableProps {
   apiOrigin: string;
   workspace: string;
+  /**
+   * `location.search` at server-render time (plan 005) — seeds `prefix`,
+   * `filters`, `nameTerm`, and `view` the same way `window.location.search`
+   * does client-side. Pass `Astro.url.search` from the frontmatter so the
+   * server's render and the client's very first render agree; omit for the
+   * pre-existing client-only-mount behavior (falls back to `window`).
+   */
+  initialSearch?: string;
+  /** Server-fetched default (unfiltered, root) folder listing, when available. */
+  initialListing?: ListingState;
+  /** Server-resolved workspace-info status, when available. */
+  initialInfo?: WorkspaceInfoStatus;
 }
 
 /** Unified row shape both `listWorkspaceFolder` and `searchWorkspaceFiles` satisfy. */
-interface FileTableRow {
+export interface FileTableRow {
   key: string;
   url: string | null;
   embedUrl: string | null;
@@ -99,7 +112,7 @@ interface FileTableRow {
   pageUrl?: string;
 }
 
-type ListingState =
+export type ListingState =
   | { status: "loading" }
   | { status: "error" }
   | {
@@ -447,10 +460,16 @@ function pluralCount(count: number, singular: string, plural = `${singular}s`): 
 // loading, PR #526): occupy the exact box the real content will occupy so
 // landing data doesn't shift the page. Kept as JSX here (not the HTML-string
 // builders) because this component's loading states render mid-tree, not as
-// a `set:html` swap — but `renderFilesPlaceholderHtml` in workspace-ui.ts
-// mirrors this markup 1:1 for the pre-mount gap in `[name].astro`, so the
-// two hand-offs (static HTML → this component's own loading render → real
-// data) are visually seamless throughout.
+// a `set:html` swap.
+//
+// Plan 005 (Phase A): `[name].astro` now renders this component itself
+// (server-side, via its own `initialInfo`/`initialListing` props) instead of
+// a separate `set:html` placeholder — so this is also what a cookie-less or
+// non-default-browse request's *server* render shows, not just the client's
+// pre-fetch gap. `renderFilesPlaceholderHtml` in workspace-ui.ts (still
+// tested, no longer wired into this page) mirrored this markup 1:1 for that
+// old hand-off; if Phase B keeps this architecture, it's a candidate for
+// removal — left alone here since `workspace-ui.ts` is out of this plan's scope.
 
 /** One masked bar — `--ws-skel-w` drives width, same custom property `.ws-skel` reads. */
 function SkelBar({ width }: { width: string }) {
@@ -536,37 +555,62 @@ function FilesLoadingSkeleton() {
 
 // ── Component ──────────────────────────────────────────────────────────
 
-export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableProps) {
-  const [info, setInfo] = useState<WorkspaceInfoStatus | { status: "loading" }>({
-    status: "loading",
-  });
+/**
+ * The actual interactive table. Not exported directly — see
+ * `WorkspaceFileTable` below for why.
+ */
+function WorkspaceFileTableInner({
+  apiOrigin,
+  workspace,
+  initialSearch,
+  initialListing,
+  initialInfo,
+}: WorkspaceFileTableProps) {
+  // Seed source for URL-derived initial state: the server-fetched
+  // `initialSearch` prop when present (SSR, and the client's first
+  // hydration-parity render), else the live location for the pre-existing
+  // client-only-mount path. `window` doesn't exist during SSR, so this must
+  // never be read unconditionally at the top of the component body.
+  const seedSearch = initialSearch ?? (typeof window !== "undefined" ? window.location.search : "");
+  // `readBrowseLocation` resolves workspace identity from the pathname; when
+  // there's no `window` yet, synthesize this route's own pathname from the
+  // `workspace` prop (this component only ever mounts on
+  // `/account/workspaces/:name`) so the server's parse agrees with the
+  // client's.
+  const seedPathname =
+    typeof window !== "undefined" ? window.location.pathname : `/account/workspaces/${workspace}`;
+
+  const [info, setInfo] = useState<WorkspaceInfoStatus | { status: "loading" }>(
+    () => initialInfo ?? { status: "loading" },
+  );
   // Bumped by the "Try again" affordance on the unavailable state to re-run
   // the workspace-info effect below without a full page reload.
   const [infoRetryNonce, setInfoRetryNonce] = useState(0);
 
-  const [prefix, setPrefix] = useState(
-    () => readBrowseLocation(window.location.search, window.location.pathname).path,
-  );
-  const [filters, setFilters] = useState<MetaFilter[]>(() =>
-    readSearchFilters(window.location.search),
-  );
+  const [prefix, setPrefix] = useState(() => readBrowseLocation(seedSearch, seedPathname).path);
+  const [filters, setFilters] = useState<MetaFilter[]>(() => readSearchFilters(seedSearch));
   const [draft, setDraft] = useState("");
   const [filterError, setFilterError] = useState<string | null>(null);
-  const [nameTerm, setNameTerm] = useState<string>(
-    () => readSearchName(window.location.search) ?? "",
-  );
+  const [nameTerm, setNameTerm] = useState<string>(() => readSearchName(seedSearch) ?? "");
   const [menuOpen, setMenuOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const [facets, setFacets] = useState<FacetKey[] | null>(null);
   const [facetsTruncated, setFacetsTruncated] = useState(false);
   const [facetValues, setFacetValues] = useState<Record<string, FacetValue[]>>({});
   const [facetValuesTruncated, setFacetValuesTruncated] = useState<Record<string, boolean>>({});
-  const [state, setState] = useState<ListingState>({ status: "loading" });
+  const [state, setState] = useState<ListingState>(() => initialListing ?? { status: "loading" });
   const [openMenuKey, setOpenMenuKey] = useState<string | null>(null);
   const [togglingKeys, setTogglingKeys] = useState<ReadonlySet<string>>(new Set());
   const [actionError, setActionError] = useState<string | null>(null);
   const [githubTitles, setGithubTitles] = useState<GithubTitleMap | null>(null);
-  const [view, setView] = useState<FilesView>(() => resolveFilesView(window.location.search));
+  // `null` for `stored`, not `resolveFilesView`'s own localStorage-reading
+  // default: the server has no `localStorage`, so its render always resolves
+  // "URL-param-or-list" — passing `null` here makes the client's first
+  // render (pre-hydration-effect) match that exactly, whether server-rendered
+  // or client-only-mounted. Reading the *real* stored preference is deferred
+  // to the mount-once effect below, once hydration has already reconciled
+  // against markup neither side disagrees on.
+  const [view, setView] = useState<FilesView>(() => resolveFilesView(seedSearch, null));
   const githubTitlesGeneration = useRef(0);
   // In-flight guards (refs, not state — must not trigger re-renders) so a
   // second call issued while the first is still pending (every keystroke on
@@ -614,6 +658,21 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
       facetValuesInFlightRef.current.delete(key);
     }
   };
+
+  // Apply the real stored view preference once, after hydration has already
+  // reconciled against the server-parity ("URL-param-or-list") render above —
+  // this is a client-only *update*, not a hydration input, so it can safely
+  // read localStorage. A `?view=` URL param still wins inside
+  // `resolveFilesView` itself, and browse/search URL writers already leave
+  // `view` untouched, so this can't fight folder/filter navigation. Mount-only
+  // by design (`[]`): re-applying on every `seedSearch` change would fire on
+  // every folder/filter navigation too, clobbering a mid-session toggle back
+  // to the stored preference's opposite.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const stored = resolveFilesView(seedSearch);
+    setView((prev) => (prev === stored ? prev : stored));
+  }, []);
 
   // Resolve workspace-level facts once (public-domain-configured),
   // gated behind the layout's session resolution like the rail (workspace-rail.ts).
@@ -1482,5 +1541,26 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
         </button>
       )}
     </div>
+  );
+}
+
+/**
+ * The exported island. Wraps `WorkspaceFileTableInner` in `IslandErrorBoundary`
+ * *inside* this same component's own render, rather than as a separate JSX
+ * child in `[name].astro`'s template — nesting a plain (no client directive)
+ * framework component inside another as astro-template JSX only serializes
+ * the inner one to static, never-hydrated HTML (verified empirically: it
+ * renders zero `<astro-island>` for the inner component). Composing the
+ * boundary here means Astro sees exactly one island (this function), so
+ * `<WorkspaceFileTable client:load .../>` hydrates the whole subtree,
+ * boundary included, as a single React root — the same effective tree the
+ * pre-plan-005 manual `withIslandBoundary(createElement(WorkspaceFileTable,
+ * …))` mount produced.
+ */
+export function WorkspaceFileTable(props: WorkspaceFileTableProps) {
+  return (
+    <IslandErrorBoundary>
+      <WorkspaceFileTableInner {...props} />
+    </IslandErrorBoundary>
   );
 }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1351,11 +1351,20 @@ function toWorkspaceFolderFile(raw: Record<string, unknown>): WorkspaceFolderFil
  * The API returns `cursor` as `string | null`; normalized here to
  * `string | undefined`. Likewise `prefixes` defaults to `[]` when the API
  * omits it (non-delimited listings).
+ *
+ * `opts.cookie` (plan 005): lets an Astro frontmatter server-fetch the
+ * default folder listing with the incoming request's session cookie —
+ * `credentials: "include"` alone only rides a browser's own cookie jar and
+ * does nothing for a server-to-server fetch. Same `sessionFetchInit`
+ * convention plan 001 added to the other `/v1/workspaces/:name/*` reads
+ * below; this is the one plan 001 didn't touch, added here narrowly because
+ * it's the actual data source `WorkspaceFileTable`'s default (unfiltered)
+ * browse view uses, not `getMyWorkspaceFiles`.
  */
 export async function listWorkspaceFolder(
   apiOrigin: string,
   workspace: string,
-  opts: { prefix?: string; cursor?: string; limit?: number } = {},
+  opts: { prefix?: string; cursor?: string; limit?: number; cookie?: string } = {},
 ): Promise<WorkspaceFolderListing> {
   const params = new URLSearchParams();
   // Always list one folder level at a time — without the delimiter the API
@@ -1367,7 +1376,7 @@ export async function listWorkspaceFolder(
   const query = params.toString();
   const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(workspace)}/files${query ? `?${query}` : ""}`;
 
-  const result = await fetchWithTimeout(url, { credentials: "include", cache: "no-store" });
+  const result = await fetchWithTimeout(url, sessionFetchInit(opts.cookie));
   if (result.kind === "unavailable" || !result.response.ok) return emptyFolderListing();
 
   const body = (await result.response.json().catch(() => null)) as {

--- a/apps/web/src/pages/account/workspaces/[name].astro
+++ b/apps/web/src/pages/account/workspaces/[name].astro
@@ -2,10 +2,38 @@
 /**
  * Workspace files — `WorkspaceLayout` + file table. Sibling routes under
  * `[name]/` cover galleries / people / settings.
+ *
+ * SSR-first (plan 005, Phase B): when the request carries a session and the
+ * URL is the plain unfiltered root browse (no `?path=`, `meta.*`, or
+ * `name=`), server-fetch the workspace summary + default folder listing so
+ * first paint has real rows instead of the loading skeleton.
+ * `WorkspaceFileTable` itself renders here with no `client:*` directive, so
+ * Astro emits it as plain static HTML (no `astro-island`, no hydration
+ * bootstrap) — the seeded rows are real, visible markup even before any JS
+ * runs. A companion JSON `<script>` carries the same props, and a manual
+ * `hydrateRoot` mount (below, off `astro:page-load`/`astro:before-swap`,
+ * same shape every sibling workspace-tab page already uses) attaches
+ * interactivity to that exact markup afterwards.
+ *
+ * Phase A prototyped `client:load` instead and rejected it: it hydrates
+ * fine in a production build, but in `astro dev` it 404s fetching
+ * `@astrojs/react`'s Fast-Refresh bootstrap before hydration ever starts —
+ * the exact class of bug this file's `astro.config.mjs` already documents
+ * and works around by keeping `client:*` out of this codebase entirely
+ * (`vite.server.hmr = false` only dodges it for the manual-mount path this
+ * page is back to using). `client:load` also opts out of the
+ * `astro:before-swap` teardown every sibling tab relies on for clean
+ * ClientRouter re-mounts. See plan 005's review-gate notes for the full
+ * writeup.
  */
+import { env } from "cloudflare:workers";
 import WorkspaceLayout from "../../../layouts/WorkspaceLayout.astro";
-import { isBrowseWorkspace } from "../../../lib/workspace-browse-url";
-import { renderFilesPlaceholderHtml } from "../../../lib/workspace-ui";
+import { WorkspaceFileTable, type ListingState } from "../../../components/WorkspaceFileTable";
+import { getWorkspaceSummary, listWorkspaceFolder } from "../../../lib/api-client";
+import { resolveSignedInOrigins } from "../../../lib/signed-in-page";
+import { isBrowseWorkspace, readBrowseLocation } from "../../../lib/workspace-browse-url";
+import { readSearchFilters, readSearchName } from "../../../lib/workspace-search-url";
+import type { WorkspaceInfoStatus } from "../../../lib/workspace-file-row";
 
 export const prerender = false;
 
@@ -16,22 +44,84 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 const tip = {
   body: "attach uploads to a pull request with <code>uploads put ./shot.png --pr 123</code> — they collect into one managed comment.",
 };
+
+const { apiOrigin } = resolveSignedInOrigins(env);
+const cookie = Astro.request.headers.get("cookie") ?? "";
+const initialSearch = Astro.url.search;
+
+let initialInfo: WorkspaceInfoStatus | undefined;
+let initialListing: ListingState | undefined;
+
+if (cookie.trim()) {
+  // Only seed the listing for the plain root browse — a deep link into a
+  // folder or an active search needs a *different* fetch than "default,
+  // unfiltered, root", and seeding the wrong data would show rows that don't
+  // match the breadcrumbs/chips the same URL seeds on the client. The
+  // workspace-info seed has no such constraint (its render is identical
+  // regardless of URL), so it's fetched unconditionally below.
+  const isDefaultBrowse =
+    readBrowseLocation(initialSearch, Astro.url.pathname).path === "" &&
+    readSearchFilters(initialSearch).length === 0 &&
+    !readSearchName(initialSearch);
+
+  const [summary, listing] = await Promise.all([
+    getWorkspaceSummary(apiOrigin, workspace, { cookie }),
+    isDefaultBrowse ? listWorkspaceFolder(apiOrigin, workspace, { cookie }) : Promise.resolve(null),
+  ]);
+
+  if (summary.kind === "success") {
+    initialInfo = { status: "ready", hasPublicUrl: summary.workspace.hasPublicUrl };
+    if (listing) {
+      initialListing = {
+        status: "ok",
+        files: listing.files,
+        prefixes: listing.prefixes,
+        cursor: listing.cursor,
+      };
+    }
+  }
+}
+
+// Carries the exact same props into the client mount script below (plain
+// `<script>`, not `client:*` — see the file-level doc comment for why).
+// `<`-escaped so a filename/metadata value containing `</script>` can't
+// break out of the tag; this is the same data `WorkspaceFileTable` above
+// already rendered, so nothing here is newly untrusted.
+const filesSeedJson = JSON.stringify({
+  apiOrigin,
+  workspace,
+  initialSearch,
+  initialListing,
+  initialInfo,
+}).replace(/</g, "\\u003c");
 ---
 
 <WorkspaceLayout workspace={workspace} tip={tip}>
-  {
-    /* React (dynamic-imported below) replaces this wholesale on mount — it
-      exists only to fill the gap before that import resolves, so it mirrors
-      WorkspaceFileTable's own `info.status === "loading"` render exactly. */
-  }
-  <div id="ws-files-table" set:html={renderFilesPlaceholderHtml()} />
+  <div id="ws-files-table">
+    <WorkspaceFileTable
+      apiOrigin={apiOrigin}
+      workspace={workspace}
+      initialSearch={initialSearch}
+      initialListing={initialListing}
+      initialInfo={initialInfo}
+    />
+  </div>
+  <script type="application/json" id="ws-files-seed" set:html={filesSeedJson} />
 
   <script>
     import { onAstroPageLoad } from "../../../lib/account-shell";
-    import { resolveActiveWorkspace } from "../../../lib/workspace-browse-url";
     import { createElement } from "react";
-    import { createRoot, type Root } from "react-dom/client";
-    import { withIslandBoundary } from "../../../components/IslandErrorBoundary";
+    import { hydrateRoot, type Root } from "react-dom/client";
+    import type { ListingState } from "../../../components/WorkspaceFileTable";
+    import type { WorkspaceInfoStatus } from "../../../lib/workspace-file-row";
+
+    interface FilesSeed {
+      apiOrigin: string;
+      workspace: string;
+      initialSearch: string;
+      initialListing?: ListingState;
+      initialInfo?: WorkspaceInfoStatus;
+    }
 
     let filesTableRoot: Root | null = null;
 
@@ -45,34 +135,37 @@ const tip = {
       filesTableRoot = null;
     }
 
+    function readSeed(): FilesSeed | null {
+      const el = document.getElementById("ws-files-seed");
+      if (!el?.textContent) return null;
+      try {
+        return JSON.parse(el.textContent) as FilesSeed;
+      } catch {
+        return null;
+      }
+    }
+
     async function boot(): Promise<void> {
       const mount = document.getElementById("ws-files-table");
-      if (!mount) return;
+      const seed = readSeed();
+      if (!mount || !seed) return;
 
       // Tear down the previous mount before Astro swaps this page's body away
       // (registered once per boot() call — {once:true} auto-clears itself so
       // repeated astro:page-load events from ClientRouter never stack listeners).
       document.addEventListener("astro:before-swap", teardown, { once: true });
 
-      const w = window as unknown as {
-        __UPLOADS_API_ORIGIN__: string;
-        __UPLOADS_ACTIVE_WORKSPACE__: string;
-      };
-      const apiOrigin = w.__UPLOADS_API_ORIGIN__;
-      // Pathname wins when the boot global is empty/stale after ClientRouter
-      // sibling navigation (same convention as WorkspaceLayout's own script).
-      const workspace = resolveActiveWorkspace(
-        window.location.pathname,
-        w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
-      );
-
+      // Lazy, not a static top-level import: keeps a Fast-Refresh/HMR dev
+      // glitch in this component from blocking the rest of the page's
+      // scripts — same reasoning every sibling workspace-tab mount uses.
       const { WorkspaceFileTable } = await import("../../../components/WorkspaceFileTable");
       if (!document.contains(mount)) return;
       teardown();
-      filesTableRoot = createRoot(mount);
-      filesTableRoot.render(
-        withIslandBoundary(createElement(WorkspaceFileTable, { apiOrigin, workspace })),
-      );
+      // `WorkspaceFileTable` already composes `IslandErrorBoundary`
+      // internally (plan 005 Phase A) — mounting it directly, with no extra
+      // wrapper, matches the SSR'd tree exactly, so `hydrateRoot` reconciles
+      // without warnings.
+      filesTableRoot = hydrateRoot(mount, createElement(WorkspaceFileTable, seed));
     }
 
     // astro:page-load fires on the initial load too (same as every sibling


### PR DESCRIPTION
## What

Server-render the workspace files table's first paint. `/account/workspaces/:name` is the highest-traffic signed-in page; it previously rendered only a skeleton, then dynamic-imported the `WorkspaceFileTable` React island and fetched the listing on the client — the skeleton→content jump on every visit. The page now server-fetches the default folder listing + workspace summary (with the request cookie) and renders the component to **static HTML**, so first paint shows real rows on warm navigations.

Follow-on to #695, which server-rendered the galleries/people/landing data. This applies the same SSR-first idea to the first React-island page.

## Approach — and why not `client:load`

This was planned as a spike. The obvious approach (an Astro `client:load` island) was prototyped and **rejected**:

- `client:load` pulls in Astro's island bootstrap (`before-hydration.js` → React Fast-Refresh), which `apps/web/astro.config.mjs` already documents as broken under this Vite 8/Rolldown + Cloudflare setup — the reason this codebase sets `vite.server.hmr = false` and uses **no** `client:*` directives anywhere. It 404s and aborts hydration under `astro dev`.
- It also opts out of the `astro:before-swap` teardown every sibling workspace tab relies on for clean `ClientRouter` re-mounts — and warm navigations are exactly what this change targets.

The shipped shape instead matches the rest of the app: the component renders with **no client directive** (static HTML, zero `astro-island`), alongside a `<`-escaped JSON `<script>` seed, and is hydrated by a manual `hydrateRoot` mount reusing the sibling tabs' `onAstroPageLoad` / `astro:before-swap` lifecycle.

## Changes

- **`WorkspaceFileTable.tsx`** — `initialSearch` / `initialListing` / `initialInfo` seed props; init-time `window`/`localStorage` reads guarded so the server and client's first render agree. The list/grid `view` preference (which reads `localStorage`) is resolved **without** storage on first render to match the server, then applied in a mount-once effect — otherwise a grid-preferring user hits a hydration mismatch.
- **`[name].astro`** — frontmatter server-fetch (cookie-gated, and only for the plain unfiltered root browse — deep links/filters still fetch client-side to keep the URL and rows consistent); static component render + JSON seed + `hydrateRoot` mount.
- **`api-client.ts`** — `listWorkspaceFolder` accepts an optional `{ cookie }` for the frontmatter fetch.

## Verification

Against a local signed-in stack (seeded workspace, real session):
- Raw HTML (no JS) contains real folder rows; the JSON seed carries the same listing; zero `astro-island`.
- `hydrateRoot` attaches live handlers — folder drill-in, breadcrumb, and refetch all work.
- **Hydration parity confirmed** including the `view=grid` case that the fix targets: 0 hydration errors; warm `ClientRouter` round-trips clean.
- `typecheck` 0 errors · `test` 651/651 · `lint` clean (no new warnings).

No changeset: `@uploads/web` is private (a changeset there would block the next CLI release).
