### PR TITLE
fix(web): crisp thumbnails via Cloudflare transforms + backfill capped screenshot groups

### DIFF
--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -37,6 +37,7 @@ import {
 } from "../lib/api-client";
 import { loadWorkspaces } from "../lib/workspaces-nav";
 import { resolveWorkspaceInfo, type WorkspaceInfoStatus } from "../lib/workspace-file-row";
+import { thumbUrl } from "../lib/thumb-url";
 import { onSession } from "../lib/account-shell";
 import { makeFileOpener, newTabLinkProps, type FileOpener } from "../lib/file-opener";
 import {
@@ -247,7 +248,7 @@ function ShotThumb({
   const base = shotPreviewCaption(item);
   const caption: PreviewCaption = base.pr ? { ...base, kind: ghKindValue } : base;
 
-  const previewSrc = showImage ? item.embedUrl : null;
+  const previewSrc = showImage ? thumbUrl(item.embedUrl!, 1120) : null;
   const shared = {
     className: "wsp-tile",
     "aria-label": `Open ${name}${stateSuffix}${caption.pr ? ` — ${caption.pr}` : ""}${paired ? " — has before/after pair" : ""}`,
@@ -261,7 +262,7 @@ function ShotThumb({
       {showImage ? (
         <span className="wsp-thumb" aria-hidden="true">
           <img
-            src={item.embedUrl!}
+            src={thumbUrl(item.embedUrl!, 560)}
             alt=""
             loading="lazy"
             decoding="async"

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -32,6 +32,7 @@ import {
   type FilesPathGroup,
   type LatestShotItem,
   type PathCatalogEntry,
+  type PathGroupItem,
   type ProjectSummary,
   type SearchFileItem,
 } from "../lib/api-client";
@@ -41,6 +42,7 @@ import { thumbUrl } from "../lib/thumb-url";
 import { onSession } from "../lib/account-shell";
 import { makeFileOpener, newTabLinkProps, type FileOpener } from "../lib/file-opener";
 import {
+  backfillTargets,
   filterCatalog,
   groupsFromCatalog,
   isRepoLabel,
@@ -55,6 +57,7 @@ import {
   shotKindFromKey,
   shotPreviewCaption,
   shotPreviewPosition,
+  shotsFromSearchItems,
   type ScreenshotsFeed,
   type ScreenshotsView,
 } from "../lib/workspace-screenshots";
@@ -564,6 +567,11 @@ function ScreenshotsByPathInner({
   const [drill, setDrill] = useState<DrillState>({ status: "idle" });
   const [drillRetryNonce, setDrillRetryNonce] = useState(0);
   const [ghState, setGhState] = useState<DrillState>({ status: "loading" });
+  // Thumb strips fetched for groups past the overview's thumbed cap, keyed
+  // `project\0path`. In-flight keys live in the ref so a re-render mid-fetch
+  // doesn't fire a duplicate search.
+  const [backfill, setBackfill] = useState<Record<string, PathGroupItem[]>>({});
+  const backfillStarted = useRef(new Set<string>());
 
   // Workspace-level facts (hasPublicUrl), gated behind session resolution —
   // same pattern as WorkspaceFileTable.
@@ -663,6 +671,52 @@ function ScreenshotsByPathInner({
       cancelled = true;
     };
   }, [apiOrigin, workspace, view.project, view.path, view.q, view.feed, drillRetryNonce]);
+
+  // Thumb backfill for groups past the overview's 50-group thumbed cap:
+  // filtering (especially by project) surfaces catalog paths whose group got
+  // no `recent` strip, which used to render as bare headings. Fetch those
+  // strips lazily through the same search route the drill-in uses, capped
+  // per pass and cached per (project, path) for the life of the mount. A
+  // failed search caches an empty strip — the heading-only fallback — rather
+  // than retrying on every keystroke.
+  useEffect(() => {
+    if (overview.status !== "ready" || view.feed !== "grouped" || view.path) return;
+    const matching = groupsFromCatalog(
+      filterCatalog(overview.catalog, { project: view.project, q: view.q }),
+      overview.groups,
+    );
+    const targets = backfillTargets(matching, backfillStarted.current);
+    if (targets.length === 0) return;
+    const projectsByPath = new Map<string, string[]>();
+    for (const target of targets) {
+      backfillStarted.current.add(`${target.project}\0${target.path}`);
+      const projects = projectsByPath.get(target.path);
+      if (projects) projects.push(target.project);
+      else projectsByPath.set(target.path, [target.project]);
+    }
+    onSession(() => {
+      for (const [path, projects] of projectsByPath) {
+        void searchWorkspaceFiles(apiOrigin, workspace, [{ key: "path", value: path }]).then(
+          (result) => {
+            // No cancellation guard: the cache is keyed by (project, path)
+            // independent of the current view, so a late response is never
+            // stale — dropping it would strand its group (started, no strip).
+            const items = result.kind === "ok" ? result.items : [];
+            setBackfill((prev) => {
+              const next = { ...prev };
+              for (const project of projects) {
+                next[`${project}\0${path}`] = shotsFromSearchItems(items, project);
+              }
+              return next;
+            });
+          },
+        );
+      }
+    });
+    // `backfill` in the deps chains passes: each resolved batch re-runs the
+    // effect for the next ≤12 targets until none remain (the started set
+    // keeps every pass strictly new, so the chain terminates).
+  }, [apiOrigin, workspace, overview, backfill, view.project, view.q, view.feed, view.path]);
 
   useEffect(() => {
     const dismiss = () => {
@@ -970,7 +1024,11 @@ function ScreenshotsByPathInner({
     project: view.project,
     q: view.q,
   });
-  const matchingGroups = groupsFromCatalog(matchingCatalog, overview.groups);
+  const matchingGroups = groupsFromCatalog(matchingCatalog, overview.groups).map((group) =>
+    group.recent.length > 0
+      ? group
+      : { ...group, recent: backfill[`${group.project}\0${group.path}`] ?? [] },
+  );
   const qTrim = view.q.trim();
   const filtering = qTrim !== "" || view.project !== "";
   // Path query hides GitHub strips that aren't path-grouped; project-only

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -56,6 +56,7 @@ import {
   resolveWorkspaceInfo,
   type WorkspaceInfoStatus,
 } from "../lib/workspace-file-row";
+import { thumbUrl } from "../lib/thumb-url";
 import {
   normalizeBrowsePath,
   readBrowseLocation,
@@ -234,7 +235,7 @@ function FileThumb({ thumb }: { thumb: ReturnType<typeof pickThumbnail> }) {
       <span className="wft-thumb" aria-hidden="true">
         <img
           className="wft-thumb__img"
-          src={thumb.src}
+          src={thumbUrl(thumb.src, 64)}
           alt=""
           loading="lazy"
           decoding="async"
@@ -1487,7 +1488,7 @@ function WorkspaceFileTableInner({
                   {thumb.kind === "image" ? (
                     <span
                       className="wft-card__img"
-                      style={{ backgroundImage: `url(${thumb.src})` }}
+                      style={{ backgroundImage: `url(${thumbUrl(thumb.src, 560)})` }}
                       aria-hidden="true"
                     />
                   ) : (

--- a/apps/web/src/lib/thumb-url.test.ts
+++ b/apps/web/src/lib/thumb-url.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { thumbUrl } from "./thumb-url";
+
+describe("thumbUrl", () => {
+  it("rewrites embed.uploads.sh URLs to a same-origin cdn-cgi transform", () => {
+    expect(thumbUrl("https://embed.uploads.sh/default/shots/home.png", 560)).toBe(
+      "https://embed.uploads.sh/cdn-cgi/image/width=560,quality=82,fit=scale-down,format=auto,onerror=redirect/default/shots/home.png",
+    );
+  });
+
+  it("rewrites storage.uploads.sh and store.uploads.sh hosts too", () => {
+    expect(thumbUrl("https://storage.uploads.sh/ws/a.webp", 64)).toBe(
+      "https://storage.uploads.sh/cdn-cgi/image/width=64,quality=82,fit=scale-down,format=auto,onerror=redirect/ws/a.webp",
+    );
+    expect(thumbUrl("https://store.uploads.sh/ws/a.webp", 64)).toBe(
+      "https://store.uploads.sh/cdn-cgi/image/width=64,quality=82,fit=scale-down,format=auto,onerror=redirect/ws/a.webp",
+    );
+  });
+
+  it("preserves query strings (capability URLs keep their params)", () => {
+    expect(thumbUrl("https://embed.uploads.sh/gh/private/abc/x.png?sig=123", 560)).toBe(
+      "https://embed.uploads.sh/cdn-cgi/image/width=560,quality=82,fit=scale-down,format=auto,onerror=redirect/gh/private/abc/x.png?sig=123",
+    );
+  });
+
+  it("passes through hosts outside the uploads.sh transform zone", () => {
+    const byo = "https://cdn.example.com/ws/a.png";
+    expect(thumbUrl(byo, 560)).toBe(byo);
+  });
+
+  it("passes through SVGs untouched", () => {
+    const svg = "https://embed.uploads.sh/ws/logo.svg";
+    expect(thumbUrl(svg, 560)).toBe(svg);
+  });
+
+  it("does not double-wrap an already transformed URL", () => {
+    const wrapped =
+      "https://embed.uploads.sh/cdn-cgi/image/width=64,quality=82,fit=scale-down,format=auto,onerror=redirect/ws/a.png";
+    expect(thumbUrl(wrapped, 560)).toBe(wrapped);
+  });
+
+  it("passes through null and unparseable input", () => {
+    expect(thumbUrl(null, 560)).toBeNull();
+    expect(thumbUrl("not a url", 560)).toBe("not a url");
+  });
+});

--- a/apps/web/src/lib/thumb-url.ts
+++ b/apps/web/src/lib/thumb-url.ts
@@ -1,0 +1,33 @@
+/**
+ * Cloudflare Image Transformations wrapper for thumbnail-sized renders.
+ *
+ * Thumbnails used to inline the full-size original and let the browser
+ * downscale it, which made text look jagged. For files served from hosts on
+ * the uploads.sh zone (where Transformations is enabled) we rewrite to the
+ * same-origin `/cdn-cgi/image/...` path form instead; any other host — BYO
+ * buckets, custom embed bases — passes through untouched, as do SVGs
+ * (already resolution-independent) and URLs that are already transforms.
+ *
+ * `fit=scale-down` never upscales small originals; `onerror=redirect` falls
+ * back to the original bytes if the transform fails. Callers pass a width of
+ * roughly 2× the CSS size so tiles stay crisp on retina displays.
+ */
+
+const TRANSFORMABLE_HOSTS = new Set(["embed.uploads.sh", "storage.uploads.sh", "store.uploads.sh"]);
+
+export function thumbUrl(src: string, width: number): string;
+export function thumbUrl(src: string | null, width: number): string | null;
+export function thumbUrl(src: string | null, width: number): string | null {
+  if (src === null) return null;
+  let url: URL;
+  try {
+    url = new URL(src);
+  } catch {
+    return src;
+  }
+  if (!TRANSFORMABLE_HOSTS.has(url.hostname.toLowerCase())) return src;
+  if (url.pathname.startsWith("/cdn-cgi/")) return src;
+  if (url.pathname.toLowerCase().endsWith(".svg")) return src;
+  const options = `width=${width},quality=82,fit=scale-down,format=auto,onerror=redirect`;
+  return `${url.origin}/cdn-cgi/image/${options}${url.pathname}${url.search}`;
+}

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  backfillTargets,
   filterCatalog,
   groupsFromCatalog,
   isRepoLabel,
@@ -14,6 +15,7 @@ import {
   shotKindFromKey,
   shotPreviewCaption,
   shotPreviewPosition,
+  shotsFromSearchItems,
 } from "./workspace-screenshots";
 
 describe("pairedShotKeys", () => {
@@ -309,5 +311,76 @@ describe("shotPreviewPosition", () => {
     );
     expect(pos.top).toBe(492); // 800 - 8 - 300
     expect(pos.left).toBe(200);
+  });
+});
+
+describe("shotsFromSearchItems", () => {
+  const item = (key: string, metadata: Record<string, string>) => ({
+    key,
+    url: `https://s/${key}`,
+    embedUrl: `https://e/${key}`,
+    metadata,
+  });
+  it("keeps only items whose metadata resolves to the group's project", () => {
+    const items = [
+      item("shots/a.png", { repo: "acme/api", path: "/billing" }),
+      item("shots/b.png", { repo: "acme/web", path: "/billing" }),
+      item("shots/c.png", { path: "/billing" }),
+    ];
+    expect(shotsFromSearchItems(items, "acme/api")).toEqual([
+      { key: "shots/a.png", url: "https://s/shots/a.png", embedUrl: "https://e/shots/a.png" },
+    ]);
+    expect(shotsFromSearchItems(items, "Other").map((shot) => shot.key)).toEqual(["shots/c.png"]);
+  });
+  it("carries state and gh metadata into the shot shape", () => {
+    const shots = shotsFromSearchItems(
+      [
+        item("shots/a.png", {
+          repo: "acme/api",
+          state: "after",
+          "gh.kind": "pull",
+          "gh.number": "12",
+        }),
+      ],
+      "acme/api",
+    );
+    expect(shots).toEqual([
+      {
+        key: "shots/a.png",
+        url: "https://s/shots/a.png",
+        embedUrl: "https://e/shots/a.png",
+        state: "after",
+        ghKind: "pull",
+        ghNumber: "12",
+      },
+    ]);
+  });
+  it("caps the result at the strip limit", () => {
+    const items = Array.from({ length: 9 }, (_, i) => item(`shots/${i}.png`, { repo: "a/b" }));
+    expect(shotsFromSearchItems(items, "a/b")).toHaveLength(6);
+    expect(shotsFromSearchItems(items, "a/b", 2)).toHaveLength(2);
+  });
+});
+
+describe("backfillTargets", () => {
+  const group = (project: string, path: string, recent: number) => ({
+    project,
+    path,
+    count: 1,
+    lastUpdated: "2026-08-01T00:00:00Z",
+    recent: Array.from({ length: recent }, (_, i) => ({
+      key: `${path}/${i}`,
+      url: null,
+      embedUrl: null,
+    })),
+  });
+  it("targets only thumbless groups that are not already cached", () => {
+    const groups = [group("a/b", "/x", 2), group("a/b", "/y", 0), group("a/b", "/z", 0)];
+    expect(backfillTargets(groups, new Set(["a/b\0/z"]))).toEqual([{ project: "a/b", path: "/y" }]);
+  });
+  it("caps how many groups are backfilled per pass", () => {
+    const groups = Array.from({ length: 20 }, (_, i) => group("a/b", `/p${i}`, 0));
+    expect(backfillTargets(groups, new Set())).toHaveLength(12);
+    expect(backfillTargets(groups, new Set(), 3)).toHaveLength(3);
   });
 });

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -272,6 +272,70 @@ export function groupsFromCatalog<TRecent>(
   });
 }
 
+type BackfillShot = {
+  key: string;
+  url: string | null;
+  embedUrl: string | null;
+  state?: string;
+  ghKind?: string;
+  ghNumber?: string;
+};
+
+/**
+ * Thumb strip for a group past the overview's thumbed cap, built from the
+ * drill-in search route's items: keep the group's own project (labels via
+ * projectLabelFromItemMeta, same as the drill-in view) and reshape to the
+ * by-path `recent` item, capped at the server's strip length.
+ */
+export function shotsFromSearchItems(
+  items: Array<{
+    key: string;
+    url: string | null;
+    embedUrl: string | null;
+    metadata?: Record<string, string>;
+  }>,
+  project: string,
+  limit = 6,
+): BackfillShot[] {
+  const shots: BackfillShot[] = [];
+  for (const item of items) {
+    if (projectLabelFromItemMeta(item.metadata) !== project) continue;
+    const state = item.metadata?.state;
+    const ghKind = item.metadata?.["gh.kind"];
+    const ghNumber = item.metadata?.["gh.number"];
+    shots.push({
+      key: item.key,
+      url: item.url,
+      embedUrl: item.embedUrl,
+      ...(state !== undefined ? { state } : {}),
+      ...(ghKind !== undefined ? { ghKind } : {}),
+      ...(ghNumber !== undefined ? { ghNumber } : {}),
+    });
+    if (shots.length === limit) break;
+  }
+  return shots;
+}
+
+/**
+ * Which rendered groups still need a thumb backfill: no `recent` strip and
+ * not already fetched (`cached` keys are `project\0path`). Capped per pass so
+ * a broad filter never fans out into dozens of search requests at once.
+ */
+export function backfillTargets(
+  groups: Array<{ project: string; path: string; recent: unknown[] }>,
+  cached: Set<string>,
+  limit = 12,
+): Array<{ project: string; path: string }> {
+  const targets: Array<{ project: string; path: string }> = [];
+  for (const group of groups) {
+    if (group.recent.length > 0) continue;
+    if (cached.has(`${group.project}\0${group.path}`)) continue;
+    targets.push({ project: group.project, path: group.path });
+    if (targets.length === limit) break;
+  }
+  return targets;
+}
+
 /** Viewport box used to place the thumbnail hover preview. */
 export type ShotPreviewBox = { left: number; top: number; right: number; bottom: number };
 


### PR DESCRIPTION
## Summary

Two thumbnail fixes on the signed-in pages:

**1. Thumbnails now go through Cloudflare Image Transformations** (`1899a97`)

Thumbnail tiles inlined the full-size original and let the browser downscale it — jagged text on small tiles, and multi-MB full-page captures fetched for 26px thumbs. New `thumbUrl(src, width)` helper rewrites uploads.sh-zone embed URLs (`embed.` / `storage.` / `store.uploads.sh`) to the same-origin `/cdn-cgi/image/width=…,quality=82,fit=scale-down,format=auto,onerror=redirect/…` path form. Applied at 2× CSS size for retina:

- File table: list thumb (64), grid card (560)
- Screenshots page: tiles (560), hover preview (1120)

Pass-through for BYO-bucket hosts, SVGs, and already-transformed URLs; `onerror=redirect` falls back to the original bytes on transform failure; `fit=scale-down` never upscales. Transformations is already enabled on the zone (verified against prod: 63KB original → ~1.7KB tile). Full-size viewers (`/f/` MediaStage, galleries) untouched. No CSP change — the transform URL is same-origin on the image host.

**2. Screenshots page: backfill thumb strips past the by-path group cap** (`985dae0`)

The by-path overview thumbs only the 50 most-recent (project, path) groups globally, while the filterable catalog carries up to 500 paths. Filtering by project surfaced catalog paths whose group fell past that cap, rendering bare headings with no tiles. Those strips are now fetched lazily through the same `files/search?meta.path=…` route the drill-in uses, filtered to the group's project via the `projectLabelFromItemMeta` mirror, batched 12 per pass (chained until done) and cached per (project, path). No API change.

## Verification

- 9 new unit tests (`thumb-url.test.ts`, `workspace-screenshots.test.ts`); full web suite 748 passing, `astro check` + worker typecheck clean.
- Prod curl: transform endpoint 200s on both embed and storage hosts with correctly resized output.
- Local stack repro: seeded a workspace where one project had 56 catalog paths and 0 thumbed groups — before the fix, 56 bare headings; after, 56/56 groups show strips, all searches 200, no console errors.


## Visual

Same prod screenshot rendered at tile width — left is the old full-size original browser-downscaled, right goes through the transform (63.6 KB → 8.5 KB transferred):

<img width="820" alt="Thumbnail quality and payload before/after Cloudflare image transform" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/726/thumb-compare.webp">
