### PR TITLE
feat: fill the real PR number into the bot comment add-media hint

### DIFF
--- a/.changeset/comment-add-media-pr-number.md
+++ b/.changeset/comment-add-media-pr-number.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Managed GitHub comment "add media" hint now uses the real PR or issue number (`uploads put <file> --pr 12`) instead of a `<N>` placeholder.

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -5,6 +5,7 @@ import {
   attachmentDensityForCount,
   attachmentImageWidth,
   attachmentPairWidth,
+  ATTACHMENTS_MARKER,
   attachmentsCommentBody,
   AUTO_RENDER_OPTIONS,
   GH_PRIVATE_ROOT,
@@ -498,6 +499,30 @@ describe("attachmentsCommentBody (api copy)", () => {
           ...c.options,
         }),
       ).toBe(c.expected);
+    });
+  });
+
+  describe("attachmentsCommentBody add-media hint", () => {
+    it("keeps the generic --pr <N> placeholder when no target is passed", () => {
+      const body = attachmentsCommentBody([]);
+      expect(body).toContain("<code>uploads put &lt;file&gt; --pr &lt;N&gt;</code>");
+    });
+
+    it("fills the PR number into the copy-paste command", () => {
+      const body = attachmentsCommentBody([], [], ATTACHMENTS_MARKER, AUTO_RENDER_OPTIONS, {
+        kind: "pull",
+        num: 12,
+      });
+      expect(body).toContain("<code>uploads put &lt;file&gt; --pr 12</code>");
+      expect(body).not.toContain("--pr &lt;N&gt;");
+    });
+
+    it("uses --issue <num> for issue targets", () => {
+      const body = attachmentsCommentBody([], [], ATTACHMENTS_MARKER, AUTO_RENDER_OPTIONS, {
+        kind: "issues",
+        num: 45,
+      });
+      expect(body).toContain("<code>uploads put &lt;file&gt; --issue 45</code>");
     });
   });
 });

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -78,6 +78,17 @@ describe("gatherCommentBody", () => {
     });
     expect(result.count).toBe(0);
     expect(result.body).toContain("_No attachments are currently associated");
+    expect(result.body).toContain("<code>uploads put &lt;file&gt; --pr 12</code>");
+  });
+
+  it("uses --issue <num> in the add-media hint for issue targets", async () => {
+    const { env, ws, workspaceName } = makeTestEnv();
+    const result = await gatherCommentBody(env, ws, workspaceName, {
+      repo: "acme/web",
+      num: 45,
+      kind: "issues",
+    });
+    expect(result.body).toContain("<code>uploads put &lt;file&gt; --issue 45</code>");
   });
 
   it("renders the workspace's own attachments under the gh prefix", async () => {

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -70,7 +70,7 @@ export async function gatherCommentBody(
   };
   // count may be 0 — attachmentsCommentBody renders a neutral empty state.
   // Callers gate create-vs-patch on count (see upsertBotComment createIfMissing).
-  return { body: attachmentsCommentBody(items, galleries, marker, renderOptions), count };
+  return { body: attachmentsCommentBody(items, galleries, marker, renderOptions, target), count };
 }
 
 /**

--- a/packages/comment-render/src/index.ts
+++ b/packages/comment-render/src/index.ts
@@ -506,14 +506,30 @@ function countInlinableMedia(sorted: AttachmentItem[], maxInlineImages: number):
 }
 
 /**
+ * Quiet add-media footer. When `target` is a real PR/issue, the command
+ * uses that number (`--pr 12` / `--issue 45`) so anyone reading the comment
+ * can copy it. Without a target the generic `--pr <N>` placeholder stays.
+ */
+function addMediaFooter(target?: Pick<GhTarget, "kind" | "num">): string {
+  const flag = target?.kind === "issues" ? "--issue" : "--pr";
+  const n =
+    target && Number.isInteger(target.num) && target.num > 0 ? String(target.num) : "&lt;N&gt;";
+  return `<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> · add media: <code>uploads put &lt;file&gt; ${flag} ${n}</code> · <a href="https://uploads.sh/docs/github-app">docs</a></sub>`;
+}
+
+/**
  * Render the one marker-owned GitHub comment. When there are no galleries this
  * intentionally preserves the legacy attachment-only body byte-for-byte.
+ *
+ * `target` is optional so goldens, the settings preview, and other callers
+ * without a PR/issue stay on the generic `--pr <N>` hint.
  */
 export function attachmentsCommentBody(
   items: AttachmentItem[],
   galleries: GalleryCommentItem[] = [],
   marker: string = ATTACHMENTS_MARKER,
   options: CommentRenderOptions = AUTO_RENDER_OPTIONS,
+  target?: Pick<GhTarget, "kind" | "num">,
 ): string {
   // Non-mutating sort (equivalent to Array#toSorted) — the api worker's
   // tsconfig targets lib ES2022, which predates Array#toSorted (ES2023);
@@ -650,8 +666,6 @@ export function attachmentsCommentBody(
   // Footer condensed to a single quiet line — the old two-line explainer
   // ("re-uploading updates everywhere", full add-media flags) repeats on
   // every PR and lost value with each appearance; details live in the docs.
-  lines.push(
-    '<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> · add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt;</code> · <a href="https://uploads.sh/docs/github-app">docs</a></sub>',
-  );
+  lines.push(addMediaFooter(target));
   return lines.join("\n");
 }

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -927,7 +927,7 @@ export async function syncAttachmentsComment(
   }
   // Append only on the local-gh path: bot posts already carry the uploads-sh
   // bot identity, so this note would be wrong there.
-  const body = `${attachmentsCommentBody(items, previewGalleries, marker, renderOptions)}\n${GH_FALLBACK_AUTHOR_NOTE}`;
+  const body = `${attachmentsCommentBody(items, previewGalleries, marker, renderOptions, target)}\n${GH_FALLBACK_AUTHOR_NOTE}`;
   const count = items.length + previewGalleries.length;
   // Empty (count 0) renders the neutral empty-state body but must not create a
   // comment — it only rewrites one that already exists (`action: "skipped"`

--- a/packages/uploads/src/comment-render.generated.ts
+++ b/packages/uploads/src/comment-render.generated.ts
@@ -508,14 +508,30 @@ function countInlinableMedia(sorted: AttachmentItem[], maxInlineImages: number):
 }
 
 /**
+ * Quiet add-media footer. When `target` is a real PR/issue, the command
+ * uses that number (`--pr 12` / `--issue 45`) so anyone reading the comment
+ * can copy it. Without a target the generic `--pr <N>` placeholder stays.
+ */
+function addMediaFooter(target?: Pick<GhTarget, "kind" | "num">): string {
+  const flag = target?.kind === "issues" ? "--issue" : "--pr";
+  const n =
+    target && Number.isInteger(target.num) && target.num > 0 ? String(target.num) : "&lt;N&gt;";
+  return `<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> · add media: <code>uploads put &lt;file&gt; ${flag} ${n}</code> · <a href="https://uploads.sh/docs/github-app">docs</a></sub>`;
+}
+
+/**
  * Render the one marker-owned GitHub comment. When there are no galleries this
  * intentionally preserves the legacy attachment-only body byte-for-byte.
+ *
+ * `target` is optional so goldens, the settings preview, and other callers
+ * without a PR/issue stay on the generic `--pr <N>` hint.
  */
 export function attachmentsCommentBody(
   items: AttachmentItem[],
   galleries: GalleryCommentItem[] = [],
   marker: string = ATTACHMENTS_MARKER,
   options: CommentRenderOptions = AUTO_RENDER_OPTIONS,
+  target?: Pick<GhTarget, "kind" | "num">,
 ): string {
   // Non-mutating sort (equivalent to Array#toSorted) — the api worker's
   // tsconfig targets lib ES2022, which predates Array#toSorted (ES2023);
@@ -652,8 +668,6 @@ export function attachmentsCommentBody(
   // Footer condensed to a single quiet line — the old two-line explainer
   // ("re-uploading updates everywhere", full add-media flags) repeats on
   // every PR and lost value with each appearance; details live in the docs.
-  lines.push(
-    '<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> · add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt;</code> · <a href="https://uploads.sh/docs/github-app">docs</a></sub>',
-  );
+  lines.push(addMediaFooter(target));
   return lines.join("\n");
 }

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -127,6 +127,7 @@ describe("runComment", () => {
     // uses the namespaced marker (phase 4b).
     expect(create!.input).toContain(attachmentsMarker("test"));
     expect(create!.input).toContain("after.png");
+    expect(create!.input).toContain("<code>uploads put &lt;file&gt; --pr 5</code>");
     // Gh-fallback only: explain why the comment is under a human account.
     expect(create!.input).toContain(GH_FALLBACK_AUTHOR_NOTE);
   });

--- a/packages/uploads/test/github-render-golden.test.ts
+++ b/packages/uploads/test/github-render-golden.test.ts
@@ -5,6 +5,7 @@ import {
   attachmentDensityForCount,
   attachmentImageWidth,
   attachmentPairWidth,
+  ATTACHMENTS_MARKER,
   attachmentsCommentBody,
   AUTO_RENDER_OPTIONS,
   GH_PRIVATE_ROOT,
@@ -489,6 +490,30 @@ describe("attachmentsCommentBody (CLI copy)", () => {
           ...c.options,
         }),
       ).toBe(c.expected);
+    });
+  });
+
+  describe("attachmentsCommentBody add-media hint", () => {
+    it("keeps the generic --pr <N> placeholder when no target is passed", () => {
+      const body = attachmentsCommentBody([]);
+      expect(body).toContain("<code>uploads put &lt;file&gt; --pr &lt;N&gt;</code>");
+    });
+
+    it("fills the PR number into the copy-paste command", () => {
+      const body = attachmentsCommentBody([], [], ATTACHMENTS_MARKER, AUTO_RENDER_OPTIONS, {
+        kind: "pull",
+        num: 12,
+      });
+      expect(body).toContain("<code>uploads put &lt;file&gt; --pr 12</code>");
+      expect(body).not.toContain("--pr &lt;N&gt;");
+    });
+
+    it("uses --issue <num> for issue targets", () => {
+      const body = attachmentsCommentBody([], [], ATTACHMENTS_MARKER, AUTO_RENDER_OPTIONS, {
+        kind: "issues",
+        num: 45,
+      });
+      expect(body).toContain("<code>uploads put &lt;file&gt; --issue 45</code>");
     });
   });
 });


### PR DESCRIPTION
The managed GitHub comment told anyone reading it to run `uploads put <file> --pr <N>`. Copying that still meant looking up the number. The footer now uses the PR or issue it is posted on, so the command is ready to paste.

| Before | After |
| --- | --- |
| <img width="380" alt="Bot comment footer still says --pr <N>" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/feat-comment-add-media-pr-number/bot-comment-footer-before.webp"> | <img width="380" alt="Bot comment footer filled in as --pr 412" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/feat-comment-add-media-pr-number/bot-comment-footer-after.webp"> |

The after shot is a mock (`412`). Once this ships, the next comment refresh on a real thread uses that thread's number.

## What it does / what it is not

- Bot-posted comments (webhook / `attach` / promote) render `--pr 12` or `--issue 45`.
- The local `gh` fallback path does the same, so CLI-posted comments stay in sync.
- The workspace settings preview still shows `--pr <N>` — it is not a real PR.
- Golden fixtures without a target stay on the placeholder, so existing snapshots do not churn.
- Existing comments pick this up on the next sync. No backfill.

## How to try it

After the API deploys, refresh any managed comment:

```bash
uploads attach --promote --pr <this-pr>
```

The footer should read `uploads put <file> --pr <this-pr>`.

## Technical notes

`attachmentsCommentBody` takes an optional `target`. `gatherCommentBody` and the CLI fallback pass the `GhTarget` they already have. The published CLI inlines the same renderer, so this is a patch changeset.

## Test plan

- [x] `github-comment-render` / golden renderer tests (placeholder, `--pr 12`, `--issue 45`)
- [x] `gatherCommentBody` asserts the interpolated command on PR and issue targets
- [x] CLI `runComment` gh-fallback posts `--pr 5` in the created body
- [x] changeset lint
- [ ] Confirm a live bot comment after merge (needs API deploy)
