### PR TITLE
feat(web): screenshots page upgrades — recent feed, GitHub icons, path autocomplete

### DIFF
--- a/apps/api/src/file-metadata-facets.test.ts
+++ b/apps/api/src/file-metadata-facets.test.ts
@@ -9,6 +9,7 @@ import {
   projectLabelFromMeta,
   BY_PATH_CATALOG_LIMIT,
   BY_PATH_GROUP_LIMIT,
+  BY_PATH_LATEST_LIMIT,
   BY_PATH_RECENT_LIMIT,
 } from "./file-metadata";
 
@@ -304,12 +305,33 @@ describe("groupObjectsByPath", () => {
     ]);
   });
 
+  it("returns a flat newest-first latest feed across groups, capped", async () => {
+    const rows = Array.from({ length: BY_PATH_LATEST_LIMIT + 2 }, (_, i) => ({
+      workspace: "acme",
+      key: `shot-${i}.png`,
+      meta: { path: i % 2 === 0 ? "/home" : "/settings", repo: "acme/web" },
+      at: at(i),
+    }));
+    const result = await groupObjectsByPath(timedDb(rows), "acme");
+    expect(result.latest).toHaveLength(BY_PATH_LATEST_LIMIT);
+    expect(result.latest[0]).toEqual({
+      key: `shot-${BY_PATH_LATEST_LIMIT + 1}.png`,
+      project: "acme/web",
+      path: BY_PATH_LATEST_LIMIT % 2 === 0 ? "/settings" : "/home",
+      uploadedAt: at(BY_PATH_LATEST_LIMIT + 1),
+    });
+    // The two oldest fell off the cap.
+    expect(result.latest.map((l) => l.key)).not.toContain("shot-0.png");
+    expect(result.latest.map((l) => l.key)).not.toContain("shot-1.png");
+  });
+
   it("returns empty groups for a workspace with no path metadata", async () => {
     const result = await groupObjectsByPath(timedDb([]), "acme");
     expect(result).toEqual({
       groups: [],
       catalog: [],
       projects: [],
+      latest: [],
       truncated: false,
       catalogTruncated: false,
     });

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -664,6 +664,8 @@ export const BY_PATH_RECENT_LIMIT = 6;
  * the thumbed-group cap so the filter bar can still name older paths.
  */
 export const BY_PATH_CATALOG_LIMIT = 500;
+/** Newest keys returned in the flat `latest` feed alongside the groups. */
+export const BY_PATH_LATEST_LIMIT = 30;
 
 export type PathGroup = {
   project: string;
@@ -675,6 +677,14 @@ export type PathGroup = {
 
 /** Unique (project, path) without thumbs — same fields as a group minus `recent`. */
 export type PathCatalogEntry = Omit<PathGroup, "recent">;
+
+/** One entry in the flat newest-first feed (the "Recent" view). */
+export type LatestPathObject = {
+  key: string;
+  project: string;
+  path: string;
+  uploadedAt: string;
+};
 
 export type ProjectSummary = { label: string; count: number; lastUpdated: string };
 
@@ -702,6 +712,7 @@ export async function groupObjectsByPath(
   groups: PathGroup[];
   catalog: PathCatalogEntry[];
   projects: ProjectSummary[];
+  latest: LatestPathObject[];
   truncated: boolean;
   catalogTruncated: boolean;
 }> {
@@ -731,6 +742,7 @@ export async function groupObjectsByPath(
   const byKey = new Map<string, PathGroup>();
   const catalog: PathCatalogEntry[] = [];
   const catalogByKey = new Map<string, PathCatalogEntry>();
+  const latest: LatestPathObject[] = [];
   let truncated = false;
   let catalogTruncated = false;
   for (const row of result.results) {
@@ -741,6 +753,11 @@ export async function groupObjectsByPath(
       app: row.app,
     });
     const groupKey = `${project}\0${row.path}`;
+
+    // Rows arrive newest-first, so the first N are the flat recent feed.
+    if (latest.length < BY_PATH_LATEST_LIMIT) {
+      latest.push({ key: row.object_key, project, path: row.path, uploadedAt: row.updated_at });
+    }
 
     let entry = catalogByKey.get(groupKey);
     if (!entry) {
@@ -785,7 +802,7 @@ export async function groupObjectsByPath(
   const projects = [...projectByLabel.values()].sort((a, b) =>
     b.lastUpdated.localeCompare(a.lastUpdated),
   );
-  return { groups, catalog, projects, truncated, catalogTruncated };
+  return { groups, catalog, projects, latest, truncated, catalogTruncated };
 }
 
 /**

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1872,6 +1872,41 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
     expect(body.projects.map((p) => p.label).sort()).toEqual(["acme/web", "x.dev"]);
   });
 
+  it("returns a flat latest feed with project, path, and upload time per shot", async () => {
+    const db = metadataDb([
+      {
+        workspace: "acme",
+        key: "shots/a.png",
+        meta: { path: "/settings", repo: "acme/web", "gh.kind": "pull", "gh.number": "42" },
+      },
+      { workspace: "acme", key: "shots/b.png", meta: { path: "/home", repo: "acme/web" } },
+    ]);
+    const env = memberEnv({ workspace: "acme", db, bucket: new FakeR2Bucket(), record: R2_RECORD });
+    const res = await app().request("/me/workspaces/acme/files/by-path", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      latest: {
+        key: string;
+        url: string | null;
+        project: string;
+        path: string;
+        uploadedAt: string;
+        ghKind?: string;
+        ghNumber?: string;
+      }[];
+    };
+    expect(body.latest).toHaveLength(2);
+    const a = body.latest.find((l) => l.key === "shots/a.png");
+    expect(a).toMatchObject({
+      url: "https://storage.uploads.sh/acme/shots/a.png",
+      project: "acme/web",
+      path: "/settings",
+      ghKind: "pull",
+      ghNumber: "42",
+    });
+    expect(typeof a?.uploadedAt).toBe("string");
+  });
+
   it("returns empty groups for a workspace with no path metadata", async () => {
     const env = memberEnv({
       workspace: "acme",
@@ -1885,6 +1920,7 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
       groups: [],
       catalog: [],
       projects: [],
+      latest: [],
       truncated: false,
       catalogTruncated: false,
     });

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -180,17 +180,30 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   .get("/:workspace/files/by-path", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
     const record = c.get("workspace");
     const name = c.get("workspaceName");
-    const { groups, catalog, projects, truncated, catalogTruncated } = await groupObjectsByPath(
-      c.env.DB,
-      name,
-    );
+    const { groups, catalog, projects, latest, truncated, catalogTruncated } =
+      await groupObjectsByPath(c.env.DB, name);
     const metaByKey = await getMetadataForKeys(
       c.env.DB,
       name,
-      groups.flatMap((group) => group.recent),
+      [...groups.flatMap((group) => group.recent), ...latest.map((item) => item.key)],
       { metaKeys: ["state", "gh.kind", "gh.number"] },
     );
     const cfg = await storageConfig(c.env, record);
+    const shotItem = (key: string) => {
+      const urls = objectPublicUrls(c.env, cfg, key);
+      const meta = metaByKey.get(key);
+      const state = meta?.state;
+      const ghKind = meta?.["gh.kind"];
+      const ghNumber = meta?.["gh.number"];
+      return {
+        key,
+        url: urls.url,
+        embedUrl: urls.embedUrl,
+        ...(state !== undefined ? { state } : {}),
+        ...(ghKind !== undefined ? { ghKind } : {}),
+        ...(ghNumber !== undefined ? { ghNumber } : {}),
+      };
+    };
 
     return c.json({
       groups: groups.map((group) => ({
@@ -198,24 +211,18 @@ export const workspaceFiles = new Hono<DualAuthVars>()
         path: group.path,
         count: group.count,
         lastUpdated: group.lastUpdated,
-        recent: group.recent.map((key) => {
-          const urls = objectPublicUrls(c.env, cfg, key);
-          const meta = metaByKey.get(key);
-          const state = meta?.state;
-          const ghKind = meta?.["gh.kind"];
-          const ghNumber = meta?.["gh.number"];
-          return {
-            key,
-            url: urls.url,
-            embedUrl: urls.embedUrl,
-            ...(state !== undefined ? { state } : {}),
-            ...(ghKind !== undefined ? { ghKind } : {}),
-            ...(ghNumber !== undefined ? { ghNumber } : {}),
-          };
-        }),
+        recent: group.recent.map(shotItem),
       })),
       catalog,
       projects,
+      // Flat newest-first feed (the "Recent" view) — same item shape as
+      // `recent`, plus which (project, path) each shot belongs to.
+      latest: latest.map((item) => ({
+        ...shotItem(item.key),
+        project: item.project,
+        path: item.path,
+        uploadedAt: item.uploadedAt,
+      })),
       truncated,
       catalogTruncated,
     });

--- a/apps/api/test/routes-workspace-files-core.test.ts
+++ b/apps/api/test/routes-workspace-files-core.test.ts
@@ -305,6 +305,7 @@ describe("canonical file catch-all route ordering", () => {
     expect(await res.json()).toEqual({
       groups: [],
       catalog: [],
+      latest: [],
       projects: [],
       truncated: false,
       catalogTruncated: false,

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -352,6 +352,7 @@ describe("GET /v1/workspaces/:workspace/files/by-path (dual auth)", () => {
     expect(await res.json()).toEqual({
       groups: [],
       catalog: [],
+      latest: [],
       projects: [],
       truncated: false,
       catalogTruncated: false,
@@ -370,6 +371,7 @@ describe("GET /v1/workspaces/:workspace/files/by-path (dual auth)", () => {
     expect(await res.json()).toEqual({
       groups: [],
       catalog: [],
+      latest: [],
       projects: [],
       truncated: false,
       catalogTruncated: false,

--- a/apps/web/src/components/ScreenshotsByPath.test.ts
+++ b/apps/web/src/components/ScreenshotsByPath.test.ts
@@ -44,7 +44,7 @@ import { readScreenshotsView } from "../lib/workspace-screenshots";
  */
 describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
   it("a default overview (empty search) seeds an empty project, path, and q", () => {
-    expect(readScreenshotsView("")).toEqual({ project: "", path: "", q: "" });
+    expect(readScreenshotsView("")).toEqual({ project: "", path: "", q: "", feed: "grouped" });
   });
 
   it("a deep-linked project view seeds that project, no path", () => {
@@ -52,6 +52,7 @@ describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
       project: "acme/web",
       path: "",
       q: "",
+      feed: "grouped",
     });
   });
 
@@ -60,6 +61,7 @@ describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
       project: "acme/web",
       path: "/admin",
       q: "",
+      feed: "grouped",
     });
   });
 
@@ -68,6 +70,7 @@ describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
       project: "",
       path: "",
       q: "/catalog",
+      feed: "grouped",
     });
   });
 });
@@ -82,6 +85,11 @@ describe("ScreenshotsByPath seed contract — no initialSearch prop (props-less 
 
   it("resolves to the same defaults today's props-less behavior always had", () => {
     expect(seedSearch).toBe("");
-    expect(readScreenshotsView(seedSearch)).toEqual({ project: "", path: "", q: "" });
+    expect(readScreenshotsView(seedSearch)).toEqual({
+      project: "",
+      path: "",
+      q: "",
+      feed: "grouped",
+    });
   });
 });

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -17,12 +17,20 @@
  */
 import { Callout, Input, Select } from "@uploads/ui";
 import "@uploads/ui/styles.css";
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from "react";
 import { IslandErrorBoundary } from "./IslandErrorBoundary";
 import {
   getWorkspaceFilesByPath,
   searchWorkspaceFiles,
   type FilesPathGroup,
+  type LatestShotItem,
   type PathCatalogEntry,
   type ProjectSummary,
   type SearchFileItem,
@@ -34,15 +42,20 @@ import { makeFileOpener, newTabLinkProps, type FileOpener } from "../lib/file-op
 import {
   filterCatalog,
   groupsFromCatalog,
+  isRepoLabel,
   lastUpdatedLabel,
   leafName,
   pairedShotKeys,
+  pathQueryMatches,
+  pathSuggestions,
   projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
   shotKindFromKey,
   shotPreviewCaption,
   shotPreviewPosition,
+  type ScreenshotsFeed,
+  type ScreenshotsView,
 } from "../lib/workspace-screenshots";
 
 /** How many path groups a project section previews before "view project →". */
@@ -104,6 +117,7 @@ export type OverviewState =
       groups: FilesPathGroup[];
       catalog: PathCatalogEntry[];
       projects: ProjectSummary[];
+      latest: LatestShotItem[];
       truncated: boolean;
       catalogTruncated: boolean;
     };
@@ -118,6 +132,57 @@ type DrillState =
 function extLabel(key: string): string {
   const match = /\.([a-z0-9]{1,8})$/i.exec(key);
   return match ? match[1].toLowerCase() : "file";
+}
+
+// ── Small GitHub glyphs (Octicons, 16-grid paths at 12px) ──────────────
+
+function GitHubMark({ size = 12 }: { size?: number }) {
+  return (
+    <svg
+      className="wsp-ghicon"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" />
+    </svg>
+  );
+}
+
+/** Pull-request or issue-opened Octicon for a `gh.kind` value; null otherwise. */
+function GhKindIcon({ kind, size = 10 }: { kind: string | undefined; size?: number }) {
+  if (kind === "pull") {
+    return (
+      <svg
+        className="wsp-ghicon"
+        width={size}
+        height={size}
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z" />
+      </svg>
+    );
+  }
+  if (kind === "issue" || kind === "issues") {
+    return (
+      <svg
+        className="wsp-ghicon"
+        width={size}
+        height={size}
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" />
+        <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z" />
+      </svg>
+    );
+  }
+  return null;
 }
 
 /** "PR #7" / "Issue #3", plus the author when present. */
@@ -163,11 +228,11 @@ function ShotThumb({
   /** True when a before/after counterpart sits in the same strip/grid. */
   paired?: boolean;
   /** Optional pill (GitHub "PR #7 · author" context) — not the state. */
-  contextLabel?: string;
+  contextLabel?: ReactNode;
   /** Known destination; when null the tile falls back to a button + `onOpen`. */
   href: string | null;
   onOpen: () => void;
-  onPreviewEnter?: (el: HTMLElement, src: string, caption: { name: string; pr?: string }) => void;
+  onPreviewEnter?: (el: HTMLElement, src: string, caption: PreviewCaption) => void;
   onPreviewLeave?: () => void;
 }) {
   const name = leafName(item.key);
@@ -178,7 +243,9 @@ function ShotThumb({
   // State stays in the accessible name, not a native `title` tooltip — that
   // tooltip sat on top of the hover preview.
   const stateSuffix = item.state ? ` (${item.state})` : "";
-  const caption = shotPreviewCaption(item);
+  const ghKindValue = item.ghKind ?? item.metadata?.["gh.kind"];
+  const base = shotPreviewCaption(item);
+  const caption: PreviewCaption = base.pr ? { ...base, kind: ghKindValue } : base;
 
   const previewSrc = showImage ? item.embedUrl : null;
   const shared = {
@@ -291,19 +358,66 @@ function FilterBar({
   project,
   q,
   path,
+  feed,
   projects,
+  catalog,
   onProject,
   onQuery,
+  onFeed,
+  onPickPath,
 }: {
   project: string;
   q: string;
   /** Exact drill-in path, shown in the input so editing it widens the filter. */
   path: string;
+  feed: ScreenshotsFeed;
   projects: string[];
+  /** Path catalog backing the input's autocomplete suggestions. */
+  catalog: PathCatalogEntry[];
   onProject: (project: string) => void;
   onQuery: (q: string) => void;
+  onFeed: (feed: ScreenshotsFeed) => void;
+  onPickPath: (path: string) => void;
 }) {
   const options = project && !projects.includes(project) ? [...projects, project] : projects;
+  const [suggestOpen, setSuggestOpen] = useState(false);
+  const [active, setActive] = useState(-1);
+  const value = path || q;
+  // Exact drill-in state means the value already IS a suggestion — nothing
+  // useful to offer until the user edits it back into a query.
+  const suggestions = path ? [] : pathSuggestions(catalog, { project, q });
+  const open = suggestOpen && suggestions.length > 0;
+
+  const pick = (picked: string) => {
+    setSuggestOpen(false);
+    setActive(-1);
+    onPickPath(picked);
+  };
+
+  const onKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (!open) {
+      if (event.key === "ArrowDown" && suggestions.length > 0) {
+        event.preventDefault();
+        setSuggestOpen(true);
+        setActive(0);
+      }
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActive((i) => (i + 1) % suggestions.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActive((i) => (i <= 0 ? suggestions.length - 1 : i - 1));
+    } else if (event.key === "Enter" && active >= 0 && suggestions[active]) {
+      event.preventDefault();
+      pick(suggestions[active].path);
+    } else if (event.key === "Escape") {
+      setSuggestOpen(false);
+      setActive(-1);
+    }
+  };
+
   return (
     <div className="wsp-filter">
       <Select
@@ -319,25 +433,84 @@ function FilterBar({
           </option>
         ))}
       </Select>
-      <Input
-        id="wsp-path-filter"
-        type="search"
-        className="wsp-filter__q"
-        aria-label="Filter by path"
-        aria-keyshortcuts="Meta+K Control+K Slash"
-        placeholder="Filter path  e.g. /catalog"
-        value={path || q}
-        spellCheck={false}
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        onChange={(event) => onQuery(event.target.value)}
-      />
+      <div className="wsp-filter__qwrap">
+        <Input
+          id="wsp-path-filter"
+          type="search"
+          className="wsp-filter__q"
+          aria-label="Filter by path"
+          aria-keyshortcuts="Meta+K Control+K Slash"
+          aria-expanded={open}
+          aria-controls="wsp-path-suggest"
+          aria-activedescendant={active >= 0 ? `wsp-path-suggest-${active}` : undefined}
+          role="combobox"
+          placeholder="Filter path  e.g. /catalog"
+          value={value}
+          spellCheck={false}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          onChange={(event) => {
+            setSuggestOpen(true);
+            setActive(-1);
+            onQuery(event.target.value);
+          }}
+          onFocus={() => setSuggestOpen(true)}
+          onBlur={() => {
+            // Delay so a mousedown on an option can land first.
+            window.setTimeout(() => setSuggestOpen(false), 120);
+          }}
+          onKeyDown={onKeyDown}
+        />
+        {open && (
+          <ul className="wsp-suggest" id="wsp-path-suggest" role="listbox" aria-label="Paths">
+            {suggestions.map((entry, index) => (
+              <li key={entry.path} role="presentation">
+                <button
+                  type="button"
+                  role="option"
+                  id={`wsp-path-suggest-${index}`}
+                  aria-selected={index === active}
+                  className={index === active ? "wsp-suggest__opt is-active" : "wsp-suggest__opt"}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    pick(entry.path);
+                  }}
+                  onMouseEnter={() => setActive(index)}
+                >
+                  <span className="wsp-suggest__path">{entry.path}</span>
+                  <span className="wsp-suggest__count">
+                    {entry.count} {entry.count === 1 ? "file" : "files"}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="wsp-toggle" role="group" aria-label="Layout">
+        <button
+          type="button"
+          className="wsp-toggle__opt"
+          aria-pressed={feed === "grouped"}
+          onClick={() => onFeed("grouped")}
+        >
+          Grouped
+        </button>
+        <button
+          type="button"
+          className="wsp-toggle__opt"
+          aria-pressed={feed === "recent"}
+          onClick={() => onFeed("recent")}
+        >
+          Recent
+        </button>
+      </div>
     </div>
   );
 }
 
-type PreviewCaption = { name: string; pr?: string };
+type PreviewCaption = { name: string; pr?: string; kind?: string };
 
 type PreviewHandlers = {
   onPreviewEnter: (el: HTMLElement, src: string, caption: PreviewCaption) => void;
@@ -377,9 +550,7 @@ function ScreenshotsByPathInner({
   // `resolveFilesView`), so there's no stored-preference divergence to guard
   // against here: the server and the client's first render already agree as
   // long as both read the same `seedSearch`, which is exactly what this does.
-  const [view, setView] = useState<{ project: string; path: string; q: string }>(() =>
-    readScreenshotsView(seedSearch),
-  );
+  const [view, setView] = useState<ScreenshotsView>(() => readScreenshotsView(seedSearch));
   const previewTimer = useRef<number | null>(null);
   const [preview, setPreview] = useState<{
     src: string;
@@ -387,6 +558,7 @@ function ScreenshotsByPathInner({
     top: number;
     name: string;
     pr?: string;
+    kind?: string;
   } | null>(null);
   const [drill, setDrill] = useState<DrillState>({ status: "idle" });
   const [drillRetryNonce, setDrillRetryNonce] = useState(0);
@@ -422,6 +594,7 @@ function ScreenshotsByPathInner({
                 groups: result.groups,
                 catalog: result.catalog,
                 projects: result.projects,
+                latest: result.latest,
                 truncated: result.truncated,
                 catalogTruncated: result.catalogTruncated,
               }
@@ -465,7 +638,7 @@ function ScreenshotsByPathInner({
     history.replaceState(
       null,
       "",
-      window.location.pathname + screenshotsSearch(view.project, view.path, view.q),
+      window.location.pathname + screenshotsSearch(view.project, view.path, view.q, view.feed),
     );
     if (!view.path) {
       setDrill({ status: "idle" });
@@ -488,7 +661,7 @@ function ScreenshotsByPathInner({
     return () => {
       cancelled = true;
     };
-  }, [apiOrigin, workspace, view.project, view.path, drillRetryNonce]);
+  }, [apiOrigin, workspace, view.project, view.path, view.q, view.feed, drillRetryNonce]);
 
   useEffect(() => {
     const dismiss = () => {
@@ -551,7 +724,14 @@ function ScreenshotsByPathInner({
         { width: window.innerWidth, height: window.innerHeight },
         { width, height },
       );
-      setPreview({ src, left: pos.left, top: pos.top, name: caption.name, pr: caption.pr });
+      setPreview({
+        src,
+        left: pos.left,
+        top: pos.top,
+        name: caption.name,
+        pr: caption.pr,
+        kind: caption.kind,
+      });
     }, delay);
   };
   const previewHandlers: PreviewHandlers = { onPreviewEnter, onPreviewLeave };
@@ -598,9 +778,10 @@ function ScreenshotsByPathInner({
 
   const opener = makeFileOpener(apiOrigin, workspace, info.hasPublicUrl);
   const onDrill = (group: { project: string; path: string }) =>
-    setView({ project: group.project, path: group.path, q: view.q });
-  const setProject = (project: string) => setView({ project, path: "", q: view.q });
-  const setQuery = (q: string) => setView({ project: view.project, path: "", q });
+    setView({ ...view, project: group.project, path: group.path });
+  const setProject = (project: string) => setView({ ...view, project, path: "" });
+  const setQuery = (q: string) => setView({ ...view, path: "", q });
+  const setFeed = (feed: ScreenshotsFeed) => setView({ ...view, path: "", feed });
 
   // GitHub items bucketed by project label, for both the overview's
   // per-project strips and the project view's full "From GitHub" section.
@@ -622,9 +803,13 @@ function ScreenshotsByPathInner({
       project={view.project}
       q={view.q}
       path={view.path}
+      feed={view.feed}
       projects={projectLabels}
+      catalog={overview.catalog}
       onProject={setProject}
       onQuery={setQuery}
+      onFeed={setFeed}
+      onPickPath={(path) => setView({ ...view, path })}
     />
   ) : null;
   const previewLayer = preview ? (
@@ -636,7 +821,11 @@ function ScreenshotsByPathInner({
       <img src={preview.src} alt="" />
       <div className="wsp-preview__meta">
         <div className="wsp-preview__name">{preview.name}</div>
-        {preview.pr && <div className="wsp-preview__pr">{preview.pr}</div>}
+        {preview.pr && (
+          <div className="wsp-preview__pr">
+            <GhKindIcon kind={preview.kind} /> {preview.pr}
+          </div>
+        )}
       </div>
     </div>
   ) : null;
@@ -665,11 +854,7 @@ function ScreenshotsByPathInner({
     return (
       <div className="wsp">
         {filterBar}
-        <button
-          type="button"
-          className="text-btn"
-          onClick={() => setView({ project: view.project, path: "", q: view.q })}
-        >
+        <button type="button" className="text-btn" onClick={() => setView({ ...view, path: "" })}>
           {view.project ? `← ${view.project}` : "← all projects"}
         </button>
         <h2 className="wsp-drill__heading">{view.path}</h2>
@@ -719,6 +904,60 @@ function ScreenshotsByPathInner({
                   : "Showing the first 100 — narrow the path to see more."}
               </p>
             )}
+          </>
+        )}
+        {previewLayer}
+      </div>
+    );
+  }
+
+  // Flat newest-first feed (?view=recent) — same filters, no grouping.
+  if (view.feed === "recent") {
+    const qTrimmed = view.q.trim();
+    const latestItems = overview.latest.filter((item) => {
+      if (view.project && item.project !== view.project) return false;
+      return pathQueryMatches(item.path, qTrimmed);
+    });
+    const latestPaired = pairedShotKeys(latestItems);
+    return (
+      <div className="wsp">
+        {filterBar}
+        {latestItems.length === 0 ? (
+          overview.latest.length === 0 && overview.catalog.length === 0 ? (
+            <EmptyShotsCta title="No screenshots yet" />
+          ) : (
+            <p className="wft-end">
+              {overview.latest.length === 0
+                ? "No recent uploads to show."
+                : "No recent uploads match this filter."}
+            </p>
+          )
+        ) : (
+          <>
+            <div className="wsp-grid">
+              {latestItems.map((item) => (
+                <ShotThumb
+                  key={item.key}
+                  item={item}
+                  paired={latestPaired.has(item.key)}
+                  contextLabel={
+                    item.ghNumber ? (
+                      <>
+                        <GhKindIcon kind={item.ghKind} />{" "}
+                        {item.ghKind === "pull" ? `PR #${item.ghNumber}` : `#${item.ghNumber}`}
+                      </>
+                    ) : undefined
+                  }
+                  href={opener.href(item)}
+                  onOpen={() => opener.activate(item)}
+                  {...previewHandlers}
+                />
+              ))}
+            </div>
+            <p className="wft-end">
+              Showing the {latestItems.length === 1 ? "newest upload" : "newest uploads"} — switch
+              to Grouped to browse by page.
+            </p>
           </>
         )}
         {previewLayer}
@@ -780,7 +1019,7 @@ function ScreenshotsByPathInner({
                 groups={previewGroups}
                 ghItems={ghItems}
                 showViewProject={!view.project}
-                onViewProject={() => setView({ project: label, path: "", q: view.q })}
+                onViewProject={() => setView({ ...view, project: label, path: "" })}
                 onDrill={onDrill}
                 opener={opener}
                 preview={previewHandlers}
@@ -847,7 +1086,10 @@ function ProjectSection({
   return (
     <div className="wsp-project">
       <div className="wsp-project__head">
-        <span className="wsp-project__label">{label}</span>
+        <span className="wsp-project__label">
+          {isRepoLabel(label) && <GitHubMark />}
+          {label}
+        </span>
         <span className="wsp-group__meta">
           {count} {count === 1 ? "file" : "files"}
           {lastUpdated ? ` · ${lastUpdatedLabel(lastUpdated, new Date())}` : ""}
@@ -894,7 +1136,11 @@ function GitHubSection({
           <ShotThumb
             key={item.key}
             item={item}
-            contextLabel={ghLabel(item)}
+            contextLabel={
+              <>
+                <GhKindIcon kind={item.metadata["gh.kind"]} /> {ghLabel(item)}
+              </>
+            }
             href={opener.href(item)}
             onOpen={() => opener.activate(item)}
             {...preview}

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -535,12 +535,45 @@ describe("getWorkspaceFilesByPath", () => {
       groups: [GROUP],
       catalog: [CATALOG],
       projects: [PROJECT],
+      latest: [],
       truncated: false,
       catalogTruncated: false,
     });
     expect(fetchMock.mock.calls[0]![0]).toBe(
       "https://api.uploads.sh/v1/workspaces/acme/files/by-path",
     );
+  });
+
+  it("passes a well-formed latest feed through, and drops a malformed one", async () => {
+    const LATEST = {
+      key: "shots/a.png",
+      url: "https://s.example/a.png",
+      embedUrl: "https://s.example/a.png",
+      project: "acme/web",
+      path: "/settings",
+      uploadedAt: "2026-08-09T21:14:03.000Z",
+    };
+    const respond = (latest: unknown) =>
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          Response.json({
+            groups: [GROUP],
+            catalog: [CATALOG],
+            projects: [PROJECT],
+            latest,
+            truncated: false,
+            catalogTruncated: false,
+          }),
+        ),
+      );
+    respond([LATEST]);
+    let result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
+    expect(result.kind === "ok" && result.latest).toEqual([LATEST]);
+    // Malformed latest degrades to an empty feed instead of failing the page.
+    respond([{ key: "x.png" }]);
+    result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
+    expect(result.kind === "ok" && result.latest).toEqual([]);
   });
 
   it("synthesizes a catalog from groups when an older API omits it", async () => {
@@ -554,6 +587,7 @@ describe("getWorkspaceFilesByPath", () => {
       groups: [GROUP],
       catalog: [CATALOG],
       projects: [PROJECT],
+      latest: [],
       truncated: true,
       catalogTruncated: true,
     });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -883,6 +883,13 @@ export interface PathCatalogEntry {
   lastUpdated: string;
 }
 
+/** One shot in the flat newest-first feed (the "Recent" view). */
+export interface LatestShotItem extends PathGroupItem {
+  project: string;
+  path: string;
+  uploadedAt: string;
+}
+
 /** One project bucket summary alongside the by-path groups. */
 export interface ProjectSummary {
   label: string;
@@ -896,6 +903,7 @@ export type FilesByPathResult =
       groups: FilesPathGroup[];
       catalog: PathCatalogEntry[];
       projects: ProjectSummary[];
+      latest: LatestShotItem[];
       truncated: boolean;
       catalogTruncated: boolean;
     }
@@ -948,6 +956,16 @@ function isPathCatalogEntry(value: unknown): value is PathCatalogEntry {
   );
 }
 
+function isLatestShotItem(value: unknown): value is LatestShotItem {
+  if (!isPathGroupItem(value)) return false;
+  const item = value as unknown as Record<string, unknown>;
+  return (
+    typeof item.project === "string" &&
+    typeof item.path === "string" &&
+    typeof item.uploadedAt === "string"
+  );
+}
+
 /** Derive a catalog from thumbed groups when an older API omitted it. */
 function catalogFromGroups(groups: FilesPathGroup[]): PathCatalogEntry[] {
   return groups.map(({ project, path, count, lastUpdated }) => ({
@@ -973,6 +991,7 @@ export async function getWorkspaceFilesByPath(
     groups?: unknown;
     catalog?: unknown;
     projects?: unknown;
+    latest?: unknown;
     truncated?: unknown;
     catalogTruncated?: unknown;
   } | null;
@@ -989,12 +1008,17 @@ export async function getWorkspaceFilesByPath(
   // Catalog is additive: an older API (web/API deploy separately) omitted it.
   // Fall back to the thumbed groups so the filter bar still has something
   // to search, and treat `truncated` as the catalog cap in that case.
+  // `latest` is additive too (older API deploys omit it) — the toggle just
+  // has an empty Recent view until the API catches up.
+  const latest =
+    Array.isArray(body.latest) && body.latest.every(isLatestShotItem) ? body.latest : [];
   if (body.catalog === undefined) {
     return {
       kind: "ok",
       groups: body.groups,
       catalog: catalogFromGroups(body.groups),
       projects: body.projects,
+      latest,
       truncated: body.truncated,
       catalogTruncated: body.truncated,
     };
@@ -1007,6 +1031,7 @@ export async function getWorkspaceFilesByPath(
     groups: body.groups,
     catalog: body.catalog,
     projects: body.projects,
+    latest,
     truncated: body.truncated,
     catalogTruncated: typeof body.catalogTruncated === "boolean" ? body.catalogTruncated : false,
   };

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   filterCatalog,
   groupsFromCatalog,
+  isRepoLabel,
   lastUpdatedLabel,
   leafName,
   pairedShotKeys,
   pathQueryMatches,
+  pathSuggestions,
   projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
@@ -135,6 +137,7 @@ describe("screenshots view URL state", () => {
       project: "acme/web",
       path: "/admin",
       q: "/cat",
+      feed: "grouped",
     });
     expect(screenshotsSearch("acme/web", "/admin", "/cat")).toBe(
       "?project=acme%2Fweb&path=%2Fadmin&q=%2Fcat",
@@ -143,13 +146,67 @@ describe("screenshots view URL state", () => {
     expect(screenshotsSearch("", "")).toBe("");
     expect(screenshotsSearch("", "", "/catalog")).toBe("?q=%2Fcatalog");
   });
+  it("round-trips the recent-feed toggle, defaulting to grouped", () => {
+    expect(readScreenshotsView("?view=recent").feed).toBe("recent");
+    expect(readScreenshotsView("?view=nonsense").feed).toBe("grouped");
+    expect(readScreenshotsView("").feed).toBe("grouped");
+    expect(screenshotsSearch("", "", "", "recent")).toBe("?view=recent");
+    expect(screenshotsSearch("acme/web", "", "", "recent")).toBe("?project=acme%2Fweb&view=recent");
+    expect(screenshotsSearch("", "", "", "grouped")).toBe("");
+  });
   it("keeps legacy bare ?path= links working", () => {
     expect(readScreenshotsView("?path=%2Fadmin")).toEqual({
       project: "",
       path: "/admin",
       q: "",
+      feed: "grouped",
     });
     expect(screenshotsSearch("", "/admin")).toBe("?path=%2Fadmin");
+  });
+});
+
+describe("isRepoLabel", () => {
+  it("flags owner/name labels and nothing else", () => {
+    expect(isRepoLabel("acme/web")).toBe(true);
+    expect(isRepoLabel("app.example.com")).toBe(false);
+    expect(isRepoLabel("local dev")).toBe(false);
+    expect(isRepoLabel("Other")).toBe(false);
+  });
+});
+
+describe("pathSuggestions", () => {
+  const catalog = [
+    { project: "acme/web", path: "/admin", count: 3 },
+    { project: "acme/api", path: "/admin", count: 2 },
+    { project: "acme/web", path: "/catalog/families", count: 5 },
+  ];
+  it("dedupes the same path across projects, summing counts", () => {
+    expect(pathSuggestions(catalog, { project: "", q: "" })).toEqual([
+      { path: "/admin", count: 5 },
+      { path: "/catalog/families", count: 5 },
+    ]);
+  });
+  it("respects the project scope and path query", () => {
+    expect(pathSuggestions(catalog, { project: "acme/web", q: "/admin" })).toEqual([
+      { path: "/admin", count: 3 },
+    ]);
+    expect(pathSuggestions(catalog, { project: "", q: "cat" })).toEqual([
+      { path: "/catalog/families", count: 5 },
+    ]);
+  });
+
+  it("matches a half-typed segment by substring, unlike pathQueryMatches", () => {
+    expect(pathSuggestions(catalog, { project: "", q: "/ca" })).toEqual([
+      { path: "/catalog/families", count: 5 },
+    ]);
+  });
+  it("caps the list", () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({
+      project: "acme/web",
+      path: `/page-${i}`,
+      count: 1,
+    }));
+    expect(pathSuggestions(many, { project: "", q: "" })).toHaveLength(8);
   });
 });
 

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -152,24 +152,75 @@ export function pairedShotKeys(items: Array<{ key: string; state?: string }>): S
   return paired;
 }
 
-/** `?project=` / `?path=` / `?q=` view state, "" when absent. */
-export function readScreenshotsView(search: string): { project: string; path: string; q: string } {
+/** Overview layout: grouped by project/path, or one flat newest-first feed. */
+export type ScreenshotsFeed = "grouped" | "recent";
+
+export interface ScreenshotsView {
+  project: string;
+  path: string;
+  q: string;
+  feed: ScreenshotsFeed;
+}
+
+/** `?project=` / `?path=` / `?q=` / `?view=` state, ""/grouped when absent. */
+export function readScreenshotsView(search: string): ScreenshotsView {
   const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
   return {
     project: params.get("project") ?? "",
     path: params.get("path") ?? "",
     q: params.get("q") ?? "",
+    feed: params.get("view") === "recent" ? "recent" : "grouped",
   };
 }
 
-/** Search string for a view ("" for all three clears back to the overview). */
-export function screenshotsSearch(project: string, path: string, q = ""): string {
+/** Search string for a view (all defaults clears back to the overview). */
+export function screenshotsSearch(
+  project: string,
+  path: string,
+  q = "",
+  feed: ScreenshotsFeed = "grouped",
+): string {
   const params = new URLSearchParams();
   if (project) params.set("project", project);
   if (path) params.set("path", path);
   if (q) params.set("q", q);
+  if (feed === "recent") params.set("view", "recent");
   const qs = params.toString();
   return qs ? `?${qs}` : "";
+}
+
+/**
+ * True when a project label names a GitHub repo. Labels come from
+ * projectLabelFromMeta's coalesce, where only the repo branches
+ * (`repo`/`gh.repo`, always "owner/name") ever contain a slash — URL hosts,
+ * app names, "local dev", and "Other" never do.
+ */
+export function isRepoLabel(label: string): boolean {
+  return label.includes("/");
+}
+
+/**
+ * Autocomplete suggestions for the path filter: catalog paths matching the
+ * current project + query, deduped across projects (counts summed), in the
+ * catalog's own recency order. Matching is a plain substring — looser than
+ * `pathQueryMatches`'s segment-prefix rule on purpose, so a half-typed
+ * segment ("/ca") still surfaces "/catalog/families" to complete into.
+ */
+export function pathSuggestions(
+  catalog: Array<{ project: string; path: string; count: number }>,
+  opts: { project: string; q: string },
+  limit = 8,
+): Array<{ path: string; count: number }> {
+  const needle = opts.q.trim().toLowerCase();
+  const byPath = new Map<string, { path: string; count: number }>();
+  for (const entry of catalog) {
+    if (opts.project && entry.project !== opts.project) continue;
+    if (needle && !entry.path.toLowerCase().includes(needle)) continue;
+    const existing = byPath.get(entry.path);
+    if (existing) existing.count += entry.count;
+    else byPath.set(entry.path, { path: entry.path, count: entry.count });
+  }
+  return [...byPath.values()].slice(0, limit);
 }
 
 /**

--- a/apps/web/src/pages/account/workspaces/[name]/files.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/files.astro
@@ -44,7 +44,7 @@ const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
 
 const tip = {
-  body: "attach uploads to a pull request with <code>uploads put ./shot.png --pr 123</code> — they collect into one managed comment.",
+  body: "Attach uploads to a pull request with <code>uploads put ./shot.png --pr 123</code> — they collect into one managed comment.",
 };
 
 const { apiOrigin } = resolveSignedInOrigins(env);

--- a/apps/web/src/pages/account/workspaces/[name]/galleries.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/galleries.astro
@@ -31,7 +31,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 const ssrView = resolveGalleriesView(Astro.url.search, null);
 
 const tip = {
-  body: "link a gallery to a PR and the public link stays current as you add shots.",
+  body: "Link a gallery to a PR and the public link stays current as you add shots.",
   href: "/docs/galleries",
   linkLabel: "Working with galleries",
 };

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -19,7 +19,7 @@ const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
 
 const tip = {
-  body: "invites are workspace-scoped — teammates see every file, not just their own.",
+  body: "Invites are workspace-scoped — teammates see every file, not just their own.",
 };
 
 // SSR-first: render the member rows read-only on the server so first paint has

--- a/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
@@ -41,9 +41,9 @@ const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
 
 const tip = {
-  body: "groups come from metadata: <code>path</code> for pages, <code>repo</code>, <code>app</code>, or the URL host for projects.",
+  body: "Groups come from metadata: <code>path</code> for pages; <code>repo</code>, <code>app</code>, or the URL host for projects.",
   href: "/docs/attach-pull-request-images#put",
-  linkLabel: "how grouping works",
+  linkLabel: "How grouping works",
 };
 
 const { apiOrigin } = resolveSignedInOrigins(env);
@@ -68,6 +68,7 @@ if (cookie.trim()) {
       groups: overview.groups,
       catalog: overview.catalog,
       projects: overview.projects,
+      latest: overview.latest,
       truncated: overview.truncated,
       catalogTruncated: overview.catalogTruncated,
     };

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -2127,14 +2127,111 @@ button.wft-card__name:focus-visible {
   font-size: 16px;
   box-sizing: border-box;
 }
-.wsp-filter .wsp-filter__q {
+.wsp-filter .wsp-filter__qwrap {
+  position: relative;
+  display: flex;
   flex: 1 1 16rem;
+  min-width: 0;
+}
+.wsp-filter .wsp-filter__q {
+  flex: 1 1 auto;
   min-width: 0;
   min-height: 36px;
   padding: 6px 12px;
   font-size: 16px;
   border-radius: 6px;
   box-sizing: border-box;
+}
+
+/* Path autocomplete under the filter input — same panel treatment as the
+   files tab's facet typeahead. */
+.wsp-suggest {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.25);
+  max-height: 280px;
+  overflow-y: auto;
+}
+.wsp-suggest__opt {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  width: 100%;
+  padding: 6px 8px;
+  background: none;
+  border: 0;
+  border-radius: 4px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.wsp-suggest__opt.is-active {
+  background: var(--bg);
+}
+.wsp-suggest__path {
+  font-size: 12.5px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.wsp-suggest__count {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 11.5px;
+  white-space: nowrap;
+}
+
+/* Grouped / Recent segmented toggle at the filter row's end. */
+.wsp-toggle {
+  display: flex;
+  align-items: stretch;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+.wsp-toggle__opt {
+  min-height: 34px;
+  padding: 0 12px;
+  background: none;
+  border: 0;
+  color: var(--muted);
+  font: inherit;
+  font-size: 12.5px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.wsp-toggle__opt + .wsp-toggle__opt {
+  border-left: 1px solid var(--line);
+}
+.wsp-toggle__opt[aria-pressed="true"] {
+  background: var(--panel);
+  color: var(--fg);
+}
+.wsp-toggle__opt:hover,
+.wsp-toggle__opt:focus-visible {
+  color: var(--fg);
+}
+
+/* Inline GitHub glyphs beside repo labels and PR/issue text. */
+.wsp-ghicon {
+  display: inline-block;
+  vertical-align: -1px;
+  margin-right: 5px;
+  flex: none;
+}
+.wsp-state .wsp-ghicon,
+.wsp-preview__pr .wsp-ghicon {
+  margin-right: 2px;
 }
 .wsp-filter__skel {
   display: flex;


### PR DESCRIPTION
## What

Five upgrades to the workspace screenshots page:

- **Grouped ⇄ Recent toggle** — a segmented control in the filter row switches between the existing by-path grouping and a flat newest-first feed of the latest uploads (`?view=recent`, URL-synced). The by-path API now returns an additive `latest` field (30 newest path-tagged shots with `project`, `path`, `uploadedAt`), enriched with the same url/state/gh metadata as group thumbs. Older clients ignore it; older APIs degrade to an empty Recent view.
- **GitHub mark next to repo project labels** — a label containing `/` can only come from the `repo`/`gh.repo` branches of the project-label coalesce, so those headers get the Octocat glyph.
- **PR/issue icons** — pull-request and issue-opened Octicons on GitHub context pills and in the hover preview's PR line.
- **Path filter autocomplete** — a keyboard-navigable (arrows/Enter/Escape) dropdown of catalog paths with counts under the filter input. Matching is substring-loose on purpose so a half-typed segment (`/ca`) still surfaces `/catalog/families`; picking a suggestion drills into that path. No new backend — it rides the existing `catalog` payload.
- **Rail tip copy** — sentence case instead of the stylized all-lowercase, on screenshots plus the galleries/files/people tips for consistency.

## Testing

- `apps/web` vitest: 736 passed; `apps/api` vitest: 2001 passed
- `astro check` + worker tsc clean
- Verified in the local stack-raw browser session: grouped view icons, Recent toggle + deep link, autocomplete pick → drill-in, PR/issue pills, sentence-case tip


## Screenshots

| Grouped | Recent feed |
| --- | --- |
| <img width="460" alt="Grouped view with GitHub marks on repo labels and the new toggle" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/725/grouped.webp"> | <img width="460" alt="Recent feed with PR and issue pills" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/725/recent-feed.webp"> |

<img width="700" alt="Path filter autocomplete suggesting /catalog/families for a half-typed /ca" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/725/path-autocomplete.webp">
