### PR TITLE
fix(web): send unsigned-in account visits to login

### DIFF
--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -76,13 +76,12 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
 // paint `#app` visible on first paint — making cold loads as snappy as the
 // warm SPA navigations the optimistic-cache script already reveals instantly.
 //
-// This only ever *reveals* for a confirmed session; every other outcome
-// (no cookie, invalid/expired, or auth unavailable) falls through to the
-// existing client gate, which still owns the signed-out state, the auth
-// "try again" retry, and the local-demo dev fallback in account-shell.ts —
-// none of which can be short-circuited server-side. The client always
-// revalidates in the background regardless, so a session revoked between this
-// render and hydration still flips to the signed-out shell.
+// This only ever *reveals* for a confirmed session. Unsigned-in visits are
+// redirected to /login?callbackURL=… in middleware (and the client gate, if
+// a session expires after paint). Auth-unavailable still falls through to
+// the "try again" UI; the loopback demo session is minted client-side. The
+// client always revalidates in the background, so a session revoked between
+// this render and hydration still leaves for login.
 const sessionCookie = Astro.request.headers.get("cookie") ?? "";
 let serverSessionUserJson: string | null = null;
 if (sessionCookie.trim()) {
@@ -112,11 +111,6 @@ const serverSignedIn = serverSessionUserJson !== null;
     <h1 class="sr-only">{pageHeading}</h1>
     <div id="checking" class="shell-status" hidden={serverSignedIn}>
       <div class="ul-callout status" role="status">Checking your session…</div>
-    </div>
-
-    <div id="signed-out" class="shell-status" hidden>
-      <div class="ul-callout status" data-state="error" role="alert">You're not signed in.</div>
-      <a class="button" href="/login">Sign in</a>
     </div>
 
     <div id="auth-unavailable" class="shell-status" hidden>
@@ -248,10 +242,10 @@ const serverSignedIn = serverSessionUserJson !== null;
       /* Issue #698: seed the session cache from the server-resolved session so
     the optimistic script below reveals `#app` and page scripts' onSession fire
     immediately on cold loads — the same cache the client would populate after
-    its first getSession. Emitted only when the server confirmed a session; the
-    signed-out path is left entirely to the client gate. Placed BEFORE the
-    optimistic script so it reads the freshly-seeded cache. data-astro-rerun:
-    re-seed after each ClientRouter body swap. */
+    its first getSession. Emitted only when the server confirmed a session;
+    unsigned-in visits already redirected (or the local-demo client gate).
+    Placed BEFORE the optimistic script so it reads the freshly-seeded cache.
+    data-astro-rerun: re-seed after each ClientRouter body swap. */
     }
     {
       serverSignedIn ? (
@@ -341,7 +335,6 @@ const serverSignedIn = serverSessionUserJson !== null;
         void resolveSessionGate({
           authOrigin: w.__UPLOADS_AUTH_ORIGIN__,
           checking: requireElement<HTMLElement>("#checking", "account"),
-          denied: requireElement<HTMLElement>("#signed-out", "account"),
           unavailable: requireElement<HTMLElement>("#auth-unavailable", "account"),
           app: requireElement<HTMLElement>("#app", "account"),
         });

--- a/apps/web/src/lib/account-shell.test.ts
+++ b/apps/web/src/lib/account-shell.test.ts
@@ -17,7 +17,7 @@ function element(): HTMLElement {
   return { hidden: false, textContent: "" } as HTMLElement;
 }
 
-type TestGate = SessionGateOptions & { who: HTMLElement };
+type TestGate = SessionGateOptions & { who: HTMLElement; denied: HTMLElement };
 
 function gate(): TestGate {
   return {
@@ -36,7 +36,12 @@ function installBrowser() {
     dispatchEvent: vi.fn(),
   };
   vi.stubGlobal("window", fakeWindow);
-  vi.stubGlobal("location", { origin: "http://127.0.0.1:4321" });
+  vi.stubGlobal("location", {
+    origin: "http://127.0.0.1:4321",
+    pathname: "/account",
+    search: "",
+    replace: vi.fn(),
+  });
   vi.stubGlobal("sessionStorage", {
     getItem: (key: string) => values.get(key) ?? null,
     removeItem: (key: string) => values.delete(key),
@@ -115,6 +120,32 @@ describe("resolveSessionGate", () => {
     // Optional #who email paint (legacy); avatar menu no longer needs it.
     expect(options.who.textContent).toBe(session.user.email);
     expect(window.dispatchEvent).toHaveBeenCalledOnce();
+  });
+
+  it("sends a signed-out visit to login with the current path as callbackURL", async () => {
+    const replace = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal("location", {
+      origin: "https://uploads.sh",
+      pathname: "/account/workspaces/acme/screenshots",
+      search: "?path=/settings",
+      replace,
+    });
+    vi.stubGlobal("sessionStorage", {
+      getItem: () => null,
+      removeItem: () => undefined,
+      setItem: () => undefined,
+    });
+    const options = gate();
+    auth.getSession.mockResolvedValue({ kind: "signed_out" });
+    auth.startLocalDemoSession.mockResolvedValue({ kind: "not_enabled" });
+
+    await expect(resolveSessionGate(options)).resolves.toBeNull();
+    expect(replace).toHaveBeenCalledWith(
+      "/login?callbackURL=%2Faccount%2Fworkspaces%2Facme%2Fscreenshots%3Fpath%3D%2Fsettings",
+    );
+    expect(options.denied.hidden).toBe(true);
+    expect(options.app.hidden).toBe(true);
   });
 
   it("shows the app without a who node when the header owns session UI", async () => {

--- a/apps/web/src/lib/account-shell.ts
+++ b/apps/web/src/lib/account-shell.ts
@@ -5,8 +5,10 @@
  * Session gate UX: after a successful check we cache the user in sessionStorage.
  * On the next navigation the layout applies that cache synchronously (inline
  * script + here) so the chrome does not flash "Checking your session…", then
- * revalidates in the background. Cache is a UX affordance only — every API
- * call still enforces the real session server-side.
+ * revalidates in the background. A signed-out result replaces the page with
+ * /login?callbackURL=… (the original path) instead of a dead-end. Cache is a
+ * UX affordance only — every API call still enforces the real session
+ * server-side.
  */
 import {
   getSession,
@@ -16,6 +18,7 @@ import {
   type SessionUser,
 } from "./auth-client";
 import { markPageLoad } from "./page-visit";
+import { loginHref } from "./signed-in-page";
 import { clearWorkspaceSnapshots } from "./workspace-cache";
 
 export { getPageVisit, isCurrentPageVisit } from "./page-visit";
@@ -80,7 +83,7 @@ function showApp(
   options: Pick<SessionGateOptions, "checking" | "denied" | "app" | "who">,
 ): void {
   options.checking.hidden = true;
-  options.denied.hidden = true;
+  if (options.denied) options.denied.hidden = true;
   options.app.hidden = false;
   if (options.who) options.who.textContent = user.email;
 }
@@ -88,14 +91,19 @@ function showApp(
 function showDenied(options: Pick<SessionGateOptions, "checking" | "denied" | "app">): void {
   options.checking.hidden = true;
   options.app.hidden = true;
-  options.denied.hidden = false;
+  if (options.denied) options.denied.hidden = false;
+}
+
+/** Replace this page with /login carrying the current path as callbackURL. */
+function redirectToSignIn(): void {
+  location.replace(loginHref(`${location.pathname}${location.search}`));
 }
 
 function showUnavailable(
   options: Pick<SessionGateOptions, "checking" | "denied" | "unavailable" | "app">,
 ): void {
   options.checking.hidden = true;
-  options.denied.hidden = true;
+  if (options.denied) options.denied.hidden = true;
   options.app.hidden = true;
   options.unavailable.hidden = false;
 }
@@ -140,7 +148,8 @@ export function onAstroPageLoad(callback: () => void): void {
 export type SessionGateOptions = {
   authOrigin: string;
   checking: HTMLElement;
-  denied: HTMLElement;
+  /** Role-mismatch UI (admin). Unsigned-in visits redirect to login instead. */
+  denied?: HTMLElement;
   unavailable: HTMLElement;
   app: HTMLElement;
   who?: HTMLElement | null;
@@ -180,10 +189,15 @@ export async function resolveSessionGate(
     showUnavailable(options);
     return null;
   }
-  if (
-    result.kind === "signed_out" ||
-    (options.requireRole && result.session.user.role !== options.requireRole)
-  ) {
+  if (result.kind === "signed_out") {
+    clearCachedSessionUser();
+    options.checking.hidden = true;
+    options.app.hidden = true;
+    if (options.denied) options.denied.hidden = true;
+    redirectToSignIn();
+    return null;
+  }
+  if (options.requireRole && result.session.user.role !== options.requireRole) {
     clearCachedSessionUser();
     showDenied(options);
     return null;

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -15,6 +15,7 @@ import {
   getOAuthWorkspaceChoice,
   repairOAuthQuery,
   setOAuthWorkspaceChoice,
+  isLocalDemoStack,
   startLocalDemoSession,
   submitOAuthConsent,
   unbanUser,
@@ -689,6 +690,16 @@ describe("setOAuthWorkspaceChoice", () => {
       }),
     );
     await expect(setOAuthWorkspaceChoice("https://auth.uploads.sh", "acme")).resolves.toBe(false);
+  });
+});
+
+describe("isLocalDemoStack", () => {
+  it("matches only the exact loopback pair", () => {
+    expect(isLocalDemoStack("http://127.0.0.1:8788", "http://127.0.0.1:4321")).toBe(true);
+    expect(isLocalDemoStack("http://127.0.0.1:8788/", "http://127.0.0.1:4321/")).toBe(true);
+    expect(isLocalDemoStack("http://localhost:8788", "http://127.0.0.1:4321")).toBe(false);
+    expect(isLocalDemoStack("http://127.0.0.1:8788", "http://localhost:4321")).toBe(false);
+    expect(isLocalDemoStack("https://auth.uploads.sh", "https://uploads.sh")).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -94,6 +94,14 @@ export type SessionResult =
 const LOCAL_STACK_AUTH_ORIGIN = "http://127.0.0.1:8788";
 const LOCAL_STACK_WEB_ORIGIN = "http://127.0.0.1:4321";
 
+/** True only on the exact loopback pair that may mint a local demo session. */
+export function isLocalDemoStack(authOriginValue: string, pageOrigin: string): boolean {
+  return (
+    authOrigin(authOriginValue) === LOCAL_STACK_AUTH_ORIGIN &&
+    pageOrigin.replace(/\/$/, "") === LOCAL_STACK_WEB_ORIGIN
+  );
+}
+
 type LocalDemoSessionStart =
   | { kind: "started" }
   | { kind: "not_enabled" }
@@ -143,7 +151,7 @@ export async function startLocalDemoSession(
   pageOrigin: string,
 ): Promise<LocalDemoSessionStart> {
   const normalizedOrigin = authOrigin(origin);
-  if (normalizedOrigin !== LOCAL_STACK_AUTH_ORIGIN || pageOrigin !== LOCAL_STACK_WEB_ORIGIN) {
+  if (!isLocalDemoStack(normalizedOrigin, pageOrigin)) {
     return { kind: "not_enabled" };
   }
 

--- a/apps/web/src/lib/client-router-boot.test.ts
+++ b/apps/web/src/lib/client-router-boot.test.ts
@@ -37,6 +37,17 @@ describe("ClientRouter boot scripts", () => {
     expect(src).toContain("JSON.stringify");
   });
 
+  it("unsigned-in account and admin shells redirect to login instead of a dead-end", () => {
+    const account = readSrc("layouts/AccountLayout.astro");
+    const admin = readSrc("layouts/AdminLayout.astro");
+    const middleware = readSrc("middleware.ts");
+    expect(account).not.toContain("You're not signed in.");
+    expect(admin).toContain("You need admin access to view this page.");
+    expect(middleware).toContain("signedInShellLoginRedirect");
+    expect(middleware).toContain("Cache-Control");
+    expect(middleware).toContain("Location");
+  });
+
   /** Layouts / chrome that soft-nav under ClientRouter. */
   const pageLoadBoot = [
     {

--- a/apps/web/src/lib/signed-in-page.test.ts
+++ b/apps/web/src/lib/signed-in-page.test.ts
@@ -7,11 +7,90 @@ import {
   authPageCsp,
   devicePageCsp,
   INVITE_CSP,
+  loginHref,
+  loginReturnPath,
   signedInCsp,
+  signedInShellLoginRedirect,
 } from "./signed-in-page";
 
 const AUTH = "https://auth.uploads.sh";
 const API = "https://api.uploads.sh";
+
+describe("signedInShellLoginRedirect", () => {
+  const search = "?path=/settings";
+  const pathname = "/account/workspaces/acme/screenshots";
+
+  it("redirects cookie-less account and admin visits", () => {
+    expect(
+      signedInShellLoginRedirect({
+        pathname,
+        search,
+        allowLocalDemo: false,
+        hasCookie: false,
+        sessionKind: null,
+      }),
+    ).toBe("/login?callbackURL=%2Faccount%2Fworkspaces%2Facme%2Fscreenshots%3Fpath%3D%2Fsettings");
+    expect(
+      signedInShellLoginRedirect({
+        pathname: "/admin/users",
+        allowLocalDemo: false,
+        hasCookie: false,
+        sessionKind: null,
+      }),
+    ).toBe("/login?callbackURL=%2Fadmin%2Fusers");
+  });
+
+  it("leaves public pages, local demo, live sessions, and auth outages alone", () => {
+    const base = {
+      pathname,
+      search,
+      allowLocalDemo: false,
+      hasCookie: false,
+      sessionKind: null,
+    } as const;
+    expect(signedInShellLoginRedirect({ ...base, pathname: "/login" })).toBeNull();
+    expect(signedInShellLoginRedirect({ ...base, pathname: "/docs" })).toBeNull();
+    expect(signedInShellLoginRedirect({ ...base, allowLocalDemo: true })).toBeNull();
+    expect(
+      signedInShellLoginRedirect({ ...base, hasCookie: true, sessionKind: "signed_in" }),
+    ).toBeNull();
+    expect(
+      signedInShellLoginRedirect({ ...base, hasCookie: true, sessionKind: "unavailable" }),
+    ).toBeNull();
+  });
+
+  it("redirects an expired cookie once session resolution says signed_out", () => {
+    expect(
+      signedInShellLoginRedirect({
+        pathname,
+        search,
+        allowLocalDemo: false,
+        hasCookie: true,
+        sessionKind: "signed_out",
+      }),
+    ).toBe("/login?callbackURL=%2Faccount%2Fworkspaces%2Facme%2Fscreenshots%3Fpath%3D%2Fsettings");
+  });
+});
+
+describe("loginHref / loginReturnPath", () => {
+  it("keeps a same-origin account path and query", () => {
+    expect(loginReturnPath("/account/workspaces/acme/screenshots?path=/settings")).toBe(
+      "/account/workspaces/acme/screenshots?path=/settings",
+    );
+    expect(loginHref("/account/workspaces/acme/screenshots?path=/settings")).toBe(
+      "/login?callbackURL=%2Faccount%2Fworkspaces%2Facme%2Fscreenshots%3Fpath%3D%2Fsettings",
+    );
+  });
+
+  it("drops /login itself and off-origin values", () => {
+    expect(loginReturnPath("/login")).toBeNull();
+    expect(loginReturnPath("/login?callbackURL=/account")).toBeNull();
+    expect(loginHref("/login")).toBe("/login");
+    expect(loginHref("https://evil.example/x")).toBe("/login");
+    expect(loginHref("//evil.example")).toBe("/login");
+    expect(loginHref(null)).toBe("/login");
+  });
+});
 
 describe("signed-in / auth CSP builders", () => {
   it("signedInCsp locks down and allows session + API + RUM", () => {

--- a/apps/web/src/lib/signed-in-page.ts
+++ b/apps/web/src/lib/signed-in-page.ts
@@ -9,11 +9,55 @@
  */
 import { resolveConsoleMode } from "./console-mode";
 import { CF_RUM_CONNECT_SRC, CF_RUM_SCRIPT_SRC, STYLE_SRC_SELF_AND_INLINE } from "./csp";
+import { safeSameOriginPath } from "./workspace-ui";
 
 type OriginEnv = {
   UPLOADS_AUTH_ORIGIN?: string;
   UPLOADS_API_ORIGIN?: string;
 };
+
+/**
+ * Same-origin path we'll send the user back to after login. Rejects `/login`
+ * itself so a bounce can't loop, and anything `safeSameOriginPath` already
+ * refuses (absolute URLs, protocol-relative, embedded schemes).
+ */
+export function loginReturnPath(raw: string | null | undefined): string | null {
+  const path = safeSameOriginPath(raw);
+  if (!path) return null;
+  const bare = path.split(/[?#]/, 1)[0] ?? path;
+  if (bare === "/login") return null;
+  return path;
+}
+
+/** `/login`, or `/login?callbackURL=` when `returnTo` is a safe in-app path. */
+export function loginHref(returnTo?: string | null): string {
+  const path = loginReturnPath(returnTo);
+  if (!path) return "/login";
+  return `/login?callbackURL=${encodeURIComponent(path)}`;
+}
+
+export function isSignedInShellPath(pathname: string): boolean {
+  return pathname.startsWith("/account") || pathname.startsWith("/admin");
+}
+
+/**
+ * Login path for an unsigned-in visitor to a signed-in shell, or null to
+ * render the page (local demo, live session, or auth unavailable).
+ */
+export function signedInShellLoginRedirect(opts: {
+  pathname: string;
+  search?: string;
+  allowLocalDemo: boolean;
+  hasCookie: boolean;
+  sessionKind: "signed_in" | "signed_out" | "unavailable" | null;
+}): string | null {
+  if (!isSignedInShellPath(opts.pathname) || opts.allowLocalDemo) return null;
+  if (opts.sessionKind === "signed_in" || opts.sessionKind === "unavailable") return null;
+  if (!opts.hasCookie || opts.sessionKind === "signed_out") {
+    return loginHref(`${opts.pathname}${opts.search ?? ""}`);
+  }
+  return null;
+}
 
 export function resolveSignedInOrigins(env: OriginEnv): {
   authOrigin: string;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,32 @@
+/**
+ * Unsigned-in visits to /account/* and /admin/* go to /login with the
+ * original path as callbackURL. Layouts cannot return Astro.redirect
+ * (HTML streaming already started); this runs before the page.
+ *
+ * Cookie-present but expired sessions are handled by the client gate so
+ * signed-in loads do not pay an extra getSession here (the layout already
+ * resolves the session for first paint).
+ */
+import { defineMiddleware } from "astro:middleware";
+import { env } from "cloudflare:workers";
+import { isLocalDemoStack } from "./lib/auth-client";
+import { resolveSignedInOrigins, signedInShellLoginRedirect } from "./lib/signed-in-page";
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const { pathname, search, origin } = context.url;
+  const { authOrigin } = resolveSignedInOrigins(env);
+  const target = signedInShellLoginRedirect({
+    pathname,
+    search,
+    allowLocalDemo: isLocalDemoStack(authOrigin, origin),
+    hasCookie: Boolean(context.request.headers.get("cookie")?.trim()),
+    sessionKind: null,
+  });
+  if (target) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: target, "Cache-Control": "no-store" },
+    });
+  }
+  return next();
+});

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -246,7 +246,10 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       if (rawCallback) {
         try {
           const url = new URL(rawCallback, location.origin);
-          if (url.origin === location.origin) callbackURL = url.href;
+          // Same-origin only, and never /login itself (avoids a bounce loop).
+          if (url.origin === location.origin && url.pathname !== "/login") {
+            callbackURL = url.href;
+          }
         } catch {
           // keep default
         }


### PR DESCRIPTION
## In plain terms

Opening an account or admin URL while signed out used to dump you on a dead-end “You’re not signed in” page. Those visits now go to the login form, and after GitHub or a magic link you land back on the page you asked for.

## What it does / what it is not

- Cookie-less `/account/*` and `/admin/*` requests 302 to `/login?callbackURL=<original path>`.
- Login already accepted same-origin `callbackURL`; it now also ignores `/login` itself so the bounce cannot loop.
- A session that expires after paint still replaces the page with login (client gate).
- Auth outages still show the existing “try again” UI instead of sending people to sign in.
- The loopback demo session is unchanged.
- Signed-in non-admins still see the admin access-denied panel.
- Device, invite, and OAuth consent keep their own sign-in UIs.

## How to try it

In a private window, open `https://uploads.sh/account/workspaces` or any workspace screenshots URL. You should get the Sign in form, not the error callout. After signing in you should return to that same path.

## Technical notes

Astro layouts cannot return `Astro.redirect` once HTML streaming has started, so the 302 lives in `src/middleware.ts`. `callbackURL` is a same-origin path only.

## Test plan

- [x] Helper: account/admin redirect, public pages skipped, local demo skipped, `/login` rejected as a return path
- [x] Client gate: signed-out → `location.replace` with callbackURL; role mismatch still denied
- [x] curl: unsigned-in `/account/…?path=` → 302 `Location: /login?callbackURL=…`
- [x] Browser: `/account/workspaces/acme/screenshots` and `/admin/users` land on Sign in with the matching callback
- [x] `/docs` still 200
- [ ] Signed-in round-trip: GitHub or magic link returns to the original path on production