### PR TITLE
feat: attach already-uploaded objects to a PR/issue by key or URL

### DIFF
--- a/.changeset/attach-existing-objects.md
+++ b/.changeset/attach-existing-objects.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads attach --pr <num> <key-or-url>...` now accepts already-uploaded objects, not just local paths: an argument that doesn't exist on disk but resolves as a workspace object key or an uploads.sh URL (storage host, embed host, or `/f/` page) is attached via a server-side copy instead of erroring `file not found`. The source's own derived metadata (`path`/`url`/`viewport`/`state`/…) rides along; `gh.repo`/`gh.kind`/`gh.number`/`gh.ref` are stamped fresh. Copy by default; `--move` deletes the source after a successful copy. A path that exists on disk always wins as a local file. The hosted MCP `promote` tool gained a matching `keys` argument alongside its existing branch-staged sweep.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "./github-comment-service": "./src/github-comment-service.ts",
     "./github-comment-render": "./src/github-comment-render.ts",
     "./github-promote-service": "./src/github-promote-service.ts",
+    "./github-attach-service": "./src/github-attach-service.ts",
     "./github-repo-binding": "./src/github-repo-binding.ts"
   },
   "scripts": {

--- a/apps/api/src/adoption.ts
+++ b/apps/api/src/adoption.ts
@@ -32,7 +32,7 @@ export type AdoptionMetric = (typeof ADOPTION_METRICS)[number];
  * CLI request from any other API request server-side, so finer-grained client
  * identity comes from the provenance bag's `client` value instead.
  */
-export type UploadSurface = "api" | "mcp" | "promote" | "github" | "rotate";
+export type UploadSurface = "api" | "mcp" | "promote" | "github" | "rotate" | "attach";
 
 /**
  * Analytics Engine dimensions. Never written to D1 — see the module docs.

--- a/apps/api/src/github-attach-service.ts
+++ b/apps/api/src/github-attach-service.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared service behind `POST /v1/workspaces/:workspace/github/attach` and
+ * the hosted MCP `promote` tool's explicit `keys` argument (issue #702).
+ * Copies one existing object into a PR/issue's attachment prefix
+ * (`github-attach.ts`), then — unlike branch-staged promote, which leaves
+ * comment sync to a separate CLI call — runs the normal managed-comment sync
+ * itself, so one API call both attaches and refreshes the comment. Also
+ * performs the same implicit repo-link claim `github-promote-service.ts`
+ * does after a 2xx promote (issue #297 claim gate on *new* bindings only).
+ */
+import { isEntitledToClaimRepo } from "./github-claim-authz";
+import {
+  attachExistingObject,
+  type AttachExistingRequest,
+  type AttachExistingResult,
+} from "./github-attach";
+import { postManagedComment, type PostCommentResult } from "./github-comment-service";
+import { findRepoLink, recordRepoLink } from "./github-repo-links";
+import type { WorkspaceRecord } from "./workspace";
+
+export type { AttachExistingRequest, AttachExistingResult };
+
+export interface AttachExistingResponse extends AttachExistingResult {
+  comment: PostCommentResult;
+}
+
+export async function postAttachExisting(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  mintingUserId: string | null,
+  req: AttachExistingRequest,
+): Promise<AttachExistingResponse> {
+  const result = await attachExistingObject(env, ws, workspaceName, req);
+
+  // Implicit claim (mirrors postPromoteBranchAttachments): first-claim-wins,
+  // never affects the attach result. Cross-tenant gate on NEW claims only
+  // (issue #297) — already-bound repos re-record via INSERT OR IGNORE (no-op).
+  const existingLink = await findRepoLink(env.DB, req.target.repo);
+  const canClaim =
+    existingLink !== null || (await isEntitledToClaimRepo(env, req.target.repo, mintingUserId));
+  if (canClaim) {
+    await recordRepoLink(env.DB, req.target.repo, workspaceName, "attach");
+  }
+
+  // Comment sync (the piece promote leaves to a separate CLI call) — never
+  // throws; postManagedComment degrades to { posted: false, reason } on any
+  // integration failure, same contract the CLI already handles.
+  const comment = await postManagedComment(env, ws, workspaceName, mintingUserId, req.target, {});
+
+  return { ...result, comment };
+}

--- a/apps/api/src/github-attach.ts
+++ b/apps/api/src/github-attach.ts
@@ -1,0 +1,255 @@
+/**
+ * Server-side "attach an already-uploaded object" (issue #702): generalizes
+ * `github-promote.ts`'s copy machinery from "sweep this branch's staged
+ * prefix" to "copy this one explicit source key" — the source can be ANY
+ * object already in the calling workspace's own bucket, not just a
+ * branch-staged one. Same destination layout as promote (plain
+ * `gh/<owner>/<name>/<pull|issues>/<num>/<filename>`, or the randomized
+ * `gh/private/<id>/...` layout when the repo resolves to private mode), same
+ * idempotent-overwrite contract, same "never leak internal error detail"
+ * doctrine on copy failure.
+ *
+ * Metadata merge is ADDITIVE (preserve mode, PR #157's contract) rather than
+ * promote's full replace: the source object's own D1 queryable metadata
+ * rides along onto the destination, with `gh.repo`/`gh.kind`/`gh.number`/
+ * `gh.ref` stamped fresh on top. This is deliberately different from
+ * `github-promote.ts`'s `putObject({ metadata: {...} })` full-replace call
+ * (which only ever inherits a staged file's own `gh.*` tags, never arbitrary
+ * caller metadata) — an attach source can be any object with any metadata
+ * (a bare `f/` upload's `path`/`viewport`/`state`, a prior attachment's own
+ * `gh.*` tags, etc.), and all of it is worth preserving on the copy.
+ *
+ * Comment sync is the caller's job (`github-attach-service.ts` wires it in,
+ * same "service composes route + comment sync" shape `promote --pr` already
+ * uses at the CLI layer, just moved server-side so one API call does both).
+ */
+import { NotFoundError, ValidationError } from "@uploads/errors";
+import { resolveEmbedBaseUrl, type Files, type StorageConfig } from "@uploads/storage";
+import type { GhTargetKind } from "@uploads/comment-render";
+import { ghKeyPrefix, ghPrivateAttachmentKey, sanitizeKeySegment } from "@uploads/comment-render";
+import { badKey, deleteObject, filePageUrl, putObject, sanitizeKeyBasename } from "./files-core";
+import { getFileMetadata, setFileMetadata } from "./file-metadata";
+import { resolveGhKeyContextSafe } from "./github-private-prefix-service";
+import { storage, storageConfig } from "./storage";
+import { objectVisibility } from "./visibility";
+import { webOrigin } from "./web-url";
+import type { WorkspaceRecord } from "./workspace";
+
+/** Single-key call to `Files["download"]` — pulled out so its return type
+ * (the single-key `StoredFile` overload) is inferred rather than spelled out. */
+async function downloadOne(store: Files, key: string) {
+  return store.download(key);
+}
+
+export interface AttachTarget {
+  /** "owner/name", already validated by the caller. */
+  repo: string;
+  kind: GhTargetKind;
+  num: number;
+}
+
+export interface AttachExistingRequest {
+  /** Object key, or an uploads.sh URL (storage host, embed host, or /f/ page) resolving to one. */
+  source: string;
+  target: AttachTarget;
+  /** Delete the source after a successful copy. Defaults to false (copy, not move). */
+  move?: boolean;
+  /** Override the destination filename; defaults to the source key's basename. */
+  filename?: string;
+}
+
+export interface AttachExistingResult {
+  key: string;
+  url: string | null;
+  embedUrl: string | null;
+  pageUrl?: string;
+  moved: boolean;
+  source: { key: string };
+}
+
+/**
+ * Resolves `input` (a raw object key, or one of the three uploads.sh URL
+ * spellings) to a key in the CALLING workspace's own bucket. Cross-workspace
+ * URLs (a different `/f/<workspace>/` segment, or a URL that doesn't match
+ * this workspace's storage/embed host at all) are rejected — attach only
+ * ever reads from the caller's own workspace, same posture as every other
+ * `files:write` route in this API.
+ */
+export async function resolveAttachSourceKey(
+  env: Env,
+  cfg: StorageConfig,
+  workspaceName: string,
+  input: string,
+): Promise<string> {
+  const trimmed = input.trim();
+  if (!trimmed) throw new ValidationError("source must not be empty.", { code: "invalid_source" });
+
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    // Not a URL — treat as a raw key.
+    if (badKey(trimmed))
+      throw new ValidationError("invalid source key.", { code: "invalid_source" });
+    return trimmed;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new ValidationError("source is not a valid URL.", { code: "invalid_source" });
+  }
+
+  const stripBase = (base: string | null): string | null => {
+    if (!base) return null;
+    let baseUrl: URL;
+    try {
+      baseUrl = new URL(base);
+    } catch {
+      return null;
+    }
+    if (url.origin !== baseUrl.origin) return null;
+    const basePath = baseUrl.pathname.endsWith("/") ? baseUrl.pathname : `${baseUrl.pathname}/`;
+    if (!url.pathname.startsWith(basePath)) return null;
+    return url.pathname
+      .slice(basePath.length)
+      .split("/")
+      .map((seg) => decodeURIComponent(seg))
+      .join("/");
+  };
+
+  // Storage host — full public key including the workspace prefix, so strip
+  // `cfg.prefix` back off after matching the base.
+  const fromStorage = stripBase(cfg.publicBaseUrl ?? null);
+  if (fromStorage !== null) {
+    const prefix = cfg.prefix ?? "";
+    if (prefix && fromStorage.startsWith(prefix)) return fromStorage.slice(prefix.length);
+    if (!prefix) return fromStorage;
+    throw new ValidationError("source URL does not belong to this workspace.", {
+      code: "invalid_source",
+    });
+  }
+
+  // Embed host twin of the storage host, same key shape.
+  const embedBase = resolveEmbedBaseUrl(cfg.publicBaseUrl ?? undefined, undefined);
+  const fromEmbed = stripBase(embedBase);
+  if (fromEmbed !== null) {
+    const prefix = cfg.prefix ?? "";
+    if (prefix && fromEmbed.startsWith(prefix)) return fromEmbed.slice(prefix.length);
+    if (!prefix) return fromEmbed;
+    throw new ValidationError("source URL does not belong to this workspace.", {
+      code: "invalid_source",
+    });
+  }
+
+  // /f/<workspace>/<key> page URL — workspace segment must be THIS workspace.
+  const webBase = `${webOrigin(env)}/f/${encodeURIComponent(workspaceName)}`;
+  const fromPage = stripBase(webBase);
+  if (fromPage !== null) return fromPage;
+
+  throw new ValidationError("source URL does not resolve to an object in this workspace.", {
+    code: "invalid_source",
+  });
+}
+
+/**
+ * Copy `req.source` (already resolved to a key by the caller — see
+ * `resolveAttachSourceKey`) into `req.target`'s attachment prefix. Additive
+ * metadata merge: the source's own D1 metadata rides along, `gh.repo`/
+ * `gh.kind`/`gh.number`/`gh.ref` are stamped fresh on top. Idempotent —
+ * re-attaching the same source to the same target overwrites the
+ * destination key in place, same as promote.
+ */
+export async function attachExistingObject(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  req: AttachExistingRequest,
+): Promise<AttachExistingResult> {
+  const cfg = await storageConfig(env, ws);
+  const sourceKey = await resolveAttachSourceKey(env, cfg, workspaceName, req.source);
+  if (badKey(sourceKey))
+    throw new ValidationError("invalid source key.", { code: "invalid_source" });
+
+  const store = await storage(env, ws);
+  let source: Awaited<ReturnType<typeof downloadOne>>;
+  try {
+    source = await downloadOne(store, sourceKey);
+  } catch {
+    throw new NotFoundError("source object not found.", { code: "source_not_found" });
+  }
+
+  const [owner, name] = req.target.repo.split("/");
+  const sourceSegments = sourceKey.split("/").filter(Boolean);
+  const sourceBasename = sourceSegments[sourceSegments.length - 1] ?? sourceKey;
+  const filename = sanitizeKeyBasename(req.filename ?? sourceBasename);
+
+  const mode = await resolveGhKeyContextSafe(
+    env,
+    workspaceName,
+    { repo: req.target.repo, target: { kind: req.target.kind, num: req.target.num } },
+    "attach",
+  );
+
+  const destKey =
+    mode.mode === "private"
+      ? ghPrivateAttachmentKey(mode.prefixId, req.target, filename)
+      : `${ghKeyPrefix(req.target)}${sanitizeKeySegment(filename)}`;
+
+  const sourceMeta = await getFileMetadata(env.DB, workspaceName, sourceKey);
+  const bytes = new Uint8Array(await source.arrayBuffer());
+  const visibility = objectVisibility(source.metadata);
+  const ref = `${owner}/${name}#${req.target.num}`.toLowerCase();
+  const nowIso = new Date().toISOString();
+
+  const put = await putObject(env, ws, destKey, bytes, workspaceName, {
+    provenance: source.metadata,
+    visibility,
+    surface: "attach",
+  });
+
+  // Additive merge (PR #157 preserve mode): the source's existing metadata
+  // rides along unchanged, gh.* is stamped fresh on top and always wins.
+  await setFileMetadata(env.DB, workspaceName, destKey, {
+    ...sourceMeta,
+    "gh.repo": `${owner}/${name}`.toLowerCase(),
+    "gh.kind": req.target.kind,
+    "gh.number": String(req.target.num),
+    "gh.ref": ref,
+    "gh.attached-at": nowIso,
+  });
+
+  if (req.move) {
+    try {
+      await deleteObject(env, ws, sourceKey, workspaceName);
+    } catch (err) {
+      // The copy already succeeded and is the object of record — a failed
+      // source delete is reported by leaving `moved: false`, never by
+      // failing the whole call (mirrors promote's "copy succeeded is final"
+      // doctrine).
+      console.error(
+        JSON.stringify({
+          message: "attach: move requested but source delete failed",
+          sourceKey,
+          destKey,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+      return {
+        key: destKey,
+        url: put.url,
+        embedUrl: put.embedUrl,
+        ...(put.url && ws.name ? { pageUrl: filePageUrl(env, ws.name, destKey) } : {}),
+        moved: false,
+        source: { key: sourceKey },
+      };
+    }
+  }
+
+  return {
+    key: destKey,
+    url: put.url,
+    embedUrl: put.embedUrl,
+    ...(put.url && ws.name ? { pageUrl: filePageUrl(env, ws.name, destKey) } : {}),
+    moved: req.move === true,
+    source: { key: sourceKey },
+  };
+}

--- a/apps/api/src/routes/github-attach-route.test.ts
+++ b/apps/api/src/routes/github-attach-route.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import { app } from "../index";
+import { getFileMetadata, setFileMetadata } from "../file-metadata";
+import { sha256Hex, type WorkspaceRecord } from "../workspace";
+import { FakeR2Bucket } from "../../test/fake-r2";
+import { UsageFakeD1 } from "../../test/usage-fake-d1";
+
+// Same node-vs-workerd Web Crypto gap as github-promote-route.test.ts.
+if (typeof crypto.subtle.timingSafeEqual !== "function") {
+  (
+    crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+  ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+    a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+const WS = "acme";
+const TOKEN = "up_acme_testtoken";
+const PREFIX = "acme/";
+const REPO = "acme/web";
+const NUM = 12;
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+function destKey(filename: string): string {
+  return `gh/acme/web/pull/${NUM}/${filename}`;
+}
+
+interface Seeded {
+  env: Env;
+  db: UsageFakeD1;
+  bucket: FakeR2Bucket;
+}
+
+// Deliberately omits GITHUB_APP_CFG_ENV: githubAppConfig(env) then returns
+// null, so postManagedComment degrades to { posted: false, reason:
+// "app_unconfigured" } with no network call, and resolveGhKeyContextSafe
+// degrades to plain mode — keeps this suite focused on the copy/metadata
+// contract without standing up the full GitHub App fixture.
+async function seededEnv(): Promise<Seeded> {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: PREFIX,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex(TOKEN), createdAt: new Date().toISOString() }],
+  };
+  const registry = {
+    get: (async (key: string) =>
+      key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  const env = {
+    REGISTRY: registry,
+    DB: db,
+    UPLOADS_DEFAULT: bucket,
+    WEB_ORIGIN: "https://uploads.sh",
+  } as unknown as Env;
+  return { env, db, bucket };
+}
+
+async function seedSource(
+  seeded: Seeded,
+  key: string,
+  opts: { bytes?: Uint8Array; meta?: Record<string, string> } = {},
+) {
+  const bytes = opts.bytes ?? PNG;
+  await seeded.bucket.put(`${PREFIX}${key}`, bytes, {
+    httpMetadata: { contentType: "image/png" },
+    customMetadata: {},
+  });
+  if (opts.meta) {
+    await setFileMetadata(seeded.env.DB, WS, key, opts.meta);
+  }
+}
+
+function post(env: Env, body: unknown, token: string = TOKEN) {
+  return app.request(
+    `/v1/workspaces/${WS}/github/attach`,
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+describe("POST /v1/workspaces/:workspace/github/attach", () => {
+  it("400s on a malformed body", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, { source: "", repo: "not-a-repo" });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s when neither pr nor issue is given", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, { source: "f/abc/x.png", repo: REPO });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s when both pr and issue are given", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, { source: "f/abc/x.png", repo: REPO, pr: 1, issue: 2 });
+    expect(res.status).toBe(400);
+  });
+
+  it("401s with an unrecognized bearer token", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, { source: "f/abc/x.png", repo: REPO, pr: NUM }, "up_acme_wrong");
+    expect(res.status).toBe(401);
+  });
+
+  it("404s when the source object does not exist", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, { source: "f/nope/missing.png", repo: REPO, pr: NUM });
+    expect(res.status).toBe(404);
+  });
+
+  it("copies a bare key into the PR attachment prefix, merging metadata additively", async () => {
+    const seeded = await seededEnv();
+    await seedSource(seeded, "f/abc123/hero.png", { meta: { path: "/settings", state: "after" } });
+
+    const res = await post(seeded.env, { source: "f/abc123/hero.png", repo: REPO, pr: NUM });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      key: string;
+      url: string | null;
+      moved: boolean;
+      source: { key: string };
+      comment: { posted: boolean };
+    };
+    expect(body.key).toBe(destKey("hero.png"));
+    expect(body.moved).toBe(false);
+    expect(body.source).toEqual({ key: "f/abc123/hero.png" });
+    expect(body.comment).toEqual({ posted: false, reason: "app_unconfigured" });
+
+    const stored = seeded.bucket.store.get(`${PREFIX}${destKey("hero.png")}`);
+    expect(stored).toBeDefined();
+    expect([...(stored?.data ?? [])]).toEqual([...PNG]);
+
+    // Source metadata rode along; gh.* stamped fresh on top.
+    const destMeta = await getFileMetadata(seeded.env.DB, WS, destKey("hero.png"));
+    expect(destMeta.path).toBe("/settings");
+    expect(destMeta.state).toBe("after");
+    expect(destMeta["gh.repo"]).toBe("acme/web");
+    expect(destMeta["gh.kind"]).toBe("pull");
+    expect(destMeta["gh.number"]).toBe("12");
+    expect(destMeta["gh.ref"]).toBe("acme/web#12");
+
+    // Source object untouched — copy, not move.
+    const sourceStored = seeded.bucket.store.get(`${PREFIX}f/abc123/hero.png`);
+    expect(sourceStored).toBeDefined();
+  });
+
+  it("resolves a storage-host URL to the same key as the bare key", async () => {
+    const seeded = await seededEnv();
+    await seedSource(seeded, "f/abc123/hero.png");
+    const url = "https://storage.uploads.sh/acme/f/abc123/hero.png";
+
+    const res = await post(seeded.env, { source: url, repo: REPO, pr: NUM });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { key: string };
+    expect(body.key).toBe(destKey("hero.png"));
+  });
+
+  it("resolves an /f/ page URL to the same key", async () => {
+    const seeded = await seededEnv();
+    await seedSource(seeded, "f/abc123/hero.png");
+    const url = "https://uploads.sh/f/acme/f/abc123/hero.png";
+
+    const res = await post(seeded.env, { source: url, repo: REPO, pr: NUM });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { key: string };
+    expect(body.key).toBe(destKey("hero.png"));
+  });
+
+  it("rejects a URL for a different workspace's /f/ page", async () => {
+    const seeded = await seededEnv();
+    await seedSource(seeded, "f/abc123/hero.png");
+    const url = "https://uploads.sh/f/someoneelse/f/abc123/hero.png";
+
+    const res = await post(seeded.env, { source: url, repo: REPO, pr: NUM });
+    expect(res.status).toBe(400);
+  });
+
+  it("is idempotent: re-attaching the same source overwrites the destination in place", async () => {
+    const seeded = await seededEnv();
+    await seedSource(seeded, "f/abc123/hero.png");
+
+    const first = await post(seeded.env, { source: "f/abc123/hero.png", repo: REPO, pr: NUM });
+    expect(first.status).toBe(200);
+    const second = await post(seeded.env, { source: "f/abc123/hero.png", repo: REPO, pr: NUM });
+    expect(second.status).toBe(200);
+    expect(await second.json()).toMatchObject({ key: destKey("hero.png") });
+  });
+
+  it("deletes the source after a successful copy when move is true", async () => {
+    const seeded = await seededEnv();
+    await seedSource(seeded, "f/abc123/hero.png");
+
+    const res = await post(seeded.env, {
+      source: "f/abc123/hero.png",
+      repo: REPO,
+      pr: NUM,
+      move: true,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { moved: boolean };
+    expect(body.moved).toBe(true);
+    expect(seeded.bucket.store.get(`${PREFIX}f/abc123/hero.png`)).toBeUndefined();
+    // Destination still landed.
+    expect(seeded.bucket.store.get(`${PREFIX}${destKey("hero.png")}`)).toBeDefined();
+  });
+
+  it("attaches to an issue with the issues key shape", async () => {
+    const seeded = await seededEnv();
+    await seedSource(seeded, "f/abc123/hero.png");
+
+    const res = await post(seeded.env, { source: "f/abc123/hero.png", repo: REPO, issue: 7 });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { key: string };
+    expect(body.key).toBe("gh/acme/web/issues/7/hero.png");
+  });
+});

--- a/apps/api/src/routes/github-attach.ts
+++ b/apps/api/src/routes/github-attach.ts
@@ -1,0 +1,88 @@
+/**
+ * POST /v1/workspaces/:workspace/github/attach (issue #702). Workspace-authed
+ * (canonical dual-auth surface, mounted from `routes/workspace-github.ts`).
+ * Attaches an ALREADY-UPLOADED object — identified by key or by an
+ * uploads.sh URL in any of the three spellings (storage host, embed host,
+ * `/f/` page) — to a PR or issue via an in-bucket server-side copy, additive
+ * metadata merge, and the normal managed-comment sync. Generalizes
+ * `routes/github-promote.ts`'s branch-staged sweep to an arbitrary explicit
+ * source; see `github-attach.ts`/`github-attach-service.ts` for the copy and
+ * comment-sync logic respectively.
+ *
+ * Copy by default; `move: true` deletes the source only after a successful
+ * copy. Idempotent — re-attaching the same source to the same target
+ * overwrites the destination key in place.
+ */
+import { ValidationError } from "@uploads/errors";
+import type { Context } from "hono";
+import { postAttachExisting } from "../github-attach-service";
+import type { WorkspaceVars } from "../workspace";
+import { jsonBody } from "./json-body";
+
+// Same repo grammar + dot-only-segment guard as github-promote.ts/github-comment.ts.
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const DOTS_ONLY_RE = /^\.+$/;
+const MAX_SOURCE_LEN = 2048;
+const MAX_FILENAME_LEN = 255;
+
+interface AttachBody {
+  source: string;
+  repo: string;
+  kind: "pull" | "issues";
+  num: number;
+  move: boolean;
+  filename?: string;
+}
+
+function parseBody(body: Record<string, unknown>): AttachBody {
+  const source = typeof body.source === "string" ? body.source : "";
+  const repo = typeof body.repo === "string" ? body.repo : "";
+  const pr = typeof body.pr === "number" ? body.pr : undefined;
+  const issue = typeof body.issue === "number" ? body.issue : undefined;
+  const move = body.move === true;
+  const filename = typeof body.filename === "string" ? body.filename : undefined;
+
+  if (source.length === 0 || source.length > MAX_SOURCE_LEN) {
+    throw new ValidationError("source must be a non-empty string.", { code: "invalid_source" });
+  }
+  if (!REPO_RE.test(repo) || repo.split("/").some((seg) => DOTS_ONLY_RE.test(seg))) {
+    throw new ValidationError("repo must be owner/name.", { code: "invalid_repo" });
+  }
+  if (pr === undefined && issue === undefined) {
+    throw new ValidationError("exactly one of pr or issue is required.", {
+      code: "invalid_target",
+    });
+  }
+  if (pr !== undefined && issue !== undefined) {
+    throw new ValidationError("pr and issue are mutually exclusive.", { code: "invalid_target" });
+  }
+  const num = pr ?? issue;
+  if (num === undefined || !Number.isSafeInteger(num) || num < 1) {
+    throw new ValidationError("pr/issue must be a positive integer.", { code: "invalid_target" });
+  }
+  if (filename !== undefined && (filename.length === 0 || filename.length > MAX_FILENAME_LEN)) {
+    throw new ValidationError("filename must be a non-empty string.", { code: "invalid_filename" });
+  }
+  if (body.move !== undefined && typeof body.move !== "boolean") {
+    throw new ValidationError("move must be a boolean.", { code: "invalid_move" });
+  }
+
+  return { source, repo, kind: pr !== undefined ? "pull" : "issues", num, move, filename };
+}
+
+export async function githubAttachHandler(c: Context<WorkspaceVars>) {
+  const parsed = parseBody(await jsonBody(c));
+  const result = await postAttachExisting(
+    c.env,
+    c.get("workspace"),
+    c.get("workspaceName"),
+    c.get("mintingUserId"),
+    {
+      source: parsed.source,
+      target: { repo: parsed.repo, kind: parsed.kind, num: parsed.num },
+      move: parsed.move,
+      filename: parsed.filename,
+    },
+  );
+  return c.json(result);
+}

--- a/apps/api/src/routes/workspace-github.ts
+++ b/apps/api/src/routes/workspace-github.ts
@@ -78,6 +78,7 @@ import { adminWorkspaceOr403, memberWorkspaceOr404 } from "../org-workspaces";
 import type { SessionVars } from "../session-auth";
 import { requireScope } from "../workspace";
 import { githubActivityHandler } from "./github-activity";
+import { githubAttachHandler } from "./github-attach";
 import { githubCommentHandler } from "./github-comment";
 import {
   githubLinkDeleteHandler,
@@ -288,6 +289,18 @@ export const workspaceGithub = new Hono<DualAuthVars>()
     scoped("files:write"),
     requireToken,
     githubPromoteHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .post(
+    "/:workspace/github/attach",
+    dualWorkspaceAuth(),
+    rateLimited,
+    // New route (issue #702) — canonical surface only, no legacy bearer-path
+    // twin (unlike comment/promote, which predate the canonical vertical).
+    // Same token-only posture as comment/promote: a session caller gets a
+    // 403 `github_requires_token`.
+    scoped("files:write"),
+    requireToken,
+    githubAttachHandler as unknown as MiddlewareHandler<DualAuthVars>,
   )
   .post(
     "/:workspace/github/private-prefix",

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -56,6 +56,10 @@ import {
   type PromoteResult,
 } from "@uploads/api/github-promote-service";
 import {
+  postAttachExisting,
+  type AttachExistingResponse,
+} from "@uploads/api/github-attach-service";
+import {
   getFileMetadata,
   listFacets,
   META_MAX_KEYS,
@@ -988,7 +992,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       annotations: mcpDestroyPublic,
       securitySchemes: mcpOAuthWrite,
       description:
-        "Copy this workspace's branch-staged attachments (gh/…/branch/… keys from put with branch, or CLI attach --branch) into a PR's stable gh/…/pull/… prefix, then optionally refresh the managed attachments comment. Hosted stand-in for `uploads attach --promote` — no git context, so repo, pr, and branch are all required. Does not delete staged originals. Promotion is a pure workspace-data copy (no GitHub API for the copy itself); the comment path is bot-only like the comment tool. Returns { promotion: { promoted, skipped }, comment?, commentError? }.",
+        "Copy attachments into a PR's stable gh/…/pull/… prefix, then optionally refresh the managed attachments comment. Two independent sources, either or both: `branch` sweeps this workspace's branch-staged attachments (gh/…/branch/… keys from put with branch, or CLI attach --branch); `keys` (issue #702) copies explicit already-uploaded objects instead — a raw object key or an uploads.sh URL (storage host, embed host, or /f/ page), each attached with additive metadata merge (the source's own metadata rides along; gh.repo/gh.kind/gh.number/gh.ref are stamped fresh). Hosted stand-in for `uploads attach --promote` / `uploads attach <key-or-url> --pr` — no git context, so repo and pr are always required, and at least one of branch/keys is required. Does not delete staged/source originals unless `move: true` (keys only). Copies are pure workspace-data operations (no GitHub API); the comment path is bot-only like the comment tool. Returns { promotion?: { promoted, skipped }, attached?: { key, url, embedUrl, moved, source }[], attachFailures?, comment?, commentError? }.",
       inputSchema: {
         type: "object",
         properties: {
@@ -999,20 +1003,33 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           },
           pr: {
             type: "number",
-            description: "Pull request number to promote into. Promotion never applies to issues.",
+            description: "Pull request number to promote/attach into. Never applies to issues.",
           },
           branch: {
             type: "string",
             description:
               "Git branch whose staged prefix (gh/…/branch/<branch>/) should be copied into the PR.",
           },
+          keys: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 1,
+            maxItems: 20,
+            description:
+              "Explicit already-uploaded sources to attach (issue #702): object keys or uploads.sh URLs (storage host, embed host, or /f/ page). Each is copied independently; one bad source does not abort the rest — see attachFailures.",
+          },
+          move: {
+            type: "boolean",
+            description:
+              "For `keys` only: delete each source object after a successful copy (default false — copy, not move). Ignored for the branch sweep, which never deletes staged originals.",
+          },
           comment: {
             type: "boolean",
             description:
-              "After a successful promote, create or update the managed attachments comment (default true when files:read is on the token; pass false to skip). A comment failure never fails the promote; see commentError.",
+              "After a successful promote/attach, create or update the managed attachments comment (default true when files:read is on the token; pass false to skip). A comment failure never fails the promote/attach; see commentError.",
           },
         },
-        required: ["repo", "pr", "branch"],
+        required: ["repo", "pr"],
         additionalProperties: false,
       },
       async handler(args) {
@@ -1022,27 +1039,69 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         if (!validRepoGrammar(repo)) usage("repo must be owner/name");
         const pr = optPosInt(args, "pr");
         if (pr === undefined) usage("pr is required");
-        const branch = branchFromArgs(args) ?? usage("branch is required");
-        // Validate branch is stageable (metadata rules) before the copy.
-        branchMetadata(repo, branch);
+        const branch = branchFromArgs(args);
+        const keys = optStringArray(args, "keys");
+        if (branch === undefined && (keys === undefined || keys.length === 0)) {
+          usage("at least one of branch or keys is required");
+        }
+        if (branch !== undefined) {
+          // Validate branch is stageable (metadata rules) before the copy.
+          branchMetadata(repo, branch);
+        }
+        const move = optBool(args, "move") ?? false;
 
         const commentArg = args.comment == null ? undefined : optBool(args, "comment");
         if (commentArg === true) requireScope("files:read");
         const wantComment = commentArg ?? ctx.authScopes.includes("files:read");
 
         // Primary job — failures throw (isError), unlike put's best-effort promote.
-        const promotion = await postPromoteBranchAttachments(
-          env,
-          workspace,
-          workspaceName,
-          ctx.mintingUserId,
-          { repo, num: pr, branch },
-        );
+        const promotion =
+          branch !== undefined
+            ? await postPromoteBranchAttachments(env, workspace, workspaceName, ctx.mintingUserId, {
+                repo,
+                num: pr,
+                branch,
+              })
+            : undefined;
+
+        // Explicit keys (issue #702): each copy is independent — one bad
+        // source degrades to attachFailures rather than aborting the batch,
+        // same "one bad item doesn't abort the rest" posture as put/attach's
+        // multi-file paths. Each successful attach already syncs its own
+        // comment server-side (postAttachExisting), so `comment`/`wantComment`
+        // below only covers the branch-sweep promotion path.
+        let attached: AttachExistingResponse[] | undefined;
+        let attachFailures: { key: string; error: ReturnType<typeof errorDetail> }[] | undefined;
+        if (keys !== undefined && keys.length > 0) {
+          attached = [];
+          attachFailures = [];
+          for (const source of keys) {
+            try {
+              attached.push(
+                await postAttachExisting(env, workspace, workspaceName, ctx.mintingUserId, {
+                  source,
+                  target: { repo, kind: "pull", num: pr },
+                  move,
+                }),
+              );
+            } catch (err) {
+              attachFailures.push({ key: source, error: errorDetail(err) });
+            }
+          }
+        }
 
         const commentResult = wantComment
           ? await attachComment({ repo, kind: "pull", num: pr })
           : undefined;
-        return { promotion, ...commentResult };
+        // Explicit-undefined values (not just absent keys) trip the SDK's
+        // structured-content validator ("Instances of \"undefined\" type are
+        // not supported") — omit rather than include-as-undefined.
+        return {
+          ...(promotion !== undefined ? { promotion } : {}),
+          ...(attached !== undefined ? { attached } : {}),
+          ...(attachFailures !== undefined ? { attachFailures } : {}),
+          ...commentResult,
+        };
       },
     },
     {

--- a/apps/mcp/test/mcp-branch-promote.test.ts
+++ b/apps/mcp/test/mcp-branch-promote.test.ts
@@ -377,18 +377,17 @@ describe("hosted promote tool", () => {
     });
   });
 
-  it("usage errors: missing branch", async () => {
+  it("usage errors: neither branch nor keys (issue #702)", async () => {
     const { env } = await makeEnv();
     const result = await callTool(env, "promote", {
       repo: "acme/widgets",
       pr: 12,
     });
     expect(result.isError).toBe(true);
-    // Schema required-property check fires before the handler.
     expect(result.content).toEqual([
       {
         type: "text",
-        text: expect.stringMatching(/required property ["']branch["']|branch is required/),
+        text: expect.stringContaining("at least one of branch or keys is required"),
       },
     ]);
   });
@@ -432,6 +431,66 @@ describe("hosted promote tool", () => {
     } finally {
       restore();
     }
+  });
+
+  it("accepts explicit source keys (issue #702), independent of the branch sweep", async () => {
+    const { env, bucket } = await makeEnv({ boundTo: WS });
+    // A plain (non-staged) upload — any already-uploaded object is a valid
+    // attach source, not just a gh/…/branch/… staged one.
+    const source = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      key: "f/abc123/hero.png",
+    });
+    expect(source.isError).toBe(false);
+
+    const result = await callTool(env, "promote", {
+      repo: "acme/widgets",
+      pr: 12,
+      keys: ["f/abc123/hero.png"],
+      comment: false,
+    });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      attached: [
+        expect.objectContaining({
+          key: "gh/acme/widgets/pull/12/hero.png",
+          moved: false,
+          source: { key: "f/abc123/hero.png" },
+        }),
+      ],
+      attachFailures: [],
+    });
+    expect(result.structuredContent).not.toHaveProperty("promotion");
+    expect(bucket.store.has("gh/acme/widgets/pull/12/hero.png")).toBe(true);
+    // Copy, not move — source stays put.
+    expect(bucket.store.has("f/abc123/hero.png")).toBe(true);
+  });
+
+  it("degrades one bad key into attachFailures without aborting the rest", async () => {
+    const { env, bucket } = await makeEnv({ boundTo: WS });
+    await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      key: "f/abc123/hero.png",
+    });
+
+    const result = await callTool(env, "promote", {
+      repo: "acme/widgets",
+      pr: 12,
+      keys: ["f/abc123/hero.png", "f/nope/missing.png"],
+      comment: false,
+    });
+    expect(result.isError).toBe(false);
+    const content = result.structuredContent as {
+      attached: { key: string }[];
+      attachFailures: { key: string; error: { code?: string } }[];
+    };
+    expect(content.attached).toHaveLength(1);
+    expect(content.attachFailures).toEqual([
+      { key: "f/nope/missing.png", error: expect.objectContaining({ code: "source_not_found" }) },
+    ]);
+    expect(bucket.store.has("gh/acme/widgets/pull/12/hero.png")).toBe(true);
   });
 });
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,28 +79,28 @@ command to run by hand, rather than overwriting your build.
 
 ## Command overview
 
-| Command                  | What it does                                                                  |
-| ------------------------ | ----------------------------------------------------------------------------- |
-| `attach <file…>`         | Attach media to the current PR (stable URLs + comment)                        |
-| `put <file>`             | Upload one file → public URL + GitHub markdown                                |
-| `screenshot <url\|html>` | Capture a page (or local HTML) and host it in one step                        |
-| `annotate <image>`       | Bake boxes, arrows, labels, strokes, and redactions onto an image             |
-| `comment`                | Create/update a PR/issue attachments comment (via `gh`)                       |
-| `ingest`                 | Mirror `github.com/user-attachments` media from a PR/issue into the workspace |
-| `list` / `find k=v`      | List objects, optionally filtered by queryable metadata                       |
-| `meta get` / `meta set`  | Read or merge-set an object's queryable metadata                              |
-| `gallery …`              | Create and organize public media galleries                                    |
-| `delete <key>`           | Delete an object                                                              |
-| `usage`                  | Workspace storage / upload counters                                           |
-| `install`                | Skills + remote MCP + hooks (Grok/Cursor); see plugins for Claude/Codex       |
-| `hook`                   | Agent harness handlers (e.g. pre-PR screenshot reminder)                      |
-| `update`                 | Update the CLI, then refresh skills / MCP / hooks                             |
-| `login` / `logout`       | Sign in (browser or enrollment code) / clear saved token                      |
-| `whoami` (`status`)      | Show the active workspace and token                                           |
-| `invite`                 | Invite a teammate to a workspace (workspace admin)                            |
-| `doctor` / `health`      | Health + auth + workspace checks / API liveness                               |
-| `setup` / `config`       | Inspect and configure CLI settings                                            |
-| `mcp`                    | Serve MCP over stdio, both spec eras (tools mirror the CLI)                   |
+| Command                    | What it does                                                                                                             |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `attach <file\|key\|url…>` | Attach media (local files, or already-uploaded keys/URLs via server-side copy) to the current PR (stable URLs + comment) |
+| `put <file>`               | Upload one file → public URL + GitHub markdown                                                                           |
+| `screenshot <url\|html>`   | Capture a page (or local HTML) and host it in one step                                                                   |
+| `annotate <image>`         | Bake boxes, arrows, labels, strokes, and redactions onto an image                                                        |
+| `comment`                  | Create/update a PR/issue attachments comment (via `gh`)                                                                  |
+| `ingest`                   | Mirror `github.com/user-attachments` media from a PR/issue into the workspace                                            |
+| `list` / `find k=v`        | List objects, optionally filtered by queryable metadata                                                                  |
+| `meta get` / `meta set`    | Read or merge-set an object's queryable metadata                                                                         |
+| `gallery …`                | Create and organize public media galleries                                                                               |
+| `delete <key>`             | Delete an object                                                                                                         |
+| `usage`                    | Workspace storage / upload counters                                                                                      |
+| `install`                  | Skills + remote MCP + hooks (Grok/Cursor); see plugins for Claude/Codex                                                  |
+| `hook`                     | Agent harness handlers (e.g. pre-PR screenshot reminder)                                                                 |
+| `update`                   | Update the CLI, then refresh skills / MCP / hooks                                                                        |
+| `login` / `logout`         | Sign in (browser or enrollment code) / clear saved token                                                                 |
+| `whoami` (`status`)        | Show the active workspace and token                                                                                      |
+| `invite`                   | Invite a teammate to a workspace (workspace admin)                                                                       |
+| `doctor` / `health`        | Health + auth + workspace checks / API liveness                                                                          |
+| `setup` / `config`         | Inspect and configure CLI settings                                                                                       |
+| `mcp`                      | Serve MCP over stdio, both spec eras (tools mirror the CLI)                                                              |
 
 Run `uploads <command> --help` for a command's flags.
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -343,6 +343,32 @@ export interface PromoteBranchAttachmentsResult {
   skipped: PromoteSkip[];
 }
 
+/**
+ * `POST /v1/workspaces/:workspace/github/attach` request/response (server
+ * contract, issue #702). `source` is a raw object key or an uploads.sh URL
+ * (storage host, embed host, or `/f/` page). Exactly one of `pr`/`issue` is
+ * required. Copy by default; `move: true` deletes the source object after a
+ * successful copy.
+ */
+export interface AttachExistingOptions {
+  source: string;
+  repo: string;
+  pr?: number;
+  issue?: number;
+  move?: boolean;
+  filename?: string;
+}
+
+export interface AttachExistingResult {
+  key: string;
+  url: string | null;
+  embedUrl: string | null;
+  pageUrl?: string;
+  moved: boolean;
+  source: { key: string };
+  comment: GithubCommentResult;
+}
+
 /** `GET`/`POST /v1/workspaces/:workspace/github/link` result (server contract, phase 4b). */
 export interface GithubLinkResult {
   repo: string;
@@ -1321,6 +1347,25 @@ export function createUploadsClient(config: UploadsClientConfig) {
       return request<PromoteBranchAttachmentsResult>(
         "POST",
         `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/github/promote`,
+        {
+          body: new TextEncoder().encode(JSON.stringify(opts)),
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    },
+
+    /**
+     * Attach an already-uploaded object to a PR/issue via a server-side copy
+     * (issue #702) — see `AttachExistingOptions`. Throws `UploadsError` on
+     * any failure (including a 404 from an older/self-hosted server without
+     * this route, or `source_not_found`) — unlike the degrade-safe promote/
+     * comment calls, this is the CLI's only way to move the object, so a
+     * failure must be visible, not silently swallowed.
+     */
+    async attachExisting(opts: AttachExistingOptions): Promise<AttachExistingResult> {
+      return request<AttachExistingResult>(
+        "POST",
+        `${config.apiUrl}/v1/workspaces/${encodeURIComponent(config.workspace)}/github/attach`,
         {
           body: new TextEncoder().encode(JSON.stringify(opts)),
           headers: { "Content-Type": "application/json" },

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -3,6 +3,7 @@ import { basename, extname } from "node:path";
 import { mapBounded } from "./async.js";
 import {
   createUploadsClient,
+  type AttachExistingResult,
   type GalleryItem,
   type GithubCommentResult,
   type GithubHealthResult,
@@ -965,6 +966,15 @@ derived metadata (path/url/env/viewport/state) is merged in automatically —
 explicit --meta/--state always win. A regenerated or edited file loses its
 sidecar silently (hash no longer matches).
 
+An argument that doesn't exist on disk but resolves as an already-uploaded
+object — a bare key (e.g. "f/AbC123/shot.webp") or an uploads.sh URL (storage
+host, embed host, or /f/ page) — attaches via a server-side copy instead of a
+re-upload: the source's own derived metadata (path/url/viewport/state/…)
+rides along, and gh.repo/gh.kind/gh.number/gh.ref are stamped fresh. Copy by
+default; --move deletes the source after a successful copy. A path that
+exists on disk always wins as a local file, even if it also happens to look
+like a key.
+
 Branch staging (pre-PR): --branch [name] stages files against a git branch
 before a pull request exists, e.g. for a coding agent working a branch that
 hasn't opened a PR yet. Key: gh/<owner>/<repo>/branch/<branch>/<filename>
@@ -996,6 +1006,8 @@ Options:
                         resolved PR and refresh the comment; not with
                         --branch/--issue/--no-promote
   --no-promote          Skip auto-promoting branch-staged attachments (default path only)
+  --move                With an already-uploaded key/URL argument: delete the source
+                        object after a successful server-side copy (default: copy)
   --repo <owner/repo>   Repository (default: gh/git inference)
   --no-comment          Upload only; don't create/update the managed comment
   --content-type <mime> Override Content-Type (applied to every file; ignored when optimize rewrites)
@@ -1073,6 +1085,63 @@ export type AttachFailure = {
   file: string;
   error: { message: string; code?: string; status?: number };
 };
+
+/**
+ * Bounded fan-out for `uploads attach`'s already-uploaded-object args (issue
+ * #702) — attach args are independent server calls (no shared batch state
+ * like `uploadAttachments`'s optimize/frame prep), so this stays a thin
+ * wrapper rather than a variant of that function.
+ */
+const ATTACH_EXISTING_CONCURRENCY = 4;
+
+async function attachExistingBatch(
+  client: UploadsClient,
+  target: GhTarget,
+  sources: readonly string[],
+  move: boolean,
+): Promise<{ results: AttachExistingResult[]; failures: AttachFailure[]; firstError?: unknown }> {
+  const outcomes = await mapBounded(sources, ATTACH_EXISTING_CONCURRENCY, async (source) => {
+    try {
+      const result = await client.attachExisting({
+        source,
+        repo: target.repo,
+        pr: target.kind === "pull" ? target.num : undefined,
+        issue: target.kind === "issues" ? target.num : undefined,
+        move,
+      });
+      return { ok: true as const, source, result };
+    } catch (err) {
+      const message =
+        err instanceof UploadsError && err.code === "NOT_FOUND"
+          ? `not a local file, and no such object in this workspace: ${source}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      return {
+        ok: false as const,
+        source,
+        cause: err,
+        error: {
+          message,
+          code: err instanceof UploadsError ? err.code : undefined,
+          status: err instanceof UploadsError ? err.status : undefined,
+        },
+      };
+    }
+  });
+  const results: AttachExistingResult[] = [];
+  const failures: AttachFailure[] = [];
+  let firstError: unknown;
+  for (const outcome of outcomes) {
+    if (outcome.ok) {
+      results.push(outcome.result);
+    } else {
+      failures.push({ file: outcome.source, error: outcome.error });
+      firstError ??= outcome.cause;
+    }
+  }
+  return { results, failures, firstError };
+}
 
 /** Shared shape of every prepare + put batch (`uploadPuts`/`uploadAttachments`). */
 export interface UploadBatchResult<T> {
@@ -1489,6 +1558,9 @@ export async function runAttach(
   if (parsed.flags.has("--no-promote") && typeof parsed.flags.get("--no-promote") === "string") {
     throw new UsageError("--no-promote takes no value — place it after the file arguments");
   }
+  if (parsed.flags.has("--move") && typeof parsed.flags.get("--move") === "string") {
+    throw new UsageError("--move takes no value — place it after the file arguments");
+  }
 
   if (parsed.flags.has("--promote")) {
     if (parsed.positionals.length > 0) {
@@ -1548,25 +1620,70 @@ export async function runAttach(
   };
   if (Object.keys(metadata).length > 0) validateMetaMap(metadata);
 
+  // Args that exist on disk are always local files, even if they'd also
+  // parse as a key/URL. Everything else is a candidate for the server-side
+  // attach-existing path (issue #702) — resolved/validated server-side, so a
+  // typo'd path and a genuinely-missing object key report the same way.
+  const localFiles = parsed.positionals.filter((p) => existsSync(p));
+  const remoteArgs = parsed.positionals.filter((p) => !existsSync(p));
+  const moveExisting = parsed.flags.has("--move");
+  if (moveExisting && remoteArgs.length === 0) {
+    throw new UsageError("--move only applies to already-uploaded key/URL arguments");
+  }
+
   const logHuman = !ctx.quiet && !ctx.json;
-  if (logHuman) {
-    const n = parsed.positionals.length;
+  if (logHuman && localFiles.length > 0) {
+    const n = localFiles.length;
     process.stderr.write(`>> uploading ${n} file${n === 1 ? "" : "s"}\n`);
   }
 
-  const { uploads, failures, firstError, sentMetadata } = await uploadAttachments({
-    client: ctx.client,
-    target,
-    files: parsed.positionals,
-    contentType: contentTypeOverride,
-    optimize: optimizeOpts,
-    frame: frameOpts,
-    metadata,
-    deriveImageFacts: derivedMetaEnabled(parsed.flags, defaults),
-  });
+  const uploadResult =
+    localFiles.length > 0
+      ? await uploadAttachments({
+          client: ctx.client,
+          target,
+          files: localFiles,
+          contentType: contentTypeOverride,
+          optimize: optimizeOpts,
+          frame: frameOpts,
+          metadata,
+          deriveImageFacts: derivedMetaEnabled(parsed.flags, defaults),
+        })
+      : { uploads: [], failures: [], firstError: undefined, sentMetadata: [] };
+  const { uploads, sentMetadata } = uploadResult;
+  const localFailures = uploadResult.failures;
 
-  // Single-file total failure: rethrow so CLI exit codes stay auth/network-aware.
-  if (uploads.length === 0 && failures.length === 1 && parsed.positionals.length === 1) {
+  if (logHuman && remoteArgs.length > 0) {
+    const n = remoteArgs.length;
+    process.stderr.write(`>> attaching ${n} existing object${n === 1 ? "" : "s"}\n`);
+  }
+  const remoteResult =
+    remoteArgs.length > 0
+      ? await attachExistingBatch(ctx.client, target, remoteArgs, moveExisting)
+      : {
+          results: [] as AttachExistingResult[],
+          failures: [] as AttachFailure[],
+          firstError: undefined,
+        };
+  const { results: attachedExisting, failures: remoteFailures } = remoteResult;
+
+  const failures = [...localFailures, ...remoteFailures];
+  const firstError = localFailures.length > 0 ? uploadResult.firstError : remoteResult.firstError;
+
+  // Single-arg total failure: rethrow so CLI exit codes stay auth/network-aware.
+  // The remote-attach path's friendlier not-found message (attachExistingBatch)
+  // wins over the raw client error text, but the original error's class/code
+  // (UploadsError) is preserved so exit-code mapping stays unaffected.
+  if (
+    uploads.length === 0 &&
+    attachedExisting.length === 0 &&
+    failures.length === 1 &&
+    parsed.positionals.length === 1
+  ) {
+    const only = failures[0]!;
+    if (firstError instanceof UploadsError && firstError.message !== only.error.message) {
+      throw new UploadsError(only.error.message, firstError.code, firstError.status);
+    }
     throw firstError instanceof Error ? firstError : new Error(String(firstError));
   }
 
@@ -1613,6 +1730,7 @@ export async function runAttach(
     await writeJson({
       target,
       uploads,
+      attachedExisting,
       failures,
       comment,
       commentError,
@@ -1633,6 +1751,15 @@ export async function runAttach(
       }
       const embedLine = result.embedUrl ? `EMBED: ${result.embedUrl}\n` : "";
       await writeStdout(`URL: ${result.url}\n${embedLine}MARKDOWN: ${result.markdown}\n`);
+    }
+    for (const attached of attachedExisting) {
+      if (logHuman) {
+        process.stderr.write(
+          `>> ${attached.source.key}: attached${attached.moved ? " (moved)" : ""} as ${attached.key}\n`,
+        );
+      }
+      const embedLine = attached.embedUrl ? `EMBED: ${attached.embedUrl}\n` : "";
+      await writeStdout(`URL: ${attached.url}\n${embedLine}`);
     }
     for (const failure of failures) {
       process.stderr.write(`warning: could not upload ${failure.file}: ${failure.error.message}\n`);

--- a/packages/uploads/src/mcp/output-schemas.ts
+++ b/packages/uploads/src/mcp/output-schemas.ts
@@ -63,6 +63,36 @@ const promoteResultSchema: JsonSchema = objectSchema(
   ["promoted", "skipped"],
 );
 
+/** Hosted `promote` tool's `attached[]` entry (issue #702, `AttachExistingResponse`). */
+const attachExistingResultSchema: JsonSchema = objectSchema(
+  {
+    key: { type: "string" },
+    url: nullableString,
+    embedUrl: nullableString,
+    pageUrl: { type: "string" },
+    moved: { type: "boolean" },
+    source: objectSchema({ key: { type: "string" } }, ["key"]),
+    comment: commentResultSchema,
+  },
+  ["key", "url", "embedUrl", "moved", "source", "comment"],
+);
+
+/** Hosted `promote` tool's `attachFailures[]` entry — one per bad `keys` source. */
+const attachFailureSchema: JsonSchema = objectSchema(
+  {
+    key: { type: "string" },
+    error: objectSchema(
+      {
+        message: { type: "string" },
+        code: { type: "string" },
+        status: { type: "number" },
+      },
+      ["message"],
+    ),
+  },
+  ["key", "error"],
+);
+
 const putObjectFields: Record<string, JsonSchema> = {
   key: { type: "string" },
   url: nullableString,
@@ -264,14 +294,15 @@ export const healthResultSchema: JsonSchema = objectSchema({
   apiUrl: { type: "string" },
 });
 
-export const promoteToolResultSchema: JsonSchema = objectSchema(
-  {
-    promotion: promoteResultSchema,
-    comment: commentResultSchema,
-    commentError: { type: "string" },
-  },
-  ["promotion"],
-);
+export const promoteToolResultSchema: JsonSchema = objectSchema({
+  // `promotion` is optional (issue #702): a `keys`-only call (no `branch`)
+  // never runs the branch sweep, so there's nothing to report under it.
+  promotion: promoteResultSchema,
+  attached: { type: "array", items: attachExistingResultSchema },
+  attachFailures: { type: "array", items: attachFailureSchema },
+  comment: commentResultSchema,
+  commentError: { type: "string" },
+});
 
 const galleryItemSchema: JsonSchema = objectSchema({
   id: { type: "string" },

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { UsageError } from "../src/cli-args.js";
 import type {
+  AttachExistingOptions,
+  AttachExistingResult,
   GithubRepoLinkResult,
   PromoteBranchAttachmentsResult,
   ResolveGhPrefixOptions,
@@ -47,12 +49,21 @@ function fakeClient(opts?: {
   resolveGhPrefix?:
     | ResolveGhPrefixResult
     | ((opts: ResolveGhPrefixOptions) => ResolveGhPrefixResult);
+  /**
+   * `client.attachExisting` behavior (issue #702). Omitted → method is
+   * absent (older-server simulation, same convention as `promote` above).
+   */
+  attachExisting?:
+    | AttachExistingResult
+    | Error
+    | ((opts: AttachExistingOptions) => AttachExistingResult | Promise<AttachExistingResult>);
 }) {
   const puts: string[] = [];
   const metadataByKey: Record<string, Record<string, string> | undefined> = {};
   const promoteCalls: { repo: string; num: number; branch: string }[] = [];
   const callOrder: string[] = [];
   const resolveGhPrefixCalls: ResolveGhPrefixOptions[] = [];
+  const attachExistingCalls: AttachExistingOptions[] = [];
   const list = async ({ prefix }: { prefix?: string } = {}) => ({
     items: puts
       .filter((key) => key.startsWith(prefix ?? ""))
@@ -130,8 +141,27 @@ function fakeClient(opts?: {
           },
         }
       : {}),
+    ...(opts?.attachExisting !== undefined
+      ? {
+          attachExisting: async (attachOpts: AttachExistingOptions) => {
+            attachExistingCalls.push(attachOpts);
+            if (opts.attachExisting instanceof Error) throw opts.attachExisting;
+            return typeof opts.attachExisting === "function"
+              ? opts.attachExisting(attachOpts)
+              : opts.attachExisting!;
+          },
+        }
+      : {}),
   } as unknown as UploadsClient;
-  return { client, puts, metadataByKey, promoteCalls, callOrder, resolveGhPrefixCalls };
+  return {
+    client,
+    puts,
+    metadataByKey,
+    promoteCalls,
+    callOrder,
+    resolveGhPrefixCalls,
+    attachExistingCalls,
+  };
 }
 
 function ctxWith(client: UploadsClient): CliContext {
@@ -1360,5 +1390,89 @@ describe("runAttach path-meta tip (issue #469 lever 3)", () => {
     }
     const payload = JSON.parse(chunks.join("")) as { hint?: string };
     expect(payload.hint).toContain("tip: add --meta path=/route");
+  });
+});
+
+describe("runAttach existing-object args (issue #702)", () => {
+  it("attaches a non-local key via the server-side copy instead of erroring file not found", async () => {
+    const { client, attachExistingCalls } = fakeClient({
+      attachExisting: (opts) => ({
+        key: `gh/buildinternet/uploads/pull/123/${opts.source.split("/").pop()}`,
+        url: `https://storage.uploads.sh/test/gh/buildinternet/uploads/pull/123/hero.webp`,
+        embedUrl: null,
+        moved: false,
+        comment: { posted: true, action: "updated", count: 1 },
+        source: { key: opts.source },
+      }),
+    });
+    const { run } = ghRunner();
+    const exitCode = await runAttach(ctxWith(client), ["f/AbC123/hero.webp"], false, run);
+    expect(exitCode).toBe(0);
+    expect(attachExistingCalls).toEqual([
+      {
+        source: "f/AbC123/hero.webp",
+        repo: "buildinternet/uploads",
+        pr: 123,
+        issue: undefined,
+        move: false,
+      },
+    ]);
+  });
+
+  it("passes --move through to the server call", async () => {
+    const { client, attachExistingCalls } = fakeClient({
+      attachExisting: (opts) => ({
+        key: "gh/buildinternet/uploads/pull/123/hero.webp",
+        url: "https://storage.uploads.sh/test/gh/buildinternet/uploads/pull/123/hero.webp",
+        embedUrl: null,
+        moved: true,
+        comment: { posted: true, action: "updated", count: 1 },
+        source: { key: opts.source },
+      }),
+    });
+    const { run } = ghRunner();
+    expect(await runAttach(ctxWith(client), ["f/AbC123/hero.webp", "--move"], false, run)).toBe(0);
+    expect(attachExistingCalls[0]?.move).toBe(true);
+  });
+
+  it("rejects --move with no key/URL arguments", async () => {
+    const { client } = fakeClient();
+    const { run } = ghRunner();
+    await expect(
+      runAttach(ctxWith(client), [...files("after.png"), "--move"], false, run),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it("reports a not-found source with an updated error message, not the local file-not-found one", async () => {
+    const { client } = fakeClient({
+      attachExisting: new UploadsError("source object not found.", "NOT_FOUND", 404),
+    });
+    const { run } = ghRunner();
+    await expect(
+      runAttach(ctxWith(client), ["f/does-not-exist/nope.webp"], false, run),
+    ).rejects.toThrow(/not a local file, and no such object in this workspace/);
+  });
+
+  it("handles a mix of a local file and an existing-object key in one call", async () => {
+    const { client, puts, attachExistingCalls } = fakeClient({
+      attachExisting: (opts) => ({
+        key: "gh/buildinternet/uploads/pull/123/hero.webp",
+        url: "https://storage.uploads.sh/test/gh/buildinternet/uploads/pull/123/hero.webp",
+        embedUrl: null,
+        moved: false,
+        comment: { posted: true, action: "updated", count: 1 },
+        source: { key: opts.source },
+      }),
+    });
+    const { run } = ghRunner();
+    const exitCode = await runAttach(
+      ctxWith(client),
+      [...files("local.png"), "f/AbC123/hero.webp"],
+      false,
+      run,
+    );
+    expect(exitCode).toBe(0);
+    expect(puts).toEqual(["gh/buildinternet/uploads/pull/123/local.png"]);
+    expect(attachExistingCalls).toHaveLength(1);
   });
 });

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -62,6 +62,21 @@ uploads attach ./shot.png --issue 45 --repo buildinternet/uploads
 Pass `--no-comment` when only stable URLs are wanted. Use `put` for lower-level
 naming and output control.
 
+**Attach an already-uploaded object (issue #702).** An `attach` argument that
+doesn't exist on disk but resolves as a workspace object key (e.g.
+`f/AbC123/shot.webp`) or an uploads.sh URL (storage host, embed host, or
+`/f/` page) attaches via a server-side copy instead of erroring
+`file not found` — no re-download/re-upload round trip. The source's own
+derived metadata (`path`/`url`/`viewport`/`state`/…) rides along; `gh.repo`/
+`gh.kind`/`gh.number`/`gh.ref` are stamped fresh. Copy by default; `--move`
+deletes the source after a successful copy. A path that exists on disk always
+wins as a local file, even if it would also parse as a key.
+
+```bash
+uploads attach f/AbC123/shot.webp --pr 123
+uploads attach https://storage.uploads.sh/<workspace>/f/AbC123/shot.webp --pr 123 --move
+```
+
 **Stage as you go, before a PR exists.** `uploads attach ./shot.png --branch
 [name]` stages files under `gh/<owner>/<repo>/branch/<branch>/<filename>`
 instead of a PR/issue number — same upload path, no target flags, no comment


### PR DESCRIPTION
## Problem

There was no way to attach an already-uploaded file to a PR or issue without
downloading and re-uploading it. Closes #702.

## What changed

**Server** — new `POST /v1/workspaces/:workspace/github/attach` on the
canonical dual-auth surface (`apps/api/src/routes/github-attach.ts`,
`github-attach.ts`, `github-attach-service.ts`):

```jsonc
// request
{
  "source": "f/AbC123/hero.png",      // object key, or an uploads.sh URL
                                       // (storage host, embed host, /f/ page)
  "repo": "owner/name",
  "pr": 123,                          // exactly one of pr | issue
  "move": false,                      // optional, default false (copy)
  "filename": "hero.png"              // optional override
}

// response
{
  "key": "gh/owner/name/pull/123/hero.png",
  "url": "https://storage.uploads.sh/...",
  "embedUrl": "https://embed.uploads.sh/...",
  "pageUrl": "https://uploads.sh/f/...",
  "moved": false,
  "source": { "key": "f/AbC123/hero.png" },
  "comment": { "posted": true, "action": "updated", "count": 1 }
}
```

- In-bucket R2 copy into the target's attachment prefix, honoring the
  `gh/private/<id>/...` layout when the repo resolves to private mode
  (same `resolveGhKeyContextSafe` used by promote).
- Metadata merge is **additive** (PR #157 preserve mode): the source's
  existing D1 metadata rides along unchanged; `gh.repo`/`gh.kind`/
  `gh.number`/`gh.ref` are stamped fresh on top. This is the one deliberate
  divergence from `github-promote.ts`, which does a full-replace `gh.*`-only
  copy — an attach source can carry arbitrary metadata (`path`/`viewport`/
  `state`/a prior attachment's own tags) worth preserving.
- Runs the normal managed-comment sync itself (`postManagedComment`) — one
  API call both attaches and refreshes the comment, unlike branch-staged
  promote which leaves that to a separate CLI call.
- Same workspace-token auth (`files:write`) and implicit repo-link claim
  posture as the existing `comment`/`promote` routes.
- Copy by default; `move: true` deletes the source only after a successful
  copy.
- Idempotent: re-attaching the same source to the same target overwrites the
  destination key in place.

Only added to the canonical `/v1/workspaces/:workspace/github/*` vertical —
no legacy bearer-only twin, since this is a new route rather than a moved one.

**CLI** (`packages/uploads`) — `uploads attach --pr/--issue <arg>...`: an arg
that doesn't exist on disk is now tried as a workspace object key or
uploads.sh URL against the new endpoint instead of erroring
`file not found`. Existing on-disk files always win. New `--move` flag.
Mixed batches (local files + keys/URLs) work in one call.

```
$ uploads attach --pr 1250 --repo buildinternet/sunny f/_IzLjHsBCVYO/family-adler-top.webp
```

**Hosted MCP** (`apps/mcp`) — the `promote` tool gained an explicit `keys`
argument (array of keys/URLs), independent of and combinable with its
existing branch-staged sweep. One bad key degrades into `attachFailures`
rather than aborting the batch; `branch` is no longer required as long as
`keys` is given.

## Tests

- `apps/api/src/routes/github-attach-route.test.ts` — 12 cases (bad body,
  auth, 404 on missing source, copy + additive metadata, all three URL
  spellings, cross-workspace URL rejection, idempotent overwrite, move,
  issue target).
- `packages/uploads/test/commands-attach.test.ts` — new `describe` block:
  key/URL attach, `--move`, mixed local+remote batch, updated not-found
  message, `--move` misuse guard.
- `apps/mcp/test/mcp-branch-promote.test.ts` — `keys` alongside/without
  `branch`, partial-failure degrade, updated required-args usage error.

`pnpm test` (4469 tests), `pnpm typecheck`, and `pnpm check` all pass.

## Deviations from the issue text

- CLI flag is `--move` (issue draft also mentioned `--from-key` as an
  alternative disambiguator for the positional arg — not needed since a
  URL/key is essentially never also a valid local path).
- Server request shape uses `pr`/`issue` (mutually exclusive) rather than a
  generic `kind`/`num` pair, mirroring the CLI's own `--pr`/`--issue` flags.
- No legacy bearer-only route twin was added (canonical surface only) — see
  the note above.

## Relationship to #700 / #701

- #701's bot link-adoption can reuse `github-attach.ts`'s copy/resolve logic
  as-is for an "adopt = attach-by-reference" flow.
- #700's nudge pointing at `uploads attach --pr <num> <key>...` is now
  actionable end to end.
