### PR TITLE
docs: trim README and refresh the stale roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ and creates or updates that same one comment. Both commands run under `npx
 
 Sign in with GitHub or a magic link, then create your own workspace or accept
 an invite into one — see [enrollment](docs/enrollment.md). Hosted files are
-public, including media attached to private repositories. Do not upload secrets
-or sensitive UI.
+public URLs — private-repo attachments get non-guessable links
+([how that works](docs/private-attachments.md)), but anyone holding a URL can
+view the file. Do not upload secrets or sensitive UI.
 
 **Teach your agent the loop.** `uploads install` wires in the agent skills and
 the MCP server, so future sessions capture at each visual milestone on their
@@ -163,50 +164,29 @@ REST routes are in [docs/api.md](docs/api.md).
 
 ## What's in this repo
 
-| Path                           | What                                                                                |
-| ------------------------------ | ----------------------------------------------------------------------------------- |
-| `apps/api/`                    | Hono worker — REST API, deploys to `api.uploads.sh`                                 |
-| `apps/auth/`                   | Better Auth worker — sessions, enrollment, device flow                              |
-| `apps/mcp/`                    | Remote MCP server                                                                   |
-| `apps/web/`                    | Astro site — uploads.sh, account and admin UI                                       |
-| `packages/storage/`            | `@uploads/storage` — files-sdk adapter factory                                      |
-| `packages/uploads/`            | `@buildinternet/uploads` — CLI + client, publishes to npm                           |
-| `packages/ui/`                 | `@uploads/ui` — shared design system                                                |
-| `packages/billing/`            | `@uploads/billing` — plans and limit resolution                                     |
-| `packages/email/`              | `@uploads/email` — transactional email templates                                    |
-| `packages/errors/`             | `@uploads/errors` — shared error codes and wire format                              |
-| `skills/github-screenshots/`   | Workflow skill — visuals into PRs/issues/share links                                |
-| `skills/annotate-screenshots/` | Callouts and redaction — `uploads annotate` / `screenshot --annotate`               |
-| `skills/uploads-cli/`          | Agent skill for driving the CLI                                                     |
-| `hooks/`                       | Shared pre-PR screenshot hook (`uploads hook pre-pr-screenshot`) for Claude + Codex |
-| `plugins/claude/`              | Claude Code plugin config (skills path, MCP, commands)                              |
-| `.claude-plugin/`              | Claude marketplace catalog + plugin manifest                                        |
-| `.codex-plugin/`               | Codex plugin manifest — skills, hosted MCP, and shared hook                         |
-| `.mcp.json`                    | Hosted MCP server for both plugins (`https://agents.uploads.sh/mcp`)                |
-| `assets/logo.png`              | Pixel chevron mark for the Codex / OpenAI plugin listing                            |
+| Path                              | What                                                                                                                                                            |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/`                           | The deployables: the REST API worker (`api.uploads.sh`), the auth worker, the remote MCP server, and the Astro site at uploads.sh                               |
+| `packages/`                       | Shared code — most notably `@buildinternet/uploads` (the CLI, published to npm) and `@uploads/storage` (the files-sdk adapter factory all storage goes through) |
+| `skills/`                         | The three agent skills that ship to users                                                                                                                       |
+| `hooks/`, `plugins/`, `.mcp.json` | Agent-runtime wiring: the shared pre-PR screenshot hook and the Claude / Codex plugin manifests                                                                 |
 
-The workers and web app are separate deployables. All storage access goes
-through `createStorage()` in `packages/storage` — adding a provider is one new
-case plus peer deps, no API changes.
+Each worker and the web app deploy separately. All storage access goes through
+`createStorage()` in `packages/storage` — adding a provider is one new case
+plus peer deps, no API changes.
 
 ## Docs
 
-Product docs live at https://uploads.sh/docs. The map for this folder is [docs/README.md](docs/README.md).
+Product docs — install, the staged loop, the GitHub App, limits — live at
+https://uploads.sh/docs. The docs in this repo are the companion: CLI and API
+reference, contributor setup, and operator material, all mapped from
+[docs/README.md](docs/README.md).
 
-| Doc                                                | Contents                                             |
-| -------------------------------------------------- | ---------------------------------------------------- |
-| [cli](docs/cli.md)                                 | CLI usage, GitHub embeds, keys, galleries            |
-| [api](docs/api.md)                                 | REST routes                                          |
-| [local-dev](docs/local-dev.md)                     | Manual setup, dev stack, smoke tests                 |
-| [enrollment](docs/enrollment.md)                   | Agent login, scopes, expiry, and migration           |
-| [private-attachments](docs/private-attachments.md) | Randomized private-repo attachment URLs and rotation |
-| [roadmap](docs/roadmap.md)                         | Planned features                                     |
-
-How to set up, test, and open a pull request:
-[CONTRIBUTING.md](CONTRIBUTING.md). Agent working conventions live in
-[AGENTS.md](AGENTS.md). Agents that land on this repo should start at
-[llms.txt](llms.txt) (product use vs monorepo contribute). The product site
-serves https://uploads.sh/llms.txt and https://uploads.sh/llms-full.txt.
+How to set up, test, and open a pull request: [CONTRIBUTING.md](CONTRIBUTING.md).
+Where the project is headed: [VISION.md](VISION.md). Agent working conventions
+live in [AGENTS.md](AGENTS.md), and agents that land on this repo should start
+at [llms.txt](llms.txt). The product site serves https://uploads.sh/llms.txt
+and https://uploads.sh/llms-full.txt.
 
 ## Local development
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,45 +1,34 @@
 # Roadmap
 
-- **Self-serve workspace registration** — shipped: `POST /v1/workspaces`
-  (session-authed, GitHub-linked accounts only) lets a user provision their
-  own organization + `<name>/` prefix on the shared bucket, no `ADMIN_TOKEN`
-  or admin involved. Tighter default limits than operator-created workspaces,
-  capped at 3 self-serve workspaces per user, admin-only raises. Surfaced from
-  `/account/workspaces` and `uploads login`. See
-  [workspaces.md#self-serve-workspaces](workspaces.md#self-serve-workspaces).
-- **MCP server** — shipped in both variants: a local stdio server in the CLI
-  (`uploads mcp`, tools mirror the CLI commands) and a remote worker on
-  `agents.uploads.sh` (alt `mcp.uploads.sh`) (`apps/mcp`, standalone worker, per-workspace bearer auth
-  like REST, put/list/delete/health).
-- **Presigned upload URLs** — shipped as `POST /v1/:workspace/files/sign`
-  (files-sdk `signedUploadUrl()`; needs HTTP S3 credentials on the workspace).
-- **Web UI** — lightweight browser console at `/console` on the Astro site;
-  longer-term: files-sdk `createFilesRouter` + browser client for full browse/manage.
-- **Key/path governance** — bare keys → `f/<shortid>/<name>`; typed destinations
-  (`screenshots` / `gh` / `f`); optional `allowedKeyPrefixes` + `maxKeyDepth` on
-  put/sign. Remaining ideas: destination-specific size rules; expose policy on
-  `usage`/`doctor`.
-- **Encrypt BYO-bucket credentials at rest** — shipped when
-  `WORKSPACE_SECRETS_KEY` is set (`enc:v1:…` AES-GCM on access/secret keys).
-  Re-write existing plaintext records to encrypt; rotate key carefully.
-- **Retention cron** — daily Worker cron sweeps workspaces with `retentionDays`.
-- **More providers**: add cases to `packages/storage` (`s3`, `gcs`, …).
-- **Point `github-screenshots` at this API** — replaces its bundled SigV4
-  script with one authenticated PUT.
-- **Enrollment “token used” notify** — org-membership accepts already email
-  the inviter (`member-joined` via Better Auth `afterAcceptInvitation`). The
-  secondary CLI enrollment path (`/admin/enrollments` → `/invite#code`)
-  has no durable inviter identity (admin bearer only); low priority now that
-  org invitations are the primary onboarding path.
-- **Session-authed invite-link generator** — consider adding a way to mint
-  `ADMIN_TOKEN`-free enrollment codes/links from the session-authed `/admin`
-  UI, so link-style invites (share a code/URL without knowing the recipient's
-  email) don't require holding `ADMIN_TOKEN`. `POST /admin/enrollments`,
-  `uploads admin invite create`, and `uploads login --code` stay as the
-  underlying mechanism; org invitations from `/admin` remain the primary,
-  recommended onboarding path.
-- **Private-repo embed privacy** — today every hosted file is on a public CDN;
-  `--pr`/`--issue` keys are predictable (`gh/<owner>/<repo>/pull/<n>/<name>`),
-  so attachments on private repos are not secret from anyone who can guess the
-  URL. Future options: signed/time-limited URLs, repo-scoped auth at the edge,
-  or non-guessable keys while keeping stable overwrite semantics.
+Where the project is headed lives in [VISION.md](../VISION.md#roadmap) — that
+is the direction document, kept current. This file tracks the smaller, concrete
+items that are on the list but not yet built.
+
+## Open items
+
+- **More storage providers** — the storage layer is provider-agnostic
+  (files-sdk via `createStorage()` in `packages/storage`), but only R2 is
+  wired up. Adding `s3`, `gcs`, etc. is one new case plus peer deps.
+- **Full web file management** — `/console` is a lightweight browser console;
+  longer-term, files-sdk's `createFilesRouter` + browser client could power
+  full browse/manage in the web app.
+- **Key-policy polish** — destination-specific size rules, and exposing a
+  workspace's key policy (`allowedKeyPrefixes`, `maxKeyDepth`) on `usage` and
+  `doctor` output.
+- **Session-authed invite-link generator** — mint enrollment codes/links from
+  the session-authed `/admin` UI so link-style invites don't require holding
+  `ADMIN_TOKEN`. Org invitations remain the primary onboarding path.
+- **Enrollment "token used" notify** — org-membership accepts already email
+  the inviter; the secondary CLI enrollment path (`/admin/enrollments` →
+  `/invite#code`) has no durable inviter identity. Low priority.
+- **Encrypt-at-rest migration** — BYO-bucket credentials encrypt when
+  `WORKSPACE_SECRETS_KEY` is set; existing plaintext records still need a
+  re-write pass, and key rotation needs care.
+
+## Recently shipped
+
+Larger items that used to live here and are now in production: self-serve
+workspace registration, local and hosted MCP servers, presigned upload URLs,
+typed key destinations (`f/` / `screenshots/` / `gh/`), the daily retention
+cron, and non-guessable private-repo attachment URLs
+([private-attachments](private-attachments.md)).

--- a/llms.txt
+++ b/llms.txt
@@ -86,7 +86,8 @@ Layout summary (full table in [README.md](README.md#whats-in-this-repo)):
 
 ## Cautions
 
-- Hosted files are **public**, including media attached to private repos.
+- Hosted files are **public URLs**. Private-repo attachments use non-guessable
+  links (docs/private-attachments.md), but anyone holding a URL can view the file.
 - Do not upload secrets, tokens, or sensitive UI.
 - APIs may change while the project is in active development.
 - Operator break-glass `ADMIN_TOKEN` is never for routine agent configs.


### PR DESCRIPTION
## In plain terms

A docs-honesty pass. The README leaned contributor-heavy for a front door, docs/roadmap.md was mostly a list of things that had already shipped, and two places still claimed private-repo attachments are on guessable public URLs — which stopped being true when randomized private prefixes landed (#641).

## What it does

- Rewrites docs/roadmap.md: points at VISION.md as the direction document, keeps only genuinely open items, and folds shipped work (self-serve workspaces, MCP servers, presigned URLs, retention cron, private-attachment prefixes) into one closing paragraph.
- Trims the README's "What's in this repo" table from 19 rows to 4 and replaces the docs table (which duplicated docs/README.md) with a short paragraph — adding a VISION.md link the README never had.
- Corrects the hosted-files privacy wording in README and llms.txt: files are public URLs, private-repo attachments get non-guessable links, anyone holding a URL can view the file.

## What it is not

- No changes to the newcomer-facing narrative (hero, "What is this?", walkthrough, "Use it") — those read well as-is.
- No product-site docs changes; the stale claim only existed in the repo README and llms.txt.

## Test plan

- [x] Verified roadmap items against code (retention cron in apps/api/wrangler.jsonc, /console page, private-attachments doc)
- [x] Grepped for remaining "public, including private repos" claims — none left
