### PR TITLE
feat(web): filename and PR in screenshot hover preview

### DIFF
--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1806,7 +1806,11 @@ describe("GET /me/workspaces/:name/files/search", () => {
 describe("GET /me/workspaces/:name/files/by-path", () => {
   it("groups path-tagged files with urls and state badges", async () => {
     const db = metadataDb([
-      { workspace: "acme", key: "shots/a.png", meta: { path: "/settings", state: "after" } },
+      {
+        workspace: "acme",
+        key: "shots/a.png",
+        meta: { path: "/settings", state: "after", "gh.kind": "pull", "gh.number": "42" },
+      },
       { workspace: "acme", key: "shots/b.png", meta: { path: "/settings" } },
       { workspace: "acme", key: "shots/c.png", meta: { app: "web" } },
     ]);
@@ -1819,7 +1823,13 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
         path: string;
         count: number;
         lastUpdated: string;
-        recent: { key: string; url: string | null; state?: string }[];
+        recent: {
+          key: string;
+          url: string | null;
+          state?: string;
+          ghKind?: string;
+          ghNumber?: string;
+        }[];
       }[];
       catalog: { project: string; path: string; count: number; lastUpdated: string }[];
       projects: { label: string; count: number; lastUpdated: string }[];
@@ -1837,9 +1847,13 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
     expect(byKey["shots/a.png"]).toMatchObject({
       url: "https://storage.uploads.sh/acme/shots/a.png",
       state: "after",
+      ghKind: "pull",
+      ghNumber: "42",
     });
-    // `state` is present only when set — no empty-string placeholder.
+    // `state` / gh fields are present only when set — no empty-string placeholder.
     expect(byKey["shots/b.png"]).not.toHaveProperty("state");
+    expect(byKey["shots/b.png"]).not.toHaveProperty("ghKind");
+    expect(byKey["shots/b.png"]).not.toHaveProperty("ghNumber");
   });
 
   it("labels groups with a project and returns the projects summary", async () => {

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -174,8 +174,9 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // `files/search?meta.path=…` route; this one answers "which paths, how
   // recent, first few keys" plus a thumbless `catalog` of every unique
   // (project, path) so the page can filter without a second query. `state`
-  // is the one metadata key enriched — the page badges before/after and
-  // nothing else, so no other keys leak into the payload.
+  // and `gh.kind`/`gh.number` are the metadata keys enriched — the page
+  // badges before/after and names the PR in the hover preview, and nothing
+  // else leaks into the payload.
   .get("/:workspace/files/by-path", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
     const record = c.get("workspace");
     const name = c.get("workspaceName");
@@ -187,7 +188,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
       c.env.DB,
       name,
       groups.flatMap((group) => group.recent),
-      { metaKeys: ["state"] },
+      { metaKeys: ["state", "gh.kind", "gh.number"] },
     );
     const cfg = await storageConfig(c.env, record);
 
@@ -199,12 +200,17 @@ export const workspaceFiles = new Hono<DualAuthVars>()
         lastUpdated: group.lastUpdated,
         recent: group.recent.map((key) => {
           const urls = objectPublicUrls(c.env, cfg, key);
-          const state = metaByKey.get(key)?.state;
+          const meta = metaByKey.get(key);
+          const state = meta?.state;
+          const ghKind = meta?.["gh.kind"];
+          const ghNumber = meta?.["gh.number"];
           return {
             key,
             url: urls.url,
             embedUrl: urls.embedUrl,
             ...(state !== undefined ? { state } : {}),
+            ...(ghKind !== undefined ? { ghKind } : {}),
+            ...(ghNumber !== undefined ? { ghNumber } : {}),
           };
         }),
       })),

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -35,11 +35,13 @@ import {
   filterCatalog,
   groupsFromCatalog,
   lastUpdatedLabel,
+  leafName,
   pairedShotKeys,
   projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
   shotKindFromKey,
+  shotPreviewCaption,
   shotPreviewPosition,
 } from "../lib/workspace-screenshots";
 
@@ -112,13 +114,6 @@ type DrillState =
   | { status: "error" }
   | { status: "ready"; items: SearchFileItem[]; truncated: boolean };
 
-/** Leaf name for an aria-label / alt text — "a/b/c.png" → "c.png". */
-function leafName(key: string): string {
-  const trimmed = key.replace(/\/$/, "");
-  const slash = trimmed.lastIndexOf("/");
-  return (slash === -1 ? trimmed : trimmed.slice(slash + 1)) || key;
-}
-
 /** Extension label for a generic (non-image, non-embeddable) tile. */
 function extLabel(key: string): string {
   const match = /\.([a-z0-9]{1,8})$/i.exec(key);
@@ -150,7 +145,15 @@ function ShotThumb({
   onPreviewEnter,
   onPreviewLeave,
 }: {
-  item: { key: string; url: string | null; embedUrl: string | null; state?: string };
+  item: {
+    key: string;
+    url: string | null;
+    embedUrl: string | null;
+    state?: string;
+    ghKind?: string;
+    ghNumber?: string;
+    metadata?: Record<string, string>;
+  };
   /** True when a before/after counterpart sits in the same strip/grid. */
   paired?: boolean;
   /** Optional pill (GitHub "PR #7 · author" context) — not the state. */
@@ -158,7 +161,7 @@ function ShotThumb({
   /** Known destination; when null the tile falls back to a button + `onOpen`. */
   href: string | null;
   onOpen: () => void;
-  onPreviewEnter?: (el: HTMLElement, src: string) => void;
+  onPreviewEnter?: (el: HTMLElement, src: string, caption: { name: string; pr?: string }) => void;
   onPreviewLeave?: () => void;
 }) {
   const name = leafName(item.key);
@@ -166,18 +169,17 @@ function ShotThumb({
   const [broken, setBroken] = useState(false);
   const showLock = kind === "image" && item.url === null;
   const showImage = kind === "image" && !!item.embedUrl && !broken;
-  // The state stays in the accessible name (and hover title) even though the
-  // tile no longer wears a BEFORE/AFTER pill — the pair badge covers the
-  // visual signal, and only when a counterpart actually exists.
+  // State stays in the accessible name, not a native `title` tooltip — that
+  // tooltip sat on top of the hover preview.
   const stateSuffix = item.state ? ` (${item.state})` : "";
+  const caption = shotPreviewCaption(item);
 
   const previewSrc = showImage ? item.embedUrl : null;
   const shared = {
     className: "wsp-tile",
-    "aria-label": `Open ${name}${stateSuffix}${paired ? " — has before/after pair" : ""}`,
-    title: item.state ? `${name}${stateSuffix}` : undefined,
+    "aria-label": `Open ${name}${stateSuffix}${caption.pr ? ` — ${caption.pr}` : ""}${paired ? " — has before/after pair" : ""}`,
     onMouseEnter: (event: { currentTarget: HTMLElement }) => {
-      if (previewSrc) onPreviewEnter?.(event.currentTarget, previewSrc);
+      if (previewSrc) onPreviewEnter?.(event.currentTarget, previewSrc, caption);
     },
     onMouseLeave: () => onPreviewLeave?.(),
   };
@@ -310,9 +312,11 @@ function FilterBar({
         ))}
       </Select>
       <Input
+        id="wsp-path-filter"
         type="search"
         className="wsp-filter__q"
         aria-label="Filter by path"
+        aria-keyshortcuts="Meta+K Control+K Slash"
         placeholder="Filter path  e.g. /catalog"
         value={path || q}
         spellCheck={false}
@@ -325,8 +329,10 @@ function FilterBar({
   );
 }
 
+type PreviewCaption = { name: string; pr?: string };
+
 type PreviewHandlers = {
-  onPreviewEnter: (el: HTMLElement, src: string) => void;
+  onPreviewEnter: (el: HTMLElement, src: string, caption: PreviewCaption) => void;
   onPreviewLeave: () => void;
 };
 
@@ -371,6 +377,8 @@ function ScreenshotsByPathInner({
     src: string;
     left: number;
     top: number;
+    name: string;
+    pr?: string;
   } | null>(null);
   const [drill, setDrill] = useState<DrillState>({ status: "idle" });
   const [drillRetryNonce, setDrillRetryNonce] = useState(0);
@@ -480,8 +488,33 @@ function ScreenshotsByPathInner({
       previewTimer.current = null;
       setPreview(null);
     };
+    const typingInField = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return false;
+      return Boolean(target.closest("input, textarea, select") || target.isContentEditable);
+    };
+    const focusPathFilter = () => {
+      const input = document.getElementById("wsp-path-filter");
+      if (!(input instanceof HTMLInputElement)) return;
+      input.focus();
+      input.select();
+    };
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") dismiss();
+      if (event.key === "Escape") {
+        dismiss();
+        return;
+      }
+      if (event.isComposing) return;
+      if ((event.key === "k" || event.key === "K") && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        focusPathFilter();
+        return;
+      }
+      if (event.key === "/" && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        if (typingInField(event)) return;
+        event.preventDefault();
+        focusPathFilter();
+      }
     };
     window.addEventListener("scroll", dismiss, true);
     window.addEventListener("keydown", onKey);
@@ -497,20 +530,20 @@ function ScreenshotsByPathInner({
     previewTimer.current = null;
     setPreview(null);
   };
-  const onPreviewEnter = (el: HTMLElement, src: string) => {
+  const onPreviewEnter = (el: HTMLElement, src: string, caption: PreviewCaption) => {
     if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
     if (previewTimer.current !== null) window.clearTimeout(previewTimer.current);
     const delay = window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : 250;
     previewTimer.current = window.setTimeout(() => {
       const rect = el.getBoundingClientRect();
       const width = Math.min(560, window.innerWidth - 24);
-      const height = Math.min(width * 0.7, window.innerHeight * 0.7);
+      const height = Math.min(width * 0.7, window.innerHeight * 0.7) + 40;
       const pos = shotPreviewPosition(
         { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom },
         { width: window.innerWidth, height: window.innerHeight },
         { width, height },
       );
-      setPreview({ src, left: pos.left, top: pos.top });
+      setPreview({ src, left: pos.left, top: pos.top, name: caption.name, pr: caption.pr });
     }, delay);
   };
   const previewHandlers: PreviewHandlers = { onPreviewEnter, onPreviewLeave };
@@ -593,6 +626,10 @@ function ScreenshotsByPathInner({
       role="presentation"
     >
       <img src={preview.src} alt="" />
+      <div className="wsp-preview__meta">
+        <div className="wsp-preview__name">{preview.name}</div>
+        {preview.pr && <div className="wsp-preview__pr">{preview.pr}</div>}
+      </div>
     </div>
   ) : null;
 

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -136,6 +136,12 @@ function ghLabel(item: SearchFileItem): string {
 
 // ── Thumb tile ─────────────────────────────────────────────────────────
 
+/** Strip thumbs size from the image's intrinsic ratio (cached + onLoad). */
+function applyShotThumbAspect(img: HTMLImageElement | null) {
+  if (!img?.naturalWidth || !img.naturalHeight) return;
+  img.parentElement?.style.setProperty("--wsp-ar", `${img.naturalWidth} / ${img.naturalHeight}`);
+}
+
 function ShotThumb({
   item,
   paired,
@@ -192,6 +198,8 @@ function ShotThumb({
             alt=""
             loading="lazy"
             decoding="async"
+            ref={applyShotThumbAspect}
+            onLoad={(event) => applyShotThumbAspect(event.currentTarget)}
             onError={() => setBroken(true)}
           />
         </span>

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -861,6 +861,9 @@ export interface PathGroupItem {
   embedUrl: string | null;
   /** Present only when the file carries `state` metadata (e.g. before/after). */
   state?: string;
+  /** Present only when the file is attached to a GitHub PR/issue. */
+  ghKind?: string;
+  ghNumber?: string;
 }
 
 /** One `path` metadata value with its recent uploads. */
@@ -905,7 +908,9 @@ function isPathGroupItem(value: unknown): value is PathGroupItem {
     typeof item.key === "string" &&
     (item.url === null || typeof item.url === "string") &&
     (item.embedUrl === null || typeof item.embedUrl === "string") &&
-    (item.state === undefined || typeof item.state === "string")
+    (item.state === undefined || typeof item.state === "string") &&
+    (item.ghKind === undefined || typeof item.ghKind === "string") &&
+    (item.ghNumber === undefined || typeof item.ghNumber === "string")
   );
 }
 

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -3,12 +3,14 @@ import {
   filterCatalog,
   groupsFromCatalog,
   lastUpdatedLabel,
+  leafName,
   pairedShotKeys,
   pathQueryMatches,
   projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
   shotKindFromKey,
+  shotPreviewCaption,
   shotPreviewPosition,
 } from "./workspace-screenshots";
 
@@ -207,6 +209,25 @@ describe("groupsFromCatalog", () => {
       groups[0],
       { project: "acme/web", path: "/older", count: 1, lastUpdated: "1", recent: [] },
     ]);
+  });
+});
+
+describe("shotPreviewCaption", () => {
+  it("uses the leaf filename and a compact PR/issue line", () => {
+    expect(leafName("shots/typical-modal-stage.webp")).toBe("typical-modal-stage.webp");
+    expect(
+      shotPreviewCaption({ key: "shots/typical-modal-stage.webp", ghKind: "pull", ghNumber: "42" }),
+    ).toEqual({ name: "typical-modal-stage.webp", pr: "PR #42" });
+    expect(
+      shotPreviewCaption({
+        key: "shots/a.png",
+        metadata: { "gh.kind": "issue", "gh.number": "7" },
+      }),
+    ).toEqual({ name: "a.png", pr: "Issue #7" });
+  });
+  it("omits the PR line when GitHub metadata is missing", () => {
+    expect(shotPreviewCaption({ key: "shots/plain.webp" })).toEqual({ name: "plain.webp" });
+    expect(shotPreviewCaption({ key: "shots/a.png", ghKind: "pull" })).toEqual({ name: "a.png" });
   });
 });
 

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -99,6 +99,34 @@ function swapPairToken(key: string): string | null {
   return dir + leaf.slice(0, start) + cased + leaf.slice(start + found.length);
 }
 
+/** Leaf name for captions / aria-labels — "a/b/c.png" → "c.png". */
+export function leafName(key: string): string {
+  const trimmed = key.replace(/\/$/, "");
+  const slash = trimmed.lastIndexOf("/");
+  return (slash === -1 ? trimmed : trimmed.slice(slash + 1)) || key;
+}
+
+/**
+ * Hover-preview caption: filename, plus a compact PR/issue line when the
+ * file carries GitHub attachment metadata. Mirrors the file page's
+ * filename + byline split without the native `title` tooltip.
+ */
+export function shotPreviewCaption(item: {
+  key: string;
+  ghKind?: string;
+  ghNumber?: string;
+  metadata?: Record<string, string>;
+}): { name: string; pr?: string } {
+  const kind = item.ghKind ?? item.metadata?.["gh.kind"];
+  const number = item.ghNumber ?? item.metadata?.["gh.number"];
+  let pr: string | undefined;
+  if (number) {
+    if (kind === "pull") pr = `PR #${number}`;
+    else if (kind === "issue" || kind === "issues") pr = `Issue #${number}`;
+  }
+  return pr ? { name: leafName(item.key), pr } : { name: leafName(item.key) };
+}
+
 export function pairedShotKeys(items: Array<{ key: string; state?: string }>): Set<string> {
   const paired = new Set<string>();
   const stated = items.filter((i) => i.state === "before" || i.state === "after");

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1987,15 +1987,25 @@ button.wft-card__name:focus-visible {
   font-weight: 600;
 }
 
-/* Horizontal strip of a group's recent thumbs (overview). */
+/* Horizontal strip of a group's recent thumbs (overview). Shared height,
+   width follows each shot's aspect ratio (set as --wsp-ar on load; 4/3
+   until then). Min/max width keep a tap target without letting one
+   ultra-wide capture eat the row — object-fit: cover only crops then. */
 .wsp-strip {
   display: flex;
+  align-items: flex-start;
   gap: 8px;
   overflow-x: auto;
   padding-bottom: 2px;
+  --wsp-strip-h: 126px;
 }
 .wsp-strip .wsp-tile {
+  box-sizing: border-box;
   flex: none;
+  width: max-content;
+  height: var(--wsp-strip-h);
+  min-width: 56px;
+  max-width: min(280px, 72vw);
 }
 
 /* Responsive grid of a full path's items (drill-in). */
@@ -2019,9 +2029,6 @@ button.wft-card__name:focus-visible {
   color: inherit;
   text-decoration: none;
 }
-.wsp-strip .wsp-tile {
-  width: 168px;
-}
 
 .wsp-thumb {
   display: block;
@@ -2033,11 +2040,22 @@ button.wft-card__name:focus-visible {
   background-size: cover;
   background-position: center;
 }
+.wsp-strip .wsp-thumb {
+  box-sizing: border-box;
+  height: var(--wsp-strip-h);
+  width: auto;
+  min-width: 56px;
+  max-width: min(280px, 72vw);
+  aspect-ratio: var(--wsp-ar, 4 / 3);
+}
 .wsp-thumb img {
   display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+.wsp-strip .wsp-thumb img {
+  object-position: top center;
 }
 .wsp-thumb--tile {
   display: grid;
@@ -2049,6 +2067,11 @@ button.wft-card__name:focus-visible {
 }
 .wsp-thumb--skel {
   background: var(--panel);
+}
+.wsp-strip .wsp-thumb--skel,
+.wsp-strip .wsp-thumb--tile {
+  width: calc(var(--wsp-strip-h) * 4 / 3);
+  aspect-ratio: 4 / 3;
 }
 
 .wsp-state {

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -2135,7 +2135,9 @@ button.wft-card__name:focus-visible {
   position: fixed;
   z-index: 40;
   pointer-events: none;
-  padding: 6px;
+  display: grid;
+  gap: 8px;
+  padding: 6px 6px 8px;
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 8px;
@@ -2149,6 +2151,23 @@ button.wft-card__name:focus-visible {
   height: auto;
   border-radius: 2px;
   outline: 1px solid oklch(1 0 0 / 0.1);
+}
+.wsp-preview__meta {
+  display: grid;
+  gap: 2px;
+  padding: 0 2px;
+  min-width: 0;
+}
+.wsp-preview__name {
+  color: var(--fg);
+  font: 600 12px var(--mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wsp-preview__pr {
+  color: var(--muted);
+  font: 11.5px var(--mono);
 }
 @media (prefers-reduced-motion: no-preference) {
   .wsp-preview {


### PR DESCRIPTION
## In plain terms

The hover preview was showing the image with the browser's native filename tooltip sitting on top of it. The popover now captions itself with the file name and the associated PR (or issue), the way the file page does, and `/` or Cmd+K jumps to the path filter.

Portrait screenshots were also cropped into 4:3 tiles in the group strip. Those thumbs now keep a shared height and let width follow each image, so a tall capture reads as tall in the row.

## What it does / what it is not

- Native `title` tooltip on thumbnails is gone, so it no longer overlaps the preview.
- Preview caption: leaf filename, then `PR #N` / `Issue #N` when the file has GitHub attachment metadata.
- `/` focuses the path filter (not when you're already typing in a field). Cmd+K / Ctrl+K does the same and selects the current query.
- Group-strip thumbs: fixed 126px height, width from the image aspect ratio (capped so one ultra-wide shot cannot eat the row).
- Not a link to GitHub from the popover, not the full file-page byline (title · repo#n).
- Drill-in grid tiles stay 4:3 cover.

## How to try it

Open a workspace screenshots page. Hover a shot attached to a PR — you should see the filename and `PR #…` under the image, with no overlapping tooltip. Press `/` or Cmd+K to jump to the path filter.

A portrait capture in a group strip should be a tall, narrow tile next to landscape ones, not a 4:3 crop of the middle.

## Technical notes

`files/by-path` now also returns `ghKind` / `ghNumber` on recent items (only when set). Drill-in already had full metadata.

Strip width comes from `--wsp-ar` set on image load (4:3 until then).

## Test plan

- [x] Caption helper: PR, issue, missing GitHub metadata
- [x] by-path route includes gh fields only when present
- [x] CSS fixture: portrait, landscape, square, ultrawide cap, min-width, grid still 4:3
- [x] Pre-commit types + lint-staged
- [ ] Signed-in hover pass on a workspace with real PR-attached shots
- [ ] Signed-in strip pass with mixed aspect-ratio captures