### PR TITLE
feat(web): SSR-first session gate and billing/profile tabs (#698, #699)

### DIFF
--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -10,6 +10,7 @@
  * re-boot on `astro:page-load` (ClientRouter).
  */
 import { env } from "cloudflare:workers";
+import { getSession } from "../lib/auth-client";
 import {
   applyAuthSecurityHeaders,
   resolveSignedInOrigins,
@@ -64,8 +65,41 @@ const workspaceBase = workspace ? `/account/workspaces/${encodeURIComponent(work
 const switcherHeading = workspace || "workspaces";
 
 const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
-// Header (not meta): frame-ancestors is ignored on meta CSP.
+// Header (not meta): frame-ancestors is ignored on meta CSP. Also sets
+// Cache-Control: no-store, so the per-request session reveal below is never
+// cached and served to another visitor.
 applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
+
+// SSR-first session gate (issue #698). The web worker already receives the
+// cross-subdomain `.uploads.sh` session cookie (it's what the per-page /me
+// data fetches authenticate with), so resolve it during the server render and
+// paint `#app` visible on first paint — making cold loads as snappy as the
+// warm SPA navigations the optimistic-cache script already reveals instantly.
+//
+// This only ever *reveals* for a confirmed session; every other outcome
+// (no cookie, invalid/expired, or auth unavailable) falls through to the
+// existing client gate, which still owns the signed-out state, the auth
+// "try again" retry, and the local-demo dev fallback in account-shell.ts —
+// none of which can be short-circuited server-side. The client always
+// revalidates in the background regardless, so a session revoked between this
+// render and hydration still flips to the signed-out shell.
+const sessionCookie = Astro.request.headers.get("cookie") ?? "";
+let serverSessionUserJson: string | null = null;
+if (sessionCookie.trim()) {
+  const session = await getSession(authOrigin, { cookie: sessionCookie });
+  if (session.kind === "signed_in") {
+    // Serialized as a JS object literal (not a quoted string) so names/emails
+    // with apostrophes need no quote-escaping; `<` is escaped so a stray
+    // "</script" or "<!--" in a value can't break out of the inline seed, and
+    // U+2028/U+2029 (legal in JSON, historically line terminators in JS) are
+    // escaped so the literal always parses.
+    serverSessionUserJson = JSON.stringify(session.session.user).replace(
+      /[<\u2028\u2029]/g,
+      (ch) => "\\u" + ch.charCodeAt(0).toString(16).padStart(4, "0"),
+    );
+  }
+}
+const serverSignedIn = serverSessionUserJson !== null;
 ---
 
 <html lang="en" transition:animate="none">
@@ -76,7 +110,7 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
   </head>
   <body>
     <h1 class="sr-only">{pageHeading}</h1>
-    <div id="checking" class="shell-status">
+    <div id="checking" class="shell-status" hidden={serverSignedIn}>
       <div class="ul-callout status" role="status">Checking your session…</div>
     </div>
 
@@ -92,7 +126,7 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
       <button class="button" type="button" id="session-retry">Try again</button>
     </div>
 
-    <div id="app" class="account-shell" hidden>
+    <div id="app" class="account-shell" hidden={!serverSignedIn}>
       <SiteHeader authOrigin={authOrigin} />
 
       <div class="shell">
@@ -209,6 +243,25 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
       {/* Sibling of .shell so the footer centers on the viewport. */}
       <Footer />
     </div>
+
+    {
+      /* Issue #698: seed the session cache from the server-resolved session so
+    the optimistic script below reveals `#app` and page scripts' onSession fire
+    immediately on cold loads — the same cache the client would populate after
+    its first getSession. Emitted only when the server confirmed a session; the
+    signed-out path is left entirely to the client gate. Placed BEFORE the
+    optimistic script so it reads the freshly-seeded cache. data-astro-rerun:
+    re-seed after each ClientRouter body swap. */
+    }
+    {
+      serverSignedIn ? (
+        <script
+          is:inline
+          data-astro-rerun
+          set:html={`window.__uploadsSessionUser=${serverSessionUserJson};try{sessionStorage.setItem("uploads:sessionUser",JSON.stringify(window.__uploadsSessionUser));}catch(e){}`}
+        />
+      ) : null
+    }
 
     {
       /* Optimistic shell + workspace section nav before deferred modules run.

--- a/apps/web/src/lib/account-profile-ui.test.ts
+++ b/apps/web/src/lib/account-profile-ui.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  loadProfilePageData,
+  renderSessionsHtml,
+  renderSignInMethodsHtml,
+} from "./account-profile-ui";
+import type { AuthSession, LinkedAccount, ProviderAccountInfo } from "./auth-client";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("renderSignInMethodsHtml", () => {
+  it("renders a magic-link fallback row plus a not-connected GitHub Connect row when nothing is linked", () => {
+    const html = renderSignInMethodsHtml([], null);
+    expect(html).toMatch(/Magic link sign-in/);
+    expect(html).toMatch(/data-connect-github/);
+    expect(html).toMatch(/Not connected/);
+  });
+
+  it("renders the live GitHub profile detail and omits the Connect row when GitHub is linked", () => {
+    const accounts: LinkedAccount[] = [
+      { id: "a1", providerId: "github", accountId: "12345", scopes: ["read:user"] },
+    ];
+    const githubInfo: ProviderAccountInfo = {
+      user: { email: "z@example.com" },
+      data: { login: "zachdunn" },
+    };
+    const html = renderSignInMethodsHtml(accounts, githubInfo);
+    expect(html).toMatch(/@zachdunn/);
+    expect(html).toMatch(/z@example\.com/);
+    expect(html).toMatch(/id 12345/);
+    expect(html).toMatch(/scopes read:user/);
+    expect(html).not.toMatch(/data-connect-github/);
+    expect(html).toMatch(/ul-badge--ok">Connected/);
+  });
+
+  it("renders a non-github provider row and still appends the not-connected GitHub row", () => {
+    const accounts: LinkedAccount[] = [
+      { id: "a2", providerId: "google", accountId: "1", createdAt: "2026-01-01T00:00:00.000Z" },
+    ];
+    const html = renderSignInMethodsHtml(accounts, null);
+    expect(html).toMatch(/google/);
+    expect(html).toMatch(/Linked/);
+    expect(html).toMatch(/data-connect-github/);
+  });
+});
+
+describe("renderSessionsHtml", () => {
+  const base: AuthSession = {
+    id: "s1",
+    token: "tok-1",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    expiresAt: "2026-09-01T00:00:00.000Z",
+  };
+
+  it("returns an empty string for the empty-sessions edge case", () => {
+    expect(renderSessionsHtml([], null)).toBe("");
+  });
+
+  it("orders the current session first regardless of updatedAt and badges/labels it", () => {
+    const older: AuthSession = { ...base, id: "s1", token: "tok-1" };
+    const newer: AuthSession = {
+      ...base,
+      id: "s2",
+      token: "tok-2",
+      updatedAt: "2026-08-10T00:00:00.000Z",
+    };
+    const html = renderSessionsHtml([older, newer], "tok-1");
+    expect(html.indexOf("This device")).toBeLessThan(html.indexOf('data-revoke="tok-2"'));
+    expect(html).toMatch(/ul-badge--accent">This device/);
+    expect(html).toMatch(/detail-current">Current/);
+  });
+
+  it("badges a CLI session and offers a revoke button for non-current sessions", () => {
+    const cli: AuthSession = {
+      ...base,
+      id: "s3",
+      token: "tok-3",
+      userAgent: "@buildinternet/uploads/1.2.3 (device-token)",
+    };
+    const html = renderSessionsHtml([cli], "some-other-token");
+    expect(html).toMatch(/uploads CLI 1\.2\.3/);
+    expect(html).toMatch(/ul-badge">CLI/);
+    expect(html).toMatch(/data-revoke="tok-3"/);
+  });
+});
+
+describe("loadProfilePageData", () => {
+  it("returns all-null fields when there is no cookie", async () => {
+    await expect(loadProfilePageData("https://auth.uploads.sh", "")).resolves.toEqual({
+      user: null,
+      currentToken: null,
+      accounts: null,
+      githubInfo: null,
+      sessions: null,
+    });
+    await expect(loadProfilePageData("https://auth.uploads.sh", "   ")).resolves.toEqual({
+      user: null,
+      currentToken: null,
+      accounts: null,
+      githubInfo: null,
+      sessions: null,
+    });
+  });
+
+  it("fetches session/accounts/sessions with the forwarded cookie and resolves github info sequentially", async () => {
+    const user = { id: "u1", email: "z@example.com", name: "Zach", role: "member" };
+    const fetcher = vi.fn<typeof fetch>(async (input) => {
+      const url = String(input);
+      if (url.includes("get-session")) {
+        return Response.json({ user, session: { token: "tok-1" } });
+      }
+      if (url.includes("list-accounts")) {
+        return Response.json([{ id: "a1", providerId: "github", accountId: "42" }]);
+      }
+      if (url.includes("list-sessions")) {
+        return Response.json([
+          { id: "s1", token: "tok-1", createdAt: "x", updatedAt: "x", expiresAt: "x" },
+        ]);
+      }
+      if (url.includes("account-info")) {
+        return Response.json({ user: { email: "z@example.com" }, data: { login: "zachdunn" } });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetcher);
+
+    const data = await loadProfilePageData(
+      "https://auth.uploads.sh",
+      "better-auth.session_token=abc",
+    );
+    expect(data.user).toEqual(user);
+    expect(data.currentToken).toBe("tok-1");
+    expect(data.accounts).toEqual([{ id: "a1", providerId: "github", accountId: "42" }]);
+    expect(data.sessions).toEqual([
+      { id: "s1", token: "tok-1", createdAt: "x", updatedAt: "x", expiresAt: "x" },
+    ]);
+    expect(data.githubInfo).toEqual({
+      user: { email: "z@example.com" },
+      data: { login: "zachdunn" },
+    });
+
+    // Every request forwarded the cookie header (server-side fetch, no cookie jar).
+    for (const call of fetcher.mock.calls) {
+      const init = call[1] as RequestInit | undefined;
+      expect(init?.headers).toEqual({ cookie: "better-auth.session_token=abc" });
+    }
+  });
+
+  it("skips the account-info lookup when no github account is linked", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("get-session")) return Response.json(null);
+      if (url.includes("list-accounts")) return Response.json([]);
+      if (url.includes("list-sessions")) return Response.json([]);
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetcher);
+
+    const data = await loadProfilePageData("https://auth.uploads.sh", "cookie=1");
+    expect(data.user).toBeNull();
+    expect(data.githubInfo).toBeNull();
+    expect(fetcher.mock.calls.some((call) => String(call[0]).includes("account-info"))).toBe(false);
+  });
+
+  it("leaves fields null when the underlying fetches fail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 503 })),
+    );
+    const data = await loadProfilePageData("https://auth.uploads.sh", "cookie=1");
+    expect(data).toEqual({
+      user: null,
+      currentToken: null,
+      accounts: null,
+      githubInfo: null,
+      sessions: null,
+    });
+  });
+});

--- a/apps/web/src/lib/account-profile-ui.ts
+++ b/apps/web/src/lib/account-profile-ui.ts
@@ -1,0 +1,207 @@
+/**
+ * Shared data loader + markup for /account/profile (issue #699) so SSR and
+ * the client paint the same "Sign-in methods" and "Sessions" rows. Mirrors
+ * developers-ui.ts's shape: a pure loader returning `T | null` fields (null =
+ * no cookie / fetch failed) plus pure, server-safe HTML renderers the client
+ * re-invokes to reconcile after its own fetch.
+ */
+import {
+  getAccountInfo,
+  getSession,
+  listAccounts,
+  listSessions,
+  type AuthSession,
+  type LinkedAccount,
+  type ProviderAccountInfo,
+  type SessionUser,
+} from "./auth-client";
+import { githubMarkSvg } from "./brand-icons";
+import { deviceLabel, formatSessionTime, isCliUserAgent } from "./session-device";
+import { escapeHtml } from "./workspace-ui";
+
+export interface ProfilePageData {
+  user: SessionUser | null;
+  /** Current session's token (drives "This device" ordering/badge); null when unresolved. */
+  currentToken: string | null;
+  accounts: LinkedAccount[] | null;
+  /** Live GitHub profile when a github account is linked; null otherwise or on failure. */
+  githubInfo: ProviderAccountInfo | null;
+  sessions: AuthSession[] | null;
+}
+
+/**
+ * Server-side data for /account/profile. An empty/missing cookie short-
+ * circuits to all-null fields (first paint falls back to the placeholder and
+ * the client fetch fills in, same contract as `loadDevelopersPageData`). The
+ * github-info lookup is sequential — it needs the linked account's id from
+ * `listAccounts` — mirroring the client's original `loadAccounts()`.
+ */
+export async function loadProfilePageData(
+  authOrigin: string,
+  cookie: string,
+): Promise<ProfilePageData> {
+  if (!cookie.trim()) {
+    return { user: null, currentToken: null, accounts: null, githubInfo: null, sessions: null };
+  }
+
+  const [sessionResult, accounts, sessions] = await Promise.all([
+    getSession(authOrigin, { cookie }),
+    listAccounts(authOrigin, { cookie }),
+    listSessions(authOrigin, { cookie }),
+  ]);
+
+  const user = sessionResult.kind === "signed_in" ? sessionResult.session.user : null;
+  const tokenValue =
+    sessionResult.kind === "signed_in" ? sessionResult.session.session?.token : undefined;
+  const currentToken = typeof tokenValue === "string" ? tokenValue : null;
+
+  // Live GitHub profile when linked (account-info needs list-accounts id).
+  const github = accounts?.find((a) => a.providerId === "github") ?? null;
+  const githubInfo = github
+    ? await getAccountInfo(authOrigin, {
+        providerId: "github",
+        accountId: github.accountId,
+        cookie,
+      })
+    : null;
+
+  return { user, currentToken, accounts, githubInfo, sessions };
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+// Official GitHub mark (same path as releases AccountIcon) — not a Lucide
+// brand icon; Lucide dropped brand logos.
+const GITHUB_ICON = githubMarkSvg({ size: 14, className: "detail-icon" });
+
+function githubDetail(account: LinkedAccount, info: ProviderAccountInfo | null): string {
+  const parts: string[] = [];
+  const login = asNonEmptyString(info?.data?.login);
+  if (login) parts.push(`@${login}`);
+  const email = asNonEmptyString(info?.user?.email) ?? asNonEmptyString(info?.data?.email);
+  if (email) parts.push(email);
+  parts.push(`id ${account.accountId}`);
+  if (account.scopes?.length) parts.push(`scopes ${account.scopes.join(", ")}`);
+  return parts.join(" · ");
+}
+
+type MethodRow = {
+  title: string;
+  detail: string;
+  ok: boolean;
+  icon?: string;
+  connectGithub?: boolean;
+};
+
+/**
+ * Sign-in-methods list rows: linked providers (GitHub gets a live-profile
+ * detail line + icon), a magic-link fallback row when nothing is linked, and
+ * a "Connect" row appended whenever GitHub isn't linked. Never empty, so
+ * unlike the other renderers in this file callers don't need a separate
+ * empty-state branch. Server-safe — no window/document access.
+ */
+export function renderSignInMethodsHtml(
+  accounts: LinkedAccount[],
+  githubInfo: ProviderAccountInfo | null,
+): string {
+  const github = accounts.find((a) => a.providerId === "github");
+
+  const rows: MethodRow[] =
+    accounts.length > 0
+      ? accounts.map((a) => {
+          if (a.providerId === "github") {
+            return {
+              title: "GitHub",
+              detail: githubDetail(a, githubInfo),
+              ok: true,
+              icon: GITHUB_ICON,
+            };
+          }
+          return {
+            title: a.providerId,
+            detail: a.createdAt ? `Linked ${formatSessionTime(a.createdAt)}` : "Connected",
+            ok: true,
+          };
+        })
+      : [{ title: "Email", detail: "Magic link sign-in", ok: true }];
+
+  if (!github) {
+    rows.push({
+      title: "GitHub",
+      detail: "Not connected",
+      ok: false,
+      icon: GITHUB_ICON,
+      connectGithub: true,
+    });
+  }
+
+  return rows
+    .map((row) => {
+      const action = row.connectGithub
+        ? `<div class="detail-action">
+                <button type="button" class="text-btn text-btn--boxed" data-connect-github>Connect</button>
+              </div>`
+        : "";
+      // Unconnected rows carry no badge: the meta line already says
+      // "Not connected", and the boxed Connect button is the state cue.
+      const badge = row.ok ? `<span class="ul-badge ul-badge--ok">Connected</span>` : "";
+      return `<li>
+            <div class="detail-main">
+              <div class="detail-title">
+                ${row.icon ?? ""}
+                <span>${escapeHtml(row.title)}</span>
+                ${badge}
+              </div>
+              <div class="detail-meta">${escapeHtml(row.detail)}</div>
+            </div>
+            ${action}
+          </li>`;
+    })
+    .join("");
+}
+
+/**
+ * Sessions list rows, current-session-first then most-recently-active.
+ * `[]` → `""` — the caller decides the "No active sessions." status text and
+ * hides the list, same branching the client used before this shared
+ * renderer existed.
+ */
+export function renderSessionsHtml(sessions: AuthSession[], currentToken: string | null): string {
+  if (!sessions.length) return "";
+  const ordered = sessions.toSorted((a, b) => {
+    if (currentToken && a.token === currentToken) return -1;
+    if (currentToken && b.token === currentToken) return 1;
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
+  return ordered
+    .map((s) => {
+      const current = currentToken != null && s.token === currentToken;
+      const badge = current
+        ? `<span class="ul-badge ul-badge--accent">This device</span>`
+        : isCliUserAgent(s.userAgent)
+          ? `<span class="ul-badge">CLI</span>`
+          : "";
+      const meta = [
+        s.ipAddress ? escapeHtml(s.ipAddress) : null,
+        `Active ${escapeHtml(formatSessionTime(s.updatedAt))}`,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+      const action = current
+        ? `<span class="detail-current">Current</span>`
+        : `<button type="button" class="text-btn" data-revoke="${escapeHtml(s.token)}">Sign out</button>`;
+      return `<li>
+            <div class="detail-main">
+              <div class="detail-title">
+                <span>${escapeHtml(deviceLabel(s.userAgent, { cliVersion: s.cliVersion }))}</span>
+                ${badge}
+              </div>
+              <div class="detail-meta">${meta}</div>
+            </div>
+            <div class="detail-action">${action}</div>
+          </li>`;
+    })
+    .join("");
+}

--- a/apps/web/src/lib/account-profile-ui.ts
+++ b/apps/web/src/lib/account-profile-ui.ts
@@ -170,7 +170,9 @@ export function renderSignInMethodsHtml(
  */
 export function renderSessionsHtml(sessions: AuthSession[], currentToken: string | null): string {
   if (!sessions.length) return "";
-  const ordered = sessions.toSorted((a, b) => {
+  // Copy-then-sort (not `toSorted`) so this shared renderer stays non-mutating
+  // without depending on ES2023 array methods in either runtime (#714 review).
+  const ordered = [...sessions].sort((a, b) => {
     if (currentToken && a.token === currentToken) return -1;
     if (currentToken && b.token === currentToken) return 1;
     return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -547,10 +547,11 @@ export type WorkspaceBillingResult =
 export async function getWorkspaceBilling(
   apiOrigin: string,
   name: string,
+  opts?: { cookie?: string },
 ): Promise<WorkspaceBillingResult> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/billing`,
-    { credentials: "include", cache: "no-store" },
+    sessionFetchInit(opts?.cookie),
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -91,6 +91,29 @@ describe("getSession", () => {
       reason: "network",
     });
   });
+
+  it("forwards a caller-supplied cookie so an Astro frontmatter can resolve the session (issue #698)", async () => {
+    const user = { id: "u1", email: "a@b.com", name: "A" };
+    const fetcher = vi.fn(async () => Response.json({ session: {}, user }));
+    vi.stubGlobal("fetch", fetcher);
+
+    await expect(
+      getSession("http://127.0.0.1:8788", { cookie: "better-auth.session_token=abc" }),
+    ).resolves.toEqual({ kind: "signed_in", session: { session: {}, user } });
+    expect(fetcher).toHaveBeenCalledWith(
+      "http://127.0.0.1:8788/api/auth/get-session",
+      expect.objectContaining({ headers: { cookie: "better-auth.session_token=abc" } }),
+    );
+  });
+
+  it("omits the cookie header on the browser path where the ambient cookie rides along", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => Response.json(null));
+    vi.stubGlobal("fetch", fetcher);
+
+    await getSession("http://127.0.0.1:8788");
+    const init = fetcher.mock.calls[0]?.[1];
+    expect(init && "headers" in init ? init.headers : undefined).toBeUndefined();
+  });
 });
 
 describe("listSessions / listAccounts", () => {
@@ -151,6 +174,32 @@ describe("listSessions / listAccounts", () => {
         scopes: ["read:user", "user:email"],
       },
     ]);
+  });
+
+  it("forwards a caller-supplied cookie so an Astro frontmatter can resolve them (issue #699)", async () => {
+    const fetcher = vi.fn(async () => Response.json([]));
+    vi.stubGlobal("fetch", fetcher);
+
+    await listSessions("http://127.0.0.1:8788", { cookie: "better-auth.session_token=abc" });
+    expect(fetcher).toHaveBeenCalledWith(
+      "http://127.0.0.1:8788/api/auth/list-sessions",
+      expect.objectContaining({ headers: { cookie: "better-auth.session_token=abc" } }),
+    );
+
+    await listAccounts("http://127.0.0.1:8788", { cookie: "better-auth.session_token=abc" });
+    expect(fetcher).toHaveBeenCalledWith(
+      "http://127.0.0.1:8788/api/auth/list-accounts",
+      expect.objectContaining({ headers: { cookie: "better-auth.session_token=abc" } }),
+    );
+  });
+
+  it("omits the cookie header on the browser path where the ambient cookie rides along", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => Response.json([]));
+    vi.stubGlobal("fetch", fetcher);
+
+    await listSessions("http://127.0.0.1:8788");
+    const init = fetcher.mock.calls[0]?.[1];
+    expect(init && "headers" in init ? init.headers : undefined).toBeUndefined();
   });
 });
 
@@ -352,6 +401,30 @@ describe("getAccountInfo", () => {
         accountId: "1",
       }),
     ).resolves.toBeNull();
+  });
+
+  it("forwards a caller-supplied cookie so an Astro frontmatter can resolve it (issue #699)", async () => {
+    const fetcher = vi.fn(async () => Response.json({ user: { email: "a@b.com" } }));
+    vi.stubGlobal("fetch", fetcher);
+
+    await getAccountInfo("https://auth.uploads.sh", {
+      providerId: "github",
+      accountId: "1",
+      cookie: "better-auth.session_token=abc",
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      expect.stringContaining("https://auth.uploads.sh/api/auth/account-info?"),
+      expect.objectContaining({ headers: { cookie: "better-auth.session_token=abc" } }),
+    );
+  });
+
+  it("omits the cookie header on the browser path where the ambient cookie rides along", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => Response.json({ user: { email: "a@b.com" } }));
+    vi.stubGlobal("fetch", fetcher);
+
+    await getAccountInfo("https://auth.uploads.sh", { providerId: "github", accountId: "1" });
+    const init = fetcher.mock.calls[0]?.[1];
+    expect(init && "headers" in init ? init.headers : undefined).toBeUndefined();
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -103,11 +103,21 @@ type LocalDemoSessionStart =
  * GET /api/auth/get-session. A valid no-session response is distinct from an
  * auth timeout, network failure, 503, or malformed response so protected
  * pages never send a user to sign in when the service is merely unavailable.
+ *
+ * `opts.cookie` lets an Astro frontmatter resolve the session during the
+ * server render by forwarding the incoming request's cookie header — a
+ * server-to-server fetch has no cookie jar, so `credentials: "include"` alone
+ * does nothing there (same pattern as `sessionFetchInit` in api-client.ts).
+ * Omitted in the browser, where the ambient session cookie rides along.
  */
-export async function getSession(origin: string): Promise<SessionResult> {
+export async function getSession(
+  origin: string,
+  opts?: { cookie?: string },
+): Promise<SessionResult> {
   const result = await fetchWithTimeout(`${authOrigin(origin)}/api/auth/get-session`, {
     credentials: "include",
     cache: "no-store",
+    ...(opts?.cookie ? { headers: { cookie: opts.cookie } } : {}),
   });
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -456,20 +466,36 @@ export async function acceptInvitation(
 /**
  * GET a JSON array from the auth worker. Returns null on outage/auth/malformed
  * so callers can distinguish "couldn't load" from an empty list.
+ *
+ * `opts.cookie` forwards a caller-supplied cookie header for a server-side
+ * fetch (same pattern as getSession's doc comment) — omitted in the browser,
+ * where the ambient session cookie rides along via `credentials: "include"`.
  */
-async function getAuthArray(origin: string, path: string): Promise<unknown[] | null> {
+async function getAuthArray(
+  origin: string,
+  path: string,
+  opts?: { cookie?: string },
+): Promise<unknown[] | null> {
   const result = await fetchWithTimeout(`${authOrigin(origin)}${path}`, {
     credentials: "include",
     cache: "no-store",
+    ...(opts?.cookie ? { headers: { cookie: opts.cookie } } : {}),
   });
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = (await result.response.json().catch(() => undefined)) as unknown;
   return Array.isArray(body) ? body : null;
 }
 
-/** GET /api/auth/list-sessions — active sessions (browser + CLI device flow). */
-export async function listSessions(origin: string): Promise<AuthSession[] | null> {
-  const body = await getAuthArray(origin, "/api/auth/list-sessions");
+/**
+ * GET /api/auth/list-sessions — active sessions (browser + CLI device flow).
+ * `opts.cookie` lets an Astro frontmatter resolve this during the server
+ * render by forwarding the incoming request's cookie header (see getSession).
+ */
+export async function listSessions(
+  origin: string,
+  opts?: { cookie?: string },
+): Promise<AuthSession[] | null> {
+  const body = await getAuthArray(origin, "/api/auth/list-sessions", opts);
   if (!body) return null;
   return body.filter((row): row is AuthSession => {
     if (!row || typeof row !== "object") return false;
@@ -668,9 +694,16 @@ export function isBannedAuthError(input: {
   );
 }
 
-/** GET /api/auth/list-accounts — linked identity providers (e.g. GitHub). */
-export async function listAccounts(origin: string): Promise<LinkedAccount[] | null> {
-  const body = await getAuthArray(origin, "/api/auth/list-accounts");
+/**
+ * GET /api/auth/list-accounts — linked identity providers (e.g. GitHub).
+ * `opts.cookie` lets an Astro frontmatter resolve this during the server
+ * render by forwarding the incoming request's cookie header (see getSession).
+ */
+export async function listAccounts(
+  origin: string,
+  opts?: { cookie?: string },
+): Promise<LinkedAccount[] | null> {
+  const body = await getAuthArray(origin, "/api/auth/list-accounts", opts);
   if (!body) return null;
   const accounts: LinkedAccount[] = [];
   for (const row of body) {
@@ -703,10 +736,12 @@ export async function listAccounts(origin: string): Promise<LinkedAccount[] | nu
  * GET /api/auth/account-info — live profile from the linked OAuth provider
  * (uses the stored access token). Pass accountId from list-accounts; without
  * it Better Auth only resolves via an account cookie we do not enable.
+ * `opts.cookie` lets an Astro frontmatter resolve this during the server
+ * render by forwarding the incoming request's cookie header (see getSession).
  */
 export async function getAccountInfo(
   origin: string,
-  opts: { providerId: string; accountId: string },
+  opts: { providerId: string; accountId: string; cookie?: string },
 ): Promise<ProviderAccountInfo | null> {
   const params = new URLSearchParams({
     providerId: opts.providerId,
@@ -715,6 +750,7 @@ export async function getAccountInfo(
   const result = await fetchWithTimeout(`${authOrigin(origin)}/api/auth/account-info?${params}`, {
     credentials: "include",
     cache: "no-store",
+    ...(opts.cookie ? { headers: { cookie: opts.cookie } } : {}),
   });
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = (await result.response.json().catch(() => undefined)) as

--- a/apps/web/src/lib/billing-ui.test.ts
+++ b/apps/web/src/lib/billing-ui.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceBilling } from "./api-client";
+import {
+  loadBillingPageData,
+  planCardLimitRows,
+  planCardPriceLine,
+  planLabel,
+  renderFileLimitsText,
+  renderPlanBlurbText,
+  renderPlanCardBodyHtml,
+  renderPlanCardPlaceholderHtml,
+  renderPlanCardsGridHtml,
+} from "./billing-ui";
+
+function makeBilling(overrides: Partial<WorkspaceBilling> = {}): WorkspaceBilling {
+  return {
+    workspace: "acme",
+    organization: { id: "org_1", slug: "acme", name: "Acme" },
+    plan: "free",
+    available: true,
+    planApplied: true,
+    limits: {
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+      maxUploadBytes: 25_000_000,
+      maxVideoUploadBytes: 8_000_000,
+    },
+    usage: null,
+    planSource: "none",
+    subscription: null,
+    ...overrides,
+  };
+}
+
+describe("loadBillingPageData", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null billing/proPrice without attempting a fetch when there is no cookie", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      loadBillingPageData("https://api.uploads.sh", "https://auth.uploads.sh", "acme", ""),
+    ).resolves.toEqual({ billing: null, proPrice: null });
+    await expect(
+      loadBillingPageData("https://api.uploads.sh", "https://auth.uploads.sh", "acme", "   "),
+    ).resolves.toEqual({ billing: null, proPrice: null });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches billing and the pro price together when a cookie is present", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/billing/prices")) {
+        return Response.json({
+          prices: { pro: { unitAmount: 1000, currency: "usd", interval: "month" } },
+        });
+      }
+      return Response.json({
+        workspace: "acme",
+        organization: { id: "org_1", slug: "acme", name: "Acme" },
+        plan: "pro",
+        available: true,
+        planApplied: true,
+        limits: {},
+        usage: null,
+        planSource: "stripe",
+        subscription: null,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadBillingPageData(
+      "https://api.uploads.sh",
+      "https://auth.uploads.sh",
+      "acme",
+      "better-auth.session=abc",
+    );
+    expect(result.billing?.plan).toBe("pro");
+    expect(result.proPrice).toEqual({ unitAmount: 1000, currency: "usd", interval: "month" });
+  });
+
+  it("returns null billing (but keeps the price fetch) when the billing fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/billing/prices")) {
+          return Response.json({ prices: { pro: null } });
+        }
+        return new Response("nope", { status: 500 });
+      }),
+    );
+
+    const result = await loadBillingPageData(
+      "https://api.uploads.sh",
+      "https://auth.uploads.sh",
+      "acme",
+      "better-auth.session=abc",
+    );
+    expect(result.billing).toBeNull();
+    expect(result.proPrice).toBeNull();
+  });
+});
+
+describe("planLabel", () => {
+  it("capitalizes the plan id", () => {
+    expect(planLabel("free")).toBe("Free");
+    expect(planLabel("pro")).toBe("Pro");
+  });
+});
+
+describe("renderFileLimitsText", () => {
+  it("renders both caps when the video ceiling differs from the upload ceiling", () => {
+    expect(
+      renderFileLimitsText({
+        maxStorageBytes: null,
+        maxUploadsPerPeriod: null,
+        maxUploadBytes: 25_000_000,
+        maxVideoUploadBytes: 8_000_000,
+      }),
+    ).toBe("Max upload size: files up to 25 MB, videos up to 8 MB.");
+  });
+
+  it("omits the video line when it equals the upload ceiling", () => {
+    expect(
+      renderFileLimitsText({
+        maxStorageBytes: null,
+        maxUploadsPerPeriod: null,
+        maxUploadBytes: 100_000_000,
+        maxVideoUploadBytes: 100_000_000,
+      }),
+    ).toBe("Max upload size: files up to 100 MB.");
+  });
+
+  it("returns an empty string when both caps are null", () => {
+    expect(
+      renderFileLimitsText({
+        maxStorageBytes: null,
+        maxUploadsPerPeriod: null,
+        maxUploadBytes: null,
+        maxVideoUploadBytes: null,
+      }),
+    ).toBe("");
+  });
+});
+
+describe("renderPlanBlurbText", () => {
+  it("reports unapplied plans honestly rather than free-tier marketing copy", () => {
+    expect(renderPlanBlurbText(makeBilling({ planApplied: false }), false)).toBe(
+      "Your current limits are shown below.",
+    );
+  });
+
+  it("flags an applied-but-unavailable plan", () => {
+    expect(renderPlanBlurbText(makeBilling({ planApplied: true, available: false }), false)).toBe(
+      "This plan isn’t available for self-serve upgrade yet.",
+    );
+  });
+
+  it("states the plan is active when there is no subscription status line", () => {
+    expect(renderPlanBlurbText(makeBilling({ planApplied: true, available: true }), false)).toBe(
+      "This plan is active on your workspace.",
+    );
+  });
+
+  it("stays empty when the subscription status line will already say so", () => {
+    expect(renderPlanBlurbText(makeBilling({ planApplied: true, available: true }), true)).toBe("");
+  });
+});
+
+describe("renderPlanCardPlaceholderHtml", () => {
+  it("renders skeleton bars for all four fields with the same ids the real render uses", () => {
+    const html = renderPlanCardPlaceholderHtml();
+    expect(html).toContain('id="ws-plan-name"');
+    expect(html).toContain('id="ws-plan-blurb"');
+    expect(html).toContain('id="ws-plan-file-limits"');
+    expect(html).toContain('id="ws-subscription-status" role="status" hidden');
+    expect(html).toContain("ws-skel");
+  });
+});
+
+describe("renderPlanCardBodyHtml", () => {
+  it("renders the plan name, blurb, and file limits for a free workspace", () => {
+    const html = renderPlanCardBodyHtml(makeBilling(), null);
+    expect(html).toContain('<strong id="ws-plan-name">Free plan</strong>');
+    expect(html).toContain("This plan is active on your workspace.");
+    expect(html).toContain("Max upload size: files up to 25 MB, videos up to 8 MB.");
+    expect(html).toContain('id="ws-subscription-status" hidden');
+  });
+
+  it("hides the blurb paragraph when the blurb text is empty", () => {
+    const html = renderPlanCardBodyHtml(
+      makeBilling({
+        plan: "pro",
+        planSource: "admin",
+      }),
+      null,
+    );
+    expect(html).toContain('id="ws-plan-blurb" hidden');
+  });
+
+  it("renders an alert-toned subscription status line with data-state", () => {
+    const html = renderPlanCardBodyHtml(
+      makeBilling({
+        plan: "pro",
+        planSource: "stripe",
+        subscription: { status: "past_due", periodEnd: null, cancelAtPeriodEnd: false },
+      }),
+      null,
+    );
+    expect(html).toContain('role="alert"');
+    expect(html).toContain('data-state="error"');
+    expect(html).toContain("Payment past due");
+  });
+
+  it("renders a muted renewing status line with the live price appended", () => {
+    const html = renderPlanCardBodyHtml(
+      makeBilling({
+        plan: "pro",
+        planSource: "stripe",
+        subscription: {
+          status: "active",
+          periodEnd: "2026-09-01T00:00:00.000Z",
+          cancelAtPeriodEnd: false,
+        },
+      }),
+      "$10 per month",
+    );
+    expect(html).toContain('role="status"');
+    expect(html).not.toContain("data-state");
+    expect(html).toContain("Renews on September 1, 2026 · $10 per month");
+  });
+
+  it("escapes plan/limit text", () => {
+    const html = renderPlanCardBodyHtml(makeBilling({ plan: "<b>evil</b>" }), null);
+    expect(html).not.toContain("<b>evil</b>");
+    expect(html).toContain("&lt;b&gt;evil&lt;/b&gt;");
+  });
+});
+
+describe("planCardLimitRows / planCardPriceLine", () => {
+  it("marks free's member cap and omits pro's (unmarketed abuse guard)", () => {
+    const free = {
+      id: "free" as const,
+      name: "Free",
+      blurb: "",
+      available: true,
+      marketsMemberCap: true,
+      byoBucket: true,
+      defaultLimits: { maxStorageBytes: 250_000_000, maxUploadBytes: 25_000_000, maxMembers: 3 },
+    };
+    const pro = {
+      id: "pro" as const,
+      name: "Pro",
+      blurb: "",
+      available: true,
+      marketsMemberCap: false,
+      byoBucket: true,
+      defaultLimits: {
+        maxStorageBytes: 10_000_000_000,
+        maxUploadBytes: 100_000_000,
+        maxMembers: 25,
+      },
+    };
+    expect(planCardLimitRows(free)).toContain("3 members");
+    expect(planCardLimitRows(pro)).toContain("Unlimited members");
+    expect(planCardPriceLine(free, "$10 per month")).toBe("$0");
+    expect(planCardPriceLine(pro, "$10 per month")).toBe("$10 per month");
+    expect(planCardPriceLine(pro, null)).toBe("");
+  });
+});
+
+describe("renderPlanCardsGridHtml", () => {
+  it("badges the current plan and offers an upgrade CTA on the pro card for a free workspace", () => {
+    const html = renderPlanCardsGridHtml(makeBilling({ plan: "free", planSource: "none" }), null);
+    expect(html).toContain('data-plan="free"');
+    expect(html).toContain("plan-card__badge");
+    expect(html).toContain('data-cta="upgrade" data-plan="pro"');
+  });
+
+  it("renders no footer CTA on the current (pro) card when a Stripe subscription backs it", () => {
+    const html = renderPlanCardsGridHtml(
+      makeBilling({ plan: "pro", planSource: "stripe" }),
+      "$10 per month",
+    );
+    const proCard = html.slice(html.indexOf('data-plan="pro"'));
+    expect(proCard).toContain("plan-card__badge");
+    expect(proCard).not.toContain("data-cta=");
+  });
+});

--- a/apps/web/src/lib/billing-ui.ts
+++ b/apps/web/src/lib/billing-ui.ts
@@ -1,0 +1,225 @@
+/**
+ * Shared markup for the workspace billing tab (issue #699 — SSR-first) so
+ * SSR and the client paint the same current-plan card + plan-cards grid.
+ * Mirrors developers-ui.ts's loader/renderer split: `loadBillingPageData`
+ * is the server-safe loader, everything else is pure string-building with
+ * no DOM access, called by both billing.astro's frontmatter and its client
+ * `<script>` reconcile path.
+ */
+import {
+  getWorkspaceBilling,
+  type WorkspaceBilling,
+  type WorkspaceBillingLimits,
+} from "./api-client";
+import { resolveBillingCta } from "./billing-cta";
+import { fetchProPrice, type PlanPrice } from "./plan-prices";
+import { resolveSubscriptionCopy, type SubscriptionCopyState } from "./subscription-copy";
+import { escapeHtml, formatBytes, formatMarketedBytes, skeletonBarHtml } from "./workspace-ui";
+
+import { PLANS, type PlanDefinition } from "@uploads/billing";
+
+export interface BillingPageData {
+  billing: WorkspaceBilling | null;
+  proPrice: PlanPrice | null;
+}
+
+/**
+ * Server-side loader for the billing tab. `cookie` empty/blank means no
+ * session on the request (SSR can't authenticate) — returns nulls rather
+ * than attempting the fetch, same contract as `loadDevelopersPageData`.
+ * `fetchProPrice` needs no cookie (public, uncredentialed endpoint) so it's
+ * always attempted alongside the billing fetch.
+ */
+export async function loadBillingPageData(
+  apiOrigin: string,
+  authOrigin: string,
+  workspace: string,
+  cookie: string,
+): Promise<BillingPageData> {
+  if (!cookie.trim()) return { billing: null, proPrice: null };
+  const [billingResult, proPrice] = await Promise.all([
+    getWorkspaceBilling(apiOrigin, workspace, { cookie }),
+    fetchProPrice(authOrigin),
+  ]);
+  return {
+    billing: billingResult.kind === "ok" ? billingResult.billing : null,
+    proPrice,
+  };
+}
+
+export function planLabel(plan: string): string {
+  return plan.charAt(0).toUpperCase() + plan.slice(1);
+}
+
+/**
+ * The current-plan card's one line that isn't already covered by the
+ * workspace rail (which shows storage + uploads-this-month usage) — the
+ * enforced max file/video size, so that information isn't lost when the
+ * standalone "Limits & usage" section is removed.
+ */
+export function renderFileLimitsText(limits: WorkspaceBillingLimits): string {
+  const parts: string[] = [];
+
+  if (limits.maxUploadBytes !== null) {
+    parts.push(`files up to ${formatBytes(limits.maxUploadBytes)}`);
+  }
+  if (limits.maxVideoUploadBytes !== null && limits.maxVideoUploadBytes !== limits.maxUploadBytes) {
+    parts.push(`videos up to ${formatBytes(limits.maxVideoUploadBytes)}`);
+  }
+
+  return parts.length ? `Max upload size: ${parts.join(", ")}.` : "";
+}
+
+/**
+ * Honest copy: a record with no plan actually applied isn't on free-tier
+ * marketing caps — it's running whatever `limits` says. When a subscription
+ * status line will render ("Included with your workspace." / "Renews on
+ * …"), it already says the plan is active, so the generic blurb stays empty
+ * rather than repeating it.
+ */
+export function renderPlanBlurbText(billing: WorkspaceBilling, hasStatusLine: boolean): string {
+  if (!billing.planApplied) return "Your current limits are shown below.";
+  if (!billing.available) return "This plan isn’t available for self-serve upgrade yet.";
+  return hasStatusLine ? "" : "This plan is active on your workspace.";
+}
+
+function renderSubscriptionStatusHtml(state: SubscriptionCopyState | null): string {
+  if (!state) {
+    return `<p id="ws-subscription-status" hidden></p>`;
+  }
+  const roleAttr = state.tone === "alert" ? "alert" : "status";
+  const dataStateAttr = state.tone === "alert" ? ` data-state="error"` : "";
+  return `<p id="ws-subscription-status" class="muted" role="${roleAttr}"${dataStateAttr}>${escapeHtml(state.text)}</p>`;
+}
+
+/**
+ * The current-plan card's inner HTML (name/blurb/file-limits/subscription
+ * status) — the `#ws-plan-card` region's entire content, painted by SSR via
+ * `set:html` and re-painted verbatim by the client on reconcile so the two
+ * never drift.
+ */
+export function renderPlanCardBodyHtml(
+  billing: WorkspaceBilling,
+  proPriceCopy: string | null,
+): string {
+  const statusState = resolveSubscriptionCopy({
+    planSource: billing.planSource,
+    subscription: billing.subscription,
+    priceText: proPriceCopy,
+  });
+  const blurbText = renderPlanBlurbText(billing, statusState !== null);
+  const fileLimitsText = renderFileLimitsText(billing.limits);
+
+  return (
+    `<p><strong id="ws-plan-name">${escapeHtml(`${planLabel(billing.plan)} plan`)}</strong></p>` +
+    `<p class="muted" id="ws-plan-blurb"${blurbText ? "" : " hidden"}>${escapeHtml(blurbText)}</p>` +
+    `<p class="muted" id="ws-plan-file-limits">${escapeHtml(fileLimitsText)}</p>` +
+    renderSubscriptionStatusHtml(statusState)
+  );
+}
+
+/** Skeleton fallback for `#ws-plan-card` when there is no server-fetched billing yet. */
+export function renderPlanCardPlaceholderHtml(): string {
+  return (
+    `<p><strong id="ws-plan-name">${skeletonBarHtml("72px")}</strong></p>` +
+    `<p class="muted" id="ws-plan-blurb">${skeletonBarHtml("80%")}</p>` +
+    `<p class="muted" id="ws-plan-file-limits">${skeletonBarHtml("60%")}</p>` +
+    `<p id="ws-subscription-status" role="status" hidden></p>`
+  );
+}
+
+/** Marketed limits for a plan card — storage + max file size for every
+ * plan, plus free's separate video ceiling (see plans.ts's comment: on pro
+ * the video ceiling equals the upload ceiling, so it isn't worth a separate
+ * line there) and the member cap. `maxUploadsPerPeriod` is an internal
+ * abuse guard and is deliberately never marketed here. */
+export function planCardLimitRows(plan: PlanDefinition): string {
+  const { defaultLimits } = plan;
+  const rows = [
+    `<li>${
+      defaultLimits.maxStorageBytes === undefined
+        ? "Unlimited storage"
+        : `${formatMarketedBytes(defaultLimits.maxStorageBytes)} storage`
+    }</li>`,
+    `<li>${
+      defaultLimits.maxUploadBytes === undefined
+        ? "Unlimited file size"
+        : `Files up to ${formatMarketedBytes(defaultLimits.maxUploadBytes)}`
+    }</li>`,
+  ];
+  // A separate video line only when the plan actually carves a distinct
+  // video ceiling out of its upload cap — catalog-driven, not per-plan.
+  if (
+    defaultLimits.maxVideoUploadBytes !== undefined &&
+    defaultLimits.maxVideoUploadBytes !== defaultLimits.maxUploadBytes
+  ) {
+    rows.push(`<li>Videos up to ${formatMarketedBytes(defaultLimits.maxVideoUploadBytes)}</li>`);
+  }
+  // Members: free markets its cap ("3 members"); pro's maxMembers is an
+  // unmarketed abuse guard, so its card says "Unlimited members" and the
+  // seatless positioning holds. Driven by the catalog's marketsMemberCap
+  // flag rather than a plan-id special case (issue #450).
+  rows.push(
+    `<li>${
+      plan.marketsMemberCap && defaultLimits.maxMembers !== undefined
+        ? `${defaultLimits.maxMembers} member${defaultLimits.maxMembers === 1 ? "" : "s"}`
+        : "Unlimited members"
+    }</li>`,
+  );
+  return rows.join("");
+}
+
+export function planCardPriceLine(plan: PlanDefinition, proPriceCopy: string | null): string {
+  if (plan.id === "free") return "$0";
+  // Live price fetched from the auth origin; omitted gracefully (no
+  // placeholder, no "$NaN") until it's known.
+  return proPriceCopy ?? "";
+}
+
+/** Renders one card per catalog plan that's `available`, plus the
+ * workspace's current plan even if it's since been marked unavailable
+ * (e.g. a legacy/custom plan) so the tab never hides where the workspace
+ * actually stands. This is `#ws-plan-cards`'s entire content — the
+ * manage-billing button/notes live outside this region and are toggled
+ * separately from `resolveBillingCta`, same inputs this function uses
+ * internally for the Pro card's footer. */
+export function renderPlanCardsGridHtml(
+  billing: WorkspaceBilling,
+  proPriceCopy: string | null,
+): string {
+  const currentPlanId = billing.plan;
+  const cardPlans = Object.values(PLANS).filter(
+    (plan) => plan.available || plan.id === currentPlanId,
+  );
+
+  const cta = resolveBillingCta({
+    proAvailable: PLANS.pro.available,
+    plan: billing.plan,
+    planSource: billing.planSource,
+  });
+
+  return cardPlans
+    .map((plan) => {
+      const isCurrent = plan.id === currentPlanId;
+      const priceLine = planCardPriceLine(plan, proPriceCopy);
+      // The current card already carries the "Current plan" badge — no
+      // footer button, so the label doesn't appear twice.
+      let footer = "";
+      if (!isCurrent && plan.id === "pro") {
+        footer =
+          cta.kind === "unavailable"
+            ? `<button type="button" class="plan-card__cta" disabled>Coming soon</button>`
+            : `<button type="button" class="plan-card__cta" data-cta="upgrade" data-plan="pro">Upgrade to Pro</button>`;
+      }
+      return `
+              <div class="plan-card${isCurrent ? " is-current" : ""}" data-plan="${plan.id}">
+                ${isCurrent ? `<span class="plan-card__badge">Current plan</span>` : ""}
+                <p class="plan-card__name">${escapeHtml(plan.name)}</p>
+                ${priceLine ? `<p class="plan-card__price">${escapeHtml(priceLine)}</p>` : ""}
+                <p class="muted plan-card__blurb">${escapeHtml(plan.blurb)}</p>
+                <ul class="plan-card__limits muted">${planCardLimitRows(plan)}</ul>
+                ${footer}
+              </div>`;
+    })
+    .join("");
+}

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -1,8 +1,25 @@
 ---
+import { env } from "cloudflare:workers";
 import AccountLayout from "../../layouts/AccountLayout.astro";
+import {
+  loadProfilePageData,
+  renderSessionsHtml,
+  renderSignInMethodsHtml,
+} from "../../lib/account-profile-ui";
+import { resolveSignedInOrigins } from "../../lib/signed-in-page";
 import { renderDetailListPlaceholderHtml } from "../../lib/workspace-ui";
 
 export const prerender = false;
+
+const { authOrigin } = resolveSignedInOrigins(env);
+const initial = await loadProfilePageData(authOrigin, Astro.request.headers.get("cookie") ?? "");
+const accountsReady = initial.accounts !== null;
+const sessionsReady = initial.sessions !== null;
+// A signed-in profile view always has at least the current session, so this
+// is a defensive edge, not the common case — kept in parity with the
+// client's original branching (hide the list, show status text) rather than
+// letting an empty <ul> render.
+const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
 ---
 
 <AccountLayout section="profile">
@@ -11,9 +28,9 @@ export const prerender = false;
     <div class="settings-section">
       <h2>Account</h2>
       <dl class="kv">
-        <dt>Email</dt><dd id="acct-email"></dd>
-        <dt>Name</dt><dd id="acct-name"></dd>
-        <dt>Role</dt><dd id="acct-role"></dd>
+        <dt>Email</dt><dd id="acct-email">{initial.user?.email ?? ""}</dd>
+        <dt>Name</dt><dd id="acct-name">{initial.user ? initial.user.name || "—" : ""}</dd>
+        <dt>Role</dt><dd id="acct-role">{initial.user ? initial.user.role || "member" : ""}</dd>
       </dl>
       <p class="muted settings-note">From your sign-in provider.</p>
     </div>
@@ -24,8 +41,10 @@ export const prerender = false;
       <ul
         class="detail-list"
         id="accounts-list"
-        aria-busy="true"
-        set:html={renderDetailListPlaceholderHtml()}
+        aria-busy={accountsReady ? "false" : "true"}
+        set:html={accountsReady
+          ? renderSignInMethodsHtml(initial.accounts ?? [], initial.githubInfo)
+          : renderDetailListPlaceholderHtml()}
       />
       <p id="accounts-error" class="detail-error" role="alert" hidden></p>
     </div>
@@ -44,12 +63,21 @@ export const prerender = false;
           <button type="button" class="text-btn" id="cli-upgrade-dismiss">Dismiss</button>
         </div>
       </div>
-      <div id="sessions-status" class="muted detail-status" hidden></div>
+      <div
+        id="sessions-status"
+        class="muted detail-status"
+        hidden={sessionsEmpty ? undefined : true}
+      >
+        {sessionsEmpty ? "No active sessions." : ""}
+      </div>
       <ul
         class="detail-list"
         id="sessions-list"
-        aria-busy="true"
-        set:html={renderDetailListPlaceholderHtml()}
+        aria-busy={sessionsReady ? "false" : "true"}
+        hidden={sessionsEmpty ? true : undefined}
+        set:html={sessionsReady
+          ? renderSessionsHtml(initial.sessions ?? [], initial.currentToken)
+          : renderDetailListPlaceholderHtml()}
       />
       <div id="sessions-recover" class="sessions-recover" hidden>
         <p class="muted">Couldn’t load sessions — sign in again to refresh.</p>
@@ -105,6 +133,7 @@ export const prerender = false;
 
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
+    import { renderSessionsHtml, renderSignInMethodsHtml } from "../../lib/account-profile-ui";
     import {
       getAccountInfo,
       getSession,
@@ -113,17 +142,13 @@ export const prerender = false;
       listSessions,
       revokeSession,
       type AuthSession,
-      type LinkedAccount,
-      type ProviderAccountInfo,
     } from "../../lib/auth-client";
-    import { githubMarkSvg } from "../../lib/brand-icons";
     import {
       bestCliVersion,
       dismissUpgrade,
       isUpgradeDismissed,
       resolveUpgradePrompt,
     } from "../../lib/cli-upgrade";
-    import { deviceLabel, formatSessionTime, isCliUserAgent } from "../../lib/session-device";
     import { renderDetailListPlaceholderHtml } from "../../lib/workspace-ui";
 
     onAstroPageLoad(() => {
@@ -131,13 +156,6 @@ export const prerender = false;
 
       const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
         .__UPLOADS_AUTH_ORIGIN__;
-
-      const escapeHtml = (value: string) =>
-        value.replace(
-          /[&<>"']/g,
-          (ch) =>
-            ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
-        );
 
       function showStatus(
         el: HTMLElement,
@@ -152,38 +170,11 @@ export const prerender = false;
         }
       }
 
-      function asNonEmptyString(value: unknown): string | null {
-        return typeof value === "string" && value.length > 0 ? value : null;
-      }
-
       function setAccountsError(message: string | null): void {
         const error = requireElement<HTMLElement>("#accounts-error", "account profile");
         error.textContent = message ?? "";
         error.hidden = !message;
       }
-
-      // Official GitHub mark (same path as releases AccountIcon) — not a Lucide
-      // brand icon; Lucide dropped brand logos.
-      const GITHUB_ICON = githubMarkSvg({ size: 14, className: "detail-icon" });
-
-      function githubDetail(account: LinkedAccount, info: ProviderAccountInfo | null): string {
-        const parts: string[] = [];
-        const login = asNonEmptyString(info?.data?.login);
-        if (login) parts.push(`@${login}`);
-        const email = asNonEmptyString(info?.user?.email) ?? asNonEmptyString(info?.data?.email);
-        if (email) parts.push(email);
-        parts.push(`id ${account.accountId}`);
-        if (account.scopes?.length) parts.push(`scopes ${account.scopes.join(", ")}`);
-        return parts.join(" · ");
-      }
-
-      type MethodRow = {
-        title: string;
-        detail: string;
-        ok: boolean;
-        icon?: string;
-        connectGithub?: boolean;
-      };
 
       async function loadAccounts(): Promise<void> {
         const status = requireElement<HTMLElement>("#accounts-status", "account profile");
@@ -210,61 +201,10 @@ export const prerender = false;
             })
           : null;
 
-        const rows: MethodRow[] =
-          accounts.length > 0
-            ? accounts.map((a) => {
-                if (a.providerId === "github") {
-                  return {
-                    title: "GitHub",
-                    detail: githubDetail(a, githubInfo),
-                    ok: true,
-                    icon: GITHUB_ICON,
-                  };
-                }
-                return {
-                  title: a.providerId,
-                  detail: a.createdAt ? `Linked ${formatSessionTime(a.createdAt)}` : "Connected",
-                  ok: true,
-                };
-              })
-            : [{ title: "Email", detail: "Magic link sign-in", ok: true }];
-
-        if (!github) {
-          rows.push({
-            title: "GitHub",
-            detail: "Not connected",
-            ok: false,
-            icon: GITHUB_ICON,
-            connectGithub: true,
-          });
-        }
-
         status.hidden = true;
         list.hidden = false;
         list.removeAttribute("aria-busy");
-        list.innerHTML = rows
-          .map((row) => {
-            const action = row.connectGithub
-              ? `<div class="detail-action">
-                <button type="button" class="text-btn text-btn--boxed" data-connect-github>Connect</button>
-              </div>`
-              : "";
-            // Unconnected rows carry no badge: the meta line already says
-            // "Not connected", and the boxed Connect button is the state cue.
-            const badge = row.ok ? `<span class="ul-badge ul-badge--ok">Connected</span>` : "";
-            return `<li>
-            <div class="detail-main">
-              <div class="detail-title">
-                ${row.icon ?? ""}
-                <span>${escapeHtml(row.title)}</span>
-                ${badge}
-              </div>
-              <div class="detail-meta">${escapeHtml(row.detail)}</div>
-            </div>
-            ${action}
-          </li>`;
-          })
-          .join("");
+        list.innerHTML = renderSignInMethodsHtml(accounts, githubInfo);
       }
 
       let currentToken: string | undefined;
@@ -341,44 +281,10 @@ export const prerender = false;
           return;
         }
 
-        const ordered = sessions.toSorted((a, b) => {
-          if (currentToken && a.token === currentToken) return -1;
-          if (currentToken && b.token === currentToken) return 1;
-          return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-        });
-
         status.hidden = true;
         list.hidden = false;
         list.removeAttribute("aria-busy");
-        list.innerHTML = ordered
-          .map((s) => {
-            const current = currentToken != null && s.token === currentToken;
-            const badge = current
-              ? `<span class="ul-badge ul-badge--accent">This device</span>`
-              : isCliUserAgent(s.userAgent)
-                ? `<span class="ul-badge">CLI</span>`
-                : "";
-            const meta = [
-              s.ipAddress ? escapeHtml(s.ipAddress) : null,
-              `Active ${escapeHtml(formatSessionTime(s.updatedAt))}`,
-            ]
-              .filter(Boolean)
-              .join(" · ");
-            const action = current
-              ? `<span class="detail-current">Current</span>`
-              : `<button type="button" class="text-btn" data-revoke="${escapeHtml(s.token)}">Sign out</button>`;
-            return `<li>
-            <div class="detail-main">
-              <div class="detail-title">
-                <span>${escapeHtml(deviceLabel(s.userAgent, { cliVersion: s.cliVersion }))}</span>
-                ${badge}
-              </div>
-              <div class="detail-meta">${meta}</div>
-            </div>
-            <div class="detail-action">${action}</div>
-          </li>`;
-          })
-          .join("");
+        list.innerHTML = renderSessionsHtml(sessions, currentToken ?? null);
 
         void maybeShowCliUpgrade(sessions);
       }

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -76,6 +76,7 @@ const cta: BillingCtaState = billing
         <div
           id="ws-plan-cards"
           class="plan-cards"
+          data-organization-id={billing ? billing.organization.id : undefined}
           set:html={billing ? renderPlanCardsGridHtml(billing, proPriceCopy) : ""}
         />
         <p
@@ -177,7 +178,10 @@ const cta: BillingCtaState = billing
         retryBtn.hidden = !retry;
       }
 
-      let organizationId = "";
+      // Seed from the SSR plan grid so a click on a server-rendered
+      // upgrade/manage button works before the client reconcile lands
+      // (#714 review). loadPlan() sets it authoritatively once billing loads.
+      let organizationId = planCardsEl.dataset.organizationId ?? "";
 
       async function handleBillingActionClick(cta: "upgrade" | "manage"): Promise<void> {
         if (!organizationId) {

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -8,15 +8,44 @@
  * whatever `limits` says (often unlimited/custom) rather than free-tier
  * marketing caps — see apps/api/src/routes/me.ts's billing route.
  */
+import { env } from "cloudflare:workers";
+import { PLANS } from "@uploads/billing";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
+import {
+  loadBillingPageData,
+  renderPlanCardBodyHtml,
+  renderPlanCardPlaceholderHtml,
+  renderPlanCardsGridHtml,
+} from "../../../../lib/billing-ui";
+import { resolveBillingCta, type BillingCtaState } from "../../../../lib/billing-cta";
+import { formatPrice } from "../../../../lib/plan-prices";
+import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
-import { skeletonBarHtml } from "../../../../lib/workspace-ui";
 
 export const prerender = false;
 
 const nameParam = Astro.params.name ?? "";
 const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
+
+// SSR-first (issue #699): fetch billing + the live Pro price server-side so
+// first paint has the real current-plan card and plan-cards grid instead of
+// skeleton bars. Only render real content when the server fetch actually
+// succeeded — a failed/absent fetch falls back to the same skeleton as
+// before and the client script paints the correct real/error state (same
+// "own region" rule as the galleries/people pages).
+const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
+const cookie = Astro.request.headers.get("cookie") ?? "";
+const initial = await loadBillingPageData(apiOrigin, authOrigin, workspace, cookie);
+const { billing } = initial;
+const proPriceCopy = formatPrice(initial.proPrice);
+const cta: BillingCtaState = billing
+  ? resolveBillingCta({
+      proAvailable: PLANS.pro.available,
+      plan: billing.plan,
+      planSource: billing.planSource,
+    })
+  : { kind: "unavailable" };
 ---
 
 <WorkspaceLayout workspace={workspace} showUsage>
@@ -33,24 +62,38 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
       </div>
 
-      <div id="ws-plan-card" class="ul-callout" aria-busy="true">
-        <p><strong id="ws-plan-name" set:html={skeletonBarHtml("72px")} /></p>
-        <p class="muted" id="ws-plan-blurb" set:html={skeletonBarHtml("80%")} />
-        <p class="muted" id="ws-plan-file-limits" set:html={skeletonBarHtml("60%")} />
-        <p id="ws-subscription-status" role="status" hidden></p>
-      </div>
+      <div
+        id="ws-plan-card"
+        class="ul-callout"
+        aria-busy={billing ? undefined : "true"}
+        set:html={billing
+          ? renderPlanCardBodyHtml(billing, proPriceCopy)
+          : renderPlanCardPlaceholderHtml()}
+      />
 
       <div class="settings-section">
         <h3>Plans</h3>
-        <div id="ws-plan-cards" class="plan-cards"></div>
-        <p class="muted" id="ws-manage-billing-note" hidden>
+        <div
+          id="ws-plan-cards"
+          class="plan-cards"
+          set:html={billing ? renderPlanCardsGridHtml(billing, proPriceCopy) : ""}
+        />
+        <p
+          class="muted"
+          id="ws-manage-billing-note"
+          hidden={cta.kind === "manage" ? undefined : true}
+        >
           To cancel or downgrade, use “Manage billing” below to open the billing portal.
         </p>
       </div>
 
       <div class="settings-section">
-        <button type="button" id="ws-manage-billing-btn" hidden>Manage billing</button>
-        <p class="muted" id="ws-comped-note" hidden>
+        <button
+          type="button"
+          id="ws-manage-billing-btn"
+          hidden={cta.kind === "manage" ? undefined : true}>Manage billing</button
+        >
+        <p class="muted" id="ws-comped-note" hidden={cta.kind === "comped" ? undefined : true}>
           This plan is comped for your workspace, so there’s no self-serve billing to manage.
           Contact support to make changes.
         </p>
@@ -60,7 +103,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
   </section>
 
   <script>
-    import { PLANS, type PlanDefinition } from "@uploads/billing";
+    import { PLANS } from "@uploads/billing";
     import {
       getPageVisit,
       isCurrentPageVisit,
@@ -68,15 +111,14 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       onSession,
       requireElement,
     } from "../../../../lib/account-shell";
-    import { getWorkspaceBilling, type WorkspaceBilling } from "../../../../lib/api-client";
+    import { getWorkspaceBilling } from "../../../../lib/api-client";
     import {
       openOrganizationBillingPortal,
       upgradeOrganizationSubscription,
     } from "../../../../lib/auth-client";
     import { resolveBillingCta } from "../../../../lib/billing-cta";
+    import { renderPlanCardBodyHtml, renderPlanCardsGridHtml } from "../../../../lib/billing-ui";
     import { fetchProPrice, formatPrice } from "../../../../lib/plan-prices";
-    import { resolveSubscriptionCopy } from "../../../../lib/subscription-copy";
-    import { escapeHtml, formatBytes, formatMarketedBytes } from "../../../../lib/workspace-ui";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
     import { loadWorkspaceSummary } from "../../../../lib/workspace-summary-source";
 
@@ -106,14 +148,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
       const slugEl = requireElement<HTMLElement>("#ws-slug", page);
       const planCardEl = requireElement<HTMLElement>("#ws-plan-card", page);
-      const planNameEl = requireElement<HTMLElement>("#ws-plan-name", page);
-      const planBlurbEl = requireElement<HTMLElement>("#ws-plan-blurb", page);
-      const planFileLimitsEl = requireElement<HTMLElement>("#ws-plan-file-limits", page);
       const planCardsEl = requireElement<HTMLElement>("#ws-plan-cards", page);
       const manageBillingNoteEl = requireElement<HTMLElement>("#ws-manage-billing-note", page);
       const manageBillingBtn = requireElement<HTMLButtonElement>("#ws-manage-billing-btn", page);
       const compedNoteEl = requireElement<HTMLElement>("#ws-comped-note", page);
-      const subscriptionStatusEl = requireElement<HTMLElement>("#ws-subscription-status", page);
       const billingErrorEl = requireElement<HTMLElement>("#ws-billing-error", page);
 
       function showError(message: string, retry = true): void {
@@ -124,16 +162,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         // The card stays on screen — the heading and back link aren't
         // invalidated by a failed billing fetch, so only the plan card's own
         // data is cleared (same "own region" rule as the people/galleries
-        // pages). `aria-busy` lives on the surviving `#ws-plan-card`
-        // container, not on markup an innerHTML swap would discard, so it's
-        // cleared here too: loading has concluded, even though it failed.
+        // pages). This also discards `#ws-plan-card`'s markup (SSR content
+        // or placeholder) wholesale, so `aria-busy` — which lives on the
+        // surviving container, not on the cleared markup — is removed here
+        // too: loading has concluded, even though it failed.
+        planCardEl.innerHTML = "";
         planCardEl.removeAttribute("aria-busy");
-        planNameEl.textContent = "";
-        planBlurbEl.textContent = "";
-        planBlurbEl.hidden = true;
-        planFileLimitsEl.textContent = "";
-        subscriptionStatusEl.hidden = true;
-        subscriptionStatusEl.textContent = "";
         planCardsEl.innerHTML = "";
         manageBillingBtn.hidden = true;
         manageBillingNoteEl.hidden = true;
@@ -143,169 +177,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         retryBtn.hidden = !retry;
       }
 
-      function planLabel(plan: string): string {
-        return plan.charAt(0).toUpperCase() + plan.slice(1);
-      }
-
-      /**
-       * The current-plan card's one line that isn't already covered by the
-       * workspace rail (which shows storage + uploads-this-month usage) —
-       * the enforced max file/video size, so that information isn't lost
-       * when the standalone "Limits & usage" section is removed.
-       */
-      function paintFileLimits(billing: WorkspaceBilling): void {
-        const { limits } = billing;
-        const parts: string[] = [];
-
-        if (limits.maxUploadBytes !== null) {
-          parts.push(`files up to ${formatBytes(limits.maxUploadBytes)}`);
-        }
-        if (
-          limits.maxVideoUploadBytes !== null &&
-          limits.maxVideoUploadBytes !== limits.maxUploadBytes
-        ) {
-          parts.push(`videos up to ${formatBytes(limits.maxVideoUploadBytes)}`);
-        }
-
-        planFileLimitsEl.textContent = parts.length ? `Max upload size: ${parts.join(", ")}.` : "";
-      }
-
-      /** Paints (or hides) the subscription status line inside the
-       * current-plan card — issue #445's remaining billing-tab surface.
-       * `resolveSubscriptionCopy` is the pure state→copy mapping
-       * (subscription-copy.ts); this is just the DOM glue. */
-      function paintSubscriptionStatus(
-        billing: WorkspaceBilling,
-        proPriceCopy: string | null,
-      ): void {
-        const state = resolveSubscriptionCopy({
-          planSource: billing.planSource,
-          subscription: billing.subscription,
-          priceText: proPriceCopy,
-        });
-        if (!state) {
-          subscriptionStatusEl.hidden = true;
-          subscriptionStatusEl.textContent = "";
-          subscriptionStatusEl.removeAttribute("data-state");
-          subscriptionStatusEl.removeAttribute("role");
-          return;
-        }
-        subscriptionStatusEl.hidden = false;
-        subscriptionStatusEl.textContent = state.text;
-        subscriptionStatusEl.className = "muted";
-        if (state.tone === "alert") {
-          subscriptionStatusEl.dataset.state = "error";
-          subscriptionStatusEl.setAttribute("role", "alert");
-        } else {
-          subscriptionStatusEl.removeAttribute("data-state");
-          subscriptionStatusEl.setAttribute("role", "status");
-        }
-      }
-
       let organizationId = "";
-
-      /** Marketed limits for a plan card — storage + max file size for every
-       * plan, plus free's separate video ceiling (see plans.ts's comment:
-       * on pro the video ceiling equals the upload ceiling, so it isn't
-       * worth a separate line there) and the member cap. `maxUploadsPerPeriod`
-       * is an internal abuse guard and is deliberately never marketed here. */
-      function planCardLimitRows(plan: PlanDefinition): string {
-        const { defaultLimits } = plan;
-        const rows = [
-          `<li>${
-            defaultLimits.maxStorageBytes === undefined
-              ? "Unlimited storage"
-              : `${formatMarketedBytes(defaultLimits.maxStorageBytes)} storage`
-          }</li>`,
-          `<li>${
-            defaultLimits.maxUploadBytes === undefined
-              ? "Unlimited file size"
-              : `Files up to ${formatMarketedBytes(defaultLimits.maxUploadBytes)}`
-          }</li>`,
-        ];
-        // A separate video line only when the plan actually carves a distinct
-        // video ceiling out of its upload cap — catalog-driven, not per-plan.
-        if (
-          defaultLimits.maxVideoUploadBytes !== undefined &&
-          defaultLimits.maxVideoUploadBytes !== defaultLimits.maxUploadBytes
-        ) {
-          rows.push(
-            `<li>Videos up to ${formatMarketedBytes(defaultLimits.maxVideoUploadBytes)}</li>`,
-          );
-        }
-        // Members: free markets its cap ("3 members"); pro's maxMembers is an
-        // unmarketed abuse guard, so its card says "Unlimited members" and the
-        // seatless positioning holds. Driven by the catalog's marketsMemberCap
-        // flag rather than a plan-id special case (issue #450).
-        rows.push(
-          `<li>${
-            plan.marketsMemberCap && defaultLimits.maxMembers !== undefined
-              ? `${defaultLimits.maxMembers} member${defaultLimits.maxMembers === 1 ? "" : "s"}`
-              : "Unlimited members"
-          }</li>`,
-        );
-        return rows.join("");
-      }
-
-      function planCardPriceLine(plan: PlanDefinition, proPriceCopy: string | null): string {
-        if (plan.id === "free") return "$0";
-        // Live price fetched from the auth origin; omitted gracefully (no
-        // placeholder, no "$NaN") until it's known.
-        return proPriceCopy ?? "";
-      }
-
-      /** Renders one card per catalog plan that's `available`, plus the
-       * workspace's current plan even if it's since been marked
-       * unavailable (e.g. a legacy/custom plan) so the tab never hides
-       * where the workspace actually stands. */
-      function renderPlanCards(billing: WorkspaceBilling, proPriceCopy: string | null): void {
-        const currentPlanId = billing.plan;
-        const cardPlans = Object.values(PLANS).filter(
-          (plan) => plan.available || plan.id === currentPlanId,
-        );
-
-        const cta = resolveBillingCta({
-          proAvailable: PLANS.pro.available,
-          plan: billing.plan,
-          planSource: billing.planSource,
-        });
-
-        const cardsHtml = cardPlans
-          .map((plan) => {
-            const isCurrent = plan.id === currentPlanId;
-            const priceLine = planCardPriceLine(plan, proPriceCopy);
-            // The current card already carries the "Current plan" badge —
-            // no footer button, so the label doesn't appear twice.
-            let footer = "";
-            if (!isCurrent && plan.id === "pro") {
-              footer =
-                cta.kind === "unavailable"
-                  ? `<button type="button" class="plan-card__cta" disabled>Coming soon</button>`
-                  : `<button type="button" class="plan-card__cta" data-cta="upgrade" data-plan="pro">Upgrade to Pro</button>`;
-            }
-            return `
-              <div class="plan-card${isCurrent ? " is-current" : ""}" data-plan="${plan.id}">
-                ${isCurrent ? `<span class="plan-card__badge">Current plan</span>` : ""}
-                <p class="plan-card__name">${escapeHtml(plan.name)}</p>
-                ${priceLine ? `<p class="plan-card__price">${escapeHtml(priceLine)}</p>` : ""}
-                <p class="muted plan-card__blurb">${escapeHtml(plan.blurb)}</p>
-                <ul class="plan-card__limits muted">${planCardLimitRows(plan)}</ul>
-                ${footer}
-              </div>`;
-          })
-          .join("");
-
-        planCardsEl.innerHTML = cardsHtml;
-
-        // "Manage billing" (also the downgrade/cancel path) only makes sense
-        // once a live Stripe subscription backs the plan. A comped/admin plan
-        // has no Stripe customer, so the portal 404s — show the comped note
-        // instead of a button that can only error.
-        manageBillingBtn.hidden = cta.kind !== "manage";
-        manageBillingBtn.disabled = false;
-        manageBillingNoteEl.hidden = cta.kind !== "manage";
-        compedNoteEl.hidden = cta.kind !== "comped";
-      }
 
       async function handleBillingActionClick(cta: "upgrade" | "manage"): Promise<void> {
         if (!organizationId) {
@@ -369,38 +241,29 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 
         const { billing } = result;
         organizationId = billing.organization.id;
-        planNameEl.textContent = `${planLabel(billing.plan)} plan`;
-        // Honest copy: a record with no plan actually applied isn't on
-        // free-tier marketing caps — it's running whatever `limits` says.
-        // When a subscription status line will render ("Included with your
-        // workspace." / "Renews on …"), it already says the plan is active,
-        // so the generic blurb stays empty rather than repeating it.
-        const hasStatusLine =
-          resolveSubscriptionCopy({
-            planSource: billing.planSource,
-            subscription: billing.subscription,
-            priceText: null,
-          }) !== null;
-        planBlurbEl.textContent = billing.planApplied
-          ? billing.available
-            ? hasStatusLine
-              ? ""
-              : "This plan is active on your workspace."
-            : "This plan isn’t available for self-serve upgrade yet."
-          : "Your current limits are shown below.";
-        planBlurbEl.hidden = planBlurbEl.textContent === "";
-        paintFileLimits(billing);
+        const proPriceCopy = formatPrice(proPrice);
         billingErrorEl.hidden = true;
         billingErrorEl.textContent = "";
-        const proPriceCopy = formatPrice(proPrice);
-        renderPlanCards(billing, proPriceCopy);
-        paintSubscriptionStatus(billing, proPriceCopy);
-        // Unlike the innerHTML-based regions on the galleries/people pages,
-        // the plan card's fields are painted field-by-field above rather
-        // than replaced wholesale, so `#ws-plan-card`'s own `aria-busy`
-        // never gets discarded along with placeholder markup — it has to be
-        // cleared explicitly once real data lands.
+        // The same pure renderers billing.astro's frontmatter uses for SSR
+        // — the client reconcile paints byte-identical markup rather than
+        // drifting from the server-rendered first paint.
+        planCardEl.innerHTML = renderPlanCardBodyHtml(billing, proPriceCopy);
         planCardEl.removeAttribute("aria-busy");
+        planCardsEl.innerHTML = renderPlanCardsGridHtml(billing, proPriceCopy);
+
+        // "Manage billing" (also the downgrade/cancel path) only makes sense
+        // once a live Stripe subscription backs the plan. A comped/admin plan
+        // has no Stripe customer, so the portal 404s — show the comped note
+        // instead of a button that can only error.
+        const cta = resolveBillingCta({
+          proAvailable: PLANS.pro.available,
+          plan: billing.plan,
+          planSource: billing.planSource,
+        });
+        manageBillingBtn.hidden = cta.kind !== "manage";
+        manageBillingBtn.disabled = false;
+        manageBillingNoteEl.hidden = cta.kind !== "manage";
+        compedNoteEl.hidden = cta.kind !== "comped";
       }
 
       async function loadBillingPage(): Promise<void> {


### PR DESCRIPTION
Closes #698. Closes #699.

Two perceived-performance follow-ups to the SSR-first work (#695–#697). Both make signed-in pages paint real content on the **first** (cold) load instead of gating on a client session check and swapping skeletons for content afterward.

## #698 — Server-resolve the session gate

`AccountLayout.astro` shipped `#app` `hidden` and revealed it either synchronously on a warm SPA nav (the optimistic-cache script) or, on a cold load, only after a client `getSession()` — so cold first paint always showed the "Checking your session…" gate even though the server had the cookie to know better.

Now the layout forwards the request cookie to `getSession` during the server render and, **only for a confirmed session**, paints `#app` visible on first paint and seeds the session cache so page scripts' `onSession` fire immediately. Because `WorkspaceLayout` wraps `AccountLayout`, this covers every workspace tab plus profile/developers.

It fails safe: no cookie / invalid / expired / auth-unavailable all fall through to the existing client gate, which still owns the signed-out state, the "try again" retry, and the local-demo dev fallback in `account-shell.ts` — none of which can be short-circuited server-side. The client always revalidates in the background, so a session revoked between render and hydration still flips to the signed-out shell. `getSession` gains an additive `{ cookie }` option (mirroring `sessionFetchInit` in `api-client.ts`); browser callers are unchanged.

**Latency note:** the server `getSession` runs **only when the request carries a session cookie**, so signed-out / first-time visitors pay zero added cost. Cookie-bearing requests add one auth round-trip on the same 8s-bounded profile as the existing per-page SSR fetches, and it fails safe if auth is unreachable. This is the conventional SSR-auth shape (Next.js/Remix/SvelteKit/Rails all validate the session server-side before rendering protected content); the previous client-only gate was the outlier.

## #699 — SSR the billing & profile tabs

Both tabs still fetched their primary data client-side after the gate. They now adopt the settled `loadXPageData(cookie)` + pure-renderer pattern (the `developers.astro` / `developers-ui.ts` shape): the frontmatter server-fetches with the request cookie and renders via `set:html`, and the client reconciles through the **same** pure renderers so SSR and client output match.

- **Billing** — new `billing-ui.ts` (loader + `renderPlanCardBodyHtml` / `renderPlanCardsGridHtml` + extracted pure helpers). The client script moves from field-by-field `textContent` painting to region `innerHTML` writes via the shared renderers. Adds `{ cookie }` to `getWorkspaceBilling`.
- **Profile** — new `account-profile-ui.ts` (loader + `renderSignInMethodsHtml` / `renderSessionsHtml`). Adds `{ cookie }` forwarding to `listAccounts` / `listSessions` / `getAccountInfo` (threaded through the shared `getAuthArray` helper).

All interactivity is preserved (billing upgrade/manage handlers and `?upgraded=1` round-trip; profile connect-GitHub, session revoke, CLI-upgrade prompt, `?error=` handling, sessions-recover).

No changeset — `@uploads/web` is a private package.

## Verification

Static (whole web package):

| Check | Result |
|-------|--------|
| `typecheck` (`wrangler types && astro check && tsc`) | 0 errors, 0 warnings |
| `test` (vitest) | 691 pass (50 files; +55 new) |
| `oxfmt` (`.ts`) / `prettier` (`.astro`) | clean |
| `oxlint` | apps/web clean (the only `pnpm lint` errors are pre-existing TS errors in `apps/mcp/src/tools.ts`, untouched here) |

Live, on the loopback dev stack (`stack-raw`), inspecting the **raw server HTML** for a cookie-bearing request:

| Marker | Signed-out render | Signed-in render (cookie) |
|--------|-------------------|---------------------------|
| `#checking` | visible | `hidden` |
| `#app` | `hidden` | revealed (no `hidden`) |
| session seed script | absent | present |
| profile: account email / sessions list / methods list | skeleton | server-rendered real rows (`aria-busy="false"`) |
| billing: plan card / plan cards | skeleton bars | `Free plan` + 2 plan cards, no skeleton |

No hydration or console errors on either tab (only pre-existing dev-only favicon CSP notices).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account profile pages now load and display user details, linked sign-in methods, and active sessions immediately.
  * Session listings identify the current device, CLI sessions, and available revoke actions.
  * Billing pages now show plan details, pricing, limits, subscription status, and relevant upgrade actions during initial loading.
  * Server-rendered pages now preserve authenticated session data across navigation.

* **Bug Fixes**
  * Improved handling of missing, unavailable, or failed account and billing data with appropriate empty states and placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->