### PR TITLE
feat(web): server-render the screenshots tab overview first paint

### DIFF
--- a/apps/web/src/components/ScreenshotsByPath.test.ts
+++ b/apps/web/src/components/ScreenshotsByPath.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { readScreenshotsView } from "../lib/workspace-screenshots";
+
+/**
+ * Plan 006: seed-prop contract for `ScreenshotsByPath`'s `initialSearch`
+ * (`view`) derivation.
+ *
+ * This package's `vitest run` cannot import `ScreenshotsByPath.tsx` (or any
+ * `.tsx` file) directly — the same limitation plan 005 documented for
+ * `WorkspaceFileTable.test.ts`: `tsc --showConfig` resolves `jsx: "preserve"`
+ * from `astro/tsconfigs/strict`, and plain Vitest never loads
+ * `@astrojs/react`'s Vite plugin (only the full `astro dev`/`astro build`
+ * pipeline does), so the raw JSX in the component reaches Rollup's
+ * import-analysis unparsed and the import throws. Verified directly: an
+ * ad-hoc `import("./ScreenshotsByPath")` probe under this same `vitest run`
+ * fails with "Failed to parse source for import analysis... jsx: preserve".
+ * No `.test.tsx` exists anywhere in this package today; standing one up
+ * needs a `vitest.config.ts` wiring in a JSX-capable Vite plugin, which is
+ * out of this plan's file scope.
+ *
+ * So this pins the *inputs* to the component's seeding, not the component's
+ * render output: `ScreenshotsByPathInner`'s `view` initializer does exactly
+ * `readScreenshotsView(seedSearch)`, where `seedSearch` is `initialSearch`
+ * when provided, else `window.location.search` when `window` exists, else
+ * `""` — see `ScreenshotsByPath.tsx`'s `seedSearch` const. `readScreenshotsView`
+ * itself is already covered by `workspace-screenshots.test.ts`; what's new
+ * here is asserting the exact seed value `screenshots.astro`'s
+ * `initialSearch={Astro.url.search}` and a props-less (window-only) mount
+ * resolve to, which is the part plan 006 actually changed.
+ *
+ * Unlike the files tab's `resolveFilesView`, `readScreenshotsView` never
+ * reads `localStorage` (grep-verified — no `localStorage` reference anywhere
+ * in `workspace-screenshots.ts` or `ScreenshotsByPath.tsx`) — it derives
+ * purely from the URL search string, so there is no separate hydration-parity
+ * ("stored" vs. server) contract to pin here the way plan 005 needed for the
+ * files tab's `view`/`resolveFilesView`. The only parity risk was the
+ * unconditional `window.location.search` read at initializer time, guarded
+ * the same way plan 005 guarded `WorkspaceFileTable`'s `seedSearch`.
+ *
+ * `initialOverview`/`initialInfo` themselves need no seed-derivation test:
+ * they're passed through `useState(() => initialOverview ?? { status:
+ * "loading" })` / `useState(() => initialInfo ?? { status: "loading" })`
+ * verbatim, with no parsing or URL-dependence to pin.
+ */
+describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
+  it("a default overview (empty search) seeds an empty project and path", () => {
+    expect(readScreenshotsView("")).toEqual({ project: "", path: "" });
+  });
+
+  it("a deep-linked project view seeds that project, no path", () => {
+    expect(readScreenshotsView("?project=acme%2Fweb")).toEqual({
+      project: "acme/web",
+      path: "",
+    });
+  });
+
+  it("a deep-linked drill-in seeds both project and path", () => {
+    expect(readScreenshotsView("?project=acme%2Fweb&path=%2Fadmin")).toEqual({
+      project: "acme/web",
+      path: "/admin",
+    });
+  });
+});
+
+describe("ScreenshotsByPath seed contract — no initialSearch prop (props-less mount)", () => {
+  // Mirrors the component's own fallback: `initialSearch ?? (typeof window
+  // !== "undefined" ? window.location.search : "")`. This Vitest run has no
+  // `window` (Node environment, no jsdom), so the fallback resolves to `""`
+  // exactly as it would during a server render with no seed prop passed —
+  // the same empty-string floor the component's own guard produces.
+  const seedSearch = typeof window !== "undefined" ? (window as Window).location.search : "";
+
+  it("resolves to the same defaults today's props-less behavior always had", () => {
+    expect(seedSearch).toBe("");
+    expect(readScreenshotsView(seedSearch)).toEqual({ project: "", path: "" });
+  });
+});

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -4,10 +4,20 @@
  * Overview = one `files/by-path` fetch; drill-in (?path=) = the existing
  * `files/search?meta.path=…` route. Files without `path` metadata never
  * appear here — the empty state says how to get them.
+ *
+ * SSR-first (plan 006, following plan 005's `WorkspaceFileTable` shape):
+ * when the request carries a session, `screenshots.astro` server-fetches the
+ * by-path overview + workspace summary and renders this component with no
+ * `client:*` directive, so first paint has real groups instead of the
+ * loading skeleton. A manual `hydrateRoot` mount (same lifecycle every
+ * sibling workspace tab uses) attaches interactivity afterwards. Only the
+ * OVERVIEW is server-seeded — the GitHub-mirrored section and the `?path=`
+ * drill-in still fetch client-side, unchanged.
  */
 import { Callout } from "@uploads/ui";
 import "@uploads/ui/styles.css";
 import { useEffect, useState, type CSSProperties } from "react";
+import { IslandErrorBoundary } from "./IslandErrorBoundary";
 import {
   getWorkspaceFilesByPath,
   searchWorkspaceFiles,
@@ -66,9 +76,21 @@ function EmptyShotsCta({ title }: { title: string }) {
 interface ScreenshotsByPathProps {
   apiOrigin: string;
   workspace: string;
+  /**
+   * `location.search` at server-render time (plan 006) — seeds the
+   * `?project=`/`?path=` `view` state the same way `window.location.search`
+   * does client-side. Pass `Astro.url.search` from the frontmatter so the
+   * server's render and the client's very first render agree; omit for the
+   * pre-existing client-only-mount behavior (falls back to `window`).
+   */
+  initialSearch?: string;
+  /** Server-fetched by-path overview, when available. */
+  initialOverview?: OverviewState;
+  /** Server-resolved workspace-info status, when available. */
+  initialInfo?: WorkspaceInfoStatus;
 }
 
-type OverviewState =
+export type OverviewState =
   | { status: "loading" }
   | { status: "error" }
   | {
@@ -193,6 +215,15 @@ function ShotThumb({
 }
 
 // ── Loading skeleton ───────────────────────────────────────────────────
+//
+// Plan 006: `screenshots.astro` now renders this component itself
+// (server-side, via its own `initialInfo`/`initialOverview` props) instead of
+// a separate `set:html` placeholder — so this is also what a cookie-less
+// request's *server* render shows, not just the client's pre-fetch gap.
+// `renderScreenshotsPlaceholderHtml` in workspace-ui.ts (still tested, no
+// longer wired into this page) mirrors this markup 1:1 for that old
+// hand-off — left alone here since `workspace-ui.ts` is out of this plan's
+// scope.
 
 function SkelBar({ width }: { width: string }) {
   return (
@@ -225,15 +256,39 @@ function OverviewLoadingSkeleton() {
 
 // ── Component ──────────────────────────────────────────────────────────
 
-export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathProps) {
-  const [info, setInfo] = useState<WorkspaceInfoStatus | { status: "loading" }>({
-    status: "loading",
-  });
+/**
+ * The actual interactive overview + drill-in. Not exported directly — see
+ * `ScreenshotsByPath` below for why.
+ */
+function ScreenshotsByPathInner({
+  apiOrigin,
+  workspace,
+  initialSearch,
+  initialOverview,
+  initialInfo,
+}: ScreenshotsByPathProps) {
+  // Seed source for URL-derived initial state: the server-fetched
+  // `initialSearch` prop when present (SSR, and the client's first
+  // hydration-parity render), else the live location for the pre-existing
+  // client-only-mount path. `window` doesn't exist during SSR, so this must
+  // never be read unconditionally at the top of the component body.
+  const seedSearch = initialSearch ?? (typeof window !== "undefined" ? window.location.search : "");
+
+  const [info, setInfo] = useState<WorkspaceInfoStatus | { status: "loading" }>(
+    () => initialInfo ?? { status: "loading" },
+  );
   const [infoRetryNonce, setInfoRetryNonce] = useState(0);
-  const [overview, setOverview] = useState<OverviewState>({ status: "loading" });
+  const [overview, setOverview] = useState<OverviewState>(
+    () => initialOverview ?? { status: "loading" },
+  );
   const [overviewRetryNonce, setOverviewRetryNonce] = useState(0);
+  // `readScreenshotsView` derives purely from the URL search string (no
+  // localStorage involved anywhere in this module — unlike the files tab's
+  // `resolveFilesView`), so there's no stored-preference divergence to guard
+  // against here: the server and the client's first render already agree as
+  // long as both read the same `seedSearch`, which is exactly what this does.
   const [view, setView] = useState<{ project: string; path: string }>(() =>
-    readScreenshotsView(window.location.search),
+    readScreenshotsView(seedSearch),
   );
   const [drill, setDrill] = useState<DrillState>({ status: "idle" });
   const [drillRetryNonce, setDrillRetryNonce] = useState(0);
@@ -544,6 +599,24 @@ export function ScreenshotsByPath({ apiOrigin, workspace }: ScreenshotsByPathPro
         </>
       )}
     </div>
+  );
+}
+
+/**
+ * The exported island. Wraps `ScreenshotsByPathInner` in `IslandErrorBoundary`
+ * *inside* this same component's own render (plan 006, following plan 005's
+ * `WorkspaceFileTable`) — composing the boundary here means Astro sees
+ * exactly one component when `screenshots.astro` renders `<ScreenshotsByPath
+ * ... />` with no client directive, so the manual `hydrateRoot` mount (which
+ * imports this same exported name) hydrates the whole subtree, boundary
+ * included, as a single React root that matches the server-rendered tree
+ * exactly — no extra wrapper the server didn't also render.
+ */
+export function ScreenshotsByPath(props: ScreenshotsByPathProps) {
+  return (
+    <IslandErrorBoundary>
+      <ScreenshotsByPathInner {...props} />
+    </IslandErrorBoundary>
   );
 }
 

--- a/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
@@ -3,10 +3,36 @@
  * Screenshots grouped by `path` metadata — `WorkspaceLayout` + the
  * `ScreenshotsByPath` island. Sibling route to `[name].astro` (files);
  * cloned structure, own mount id.
+ *
+ * SSR-first (plan 006, following plan 005's `WorkspaceFileTable`/`[name].astro`
+ * shape): when the request carries a session, server-fetch the workspace
+ * summary + by-path overview so first paint has real groups instead of the
+ * loading skeleton. `ScreenshotsByPath` itself renders here with no
+ * `client:*` directive, so Astro emits it as plain static HTML (no
+ * `astro-island`, no hydration bootstrap) — the seeded groups are real,
+ * visible markup even before any JS runs. A companion JSON `<script>` carries
+ * the same props, and a manual `hydrateRoot` mount (below, off
+ * `astro:page-load`/`astro:before-swap`, same shape every sibling
+ * workspace-tab page already uses) attaches interactivity to that exact
+ * markup afterwards. See `[name].astro`'s doc comment for why this codebase
+ * uses a manual mount instead of `client:load`.
+ *
+ * Unlike the files tab's `listWorkspaceFolder` (which depends on the current
+ * folder, so plan 005 only seeds it for the plain root browse),
+ * `getWorkspaceFilesByPath` always returns the same complete by-path overview
+ * regardless of the URL — `?project=`/`?path=` only change how
+ * `ScreenshotsByPath` filters/renders that same data (project view) or
+ * switches to a *different* client-side fetch (drill-in search). So the
+ * overview seed below is unconditional, not gated to a "default view" URL
+ * the way plan 005's listing seed is.
  */
+import { env } from "cloudflare:workers";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
+import { ScreenshotsByPath, type OverviewState } from "../../../../components/ScreenshotsByPath";
+import { getWorkspaceFilesByPath, getWorkspaceSummary } from "../../../../lib/api-client";
+import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
-import { renderScreenshotsPlaceholderHtml } from "../../../../lib/workspace-ui";
+import type { WorkspaceInfoStatus } from "../../../../lib/workspace-file-row";
 
 export const prerender = false;
 
@@ -19,23 +45,73 @@ const tip = {
   href: "/docs/attach-pull-request-images#put",
   linkLabel: "how grouping works",
 };
+
+const { apiOrigin } = resolveSignedInOrigins(env);
+const cookie = Astro.request.headers.get("cookie") ?? "";
+const initialSearch = Astro.url.search;
+
+let initialInfo: WorkspaceInfoStatus | undefined;
+let initialOverview: OverviewState | undefined;
+
+if (cookie.trim()) {
+  const [summary, overview] = await Promise.all([
+    getWorkspaceSummary(apiOrigin, workspace, { cookie }),
+    getWorkspaceFilesByPath(apiOrigin, workspace, { cookie }),
+  ]);
+
+  if (summary.kind === "success") {
+    initialInfo = { status: "ready", hasPublicUrl: summary.workspace.hasPublicUrl };
+  }
+  if (overview.kind === "ok") {
+    initialOverview = {
+      status: "ready",
+      groups: overview.groups,
+      projects: overview.projects,
+      truncated: overview.truncated,
+    };
+  }
+}
+
+// Carries the exact same props into the client mount script below (plain
+// `<script>`, not `client:*` — see the file-level doc comment for why).
+// `<`-escaped so a filename/metadata value containing `</script>` can't
+// break out of the tag; this is the same data `ScreenshotsByPath` above
+// already rendered, so nothing here is newly untrusted.
+const screenshotsSeedJson = JSON.stringify({
+  apiOrigin,
+  workspace,
+  initialSearch,
+  initialOverview,
+  initialInfo,
+}).replace(/</g, "\\u003c");
 ---
 
 <WorkspaceLayout workspace={workspace} tip={tip} showQuickActions={false}>
-  {
-    /* React (dynamic-imported below) replaces this wholesale on mount. The
-      placeholder mirrors the component's own OverviewLoadingSkeleton, so the
-      gap before that import resolves shows the same skeleton the component
-      renders next — no dead space, no jump. */
-  }
-  <div id="ws-screenshots" set:html={renderScreenshotsPlaceholderHtml()} />
+  <div id="ws-screenshots">
+    <ScreenshotsByPath
+      apiOrigin={apiOrigin}
+      workspace={workspace}
+      initialSearch={initialSearch}
+      initialOverview={initialOverview}
+      initialInfo={initialInfo}
+    />
+  </div>
+  <script type="application/json" id="ws-screenshots-seed" set:html={screenshotsSeedJson} />
 
   <script>
     import { onAstroPageLoad } from "../../../../lib/account-shell";
-    import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
     import { createElement } from "react";
-    import { createRoot, type Root } from "react-dom/client";
-    import { withIslandBoundary } from "../../../../components/IslandErrorBoundary";
+    import { hydrateRoot, type Root } from "react-dom/client";
+    import type { OverviewState } from "../../../../components/ScreenshotsByPath";
+    import type { WorkspaceInfoStatus } from "../../../../lib/workspace-file-row";
+
+    interface ScreenshotsSeed {
+      apiOrigin: string;
+      workspace: string;
+      initialSearch: string;
+      initialOverview?: OverviewState;
+      initialInfo?: WorkspaceInfoStatus;
+    }
 
     let screenshotsRoot: Root | null = null;
 
@@ -49,34 +125,36 @@ const tip = {
       screenshotsRoot = null;
     }
 
+    function readSeed(): ScreenshotsSeed | null {
+      const el = document.getElementById("ws-screenshots-seed");
+      if (!el?.textContent) return null;
+      try {
+        return JSON.parse(el.textContent) as ScreenshotsSeed;
+      } catch {
+        return null;
+      }
+    }
+
     async function boot(): Promise<void> {
       const mount = document.getElementById("ws-screenshots");
-      if (!mount) return;
+      const seed = readSeed();
+      if (!mount || !seed) return;
 
       // Tear down the previous mount before Astro swaps this page's body away
       // (registered once per boot() call — {once:true} auto-clears itself so
       // repeated astro:page-load events from ClientRouter never stack listeners).
       document.addEventListener("astro:before-swap", teardown, { once: true });
 
-      const w = window as unknown as {
-        __UPLOADS_API_ORIGIN__: string;
-        __UPLOADS_ACTIVE_WORKSPACE__: string;
-      };
-      const apiOrigin = w.__UPLOADS_API_ORIGIN__;
-      // Pathname wins when the boot global is empty/stale after ClientRouter
-      // sibling navigation (same convention as WorkspaceLayout's own script).
-      const workspace = resolveActiveWorkspace(
-        window.location.pathname,
-        w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
-      );
-
+      // Lazy, not a static top-level import: keeps a Fast-Refresh/HMR dev
+      // glitch in this component from blocking the rest of the page's
+      // scripts — same reasoning every sibling workspace-tab mount uses.
       const { ScreenshotsByPath } = await import("../../../../components/ScreenshotsByPath");
       if (!document.contains(mount)) return;
       teardown();
-      screenshotsRoot = createRoot(mount);
-      screenshotsRoot.render(
-        withIslandBoundary(createElement(ScreenshotsByPath, { apiOrigin, workspace })),
-      );
+      // `ScreenshotsByPath` already composes `IslandErrorBoundary` internally
+      // (plan 006) — mounting it directly, with no extra wrapper, matches the
+      // SSR'd tree exactly, so `hydrateRoot` reconciles without warnings.
+      screenshotsRoot = hydrateRoot(mount, createElement(ScreenshotsByPath, seed));
     }
 
     // astro:page-load fires on the initial load too (same as every sibling


### PR DESCRIPTION
## What

Server-render the screenshots tab's overview on first paint. `/account/workspaces/:name/screenshots` is the second most-visited workspace tab and had the same skeleton→content jump the files table did in #696: it rendered only a placeholder, then dynamic-imported the `ScreenshotsByPath` island which mounted and *then* fetched. The page now server-fetches the by-path overview + workspace summary (with the request cookie) and renders the component to **static HTML**, so first paint shows real screenshot groups on warm navigations.

Follow-on to #696 — this reuses the exact shape that PR settled, applied to the second (and final) React-island workspace tab.

## Approach

Same as #696 (see its description for why this codebase uses a manual mount instead of `client:load`): the component renders with **no client directive** (static HTML, zero `astro-island`), alongside a `<`-escaped JSON `<script>` seed, hydrated by a manual `hydrateRoot` mount reusing the sibling tabs' `onAstroPageLoad` / `astro:before-swap` lifecycle.

Two differences from #696, both deliberate:
- **Overview seed is unconditional.** `getWorkspaceFilesByPath` returns the same complete by-path overview regardless of the URL (`?project=` / `?path=` only change how the component filters/renders it, or switch to a different client-side fetch), so there's no "default view" gate like the files listing needed.
- **No `localStorage` parity concern.** `readScreenshotsView` derives purely from the URL, so — unlike the files tab's `view` (which reads `localStorage` and needed a post-mount effect) — the server and client's first render already agree from `initialSearch` alone.

Only the overview is seeded; the GitHub-mirrored section and the `?path=` drill-in keep fetching client-side, unchanged.

## Changes

- **`ScreenshotsByPath.tsx`** — `initialSearch` / `initialOverview` / `initialInfo` seed props; init-time `window.location.search` read guarded; `IslandErrorBoundary` composed inside an exported wrapper so the SSR tree and the `hydrateRoot` mount match exactly. GitHub-section and drill-in effects untouched (only wrapped in the renamed inner component).
- **`screenshots.astro`** — frontmatter server-fetch (cookie-gated); static component render + JSON seed + `hydrateRoot` mount.
- No `api-client.ts` change needed — `getWorkspaceFilesByPath` already took `{ cookie }` from the #695 batch.

## Verification

Against a local signed-in stack (workspace seeded with screenshots carrying `path`/`gh.repo` metadata):
- Raw HTML (no JS) contains real `wsp-group` / `wsp-project` markup and a seed JSON with the real overview; zero `astro-island`.
- **0 hydration errors** on the default view, `?project=`, and `?path=` drill-in (real data).
- `hydrateRoot` attaches; warm `ClientRouter` round-trip re-renders 5 groups cleanly; `?path=` drill-in renders its context and client-fetches shots.
- `typecheck` 0 errors · `test` 648 · `lint` exit 0 (one pre-existing unused-import warning in this file, present before this change).

No changeset: `@uploads/web` is private.
