### PR TITLE
feat(web): filter screenshots by path and project

### DIFF
--- a/apps/api/src/file-metadata-facets.test.ts
+++ b/apps/api/src/file-metadata-facets.test.ts
@@ -7,6 +7,7 @@ import {
   facetValues,
   groupObjectsByPath,
   projectLabelFromMeta,
+  BY_PATH_CATALOG_LIMIT,
   BY_PATH_GROUP_LIMIT,
   BY_PATH_RECENT_LIMIT,
 } from "./file-metadata";
@@ -181,6 +182,7 @@ describe("groupObjectsByPath", () => {
       "acme",
     );
     expect(result.truncated).toBe(false);
+    expect(result.catalogTruncated).toBe(false);
     expect(result.groups).toEqual([
       {
         project: "Other",
@@ -190,6 +192,10 @@ describe("groupObjectsByPath", () => {
         recent: ["c.png", "a.png"],
       },
       { project: "Other", path: "/home", count: 1, lastUpdated: at(2), recent: ["b.png"] },
+    ]);
+    expect(result.catalog).toEqual([
+      { project: "Other", path: "/settings", count: 2, lastUpdated: at(3) },
+      { project: "Other", path: "/home", count: 1, lastUpdated: at(2) },
     ]);
     expect(result.projects).toEqual([{ label: "Other", count: 3, lastUpdated: at(3) }]);
   });
@@ -244,6 +250,44 @@ describe("groupObjectsByPath", () => {
     expect(result.truncated).toBe(true);
     // Group cap keeps the most recently active groups, drops the oldest.
     expect(result.groups.map((g) => g.path)).not.toContain("/page-0");
+    // Catalog keeps the dropped path so the filter bar can still name it.
+    expect(result.catalog).toHaveLength(BY_PATH_GROUP_LIMIT + 1);
+    expect(result.catalogTruncated).toBe(false);
+    expect(result.catalog.map((e) => e.path)).toContain("/page-0");
+  });
+
+  it("keeps a catalog-only project that missed the thumbed-group cap", async () => {
+    const rows = [
+      ...Array.from({ length: BY_PATH_GROUP_LIMIT }, (_, i) => ({
+        workspace: "acme",
+        key: `web-${i}.png`,
+        meta: { path: `/web-${i}`, repo: "acme/web" },
+        at: at(i + 1),
+      })),
+      {
+        workspace: "acme",
+        key: "api-old.png",
+        meta: { path: "/admin", repo: "acme/api" },
+        at: at(0),
+      },
+    ];
+    const result = await groupObjectsByPath(timedDb(rows), "acme");
+    expect(result.groups.every((g) => g.project === "acme/web")).toBe(true);
+    expect(result.catalog.some((e) => e.project === "acme/api" && e.path === "/admin")).toBe(true);
+    expect(result.projects.map((p) => p.label).sort()).toEqual(["acme/api", "acme/web"]);
+    expect(result.projects.find((p) => p.label === "acme/api")?.count).toBe(1);
+  });
+
+  it("caps the catalog at BY_PATH_CATALOG_LIMIT", async () => {
+    const rows = Array.from({ length: BY_PATH_CATALOG_LIMIT + 1 }, (_, i) => ({
+      workspace: "acme",
+      key: `shot-${i}.png`,
+      meta: { path: `/page-${i}` },
+      at: new Date(Date.UTC(2026, 7, 1, 0, 0, i)).toISOString(),
+    }));
+    const result = await groupObjectsByPath(timedDb(rows), "acme");
+    expect(result.catalog).toHaveLength(BY_PATH_CATALOG_LIMIT);
+    expect(result.catalogTruncated).toBe(true);
   });
 
   it("ignores other workspaces and other meta keys", async () => {
@@ -262,7 +306,13 @@ describe("groupObjectsByPath", () => {
 
   it("returns empty groups for a workspace with no path metadata", async () => {
     const result = await groupObjectsByPath(timedDb([]), "acme");
-    expect(result).toEqual({ groups: [], projects: [], truncated: false });
+    expect(result).toEqual({
+      groups: [],
+      catalog: [],
+      projects: [],
+      truncated: false,
+      catalogTruncated: false,
+    });
   });
 
   it("splits the same path across projects and summarizes projects", async () => {

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -659,6 +659,11 @@ export async function facetValues(
 export const BY_PATH_GROUP_LIMIT = 50;
 /** Recent object keys returned per path group. */
 export const BY_PATH_RECENT_LIMIT = 6;
+/**
+ * Max unique (project, path) pairs in the screenshots catalog. Larger than
+ * the thumbed-group cap so the filter bar can still name older paths.
+ */
+export const BY_PATH_CATALOG_LIMIT = 500;
 
 export type PathGroup = {
   project: string;
@@ -668,14 +673,19 @@ export type PathGroup = {
   recent: string[];
 };
 
+/** Unique (project, path) without thumbs — same fields as a group minus `recent`. */
+export type PathCatalogEntry = Omit<PathGroup, "recent">;
+
 export type ProjectSummary = { label: string; count: number; lastUpdated: string };
 
 /**
  * Recent uploads grouped by (project, path) — the screenshots page's one
  * query (spec: docs/superpowers/specs/2026-08-11-screenshots-project-grouping-design.md).
  * Groups come back most-recently-active first, each carrying its newest
- * BY_PATH_RECENT_LIMIT keys and total count. `projects` summarizes the same
- * data by project label alone, most-recent first.
+ * BY_PATH_RECENT_LIMIT keys and total count. `catalog` is the same unique
+ * pairs without thumbs, up to BY_PATH_CATALOG_LIMIT, so the page can filter
+ * by path without a second query. `projects` summarizes the catalog by
+ * project label, most-recent first.
  *
  * One flat scan of the `path` rows (seeked via `file_metadata_lookup_idx
  * (workspace, meta_key, meta_value)`), with the three project-label keys
@@ -688,7 +698,13 @@ export type ProjectSummary = { label: string; count: number; lastUpdated: string
 export async function groupObjectsByPath(
   db: D1Database,
   workspace: string,
-): Promise<{ groups: PathGroup[]; projects: ProjectSummary[]; truncated: boolean }> {
+): Promise<{
+  groups: PathGroup[];
+  catalog: PathCatalogEntry[];
+  projects: ProjectSummary[];
+  truncated: boolean;
+  catalogTruncated: boolean;
+}> {
   const result = await db
     .prepare(
       `SELECT p.meta_value AS path, p.object_key AS object_key, p.updated_at AS updated_at,
@@ -713,7 +729,10 @@ export async function groupObjectsByPath(
 
   const groups: PathGroup[] = [];
   const byKey = new Map<string, PathGroup>();
+  const catalog: PathCatalogEntry[] = [];
+  const catalogByKey = new Map<string, PathCatalogEntry>();
   let truncated = false;
+  let catalogTruncated = false;
   for (const row of result.results) {
     const project = projectLabelFromMeta({
       repo: row.repo,
@@ -722,6 +741,19 @@ export async function groupObjectsByPath(
       app: row.app,
     });
     const groupKey = `${project}\0${row.path}`;
+
+    let entry = catalogByKey.get(groupKey);
+    if (!entry) {
+      if (catalog.length === BY_PATH_CATALOG_LIMIT) {
+        catalogTruncated = true;
+      } else {
+        entry = { project, path: row.path, count: 0, lastUpdated: row.updated_at };
+        catalogByKey.set(groupKey, entry);
+        catalog.push(entry);
+      }
+    }
+    if (entry) entry.count += 1;
+
     let group = byKey.get(groupKey);
     if (!group) {
       if (groups.length === BY_PATH_GROUP_LIMIT) {
@@ -737,23 +769,23 @@ export async function groupObjectsByPath(
   }
 
   const projectByLabel = new Map<string, ProjectSummary>();
-  for (const group of groups) {
-    const existing = projectByLabel.get(group.project);
+  for (const entry of catalog) {
+    const existing = projectByLabel.get(entry.project);
     if (existing) {
-      existing.count += group.count;
-      if (group.lastUpdated > existing.lastUpdated) existing.lastUpdated = group.lastUpdated;
+      existing.count += entry.count;
+      if (entry.lastUpdated > existing.lastUpdated) existing.lastUpdated = entry.lastUpdated;
     } else {
-      projectByLabel.set(group.project, {
-        label: group.project,
-        count: group.count,
-        lastUpdated: group.lastUpdated,
+      projectByLabel.set(entry.project, {
+        label: entry.project,
+        count: entry.count,
+        lastUpdated: entry.lastUpdated,
       });
     }
   }
   const projects = [...projectByLabel.values()].sort((a, b) =>
     b.lastUpdated.localeCompare(a.lastUpdated),
   );
-  return { groups, projects, truncated };
+  return { groups, catalog, projects, truncated, catalogTruncated };
 }
 
 /**

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1821,12 +1821,18 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
         lastUpdated: string;
         recent: { key: string; url: string | null; state?: string }[];
       }[];
+      catalog: { project: string; path: string; count: number; lastUpdated: string }[];
       projects: { label: string; count: number; lastUpdated: string }[];
       truncated: boolean;
+      catalogTruncated: boolean;
     };
     expect(body.truncated).toBe(false);
+    expect(body.catalogTruncated).toBe(false);
     expect(body.groups).toHaveLength(1);
     expect(body.groups[0]).toMatchObject({ project: "Other", path: "/settings", count: 2 });
+    expect(body.catalog).toEqual([
+      expect.objectContaining({ project: "Other", path: "/settings", count: 2 }),
+    ]);
     const byKey = Object.fromEntries(body.groups[0]!.recent.map((r) => [r.key, r]));
     expect(byKey["shots/a.png"]).toMatchObject({
       url: "https://storage.uploads.sh/acme/shots/a.png",
@@ -1861,7 +1867,13 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
     });
     const res = await app().request("/me/workspaces/acme/files/by-path", {}, env);
     expect(res.status).toBe(200);
-    expect((await res.json()) as unknown).toEqual({ groups: [], projects: [], truncated: false });
+    expect((await res.json()) as unknown).toEqual({
+      groups: [],
+      catalog: [],
+      projects: [],
+      truncated: false,
+      catalogTruncated: false,
+    });
   });
 
   it("404s for a workspace the caller is not a member of", async () => {

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -171,14 +171,18 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // Recent uploads grouped by their `path` metadata value — the screenshots
   // page's single overview query (spec: docs/superpowers/specs/
   // 2026-08-10-screenshots-by-path-design.md). Drill-in reuses the sibling
-  // `files/search?meta.path=…` route; this one only answers "which paths,
-  // how recent, first few keys". `state` is the one metadata key enriched —
-  // the page badges before/after and nothing else, so no other keys leak
-  // into the payload.
+  // `files/search?meta.path=…` route; this one answers "which paths, how
+  // recent, first few keys" plus a thumbless `catalog` of every unique
+  // (project, path) so the page can filter without a second query. `state`
+  // is the one metadata key enriched — the page badges before/after and
+  // nothing else, so no other keys leak into the payload.
   .get("/:workspace/files/by-path", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
     const record = c.get("workspace");
     const name = c.get("workspaceName");
-    const { groups, projects, truncated } = await groupObjectsByPath(c.env.DB, name);
+    const { groups, catalog, projects, truncated, catalogTruncated } = await groupObjectsByPath(
+      c.env.DB,
+      name,
+    );
     const metaByKey = await getMetadataForKeys(
       c.env.DB,
       name,
@@ -204,8 +208,10 @@ export const workspaceFiles = new Hono<DualAuthVars>()
           };
         }),
       })),
+      catalog,
       projects,
       truncated,
+      catalogTruncated,
     });
   })
 

--- a/apps/api/test/routes-workspace-files-core.test.ts
+++ b/apps/api/test/routes-workspace-files-core.test.ts
@@ -302,7 +302,13 @@ describe("canonical file catch-all route ordering", () => {
       env,
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ groups: [], projects: [], truncated: false });
+    expect(await res.json()).toEqual({
+      groups: [],
+      catalog: [],
+      projects: [],
+      truncated: false,
+      catalogTruncated: false,
+    });
   });
 
   it("keeps files/file-url on the static URL handler", async () => {

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -349,7 +349,13 @@ describe("GET /v1/workspaces/:workspace/files/by-path (dual auth)", () => {
       env,
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ groups: [], projects: [], truncated: false });
+    expect(await res.json()).toEqual({
+      groups: [],
+      catalog: [],
+      projects: [],
+      truncated: false,
+      catalogTruncated: false,
+    });
   });
 
   it("session cookie: reaches the same handler", async () => {
@@ -361,7 +367,13 @@ describe("GET /v1/workspaces/:workspace/files/by-path (dual auth)", () => {
       env,
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ groups: [], projects: [], truncated: false });
+    expect(await res.json()).toEqual({
+      groups: [],
+      catalog: [],
+      projects: [],
+      truncated: false,
+      catalogTruncated: false,
+    });
   });
 });
 

--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -45,12 +45,12 @@ const MENU_ITEMS = [
     readCachedSessionUser,
     writeCachedSessionUser,
   } from "../lib/account-shell";
-  import { readCachedActiveWorkspace } from "../lib/workspaces-nav";
+  import { readCachedActiveWorkspace, workspaceHomePath } from "../lib/workspaces-nav";
 
-  /** Last-used workspace files, else the workspaces list (same as home CTA). */
+  /** Last-used workspace home (screenshots), else the workspaces list (same as home CTA). */
   function filesHref(): string {
     const ws = readCachedActiveWorkspace();
-    return ws ? `/account/workspaces/${encodeURIComponent(ws)}` : "/account/workspaces";
+    return ws ? workspaceHomePath(ws) : "/account/workspaces";
   }
 
   /** SiteHeader's signed-in-only Files link (absent on pages without the header). */

--- a/apps/web/src/components/ScreenshotsByPath.test.ts
+++ b/apps/web/src/components/ScreenshotsByPath.test.ts
@@ -43,14 +43,15 @@ import { readScreenshotsView } from "../lib/workspace-screenshots";
  * verbatim, with no parsing or URL-dependence to pin.
  */
 describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
-  it("a default overview (empty search) seeds an empty project and path", () => {
-    expect(readScreenshotsView("")).toEqual({ project: "", path: "" });
+  it("a default overview (empty search) seeds an empty project, path, and q", () => {
+    expect(readScreenshotsView("")).toEqual({ project: "", path: "", q: "" });
   });
 
   it("a deep-linked project view seeds that project, no path", () => {
     expect(readScreenshotsView("?project=acme%2Fweb")).toEqual({
       project: "acme/web",
       path: "",
+      q: "",
     });
   });
 
@@ -58,6 +59,15 @@ describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
     expect(readScreenshotsView("?project=acme%2Fweb&path=%2Fadmin")).toEqual({
       project: "acme/web",
       path: "/admin",
+      q: "",
+    });
+  });
+
+  it("a deep-linked path query seeds q without entering drill-in", () => {
+    expect(readScreenshotsView("?q=%2Fcatalog")).toEqual({
+      project: "",
+      path: "",
+      q: "/catalog",
     });
   });
 });
@@ -72,6 +82,6 @@ describe("ScreenshotsByPath seed contract — no initialSearch prop (props-less 
 
   it("resolves to the same defaults today's props-less behavior always had", () => {
     expect(seedSearch).toBe("");
-    expect(readScreenshotsView(seedSearch)).toEqual({ project: "", path: "" });
+    expect(readScreenshotsView(seedSearch)).toEqual({ project: "", path: "", q: "" });
   });
 });

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -1,9 +1,10 @@
 /**
  * Screenshots grouped by `path` metadata (spec:
  * docs/superpowers/specs/2026-08-10-screenshots-by-path-design.md).
- * Overview = one `files/by-path` fetch; drill-in (?path=) = the existing
- * `files/search?meta.path=…` route. Files without `path` metadata never
- * appear here — the empty state says how to get them.
+ * Overview = one `files/by-path` fetch; `?project=` / `?q=` filter that
+ * payload in the toolbar (project select + path input). Drill-in (?path=)
+ * = the existing `files/search?meta.path=…` route. Files without `path`
+ * metadata never appear here — the empty state says how to get them.
  *
  * SSR-first (plan 006, following plan 005's `WorkspaceFileTable` shape):
  * when the request carries a session, `screenshots.astro` server-fetches the
@@ -14,15 +15,15 @@
  * OVERVIEW is server-seeded — the GitHub-mirrored section and the `?path=`
  * drill-in still fetch client-side, unchanged.
  */
-import { Callout } from "@uploads/ui";
+import { Callout, Input, Select } from "@uploads/ui";
 import "@uploads/ui/styles.css";
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { IslandErrorBoundary } from "./IslandErrorBoundary";
 import {
   getWorkspaceFilesByPath,
   searchWorkspaceFiles,
   type FilesPathGroup,
-  type PathGroupItem,
+  type PathCatalogEntry,
   type ProjectSummary,
   type SearchFileItem,
 } from "../lib/api-client";
@@ -31,12 +32,15 @@ import { resolveWorkspaceInfo, type WorkspaceInfoStatus } from "../lib/workspace
 import { onSession } from "../lib/account-shell";
 import { makeFileOpener, newTabLinkProps, type FileOpener } from "../lib/file-opener";
 import {
+  filterCatalog,
+  groupsFromCatalog,
   lastUpdatedLabel,
   pairedShotKeys,
   projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
   shotKindFromKey,
+  shotPreviewPosition,
 } from "../lib/workspace-screenshots";
 
 /** How many path groups a project section previews before "view project →". */
@@ -96,8 +100,10 @@ export type OverviewState =
   | {
       status: "ready";
       groups: FilesPathGroup[];
+      catalog: PathCatalogEntry[];
       projects: ProjectSummary[];
       truncated: boolean;
+      catalogTruncated: boolean;
     };
 
 type DrillState =
@@ -141,6 +147,8 @@ function ShotThumb({
   contextLabel,
   href,
   onOpen,
+  onPreviewEnter,
+  onPreviewLeave,
 }: {
   item: { key: string; url: string | null; embedUrl: string | null; state?: string };
   /** True when a before/after counterpart sits in the same strip/grid. */
@@ -150,6 +158,8 @@ function ShotThumb({
   /** Known destination; when null the tile falls back to a button + `onOpen`. */
   href: string | null;
   onOpen: () => void;
+  onPreviewEnter?: (el: HTMLElement, src: string) => void;
+  onPreviewLeave?: () => void;
 }) {
   const name = leafName(item.key);
   const kind = shotKindFromKey(item.key);
@@ -161,10 +171,15 @@ function ShotThumb({
   // visual signal, and only when a counterpart actually exists.
   const stateSuffix = item.state ? ` (${item.state})` : "";
 
+  const previewSrc = showImage ? item.embedUrl : null;
   const shared = {
     className: "wsp-tile",
     "aria-label": `Open ${name}${stateSuffix}${paired ? " — has before/after pair" : ""}`,
     title: item.state ? `${name}${stateSuffix}` : undefined,
+    onMouseEnter: (event: { currentTarget: HTMLElement }) => {
+      if (previewSrc) onPreviewEnter?.(event.currentTarget, previewSrc);
+    },
+    onMouseLeave: () => onPreviewLeave?.(),
   };
   const body = (
     <>
@@ -238,6 +253,14 @@ function SkelBar({ width }: { width: string }) {
 function OverviewLoadingSkeleton() {
   return (
     <div className="wsp" aria-busy="true">
+      <div className="wsp-filter">
+        <span className="wsp-filter__project wsp-filter__skel">
+          <SkelBar width="120px" />
+        </span>
+        <span className="wsp-filter__q wsp-filter__skel">
+          <SkelBar width="60%" />
+        </span>
+      </div>
       {[0, 1, 2].map((row) => (
         <div className="wsp-group" key={row}>
           <div className="wsp-group__head">
@@ -253,6 +276,59 @@ function OverviewLoadingSkeleton() {
     </div>
   );
 }
+
+function FilterBar({
+  project,
+  q,
+  path,
+  projects,
+  onProject,
+  onQuery,
+}: {
+  project: string;
+  q: string;
+  /** Exact drill-in path, shown in the input so editing it widens the filter. */
+  path: string;
+  projects: string[];
+  onProject: (project: string) => void;
+  onQuery: (q: string) => void;
+}) {
+  const options = project && !projects.includes(project) ? [...projects, project] : projects;
+  return (
+    <div className="wsp-filter">
+      <Select
+        className="ul-select--sm wsp-filter__project"
+        aria-label="Filter by project"
+        value={project}
+        onChange={(event) => onProject(event.target.value)}
+      >
+        <option value="">All projects</option>
+        {options.map((label) => (
+          <option key={label} value={label}>
+            {label}
+          </option>
+        ))}
+      </Select>
+      <Input
+        type="search"
+        className="wsp-filter__q"
+        aria-label="Filter by path"
+        placeholder="Filter path  e.g. /catalog"
+        value={path || q}
+        spellCheck={false}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        onChange={(event) => onQuery(event.target.value)}
+      />
+    </div>
+  );
+}
+
+type PreviewHandlers = {
+  onPreviewEnter: (el: HTMLElement, src: string) => void;
+  onPreviewLeave: () => void;
+};
 
 // ── Component ──────────────────────────────────────────────────────────
 
@@ -287,9 +363,15 @@ function ScreenshotsByPathInner({
   // `resolveFilesView`), so there's no stored-preference divergence to guard
   // against here: the server and the client's first render already agree as
   // long as both read the same `seedSearch`, which is exactly what this does.
-  const [view, setView] = useState<{ project: string; path: string }>(() =>
+  const [view, setView] = useState<{ project: string; path: string; q: string }>(() =>
     readScreenshotsView(seedSearch),
   );
+  const previewTimer = useRef<number | null>(null);
+  const [preview, setPreview] = useState<{
+    src: string;
+    left: number;
+    top: number;
+  } | null>(null);
   const [drill, setDrill] = useState<DrillState>({ status: "idle" });
   const [drillRetryNonce, setDrillRetryNonce] = useState(0);
   const [ghState, setGhState] = useState<DrillState>({ status: "loading" });
@@ -322,8 +404,10 @@ function ScreenshotsByPathInner({
             ? {
                 status: "ready",
                 groups: result.groups,
+                catalog: result.catalog,
                 projects: result.projects,
                 truncated: result.truncated,
+                catalogTruncated: result.catalogTruncated,
               }
             : { status: "error" },
         );
@@ -365,7 +449,7 @@ function ScreenshotsByPathInner({
     history.replaceState(
       null,
       "",
-      window.location.pathname + screenshotsSearch(view.project, view.path),
+      window.location.pathname + screenshotsSearch(view.project, view.path, view.q),
     );
     if (!view.path) {
       setDrill({ status: "idle" });
@@ -389,6 +473,47 @@ function ScreenshotsByPathInner({
       cancelled = true;
     };
   }, [apiOrigin, workspace, view.project, view.path, drillRetryNonce]);
+
+  useEffect(() => {
+    const dismiss = () => {
+      if (previewTimer.current !== null) window.clearTimeout(previewTimer.current);
+      previewTimer.current = null;
+      setPreview(null);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") dismiss();
+    };
+    window.addEventListener("scroll", dismiss, true);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      if (previewTimer.current !== null) window.clearTimeout(previewTimer.current);
+      window.removeEventListener("scroll", dismiss, true);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, []);
+
+  const onPreviewLeave = () => {
+    if (previewTimer.current !== null) window.clearTimeout(previewTimer.current);
+    previewTimer.current = null;
+    setPreview(null);
+  };
+  const onPreviewEnter = (el: HTMLElement, src: string) => {
+    if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
+    if (previewTimer.current !== null) window.clearTimeout(previewTimer.current);
+    const delay = window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : 250;
+    previewTimer.current = window.setTimeout(() => {
+      const rect = el.getBoundingClientRect();
+      const width = Math.min(560, window.innerWidth - 24);
+      const height = Math.min(width * 0.7, window.innerHeight * 0.7);
+      const pos = shotPreviewPosition(
+        { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom },
+        { width: window.innerWidth, height: window.innerHeight },
+        { width, height },
+      );
+      setPreview({ src, left: pos.left, top: pos.top });
+    }, delay);
+  };
+  const previewHandlers: PreviewHandlers = { onPreviewEnter, onPreviewLeave };
 
   if (info.status === "loading" || overview.status === "loading") {
     return <OverviewLoadingSkeleton />;
@@ -432,7 +557,9 @@ function ScreenshotsByPathInner({
 
   const opener = makeFileOpener(apiOrigin, workspace, info.hasPublicUrl);
   const onDrill = (group: { project: string; path: string }) =>
-    setView({ project: group.project, path: group.path });
+    setView({ project: group.project, path: group.path, q: view.q });
+  const setProject = (project: string) => setView({ project, path: "", q: view.q });
+  const setQuery = (q: string) => setView({ project: view.project, path: "", q });
 
   // GitHub items bucketed by project label, for both the overview's
   // per-project strips and the project view's full "From GitHub" section.
@@ -444,20 +571,59 @@ function ScreenshotsByPathInner({
     }
   }
 
+  const ghOnlyLabels = [...ghByProject.keys()].filter(
+    (label) => !overview.projects.some((p) => p.label === label),
+  );
+  const projectLabels = [...overview.projects.map((p) => p.label), ...ghOnlyLabels];
+  const showFilter = projectLabels.length > 0 || overview.catalog.length > 0;
+  const filterBar = showFilter ? (
+    <FilterBar
+      project={view.project}
+      q={view.q}
+      path={view.path}
+      projects={projectLabels}
+      onProject={setProject}
+      onQuery={setQuery}
+    />
+  ) : null;
+  const previewLayer = preview ? (
+    <div
+      className="wsp-preview"
+      style={{ left: preview.left, top: preview.top }}
+      role="presentation"
+    >
+      <img src={preview.src} alt="" />
+    </div>
+  ) : null;
+
   // Drill-in view (?path=, optionally scoped to ?project=).
   if (view.path) {
-    const drillItems =
-      drill.status === "ready"
-        ? view.project === ""
-          ? drill.items
-          : drill.items.filter((item) => projectLabelFromItemMeta(item.metadata) === view.project)
-        : [];
+    let drillItems: SearchFileItem[] = [];
+    if (drill.status === "ready") {
+      drillItems = drill.items;
+      if (view.project) {
+        drillItems = drillItems.filter(
+          (item) => projectLabelFromItemMeta(item.metadata) === view.project,
+        );
+      }
+    }
+    const drillPaired = pairedShotKeys(
+      drillItems.map((item) => ({ key: item.key, state: item.metadata?.state })),
+    );
+    let drillEmptyMessage = "No screenshots at this path.";
+    if (view.project && drill.status === "ready" && drill.truncated) {
+      drillEmptyMessage = `None of the first 100 at this path belong to ${view.project} — there may be more beyond that.`;
+    } else if (view.project) {
+      drillEmptyMessage = "No screenshots at this path for this project.";
+    }
+
     return (
       <div className="wsp">
+        {filterBar}
         <button
           type="button"
           className="text-btn"
-          onClick={() => setView({ project: view.project, path: "" })}
+          onClick={() => setView({ project: view.project, path: "", q: view.q })}
         >
           {view.project ? `← ${view.project}` : "← all projects"}
         </button>
@@ -484,39 +650,23 @@ function ScreenshotsByPathInner({
         {drill.status === "ready" && (
           <>
             <div className="wsp-grid">
-              {(() => {
-                const withState = drillItems.map((item) => ({
-                  item,
-                  state: item.metadata?.state,
-                }));
-                const paired = pairedShotKeys(
-                  withState.map(({ item, state }) => ({ key: item.key, state })),
-                );
-                return withState.map(({ item, state }) => (
-                  <ShotThumb
-                    key={item.key}
-                    item={{ ...item, state }}
-                    paired={paired.has(item.key)}
-                    href={opener.href(item)}
-                    onOpen={() => opener.activate(item)}
-                  />
-                ));
-              })()}
+              {drillItems.map((item) => (
+                <ShotThumb
+                  key={item.key}
+                  item={{ ...item, state: item.metadata?.state }}
+                  paired={drillPaired.has(item.key)}
+                  href={opener.href(item)}
+                  onOpen={() => opener.activate(item)}
+                  {...previewHandlers}
+                />
+              ))}
             </div>
             {/* The project scope is applied client-side AFTER the search's
                 100-item cap (the origin-labeled fallback can't be expressed
                 as a metadata filter — spec keeps URL-prefix search out of
                 scope), so a truncated response may hide project matches: say
                 so rather than claiming an empty/complete result. */}
-            {drillItems.length === 0 && (
-              <p className="wft-end">
-                {view.project && drill.truncated
-                  ? `None of the first 100 at this path belong to ${view.project} — there may be more beyond that.`
-                  : view.project
-                    ? "No screenshots at this path for this project."
-                    : "No screenshots at this path."}
-              </p>
-            )}
+            {drillItems.length === 0 && <p className="wft-end">{drillEmptyMessage}</p>}
             {drillItems.length > 0 && drill.truncated && (
               <p className="wft-end">
                 {view.project
@@ -526,78 +676,81 @@ function ScreenshotsByPathInner({
             )}
           </>
         )}
+        {previewLayer}
       </div>
     );
   }
 
-  // Project view (?project=, no ?path=): every path group and the full
-  // GitHub strip for a single project, no preview truncation.
+  const matchingCatalog = filterCatalog(overview.catalog, {
+    project: view.project,
+    q: view.q,
+  });
+  const matchingGroups = groupsFromCatalog(matchingCatalog, overview.groups);
+  const qTrim = view.q.trim();
+  const filtering = qTrim !== "" || view.project !== "";
+  // Path query hides GitHub strips that aren't path-grouped; project-only
+  // still shows that project's GitHub items.
+  const showGh = qTrim === "";
+
+  const sectionHasContent = (label: string) =>
+    matchingGroups.some((group) => group.project === label) || (showGh && ghByProject.has(label));
+  let sectionLabels: string[];
   if (view.project) {
-    const projectGroups = overview.groups.filter((group) => group.project === view.project);
-    const projectGh = ghByProject.get(view.project);
-    const isEmpty = projectGroups.length === 0 && !projectGh;
-    return (
-      <div className="wsp">
-        <button
-          type="button"
-          className="text-btn"
-          onClick={() => setView({ project: "", path: "" })}
-        >
-          ← all projects
-        </button>
-        <h2 className="wsp-drill__heading">{view.project}</h2>
-        {isEmpty ? (
-          <EmptyShotsCta title="No screenshots for this project" />
-        ) : (
-          <>
-            {projectGroups.map((group) => (
-              <PathGroupSection key={group.path} group={group} onDrill={onDrill} opener={opener} />
-            ))}
-            {projectGh && <GitHubSection items={projectGh} opener={opener} />}
-          </>
-        )}
-      </div>
-    );
+    sectionLabels = sectionHasContent(view.project) ? [view.project] : [];
+  } else {
+    sectionLabels = [
+      ...overview.projects.map((p) => p.label),
+      ...(showGh ? ghOnlyLabels : []),
+    ].filter(sectionHasContent);
   }
 
-  // Overview: one section per project (recency-ordered API projects, then
-  // GH-only labels), each with a preview of its path groups plus its
-  // "From GitHub" strip when present. The empty state shows only when there
-  // are no sections at all — a project with only GitHub-mirrored files (no
-  // `path` metadata) still gets a section via ghByProject.
-  const sectionLabels = [
-    ...overview.projects.map((p) => p.label),
-    ...[...ghByProject.keys()].filter((label) => !overview.projects.some((p) => p.label === label)),
-  ];
+  const isEmptyWorkspace = overview.catalog.length === 0 && ghByProject.size === 0;
+  const isEmptyFilter = !isEmptyWorkspace && sectionLabels.length === 0;
+  let emptyFilterMessage = "No screenshots for this project.";
+  if (qTrim) {
+    emptyFilterMessage = overview.catalogTruncated
+      ? `No paths matching ${qTrim} in the most active set.`
+      : `No paths matching ${qTrim}.`;
+  }
 
   return (
     <div className="wsp">
-      {sectionLabels.length === 0 ? (
+      {filterBar}
+      {isEmptyWorkspace ? (
         <EmptyShotsCta title="No screenshots yet" />
+      ) : isEmptyFilter ? (
+        <p className="wft-end">{emptyFilterMessage}</p>
       ) : (
         <>
           {sectionLabels.map((label) => {
             const projectSummary = overview.projects.find((p) => p.label === label);
-            const groups = overview.groups.filter((group) => group.project === label);
-            const ghItems = ghByProject.get(label);
+            const groups = matchingGroups.filter((group) => group.project === label);
+            const previewGroups = filtering ? groups : groups.slice(0, PREVIEW_PATHS_PER_PROJECT);
+            const ghItems = showGh ? ghByProject.get(label) : undefined;
             return (
               <ProjectSection
                 key={label}
                 label={label}
                 summary={projectSummary}
-                groups={groups.slice(0, PREVIEW_PATHS_PER_PROJECT)}
+                groups={previewGroups}
                 ghItems={ghItems}
-                onViewProject={() => setView({ project: label, path: "" })}
+                showViewProject={!view.project}
+                onViewProject={() => setView({ project: label, path: "", q: view.q })}
                 onDrill={onDrill}
                 opener={opener}
+                preview={previewHandlers}
               />
             );
           })}
-          {overview.truncated && (
-            <p className="wft-end">Showing the most active paths — narrow with a specific path.</p>
+          {!filtering && overview.truncated && (
+            <p className="wft-end">Showing the most active paths — filter by path to see more.</p>
+          )}
+          {filtering && overview.catalogTruncated && (
+            <p className="wft-end">Showing the most active paths — there may be more.</p>
           )}
         </>
       )}
+      {previewLayer}
     </div>
   );
 }
@@ -625,17 +778,21 @@ function ProjectSection({
   summary,
   groups,
   ghItems,
+  showViewProject,
   onViewProject,
   onDrill,
   opener,
+  preview,
 }: {
   label: string;
   summary: ProjectSummary | undefined;
   groups: FilesPathGroup[];
   ghItems: SearchFileItem[] | undefined;
+  showViewProject: boolean;
   onViewProject: () => void;
   onDrill: (group: { project: string; path: string }) => void;
   opener: FileOpener;
+  preview: PreviewHandlers;
 }) {
   // A GH-only label (no by-path groups) has no ProjectSummary — fall back to
   // the GitHub items' count so the header still reads sensibly.
@@ -650,19 +807,35 @@ function ProjectSection({
           {count} {count === 1 ? "file" : "files"}
           {lastUpdated ? ` · ${lastUpdatedLabel(lastUpdated, new Date())}` : ""}
         </span>
-        <button type="button" className="text-btn wsp-project__viewall" onClick={onViewProject}>
-          view project →
-        </button>
+        {showViewProject && (
+          <button type="button" className="text-btn wsp-project__viewall" onClick={onViewProject}>
+            view project →
+          </button>
+        )}
       </div>
       {groups.map((group) => (
-        <PathGroupSection key={group.path} group={group} onDrill={onDrill} opener={opener} />
+        <PathGroupSection
+          key={group.path}
+          group={group}
+          onDrill={onDrill}
+          opener={opener}
+          preview={preview}
+        />
       ))}
-      {ghItems && <GitHubSection items={ghItems} opener={opener} />}
+      {ghItems && <GitHubSection items={ghItems} opener={opener} preview={preview} />}
     </div>
   );
 }
 
-function GitHubSection({ items, opener }: { items: SearchFileItem[]; opener: FileOpener }) {
+function GitHubSection({
+  items,
+  opener,
+  preview,
+}: {
+  items: SearchFileItem[];
+  opener: FileOpener;
+  preview: PreviewHandlers;
+}) {
   return (
     <div className="wsp-group">
       <div className="wsp-group__head">
@@ -679,6 +852,7 @@ function GitHubSection({ items, opener }: { items: SearchFileItem[]; opener: Fil
             contextLabel={ghLabel(item)}
             href={opener.href(item)}
             onOpen={() => opener.activate(item)}
+            {...preview}
           />
         ))}
       </div>
@@ -690,11 +864,14 @@ function PathGroupSection({
   group,
   onDrill,
   opener,
+  preview,
 }: {
   group: FilesPathGroup;
   onDrill: (group: { project: string; path: string }) => void;
   opener: FileOpener;
+  preview: PreviewHandlers;
 }) {
+  const paired = pairedShotKeys(group.recent);
   return (
     <div className="wsp-group">
       <button type="button" className="wsp-group__head" onClick={() => onDrill(group)}>
@@ -705,20 +882,20 @@ function PathGroupSection({
         </span>
         <span className="wsp-group__viewall">view all →</span>
       </button>
-      <div className="wsp-strip">
-        {(() => {
-          const paired = pairedShotKeys(group.recent);
-          return group.recent.map((item) => (
+      {group.recent.length > 0 && (
+        <div className="wsp-strip">
+          {group.recent.map((item) => (
             <ShotThumb
               key={item.key}
               item={item}
               paired={paired.has(item.key)}
               href={opener.href(item)}
               onOpen={() => opener.activate(item)}
+              {...preview}
             />
-          ));
-        })()}
-      </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/SiteHeader.astro
+++ b/apps/web/src/components/SiteHeader.astro
@@ -42,15 +42,11 @@ const stars = await githubStarCount();
           /*
           Screenshots is signed-in only. AuthIndicator toggles
           [data-header-files] after the session check (optimistic paint from
-          session cache). `?to=screenshots` makes the workspaces index's
-          auto-open land on the active workspace's screenshots tab.
+          session cache). The workspaces index auto-opens on screenshots.
         */
         }
-        <a
-          class="site-header__link"
-          data-header-files
-          href="/account/workspaces?to=screenshots"
-          hidden>Screenshots</a
+        <a class="site-header__link" data-header-files href="/account/workspaces" hidden
+          >Screenshots</a
         >
         <a class="site-header__link" href="/docs">Docs</a>
       </nav>

--- a/apps/web/src/components/WorkspaceFileTable.test.ts
+++ b/apps/web/src/components/WorkspaceFileTable.test.ts
@@ -34,7 +34,7 @@ import { resolveFilesView } from "../lib/workspace-files-view";
 describe("WorkspaceFileTable seed contract — initialSearch provided", () => {
   it("a default root browse (empty search) seeds an empty prefix, no filters, no name, list view", () => {
     const seedSearch = "";
-    const seedPathname = "/account/workspaces/acme";
+    const seedPathname = "/account/workspaces/acme/files";
     expect(readBrowseLocation(seedSearch, seedPathname).path).toBe("");
     expect(readSearchFilters(seedSearch)).toEqual([]);
     expect(readSearchName(seedSearch) ?? "").toBe("");
@@ -43,7 +43,7 @@ describe("WorkspaceFileTable seed contract — initialSearch provided", () => {
 
   it("a deep-linked folder path seeds that prefix", () => {
     const seedSearch = "?path=screenshots%2Freleases%2F";
-    const seedPathname = "/account/workspaces/acme";
+    const seedPathname = "/account/workspaces/acme/files";
     expect(readBrowseLocation(seedSearch, seedPathname).path).toBe("screenshots/releases/");
   });
 

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -575,10 +575,12 @@ function WorkspaceFileTableInner({
   // `readBrowseLocation` resolves workspace identity from the pathname; when
   // there's no `window` yet, synthesize this route's own pathname from the
   // `workspace` prop (this component only ever mounts on
-  // `/account/workspaces/:name`) so the server's parse agrees with the
+  // `/account/workspaces/:name/files`) so the server's parse agrees with the
   // client's.
   const seedPathname =
-    typeof window !== "undefined" ? window.location.pathname : `/account/workspaces/${workspace}`;
+    typeof window !== "undefined"
+      ? window.location.pathname
+      : `/account/workspaces/${encodeURIComponent(workspace)}/files`;
 
   const [info, setInfo] = useState<WorkspaceInfoStatus | { status: "loading" }>(
     () => initialInfo ?? { status: "loading" },

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -57,7 +57,7 @@ const pageHeading = title ?? (workspace || titles[section]);
 const docTitle = `${pageHeading} · uploads.sh`;
 
 const activeTab: WorkspaceNavTab | "" = workspace
-  ? workspaceTabFromPathname(Astro.url.pathname) || "files"
+  ? workspaceTabFromPathname(Astro.url.pathname) || "screenshots"
   : "";
 const settingsSubpage =
   activeTab === "settings" ? workspaceSettingsSubpageFromPathname(Astro.url.pathname) : "";

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -511,21 +511,69 @@ describe("getWorkspaceFilesByPath", () => {
   };
   const PROJECT = { label: "acme/web", count: 2, lastUpdated: "2026-08-09T21:14:03.000Z" };
 
-  it("returns groups and projects on a well-formed response", async () => {
+  const CATALOG = {
+    project: "acme/web",
+    path: "/settings",
+    count: 2,
+    lastUpdated: "2026-08-09T21:14:03.000Z",
+  };
+
+  it("returns groups, catalog, and projects on a well-formed response", async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
-      Response.json({ groups: [GROUP], projects: [PROJECT], truncated: false }),
+      Response.json({
+        groups: [GROUP],
+        catalog: [CATALOG],
+        projects: [PROJECT],
+        truncated: false,
+        catalogTruncated: false,
+      }),
     );
     vi.stubGlobal("fetch", fetchMock);
     const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
     expect(result).toEqual({
       kind: "ok",
       groups: [GROUP],
+      catalog: [CATALOG],
       projects: [PROJECT],
       truncated: false,
+      catalogTruncated: false,
     });
     expect(fetchMock.mock.calls[0]![0]).toBe(
       "https://api.uploads.sh/v1/workspaces/acme/files/by-path",
     );
+  });
+
+  it("synthesizes a catalog from groups when an older API omits it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ groups: [GROUP], projects: [PROJECT], truncated: true })),
+    );
+    const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
+    expect(result).toEqual({
+      kind: "ok",
+      groups: [GROUP],
+      catalog: [CATALOG],
+      projects: [PROJECT],
+      truncated: true,
+      catalogTruncated: true,
+    });
+  });
+
+  it("is unavailable on a malformed catalog", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          groups: [GROUP],
+          catalog: [{ path: 1 }],
+          projects: [PROJECT],
+          truncated: false,
+        }),
+      ),
+    );
+    const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
+    expect(result.kind).toBe("unavailable");
+    expect((result as { reason: string }).reason).toBe("malformed");
   });
 
   it("is unavailable on a malformed body", async () => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -872,6 +872,14 @@ export interface FilesPathGroup {
   recent: PathGroupItem[];
 }
 
+/** One unique (project, path) pair without thumbs — the filter-bar catalog. */
+export interface PathCatalogEntry {
+  project: string;
+  path: string;
+  count: number;
+  lastUpdated: string;
+}
+
 /** One project bucket summary alongside the by-path groups. */
 export interface ProjectSummary {
   label: string;
@@ -880,7 +888,14 @@ export interface ProjectSummary {
 }
 
 export type FilesByPathResult =
-  | { kind: "ok"; groups: FilesPathGroup[]; projects: ProjectSummary[]; truncated: boolean }
+  | {
+      kind: "ok";
+      groups: FilesPathGroup[];
+      catalog: PathCatalogEntry[];
+      projects: ProjectSummary[];
+      truncated: boolean;
+      catalogTruncated: boolean;
+    }
   | { kind: "unavailable"; reason: RequestFailure | "server" | "malformed" };
 
 function isPathGroupItem(value: unknown): value is PathGroupItem {
@@ -917,6 +932,27 @@ function isProjectSummary(value: unknown): value is ProjectSummary {
   );
 }
 
+function isPathCatalogEntry(value: unknown): value is PathCatalogEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.project === "string" &&
+    typeof entry.path === "string" &&
+    typeof entry.count === "number" &&
+    typeof entry.lastUpdated === "string"
+  );
+}
+
+/** Derive a catalog from thumbed groups when an older API omitted it. */
+function catalogFromGroups(groups: FilesPathGroup[]): PathCatalogEntry[] {
+  return groups.map(({ project, path, count, lastUpdated }) => ({
+    project,
+    path,
+    count,
+    lastUpdated,
+  }));
+}
+
 /** GET /v1/workspaces/:name/files/by-path — recent uploads grouped by `path` metadata. */
 export async function getWorkspaceFilesByPath(
   apiOrigin: string,
@@ -930,8 +966,10 @@ export async function getWorkspaceFilesByPath(
   if (!response.ok) return { kind: "unavailable", reason: "server" };
   const body = (await response.json().catch(() => null)) as {
     groups?: unknown;
+    catalog?: unknown;
     projects?: unknown;
     truncated?: unknown;
+    catalogTruncated?: unknown;
   } | null;
   if (
     !body ||
@@ -943,7 +981,30 @@ export async function getWorkspaceFilesByPath(
   ) {
     return { kind: "unavailable", reason: "malformed" };
   }
-  return { kind: "ok", groups: body.groups, projects: body.projects, truncated: body.truncated };
+  // Catalog is additive: an older API (web/API deploy separately) omitted it.
+  // Fall back to the thumbed groups so the filter bar still has something
+  // to search, and treat `truncated` as the catalog cap in that case.
+  if (body.catalog === undefined) {
+    return {
+      kind: "ok",
+      groups: body.groups,
+      catalog: catalogFromGroups(body.groups),
+      projects: body.projects,
+      truncated: body.truncated,
+      catalogTruncated: body.truncated,
+    };
+  }
+  if (!Array.isArray(body.catalog) || !body.catalog.every(isPathCatalogEntry)) {
+    return { kind: "unavailable", reason: "malformed" };
+  }
+  return {
+    kind: "ok",
+    groups: body.groups,
+    catalog: body.catalog,
+    projects: body.projects,
+    truncated: body.truncated,
+    catalogTruncated: typeof body.catalogTruncated === "boolean" ? body.catalogTruncated : false,
+  };
 }
 
 /** One metadata key present in a workspace, with its file and value counts. */

--- a/apps/web/src/lib/workspace-browse-url.test.ts
+++ b/apps/web/src/lib/workspace-browse-url.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyBrowseLocation,
   isBrowseWorkspace,
+  isFilesBrowseSearch,
   normalizeBrowsePath,
   readBrowseLocation,
   resolveActiveWorkspace,
@@ -94,7 +95,7 @@ describe("applyBrowseLocation", () => {
       workspace: "buildinternet",
       path: "screenshots/",
     });
-    expect(withPath.pathname).toBe("/account/workspaces/buildinternet");
+    expect(withPath.pathname).toBe("/account/workspaces/buildinternet/files");
     expect(withPath.searchParams.get("ws")).toBeNull();
     expect(withPath.searchParams.get("path")).toBe("screenshots/");
     expect(withPath.searchParams.get("tab")).toBe("1");
@@ -114,8 +115,19 @@ describe("applyBrowseLocation", () => {
       workspace: "buildinternet",
       path: "screenshots/",
     });
-    expect(next.pathname).toBe("/account/workspaces/buildinternet");
+    expect(next.pathname).toBe("/account/workspaces/buildinternet/files");
     expect(next.searchParams.get("path")).toBe("screenshots/");
+  });
+});
+
+describe("isFilesBrowseSearch", () => {
+  it("detects files-tab query keys", () => {
+    expect(isFilesBrowseSearch("?path=screenshots/")).toBe(true);
+    expect(isFilesBrowseSearch("?name=hero")).toBe(true);
+    expect(isFilesBrowseSearch("?view=grid")).toBe(true);
+    expect(isFilesBrowseSearch("?meta.app=web")).toBe(true);
+    expect(isFilesBrowseSearch("?project=acme")).toBe(false);
+    expect(isFilesBrowseSearch("")).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/workspace-browse-url.ts
+++ b/apps/web/src/lib/workspace-browse-url.ts
@@ -91,25 +91,36 @@ export function readBrowseLocation(search: string, pathname = ""): BrowseLocatio
 }
 
 /**
+ * True when the query is a files-tab deep link (folder `path`, filename
+ * `name`, `meta.*` filters, or `view=`). Used to send the workspace root
+ * URL to `/files` instead of the screenshots home.
+ */
+export function isFilesBrowseSearch(search: string): boolean {
+  const raw = search.startsWith("?") ? search.slice(1) : search;
+  const params = new URLSearchParams(raw);
+  if (params.has("path") || params.has("name") || params.has("view")) return true;
+  for (const key of params.keys()) {
+    if (key.startsWith("meta.")) return true;
+  }
+  return false;
+}
+
+/**
  * Apply browse location onto a URL. When already under
- * `/account/workspaces/:name` (or navigating to one), the workspace lives in
- * the pathname and `ws` is stripped from the query. Returns a new URL for
- * `history.replaceState`.
+ * `/account/workspaces/:name/files` (or navigating to one), the workspace
+ * lives in the pathname and `ws` is stripped from the query. Returns a new
+ * URL for `history.replaceState`.
  */
 export function applyBrowseLocation(current: URL, location: BrowseLocation): URL {
   const next = new URL(current.href);
   const workspace = isBrowseWorkspace(location.workspace) ? location.workspace : "";
   const path = workspace ? normalizeBrowsePath(location.path) : "";
-  const pathWorkspace = workspaceFromPathname(next.pathname);
 
   if (workspace) {
-    if (pathWorkspace !== workspace) {
-      next.pathname = `/account/workspaces/${encodeURIComponent(workspace)}`;
-    }
-    next.searchParams.delete("ws");
-  } else {
-    next.searchParams.delete("ws");
+    const filesPath = `/account/workspaces/${encodeURIComponent(workspace)}/files`;
+    if (next.pathname !== filesPath) next.pathname = filesPath;
   }
+  next.searchParams.delete("ws");
   if (path) next.searchParams.set("path", path);
   else next.searchParams.delete("path");
   return next;

--- a/apps/web/src/lib/workspace-files-view.test.ts
+++ b/apps/web/src/lib/workspace-files-view.test.ts
@@ -48,14 +48,14 @@ describe("resolveFilesView", () => {
 
 describe("applyFilesView", () => {
   it("sets view without clobbering other params", () => {
-    const base = new URL("https://uploads.sh/account/workspaces/acme?path=screenshots/");
+    const base = new URL("https://uploads.sh/account/workspaces/acme/files?path=screenshots/");
     const next = applyFilesView(base, "grid");
     expect(next.searchParams.get("view")).toBe("grid");
     expect(next.searchParams.get("path")).toBe("screenshots/");
   });
 
   it("can override a prior view value", () => {
-    const base = new URL("https://uploads.sh/account/workspaces/acme?view=grid");
+    const base = new URL("https://uploads.sh/account/workspaces/acme/files?view=grid");
     expect(applyFilesView(base, "list").searchParams.get("view")).toBe("list");
   });
 });

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  filterCatalog,
+  groupsFromCatalog,
   lastUpdatedLabel,
   pairedShotKeys,
+  pathQueryMatches,
   projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
   shotKindFromKey,
+  shotPreviewPosition,
 } from "./workspace-screenshots";
 
 describe("pairedShotKeys", () => {
@@ -124,17 +128,108 @@ describe("projectLabelFromItemMeta", () => {
 });
 
 describe("screenshots view URL state", () => {
-  it("round-trips project and path", () => {
-    expect(readScreenshotsView("?project=acme%2Fweb&path=%2Fadmin")).toEqual({
+  it("round-trips project, path, and q", () => {
+    expect(readScreenshotsView("?project=acme%2Fweb&path=%2Fadmin&q=%2Fcat")).toEqual({
       project: "acme/web",
       path: "/admin",
+      q: "/cat",
     });
-    expect(screenshotsSearch("acme/web", "/admin")).toBe("?project=acme%2Fweb&path=%2Fadmin");
+    expect(screenshotsSearch("acme/web", "/admin", "/cat")).toBe(
+      "?project=acme%2Fweb&path=%2Fadmin&q=%2Fcat",
+    );
     expect(screenshotsSearch("acme/web", "")).toBe("?project=acme%2Fweb");
     expect(screenshotsSearch("", "")).toBe("");
+    expect(screenshotsSearch("", "", "/catalog")).toBe("?q=%2Fcatalog");
   });
   it("keeps legacy bare ?path= links working", () => {
-    expect(readScreenshotsView("?path=%2Fadmin")).toEqual({ project: "", path: "/admin" });
+    expect(readScreenshotsView("?path=%2Fadmin")).toEqual({
+      project: "",
+      path: "/admin",
+      q: "",
+    });
     expect(screenshotsSearch("", "/admin")).toBe("?path=%2Fadmin");
+  });
+});
+
+describe("pathQueryMatches", () => {
+  it("treats a leading slash as a path-segment prefix", () => {
+    expect(pathQueryMatches("/catalog", "/catalog")).toBe(true);
+    expect(pathQueryMatches("/catalog/families/ezel", "/catalog")).toBe(true);
+    expect(pathQueryMatches("/catalog/families/ezel", "/catalog/")).toBe(true);
+    expect(pathQueryMatches("/catalogue", "/catalog")).toBe(false);
+    expect(pathQueryMatches("/admin/catalog", "/catalog")).toBe(false);
+  });
+  it("treats a slash-less query as a case-insensitive substring", () => {
+    expect(pathQueryMatches("/Catalog/Families", "famil")).toBe(true);
+    expect(pathQueryMatches("/admin/oauth", "OAuth")).toBe(true);
+    expect(pathQueryMatches("/home", "zzz")).toBe(false);
+  });
+  it("matches everything when the query is empty", () => {
+    expect(pathQueryMatches("/home", "")).toBe(true);
+    expect(pathQueryMatches("/home", "  ")).toBe(true);
+  });
+});
+
+describe("filterCatalog", () => {
+  const catalog = [
+    { project: "acme/web", path: "/catalog/families/ezel", count: 6, lastUpdated: "2" },
+    { project: "acme/web", path: "/admin", count: 2, lastUpdated: "1" },
+    { project: "local dev", path: "/catalog", count: 1, lastUpdated: "3" },
+  ];
+  it("filters by project and path query together", () => {
+    expect(
+      filterCatalog(catalog, { project: "acme/web", q: "/catalog" }).map((e) => e.path),
+    ).toEqual(["/catalog/families/ezel"]);
+    expect(filterCatalog(catalog, { project: "", q: "/catalog" }).map((e) => e.project)).toEqual([
+      "acme/web",
+      "local dev",
+    ]);
+    expect(filterCatalog(catalog, { project: "acme/web", q: "" })).toHaveLength(2);
+  });
+});
+
+describe("groupsFromCatalog", () => {
+  it("keeps thumbed groups and fills catalog-only paths with empty recent", () => {
+    const catalog = [
+      { project: "acme/web", path: "/admin", count: 2, lastUpdated: "2" },
+      { project: "acme/web", path: "/older", count: 1, lastUpdated: "1" },
+    ];
+    const groups = [
+      {
+        project: "acme/web",
+        path: "/admin",
+        count: 2,
+        lastUpdated: "2",
+        recent: [{ key: "a.png", url: null, embedUrl: null }],
+      },
+    ];
+    expect(groupsFromCatalog(catalog, groups)).toEqual([
+      groups[0],
+      { project: "acme/web", path: "/older", count: 1, lastUpdated: "1", recent: [] },
+    ]);
+  });
+});
+
+describe("shotPreviewPosition", () => {
+  const preview = { width: 480, height: 300 };
+  const viewport = { width: 1200, height: 800 };
+  it("prefers the right side when there is room", () => {
+    expect(
+      shotPreviewPosition({ left: 20, top: 40, right: 188, bottom: 166 }, viewport, preview),
+    ).toEqual({ left: 200, top: 40 });
+  });
+  it("flips to the left when the right side would clip", () => {
+    expect(
+      shotPreviewPosition({ left: 900, top: 40, right: 1068, bottom: 166 }, viewport, preview),
+    ).toEqual({ left: 408, top: 40 });
+  });
+  it("clamps vertically when the preview would run off the bottom", () => {
+    const pos = shotPreviewPosition(
+      { left: 20, top: 700, right: 188, bottom: 826 },
+      viewport,
+      preview,
+    );
+    expect(pos.top).toBe(492); // 800 - 8 - 300
+    expect(pos.left).toBe(200);
   });
 });

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -124,17 +124,105 @@ export function pairedShotKeys(items: Array<{ key: string; state?: string }>): S
   return paired;
 }
 
-/** `?project=` / `?path=` view state, "" when absent. */
-export function readScreenshotsView(search: string): { project: string; path: string } {
+/** `?project=` / `?path=` / `?q=` view state, "" when absent. */
+export function readScreenshotsView(search: string): { project: string; path: string; q: string } {
   const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
-  return { project: params.get("project") ?? "", path: params.get("path") ?? "" };
+  return {
+    project: params.get("project") ?? "",
+    path: params.get("path") ?? "",
+    q: params.get("q") ?? "",
+  };
 }
 
-/** Search string for a view ("" for both clears back to the overview). */
-export function screenshotsSearch(project: string, path: string): string {
+/** Search string for a view ("" for all three clears back to the overview). */
+export function screenshotsSearch(project: string, path: string, q = ""): string {
   const params = new URLSearchParams();
   if (project) params.set("project", project);
   if (path) params.set("path", path);
+  if (q) params.set("q", q);
   const qs = params.toString();
   return qs ? `?${qs}` : "";
+}
+
+/**
+ * Live path filter. A query that starts with `/` is a path-segment prefix
+ * (`/catalog` matches `/catalog` and `/catalog/families`, not `/catalogue`).
+ * Anything else is a case-insensitive substring.
+ */
+export function pathQueryMatches(path: string, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  const haystack = path.toLowerCase();
+  if (needle.startsWith("/")) {
+    const prefix = needle.endsWith("/") ? needle.slice(0, -1) : needle;
+    return haystack === prefix || haystack.startsWith(`${prefix}/`);
+  }
+  return haystack.includes(needle);
+}
+
+export function filterCatalog<T extends { project: string; path: string }>(
+  catalog: T[],
+  opts: { project: string; q: string },
+): T[] {
+  return catalog.filter((entry) => {
+    if (opts.project && entry.project !== opts.project) return false;
+    return pathQueryMatches(entry.path, opts.q);
+  });
+}
+
+type PathCatalogFields = {
+  project: string;
+  path: string;
+  count: number;
+  lastUpdated: string;
+};
+
+/**
+ * Join filtered catalog entries with thumbed groups. Catalog-only paths
+ * (beyond the thumbed cap) render as empty `recent` strips.
+ */
+export function groupsFromCatalog<TRecent>(
+  catalog: PathCatalogFields[],
+  groups: Array<PathCatalogFields & { recent: TRecent[] }>,
+): Array<PathCatalogFields & { recent: TRecent[] }> {
+  const byKey = new Map(groups.map((group) => [`${group.project}\0${group.path}`, group]));
+  return catalog.map((entry) => {
+    const group = byKey.get(`${entry.project}\0${entry.path}`);
+    if (group) return group;
+    return { ...entry, recent: [] };
+  });
+}
+
+/** Viewport box used to place the thumbnail hover preview. */
+export type ShotPreviewBox = { left: number; top: number; right: number; bottom: number };
+
+/**
+ * Place a hover preview next to a thumbnail, flipping if it would clip the
+ * viewport. Prefers the right side, then left, then below; clamps to an
+ * 8px inset.
+ */
+export function shotPreviewPosition(
+  thumb: ShotPreviewBox,
+  viewport: { width: number; height: number },
+  preview: { width: number; height: number },
+  gap = 12,
+): { left: number; top: number } {
+  const inset = 8;
+  const roomRight = viewport.width - inset - (thumb.right + gap);
+  const roomLeft = thumb.left - gap - inset;
+  let left: number;
+  if (roomRight >= preview.width) left = thumb.right + gap;
+  else if (roomLeft >= preview.width) left = thumb.left - gap - preview.width;
+  else left = Math.max(inset, Math.min(thumb.left, viewport.width - inset - preview.width));
+
+  let top = thumb.top;
+  if (top + preview.height > viewport.height - inset) {
+    top = Math.max(inset, viewport.height - inset - preview.height);
+  }
+  if (top < inset) top = inset;
+  if (left < inset) left = inset;
+  if (left + preview.width > viewport.width - inset) {
+    left = Math.max(inset, viewport.width - inset - preview.width);
+  }
+  return { left, top };
 }

--- a/apps/web/src/lib/workspace-search-url.ts
+++ b/apps/web/src/lib/workspace-search-url.ts
@@ -97,8 +97,9 @@ export function replaceSearchLocation(
   next.searchParams.delete("path");
   const ws = isBrowseWorkspace(workspace) ? workspace : "";
   if (ws) {
-    if (workspaceFromPathname(next.pathname) !== ws) {
-      next.pathname = `/account/workspaces/${encodeURIComponent(ws)}`;
+    const filesPath = `/account/workspaces/${encodeURIComponent(ws)}/files`;
+    if (next.pathname !== filesPath) {
+      next.pathname = filesPath;
     }
     next.searchParams.delete("ws");
   } else {

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -623,11 +623,15 @@ export function renderGalleriesPlaceholderForView(view: GalleriesLayout): string
  * layout jump. Change the two together.
  */
 export function renderScreenshotsPlaceholderHtml(rows = 3, thumbs = 4): string {
+  const filter = `<div class="wsp-filter">
+  <span class="wsp-filter__project wsp-filter__skel">${skeletonBarHtml("120px")}</span>
+  <span class="wsp-filter__q wsp-filter__skel">${skeletonBarHtml("60%")}</span>
+</div>`;
   const group = `<div class="wsp-group">
   <div class="wsp-group__head">${skeletonBarHtml("140px")}</div>
   <div class="wsp-strip">${`<span class="wsp-thumb wsp-thumb--skel" aria-hidden="true"></span>`.repeat(thumbs)}</div>
 </div>`;
-  return `<div class="wsp" aria-busy="true">${group.repeat(rows)}</div>`;
+  return `<div class="wsp" aria-busy="true">${filter}${group.repeat(rows)}</div>`;
 }
 
 /**

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -14,6 +14,9 @@ import {
   resolveSidebarWorkspace,
   shouldShowTriggerBadge,
   switcherLabel,
+  workspaceHomePath,
+  workspaceOpenTab,
+  workspacePath,
   workspaceTabFromPathname,
   writeCachedActiveWorkspace,
   readCachedQuota,
@@ -101,8 +104,9 @@ describe("workspaces cache", () => {
 
 describe("workspaceTabFromPathname", () => {
   it("maps workspace shell paths to tab ids", () => {
-    expect(workspaceTabFromPathname("/account/workspaces/buildinternet")).toBe("files");
-    expect(workspaceTabFromPathname("/account/workspaces/buildinternet/")).toBe("files");
+    expect(workspaceTabFromPathname("/account/workspaces/buildinternet")).toBe("screenshots");
+    expect(workspaceTabFromPathname("/account/workspaces/buildinternet/")).toBe("screenshots");
+    expect(workspaceTabFromPathname("/account/workspaces/buildinternet/files")).toBe("files");
     expect(workspaceTabFromPathname("/account/workspaces/buildinternet/galleries")).toBe(
       "galleries",
     );
@@ -114,6 +118,15 @@ describe("workspaceTabFromPathname", () => {
 
   it("maps /screenshots to the screenshots tab", () => {
     expect(workspaceTabFromPathname("/account/workspaces/acme/screenshots")).toBe("screenshots");
+  });
+
+  it("builds the screenshots home and files tab paths", () => {
+    expect(workspaceHomePath("acme")).toBe("/account/workspaces/acme/screenshots");
+    expect(workspacePath("acme", "files")).toBe("/account/workspaces/acme/files");
+    expect(workspacePath("acme", "")).toBe("/account/workspaces/acme/screenshots");
+    expect(workspaceOpenTab("files")).toBe("files");
+    expect(workspaceOpenTab("screenshots")).toBe("screenshots");
+    expect(workspaceOpenTab(null)).toBe("screenshots");
   });
 
   it("returns empty outside the workspace shell", () => {
@@ -325,10 +338,12 @@ describe("shouldShowTriggerBadge", () => {
 describe("renderSwitcherMenuHtml", () => {
   it("lists memberships, marks the active one, and includes new workspace", () => {
     const html = renderSwitcherMenuHtml(sample, { active: "buildinternet" });
-    expect(html).toContain('href="/account/workspaces/buildinternet"');
-    expect(html).toContain('href="/account/workspaces/side"');
-    expect(html).toMatch(/href="\/account\/workspaces\/buildinternet"[^>]*aria-current="true"/);
-    expect(html).not.toMatch(/href="\/account\/workspaces\/side"[^>]*aria-current/);
+    expect(html).toContain('href="/account/workspaces/buildinternet/screenshots"');
+    expect(html).toContain('href="/account/workspaces/side/screenshots"');
+    expect(html).toMatch(
+      /href="\/account\/workspaces\/buildinternet\/screenshots"[^>]*aria-current="true"/,
+    );
+    expect(html).not.toMatch(/href="\/account\/workspaces\/side\/screenshots"[^>]*aria-current/);
     expect(html).toContain('href="/account/workspaces/new"');
     expect(html).toContain("+ new workspace");
     expect(html).toContain("ws-switcher__sep");
@@ -350,11 +365,13 @@ describe("renderSwitcherMenuHtml", () => {
     expect(html).toContain('href="/account/workspaces/side/settings"');
   });
 
-  it("links the workspace root for the files tab and off-workspace routes", () => {
+  it("links the files tab and defaults off-workspace routes to screenshots", () => {
     expect(
       renderSwitcherMenuHtml(sample, { active: "buildinternet", activeTab: "files" }),
-    ).toContain('href="/account/workspaces/side"');
-    expect(renderSwitcherMenuHtml(sample, {})).toContain('href="/account/workspaces/side"');
+    ).toContain('href="/account/workspaces/side/files"');
+    expect(renderSwitcherMenuHtml(sample, {})).toContain(
+      'href="/account/workspaces/side/screenshots"',
+    );
   });
 
   it("still shows + new workspace with an empty membership list", () => {
@@ -371,7 +388,7 @@ describe("renderSwitcherMenuHtml", () => {
     ];
     const html = renderSwitcherMenuHtml(withPlans, { active: "buildinternet" });
     expect(html).toMatch(/buildinternet[\s\S]*?<span class="pro-badge">Pro<\/span>/);
-    const sideItem = html.slice(html.indexOf('href="/account/workspaces/side"'));
+    const sideItem = html.slice(html.indexOf('href="/account/workspaces/side/screenshots"'));
     expect(sideItem).not.toContain("pro-badge");
   });
 
@@ -410,7 +427,8 @@ describe("renderSwitcherMenuHtml", () => {
 describe("renderWorkspaceSectionNavHtml", () => {
   it("renders section links for an active workspace and marks the tab", () => {
     const html = renderWorkspaceSectionNavHtml("buildinternet", "galleries");
-    expect(html).toContain('href="/account/workspaces/buildinternet"');
+    expect(html).toContain('href="/account/workspaces/buildinternet/screenshots"');
+    expect(html).toContain('href="/account/workspaces/buildinternet/files"');
     expect(html).toContain('href="/account/workspaces/buildinternet/galleries"');
     expect(html).toContain('href="/account/workspaces/buildinternet/people"');
     expect(html).toContain('href="/account/workspaces/buildinternet/billing"');
@@ -421,11 +439,12 @@ describe("renderWorkspaceSectionNavHtml", () => {
     expect(html).toContain('class="side-link"');
   });
 
-  it("renders a screenshots link between files and galleries", () => {
+  it("renders screenshots first, then files, then galleries", () => {
     const html = renderWorkspaceSectionNavHtml("acme", "screenshots");
     expect(html).toContain('href="/account/workspaces/acme/screenshots"');
-    expect(html.indexOf("screenshots")).toBeGreaterThan(html.indexOf("files"));
-    expect(html.indexOf("screenshots")).toBeLessThan(html.indexOf("galleries"));
+    expect(html).toContain('href="/account/workspaces/acme/files"');
+    expect(html.indexOf("screenshots")).toBeLessThan(html.indexOf(">files<"));
+    expect(html.indexOf(">files<")).toBeLessThan(html.indexOf("galleries"));
     expect(html).toContain('aria-current="page"');
   });
 
@@ -436,6 +455,6 @@ describe("renderWorkspaceSectionNavHtml", () => {
   it("marks no tab current when activeTab is empty (personal routes)", () => {
     const html = renderWorkspaceSectionNavHtml("buildinternet", "");
     expect(html).not.toContain('aria-current="page"');
-    expect(html).toContain('href="/account/workspaces/buildinternet"');
+    expect(html).toContain('href="/account/workspaces/buildinternet/screenshots"');
   });
 });

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -36,16 +36,36 @@ export type WorkspaceNavTab =
 export const WORKSPACE_NAV_TABS: {
   id: WorkspaceNavTab;
   label: string;
-  /** Path suffix after `/account/workspaces/:name` — empty for files. */
+  /** Path suffix after `/account/workspaces/:name`. */
   path: string;
 }[] = [
-  { id: "files", label: "files", path: "" },
   { id: "screenshots", label: "screenshots", path: "/screenshots" },
+  { id: "files", label: "files", path: "/files" },
   { id: "galleries", label: "galleries", path: "/galleries" },
   { id: "people", label: "people", path: "/people" },
   { id: "billing", label: "billing", path: "/billing" },
   { id: "settings", label: "settings", path: "/settings" },
 ];
+
+/** Workspace home — the screenshots tab. */
+export function workspaceHomePath(workspace: string): string {
+  return workspacePath(workspace, "screenshots");
+}
+
+/** Path for a workspace tab. Unknown/empty tab falls through to screenshots. */
+export function workspacePath(
+  workspace: string,
+  tab: WorkspaceNavTab | "" = "screenshots",
+): string {
+  const base = `/account/workspaces/${encodeURIComponent(workspace)}`;
+  const suffix = tabPathSuffix(tab);
+  return `${base}${suffix}`;
+}
+
+/** `?to=` allowlist for the workspaces index auto-open. Anything else is home. */
+export function workspaceOpenTab(to: string | null | undefined): "files" | "screenshots" {
+  return to === "files" ? "files" : "screenshots";
+}
 
 export type WorkspacesNavOptions = {
   active?: string;
@@ -261,8 +281,9 @@ export function workspaceTabFromPathname(pathname: string): WorkspaceNavTab | ""
   const slug = decodeURIComponent(match[1] ?? "");
   if (!slug || slug === "new") return "";
   const segment = match[2] ?? "";
-  if (!segment) return "files";
+  if (!segment) return "screenshots";
   if (segment === "screenshots") return "screenshots";
+  if (segment === "files") return "files";
   if (segment === "galleries") return "galleries";
   if (segment === "people" || segment === "invite") return "people";
   if (segment === "billing") return "billing";
@@ -288,25 +309,26 @@ export function workspaceSettingsSubpageFromPathname(
   return "";
 }
 
-/** Path suffix that keeps the current tab when switching workspaces ("" for
- * files or off-workspace routes). Settings deliberately maps to the tab root,
- * not the sub-page — sub-pages are workspace-specific detail views. */
+/** Path suffix that keeps the current tab when switching workspaces.
+ * Off-workspace routes (empty tab) land on screenshots, the workspace home.
+ * Settings deliberately maps to the tab root, not the sub-page — sub-pages
+ * are workspace-specific detail views. */
 function tabPathSuffix(tab: WorkspaceNavTab | ""): string {
-  if (!tab) return "";
-  return WORKSPACE_NAV_TABS.find((t) => t.id === tab)?.path ?? "";
+  if (!tab) return "/screenshots";
+  return WORKSPACE_NAV_TABS.find((t) => t.id === tab)?.path ?? "/screenshots";
 }
 
 /** Switcher dropdown HTML. Rows preserve `activeTab` so switching workspaces
- * lands on the same section instead of resetting to files. */
+ * lands on the same section instead of resetting to screenshots. */
 export function renderSwitcherMenuHtml(
   workspaces: MyWorkspace[],
   options: WorkspacesNavOptions = {},
 ): string {
   const active = options.active ?? "";
-  const tabSuffix = tabPathSuffix(options.activeTab || "");
+  const activeTab = options.activeTab || "";
   const rows = workspaces
     .map((ws) => {
-      const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}${tabSuffix}`;
+      const href = workspacePath(ws.workspace, activeTab);
       const current = active === ws.workspace;
       const cls = current ? "ws-switcher__item is-current" : "ws-switcher__item";
       const aria = current ? ' aria-current="true"' : "";
@@ -359,9 +381,8 @@ export function renderWorkspaceSectionNavHtml(
   settingsSubpage: WorkspaceSettingsSubpage | "" = "",
 ): string {
   if (!workspace) return "";
-  const base = `/account/workspaces/${encodeURIComponent(workspace)}`;
   return WORKSPACE_NAV_TABS.map((tab) => {
-    const href = `${base}${tab.path}`;
+    const href = workspacePath(workspace, tab.id);
     const current = activeTab === tab.id ? ' aria-current="page"' : "";
     const link = `<a href="${escapeHtml(href)}" class="side-link"${current}>${escapeHtml(tab.label)}</a>`;
     const subnav =

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -1,7 +1,7 @@
 ---
 /**
  * Workspaces index.
- * Legacy `?ws=` deep links redirect to `/account/workspaces/<name>`.
+ * Legacy `?ws=` deep links redirect to the workspace home (screenshots).
  * Auto-opens a workspace (last-used, else first owned) so a signed-in user
  * lands somewhere; `?manage=1` asks for the list itself instead.
  */
@@ -11,14 +11,17 @@ import { getMyWorkspaces } from "../../lib/api-client";
 import { resolveSignedInOrigins } from "../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../lib/workspace-browse-url";
 import { renderWorkspacesPlaceholderHtml } from "../../lib/workspace-ui";
+import { workspaceOpenTab, workspacePath } from "../../lib/workspaces-nav";
 
 export const prerender = false;
 
 const legacyWs = (Astro.url.searchParams.get("ws") ?? "").trim();
 if (isBrowseWorkspace(legacyWs)) {
   // Same `?to=<tab>` allowlist as the client-side auto-open below.
-  const suffix = Astro.url.searchParams.get("to") === "screenshots" ? "/screenshots" : "";
-  const dest = new URL(`/account/workspaces/${encodeURIComponent(legacyWs)}${suffix}`, Astro.url);
+  const dest = new URL(
+    workspacePath(legacyWs, workspaceOpenTab(Astro.url.searchParams.get("to"))),
+    Astro.url,
+  );
   dest.search = "";
   for (const [key, value] of Astro.url.searchParams) {
     if (key !== "ws" && key !== "to") dest.searchParams.append(key, value);
@@ -39,8 +42,7 @@ if (!managing) {
     if (result.kind === "success" && result.workspaces.length === 1) {
       const only = result.workspaces[0].workspace;
       const to = new URLSearchParams(Astro.url.search).get("to");
-      const suffix = to === "screenshots" ? "/screenshots" : "";
-      return Astro.redirect(`/account/workspaces/${encodeURIComponent(only)}${suffix}`);
+      return Astro.redirect(workspacePath(only, workspaceOpenTab(to)));
     }
   }
 }
@@ -75,6 +77,9 @@ if (!managing) {
       loadWorkspaces,
       readCachedActiveWorkspace,
       resolveDefaultWorkspace,
+      workspaceHomePath,
+      workspaceOpenTab,
+      workspacePath,
     } from "../../lib/workspaces-nav";
     import { workspaceCapMessage } from "@uploads/billing";
     import { shouldShowProBadge } from "../../lib/plan-badge";
@@ -154,12 +159,11 @@ if (!managing) {
           list.removeAttribute("aria-busy");
           status.hidden = false;
           status.textContent = "Opening…";
-          // `?to=<tab>` lands the auto-open on a workspace sub-tab (the
-          // header's Screenshots link uses it). Allowlisted so a crafted
-          // query can't steer the redirect anywhere else.
+          // `?to=<tab>` lands the auto-open on a workspace sub-tab.
+          // Default is screenshots (the workspace home). Allowlisted so a
+          // crafted query can't steer the redirect anywhere else.
           const to = new URLSearchParams(location.search).get("to");
-          const suffix = to === "screenshots" ? "/screenshots" : "";
-          location.replace(`/account/workspaces/${encodeURIComponent(open)}${suffix}`);
+          location.replace(workspacePath(open, workspaceOpenTab(to)));
           return;
         }
 
@@ -169,7 +173,7 @@ if (!managing) {
         list.innerHTML = workspaces
           .map((ws) => {
             const name = ws.organization.name || ws.workspace;
-            const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
+            const href = workspaceHomePath(ws.workspace);
             const badge = shouldShowProBadge(ws.plan) ? ` <span class="pro-badge">Pro</span>` : "";
             return `<li>
               <a href="${escapeHtml(href)}">${escapeHtml(name)}</a>${badge}

--- a/apps/web/src/pages/account/workspaces/[name].astro
+++ b/apps/web/src/pages/account/workspaces/[name].astro
@@ -1,39 +1,11 @@
 ---
 /**
- * Workspace files — `WorkspaceLayout` + file table. Sibling routes under
- * `[name]/` cover galleries / people / settings.
- *
- * SSR-first (plan 005, Phase B): when the request carries a session and the
- * URL is the plain unfiltered root browse (no `?path=`, `meta.*`, or
- * `name=`), server-fetch the workspace summary + default folder listing so
- * first paint has real rows instead of the loading skeleton.
- * `WorkspaceFileTable` itself renders here with no `client:*` directive, so
- * Astro emits it as plain static HTML (no `astro-island`, no hydration
- * bootstrap) — the seeded rows are real, visible markup even before any JS
- * runs. A companion JSON `<script>` carries the same props, and a manual
- * `hydrateRoot` mount (below, off `astro:page-load`/`astro:before-swap`,
- * same shape every sibling workspace-tab page already uses) attaches
- * interactivity to that exact markup afterwards.
- *
- * Phase A prototyped `client:load` instead and rejected it: it hydrates
- * fine in a production build, but in `astro dev` it 404s fetching
- * `@astrojs/react`'s Fast-Refresh bootstrap before hydration ever starts —
- * the exact class of bug this file's `astro.config.mjs` already documents
- * and works around by keeping `client:*` out of this codebase entirely
- * (`vite.server.hmr = false` only dodges it for the manual-mount path this
- * page is back to using). `client:load` also opts out of the
- * `astro:before-swap` teardown every sibling tab relies on for clean
- * ClientRouter re-mounts. See plan 005's review-gate notes for the full
- * writeup.
+ * Workspace home. Screenshots is the default tab, so the bare
+ * `/account/workspaces/:name` URL redirects there. Files-tab deep links
+ * (`?path=`, `meta.*`, `name=`, `view=`) keep working by sending to `/files`.
  */
-import { env } from "cloudflare:workers";
-import WorkspaceLayout from "../../../layouts/WorkspaceLayout.astro";
-import { WorkspaceFileTable, type ListingState } from "../../../components/WorkspaceFileTable";
-import { getWorkspaceSummary, listWorkspaceFolder } from "../../../lib/api-client";
-import { resolveSignedInOrigins } from "../../../lib/signed-in-page";
-import { isBrowseWorkspace, readBrowseLocation } from "../../../lib/workspace-browse-url";
-import { readSearchFilters, readSearchName } from "../../../lib/workspace-search-url";
-import type { WorkspaceInfoStatus } from "../../../lib/workspace-file-row";
+import { isBrowseWorkspace, isFilesBrowseSearch } from "../../../lib/workspace-browse-url";
+import { workspaceHomePath, workspacePath } from "../../../lib/workspaces-nav";
 
 export const prerender = false;
 
@@ -41,136 +13,9 @@ const nameParam = Astro.params.name ?? "";
 const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
 
-const tip = {
-  body: "attach uploads to a pull request with <code>uploads put ./shot.png --pr 123</code> — they collect into one managed comment.",
-};
-
-const { apiOrigin } = resolveSignedInOrigins(env);
-const cookie = Astro.request.headers.get("cookie") ?? "";
-const initialSearch = Astro.url.search;
-
-let initialInfo: WorkspaceInfoStatus | undefined;
-let initialListing: ListingState | undefined;
-
-if (cookie.trim()) {
-  // Only seed the listing for the plain root browse — a deep link into a
-  // folder or an active search needs a *different* fetch than "default,
-  // unfiltered, root", and seeding the wrong data would show rows that don't
-  // match the breadcrumbs/chips the same URL seeds on the client. The
-  // workspace-info seed has no such constraint (its render is identical
-  // regardless of URL), so it's fetched unconditionally below.
-  const isDefaultBrowse =
-    readBrowseLocation(initialSearch, Astro.url.pathname).path === "" &&
-    readSearchFilters(initialSearch).length === 0 &&
-    !readSearchName(initialSearch);
-
-  const [summary, listing] = await Promise.all([
-    getWorkspaceSummary(apiOrigin, workspace, { cookie }),
-    isDefaultBrowse ? listWorkspaceFolder(apiOrigin, workspace, { cookie }) : Promise.resolve(null),
-  ]);
-
-  if (summary.kind === "success") {
-    initialInfo = { status: "ready", hasPublicUrl: summary.workspace.hasPublicUrl };
-    if (listing) {
-      initialListing = {
-        status: "ok",
-        files: listing.files,
-        prefixes: listing.prefixes,
-        cursor: listing.cursor,
-      };
-    }
-  }
+const rest = `${Astro.url.search}${Astro.url.hash}`;
+if (isFilesBrowseSearch(Astro.url.search)) {
+  return Astro.redirect(`${workspacePath(workspace, "files")}${rest}`);
 }
-
-// Carries the exact same props into the client mount script below (plain
-// `<script>`, not `client:*` — see the file-level doc comment for why).
-// `<`-escaped so a filename/metadata value containing `</script>` can't
-// break out of the tag; this is the same data `WorkspaceFileTable` above
-// already rendered, so nothing here is newly untrusted.
-const filesSeedJson = JSON.stringify({
-  apiOrigin,
-  workspace,
-  initialSearch,
-  initialListing,
-  initialInfo,
-}).replace(/</g, "\\u003c");
+return Astro.redirect(`${workspaceHomePath(workspace)}${rest}`);
 ---
-
-<WorkspaceLayout workspace={workspace} tip={tip}>
-  <div id="ws-files-table">
-    <WorkspaceFileTable
-      apiOrigin={apiOrigin}
-      workspace={workspace}
-      initialSearch={initialSearch}
-      initialListing={initialListing}
-      initialInfo={initialInfo}
-    />
-  </div>
-  <script type="application/json" id="ws-files-seed" set:html={filesSeedJson} />
-
-  <script>
-    import { onAstroPageLoad } from "../../../lib/account-shell";
-    import { createElement } from "react";
-    import { hydrateRoot, type Root } from "react-dom/client";
-    import type { ListingState } from "../../../components/WorkspaceFileTable";
-    import type { WorkspaceInfoStatus } from "../../../lib/workspace-file-row";
-
-    interface FilesSeed {
-      apiOrigin: string;
-      workspace: string;
-      initialSearch: string;
-      initialListing?: ListingState;
-      initialInfo?: WorkspaceInfoStatus;
-    }
-
-    let filesTableRoot: Root | null = null;
-
-    function teardown(): void {
-      if (!filesTableRoot) return;
-      try {
-        filesTableRoot.unmount();
-      } catch {
-        // Container may already be gone after a body swap.
-      }
-      filesTableRoot = null;
-    }
-
-    function readSeed(): FilesSeed | null {
-      const el = document.getElementById("ws-files-seed");
-      if (!el?.textContent) return null;
-      try {
-        return JSON.parse(el.textContent) as FilesSeed;
-      } catch {
-        return null;
-      }
-    }
-
-    async function boot(): Promise<void> {
-      const mount = document.getElementById("ws-files-table");
-      const seed = readSeed();
-      if (!mount || !seed) return;
-
-      // Tear down the previous mount before Astro swaps this page's body away
-      // (registered once per boot() call — {once:true} auto-clears itself so
-      // repeated astro:page-load events from ClientRouter never stack listeners).
-      document.addEventListener("astro:before-swap", teardown, { once: true });
-
-      // Lazy, not a static top-level import: keeps a Fast-Refresh/HMR dev
-      // glitch in this component from blocking the rest of the page's
-      // scripts — same reasoning every sibling workspace-tab mount uses.
-      const { WorkspaceFileTable } = await import("../../../components/WorkspaceFileTable");
-      if (!document.contains(mount)) return;
-      teardown();
-      // `WorkspaceFileTable` already composes `IslandErrorBoundary`
-      // internally (plan 005 Phase A) — mounting it directly, with no extra
-      // wrapper, matches the SSR'd tree exactly, so `hydrateRoot` reconciles
-      // without warnings.
-      filesTableRoot = hydrateRoot(mount, createElement(WorkspaceFileTable, seed));
-    }
-
-    // astro:page-load fires on the initial load too (same as every sibling
-    // tab), so this single registration mounts on first load and on nav —
-    // no separate eager call, which would double-mount + double-fetch.
-    onAstroPageLoad(() => void boot());
-  </script>
-</WorkspaceLayout>

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -21,6 +21,7 @@ import { resolveBillingCta, type BillingCtaState } from "../../../../lib/billing
 import { formatPrice } from "../../../../lib/plan-prices";
 import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
+import { workspaceHomePath } from "../../../../lib/workspaces-nav";
 
 export const prerender = false;
 
@@ -59,7 +60,7 @@ const cta: BillingCtaState = billing
           <h2>Billing</h2>
           <p class="muted" id="ws-slug"></p>
         </div>
-        <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
+        <a class="text-btn" id="ws-back" href={workspaceHomePath(workspace)}>← Workspace</a>
       </div>
 
       <div

--- a/apps/web/src/pages/account/workspaces/[name]/files.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/files.astro
@@ -1,0 +1,178 @@
+---
+/**
+ * Workspace files — `WorkspaceLayout` + file table. Sibling of screenshots
+ * (the workspace home). The bare `/account/workspaces/:name` URL redirects
+ * here only for files-tab deep links (`?path=`, `meta.*`, `name=`, `view=`);
+ * everything else goes to screenshots.
+ *
+ * SSR-first (plan 005, Phase B): when the request carries a session and the
+ * URL is the plain unfiltered root browse (no `?path=`, `meta.*`, or
+ * `name=`), server-fetch the workspace summary + default folder listing so
+ * first paint has real rows instead of the loading skeleton.
+ * `WorkspaceFileTable` itself renders here with no `client:*` directive, so
+ * Astro emits it as plain static HTML (no `astro-island`, no hydration
+ * bootstrap) — the seeded rows are real, visible markup even before any JS
+ * runs. A companion JSON `<script>` carries the same props, and a manual
+ * `hydrateRoot` mount (below, off `astro:page-load`/`astro:before-swap`,
+ * same shape every sibling workspace-tab page already uses) attaches
+ * interactivity to that exact markup afterwards.
+ *
+ * Phase A prototyped `client:load` instead and rejected it: it hydrates
+ * fine in a production build, but in `astro dev` it 404s fetching
+ * `@astrojs/react`'s Fast-Refresh bootstrap before hydration ever starts —
+ * the exact class of bug this file's `astro.config.mjs` already documents
+ * and works around by keeping `client:*` out of this codebase entirely
+ * (`vite.server.hmr = false` only dodges it for the manual-mount path this
+ * page is back to using). `client:load` also opts out of the
+ * `astro:before-swap` teardown every sibling tab relies on for clean
+ * ClientRouter re-mounts. See plan 005's review-gate notes for the full
+ * writeup.
+ */
+import { env } from "cloudflare:workers";
+import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
+import { WorkspaceFileTable, type ListingState } from "../../../../components/WorkspaceFileTable";
+import { getWorkspaceSummary, listWorkspaceFolder } from "../../../../lib/api-client";
+import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
+import { isBrowseWorkspace, readBrowseLocation } from "../../../../lib/workspace-browse-url";
+import { readSearchFilters, readSearchName } from "../../../../lib/workspace-search-url";
+import type { WorkspaceInfoStatus } from "../../../../lib/workspace-file-row";
+
+export const prerender = false;
+
+const nameParam = Astro.params.name ?? "";
+const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
+if (!workspace) return Astro.redirect("/account/workspaces");
+
+const tip = {
+  body: "attach uploads to a pull request with <code>uploads put ./shot.png --pr 123</code> — they collect into one managed comment.",
+};
+
+const { apiOrigin } = resolveSignedInOrigins(env);
+const cookie = Astro.request.headers.get("cookie") ?? "";
+const initialSearch = Astro.url.search;
+
+let initialInfo: WorkspaceInfoStatus | undefined;
+let initialListing: ListingState | undefined;
+
+if (cookie.trim()) {
+  // Only seed the listing for the plain root browse — a deep link into a
+  // folder or an active search needs a *different* fetch than "default,
+  // unfiltered, root", and seeding the wrong data would show rows that don't
+  // match the breadcrumbs/chips the same URL seeds on the client. The
+  // workspace-info seed has no such constraint (its render is identical
+  // regardless of URL), so it's fetched unconditionally below.
+  const isDefaultBrowse =
+    readBrowseLocation(initialSearch, Astro.url.pathname).path === "" &&
+    readSearchFilters(initialSearch).length === 0 &&
+    !readSearchName(initialSearch);
+
+  const [summary, listing] = await Promise.all([
+    getWorkspaceSummary(apiOrigin, workspace, { cookie }),
+    isDefaultBrowse ? listWorkspaceFolder(apiOrigin, workspace, { cookie }) : Promise.resolve(null),
+  ]);
+
+  if (summary.kind === "success") {
+    initialInfo = { status: "ready", hasPublicUrl: summary.workspace.hasPublicUrl };
+    if (listing) {
+      initialListing = {
+        status: "ok",
+        files: listing.files,
+        prefixes: listing.prefixes,
+        cursor: listing.cursor,
+      };
+    }
+  }
+}
+
+// Carries the exact same props into the client mount script below (plain
+// `<script>`, not `client:*` — see the file-level doc comment for why).
+// `<`-escaped so a filename/metadata value containing `</script>` can't
+// break out of the tag; this is the same data `WorkspaceFileTable` above
+// already rendered, so nothing here is newly untrusted.
+const filesSeedJson = JSON.stringify({
+  apiOrigin,
+  workspace,
+  initialSearch,
+  initialListing,
+  initialInfo,
+}).replace(/</g, "\\u003c");
+---
+
+<WorkspaceLayout workspace={workspace} tip={tip}>
+  <div id="ws-files-table">
+    <WorkspaceFileTable
+      apiOrigin={apiOrigin}
+      workspace={workspace}
+      initialSearch={initialSearch}
+      initialListing={initialListing}
+      initialInfo={initialInfo}
+    />
+  </div>
+  <script type="application/json" id="ws-files-seed" set:html={filesSeedJson} />
+
+  <script>
+    import { onAstroPageLoad } from "../../../../lib/account-shell";
+    import { createElement } from "react";
+    import { hydrateRoot, type Root } from "react-dom/client";
+    import type { ListingState } from "../../../../components/WorkspaceFileTable";
+    import type { WorkspaceInfoStatus } from "../../../../lib/workspace-file-row";
+
+    interface FilesSeed {
+      apiOrigin: string;
+      workspace: string;
+      initialSearch: string;
+      initialListing?: ListingState;
+      initialInfo?: WorkspaceInfoStatus;
+    }
+
+    let filesTableRoot: Root | null = null;
+
+    function teardown(): void {
+      if (!filesTableRoot) return;
+      try {
+        filesTableRoot.unmount();
+      } catch {
+        // Container may already be gone after a body swap.
+      }
+      filesTableRoot = null;
+    }
+
+    function readSeed(): FilesSeed | null {
+      const el = document.getElementById("ws-files-seed");
+      if (!el?.textContent) return null;
+      try {
+        return JSON.parse(el.textContent) as FilesSeed;
+      } catch {
+        return null;
+      }
+    }
+
+    async function boot(): Promise<void> {
+      const mount = document.getElementById("ws-files-table");
+      const seed = readSeed();
+      if (!mount || !seed) return;
+
+      // Tear down the previous mount before Astro swaps this page's body away
+      // (registered once per boot() call — {once:true} auto-clears itself so
+      // repeated astro:page-load events from ClientRouter never stack listeners).
+      document.addEventListener("astro:before-swap", teardown, { once: true });
+
+      // Lazy, not a static top-level import: keeps a Fast-Refresh/HMR dev
+      // glitch in this component from blocking the rest of the page's
+      // scripts — same reasoning every sibling workspace-tab mount uses.
+      const { WorkspaceFileTable } = await import("../../../../components/WorkspaceFileTable");
+      if (!document.contains(mount)) return;
+      teardown();
+      // `WorkspaceFileTable` already composes `IslandErrorBoundary`
+      // internally (plan 005 Phase A) — mounting it directly, with no extra
+      // wrapper, matches the SSR'd tree exactly, so `hydrateRoot` reconciles
+      // without warnings.
+      filesTableRoot = hydrateRoot(mount, createElement(WorkspaceFileTable, seed));
+    }
+
+    // astro:page-load fires on the initial load too (same as every sibling
+    // tab), so this single registration mounts on first load and on nav —
+    // no separate eager call, which would double-mount + double-fetch.
+    onAstroPageLoad(() => void boot());
+  </script>
+</WorkspaceLayout>

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -10,6 +10,7 @@ import { getWorkspacePeople } from "../../../../lib/api-client";
 import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
 import { renderMembersHtml, renderMembersPlaceholderHtml } from "../../../../lib/workspace-ui";
+import { workspaceHomePath } from "../../../../lib/workspaces-nav";
 
 export const prerender = false;
 
@@ -50,7 +51,7 @@ if (cookie.trim()) {
           <h2>People</h2>
           <p class="muted" id="ws-slug"></p>
         </div>
-        <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
+        <a class="text-btn" id="ws-back" href={workspaceHomePath(workspace)}>← Workspace</a>
       </div>
       <div
         id="ws-members"

--- a/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
@@ -1,7 +1,7 @@
 ---
 /**
  * Screenshots grouped by `path` metadata — `WorkspaceLayout` + the
- * `ScreenshotsByPath` island. Sibling route to `[name].astro` (files);
+ * `ScreenshotsByPath` island. Workspace home; files live at `[name]/files`.
  * cloned structure, own mount id.
  *
  * SSR-first (plan 006, following plan 005's `WorkspaceFileTable`/`[name].astro`
@@ -20,11 +20,11 @@
  * Unlike the files tab's `listWorkspaceFolder` (which depends on the current
  * folder, so plan 005 only seeds it for the plain root browse),
  * `getWorkspaceFilesByPath` always returns the same complete by-path overview
- * regardless of the URL — `?project=`/`?path=` only change how
- * `ScreenshotsByPath` filters/renders that same data (project view) or
- * switches to a *different* client-side fetch (drill-in search). So the
- * overview seed below is unconditional, not gated to a "default view" URL
- * the way plan 005's listing seed is.
+ * regardless of the URL — `?project=`/`?q=` only change how
+ * `ScreenshotsByPath` filters that same data (project + path query), and
+ * `?path=` switches to a *different* client-side fetch (drill-in search).
+ * So the overview seed below is unconditional, not gated to a "default
+ * view" URL the way plan 005's listing seed is.
  */
 import { env } from "cloudflare:workers";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
@@ -66,8 +66,10 @@ if (cookie.trim()) {
     initialOverview = {
       status: "ready",
       groups: overview.groups,
+      catalog: overview.catalog,
       projects: overview.projects,
       truncated: overview.truncated,
+      catalogTruncated: overview.catalogTruncated,
     };
   }
 }

--- a/apps/web/src/pages/account/workspaces/new.astro
+++ b/apps/web/src/pages/account/workspaces/new.astro
@@ -109,6 +109,7 @@ export const prerender = false;
       clearCachedWorkspaces,
       loadWorkspaces,
       readCachedQuota,
+      workspaceHomePath,
     } from "../../../lib/workspaces-nav";
     import { workspaceCapMessage } from "@uploads/billing";
     import {
@@ -250,7 +251,7 @@ export const prerender = false;
             }
             input.value = "";
             createdName.textContent = name;
-            openLink.href = `/account/workspaces/${encodeURIComponent(name)}`;
+            openLink.href = workspaceHomePath(name);
             successEl.hidden = false;
             return;
           }

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -27,6 +27,7 @@ import {
 import { oembedDiscoveryHref } from "../../../lib/oembed";
 import { OG_DEFAULT_IMAGE, OG_SITE_NAME, ogImageFor } from "../../../lib/og";
 import { env } from "cloudflare:workers";
+import { workspaceHomePath } from "../../../lib/workspaces-nav";
 
 export const prerender = false;
 
@@ -634,8 +635,8 @@ const ogImage = file
               <code>file.deleted</code>
               <h1>File deleted</h1>
               <p>This file has been permanently removed.</p>
-              <a class="signin" href={`/account/workspaces/${workspace}`}>
-                Workspace files
+              <a class="signin" href={workspaceHomePath(workspace)}>
+                Workspace
               </a>
             </section>
           </>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -823,12 +823,12 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         readCachedSessionUser,
         writeCachedSessionUser,
       } from "../lib/account-shell";
-      import { readCachedActiveWorkspace } from "../lib/workspaces-nav";
+      import { readCachedActiveWorkspace, workspaceHomePath } from "../lib/workspaces-nav";
 
       /** Signed-in landing CTA: last-used workspace when known, else the list. */
       function workspaceHref(): string {
         const ws = readCachedActiveWorkspace();
-        return ws ? `/account/workspaces/${encodeURIComponent(ws)}` : "/account/workspaces";
+        return ws ? workspaceHomePath(ws) : "/account/workspaces";
       }
 
       function paintHomeCta(signedIn: boolean): void {

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -2085,3 +2085,86 @@ button.wft-card__name:focus-visible {
 .wsp-pair svg {
   display: block;
 }
+
+/* Path/project filter — compact row above the grouped feed. Native select
+   + search input, same 36px box as the files tab filter so the two tabs
+   sit in one system. 16px type on small viewports so iOS doesn't zoom. */
+.wsp-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: stretch;
+}
+.wsp-filter .wsp-filter__project {
+  width: auto;
+  flex: 0 1 16rem;
+  min-width: 12rem;
+  max-width: 100%;
+  min-height: 36px;
+  font-size: 16px;
+  box-sizing: border-box;
+}
+.wsp-filter .wsp-filter__q {
+  flex: 1 1 16rem;
+  min-width: 0;
+  min-height: 36px;
+  padding: 6px 12px;
+  font-size: 16px;
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+.wsp-filter__skel {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--bg);
+  box-sizing: border-box;
+}
+@media (min-width: 640px) {
+  .wsp-filter .wsp-filter__project,
+  .wsp-filter .wsp-filter__q {
+    font-size: 12.5px;
+  }
+}
+
+/* Hover preview — hover-capable pointers only. pointer-events none so
+   scanning the strip doesn't get stuck on the popover. */
+.wsp-preview {
+  position: fixed;
+  z-index: 40;
+  pointer-events: none;
+  padding: 6px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: 0 12px 32px color-mix(in srgb, #000 45%, transparent);
+}
+.wsp-preview img {
+  display: block;
+  max-width: min(560px, calc(100vw - 24px));
+  max-height: 70vh;
+  width: auto;
+  height: auto;
+  border-radius: 2px;
+  outline: 1px solid oklch(1 0 0 / 0.1);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .wsp-preview {
+    animation: wsp-preview-in 150ms ease-out;
+  }
+}
+@keyframes wsp-preview-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@media (hover: none) {
+  .wsp-preview {
+    display: none;
+  }
+}


### PR DESCRIPTION
## In plain terms

The screenshots page was a recency feed you had to scroll. You can now filter it by project and by path (`/catalog`), hover a thumbnail for a larger preview, and opening a workspace lands on screenshots instead of the file list.

## What it does / what it is not

- A project select and a live path filter sit above the grouped feed. `/catalog` matches that path and its children, not `/catalogue`. Slash-less text is a substring. State lives in `?project=` and `?q=`.
- Hovering a thumbnail (fine pointer only) shows an uncropped preview of the already-loaded image. Click still opens the file. Touch and video skip it.
- Screenshots is the workspace home. The file list moved to `/files`. `/account/workspaces/<name>` redirects there, except files deep links (`?path=`, `meta.*`, `name=`, `view=`) which still open the files tab.
- Not a metadata typeahead, not a KV index, not a prefix search on `files/search`.

## How to try it

Sign in and open a workspace — you should land on Screenshots. Type `/catalog` in the path field, pick a project from the dropdown, hover a thumbnail.

Old files bookmarks still work: `/account/workspaces/<name>?path=screenshots/` opens the files tab.

## Technical notes

`GET /v1/workspaces/:name/files/by-path` gains a thumbless `catalog` of unique `(project, path)` pairs (up to 500) so the filter stays complete past the 50-group thumbnail cap. Web synthesizes a catalog from `groups` if an older API omits it (separate deployables).

## Test plan

- [x] API: catalog past the group cap, catalog-only project, catalog limit
- [x] Web: path-query matching, URL state, nav paths, by-path client parse / older-API fallback
- [x] Pre-commit types + lint-staged
- [ ] Signed-in browser pass on a workspace with real shots