### PR TITLE
fix(web): collapse promoted branch screenshots on the screenshots page

### DIFF
--- a/apps/api/src/file-metadata-facets.test.ts
+++ b/apps/api/src/file-metadata-facets.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   facetKeys,
   facetValues,
+  findObjectsByMetadata,
   groupObjectsByPath,
   projectLabelFromMeta,
   BY_PATH_CATALOG_LIMIT,
@@ -305,6 +306,66 @@ describe("groupObjectsByPath", () => {
     ]);
   });
 
+  it("hides a promoted branch original in favor of its pull copy (dedupe)", async () => {
+    const result = await groupObjectsByPath(
+      timedDb([
+        {
+          workspace: "acme",
+          key: "gh/o/r/pull/703/shot-after.webp",
+          meta: { path: "/x", repo: "o/r", "gh.kind": "pull", state: "after" },
+          at: at(2),
+        },
+        {
+          workspace: "acme",
+          key: "gh/o/r/branch/feat/shot-after.webp",
+          meta: {
+            path: "/x",
+            repo: "o/r",
+            "gh.kind": "branch",
+            "gh.status": "promoted",
+            "gh.promoted-to": "o/r#703",
+            state: "after",
+          },
+          at: at(1),
+        },
+      ]),
+      "acme",
+    );
+    expect(result.groups).toEqual([
+      {
+        project: "o/r",
+        path: "/x",
+        count: 1,
+        lastUpdated: at(2),
+        recent: ["gh/o/r/pull/703/shot-after.webp"],
+      },
+    ]);
+    expect(result.latest.map((l) => l.key)).toEqual(["gh/o/r/pull/703/shot-after.webp"]);
+  });
+
+  it("still shows a staged branch shot that has no promoted pull copy yet", async () => {
+    const result = await groupObjectsByPath(
+      timedDb([
+        {
+          workspace: "acme",
+          key: "gh/o/r/branch/feat/shot-after.webp",
+          meta: { path: "/x", repo: "o/r", "gh.kind": "branch", "gh.status": "staged" },
+          at: at(1),
+        },
+      ]),
+      "acme",
+    );
+    expect(result.groups).toEqual([
+      {
+        project: "o/r",
+        path: "/x",
+        count: 1,
+        lastUpdated: at(1),
+        recent: ["gh/o/r/branch/feat/shot-after.webp"],
+      },
+    ]);
+  });
+
   it("returns a flat newest-first latest feed across groups, capped", async () => {
     const rows = Array.from({ length: BY_PATH_LATEST_LIMIT + 2 }, (_, i) => ({
       workspace: "acme",
@@ -373,6 +434,77 @@ describe("groupObjectsByPath", () => {
       "acme",
     );
     expect(result.groups[0]).toMatchObject({ project: "acme/web", path: "/p" });
+  });
+});
+
+describe("findObjectsByMetadata", () => {
+  const promotedPair = () =>
+    db([
+      {
+        workspace: "acme",
+        key: "gh/o/r/pull/703/shot.webp",
+        meta: { path: "/x", "gh.kind": "pull" },
+      },
+      {
+        workspace: "acme",
+        key: "gh/o/r/branch/feat/shot.webp",
+        meta: { path: "/x", "gh.kind": "branch", "gh.status": "promoted" },
+      },
+    ]);
+
+  it("returns both branch and pull copies by default (general search unchanged)", async () => {
+    const found = await findObjectsByMetadata(promotedPair(), "acme", { path: "/x" });
+    expect(found.map((f) => f.key).sort()).toEqual([
+      "gh/o/r/branch/feat/shot.webp",
+      "gh/o/r/pull/703/shot.webp",
+    ]);
+  });
+
+  it("drops the promoted branch original when collapsePromotedShadows is set", async () => {
+    const found = await findObjectsByMetadata(
+      promotedPair(),
+      "acme",
+      { path: "/x" },
+      { collapsePromotedShadows: true },
+    );
+    expect(found.map((f) => f.key)).toEqual(["gh/o/r/pull/703/shot.webp"]);
+  });
+
+  it("keeps a still-staged branch shot even with collapsePromotedShadows", async () => {
+    const found = await findObjectsByMetadata(
+      db([
+        {
+          workspace: "acme",
+          key: "gh/o/r/branch/feat/shot.webp",
+          meta: { path: "/x", "gh.kind": "branch", "gh.status": "staged" },
+        },
+      ]),
+      "acme",
+      { path: "/x" },
+      { collapsePromotedShadows: true },
+    );
+    expect(found.map((f) => f.key)).toEqual(["gh/o/r/branch/feat/shot.webp"]);
+  });
+
+  it("collapses across an INTERSECT of multiple filters too", async () => {
+    const found = await findObjectsByMetadata(
+      db([
+        {
+          workspace: "acme",
+          key: "gh/o/r/pull/703/shot.webp",
+          meta: { path: "/x", repo: "o/r", "gh.kind": "pull" },
+        },
+        {
+          workspace: "acme",
+          key: "gh/o/r/branch/feat/shot.webp",
+          meta: { path: "/x", repo: "o/r", "gh.kind": "branch", "gh.status": "promoted" },
+        },
+      ]),
+      "acme",
+      { path: "/x", repo: "o/r" },
+      { collapsePromotedShadows: true },
+    );
+    expect(found.map((f) => f.key)).toEqual(["gh/o/r/pull/703/shot.webp"]);
   });
 });
 

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -505,6 +505,19 @@ const FIND_PROBE_MAX_LIMIT = FIND_MAX_LIMIT + 1;
 const PREFIX_FILTER_SQL = `substr(object_key, 1, length(?)) = ?`;
 
 /**
+ * Predicate matching a branch-staged screenshot that has been promoted
+ * (`gh.status=promoted`). Promotion copies such a shot to a canonical
+ * `pull/<n>/` key — which inherits its `path`/`state` via content-hash
+ * inheritance — and never deletes the branch original, so a promoted shot
+ * carries the same `path` under both keys. The screenshots surfaces collapse
+ * the branch original (`groupObjectsByPath`, and the opt-in `collapsePromotedShadows`
+ * search below) so it isn't listed twice. General metadata search leaves it
+ * in — `find_files({ "gh.status": "promoted" })` must still return it. Written
+ * against a subquery alias `s`; the caller supplies how to reach the outer row.
+ */
+const PROMOTED_SHADOW_STATUS_SQL = `s.meta_key = 'gh.status' AND s.meta_value = 'promoted'`;
+
+/**
  * Finds objects whose metadata matches ALL `filters` (ANDed equality), with
  * an optional key-prefix and result limit. Returns each match's key plus its
  * full metadata map (not just the matched pairs).
@@ -514,12 +527,16 @@ const PREFIX_FILTER_SQL = `substr(object_key, 1, length(?)) = ?`;
  * - multi-filter → INTERSECT of per-filter key sets (each leg uses the index)
  *   rather than OR + GROUP BY HAVING, which over-reads when any filter value
  *   is common (e.g. `gh.kind=pull`).
+ *
+ * `collapsePromotedShadows` (opt-in, off by default) drops promoted branch
+ * originals (`PROMOTED_SHADOW_STATUS_SQL`) so the screenshots drill-in doesn't
+ * show a shot twice; general search keeps them.
  */
 export async function findObjectsByMetadata(
   db: D1Database,
   workspace: string,
   filters: Record<string, string>,
-  opts: { prefix?: string; limit?: number } = {},
+  opts: { prefix?: string; limit?: number; collapsePromotedShadows?: boolean } = {},
 ): Promise<Array<{ key: string; metadata: Record<string, string> }>> {
   const entries = Object.entries(filters);
   if (entries.length === 0) return [];
@@ -548,6 +565,18 @@ export async function findObjectsByMetadata(
       sql += ` WHERE ${PREFIX_FILTER_SQL}`;
       params.push(opts.prefix, opts.prefix);
     }
+  }
+  // Wrap once (after prefix, before ORDER BY/LIMIT) so the exclusion applies to
+  // both the single-leg and INTERSECT forms. The derived set projects only
+  // `object_key`, so the correlated NOT EXISTS binds the workspace explicitly.
+  if (opts.collapsePromotedShadows) {
+    sql = `SELECT object_key FROM (${sql}) AS f
+           WHERE NOT EXISTS (
+             SELECT 1 FROM file_metadata s
+             WHERE s.workspace = ? AND s.object_key = f.object_key
+               AND ${PROMOTED_SHADOW_STATUS_SQL}
+           )`;
+    params.push(workspace);
   }
   sql += ` ORDER BY object_key LIMIT ?`;
   params.push(limit);
@@ -704,6 +733,13 @@ export type ProjectSummary = { label: string; count: number; lastUpdated: string
  * whole metadata table. Grouping/windowing moves to JS because the group key
  * (project label) is a coalesce SQL can't express cleanly — rows arrive
  * newest-first, so first-seen order is the recency order.
+ *
+ * A branch-staged original that has been promoted (`gh.status=promoted`) is
+ * excluded: promotion copies it to the canonical `pull/<n>/` key (which
+ * inherits its `path`/`state` via content-hash inheritance), and the promoted
+ * original is never deleted, so without this filter every promoted shot would
+ * show twice — once from `branch/<b>/` and once from `pull/<n>/`. Still-staged
+ * (`gh.status=staged`) branch shots have no pull twin yet and are kept.
  */
 export async function groupObjectsByPath(
   db: D1Database,
@@ -725,6 +761,11 @@ export async function groupObjectsByPath(
               (SELECT meta_value FROM file_metadata m WHERE m.workspace = p.workspace AND m.object_key = p.object_key AND m.meta_key = 'app') AS app
        FROM file_metadata p
        WHERE p.workspace = ? AND p.meta_key = 'path'
+         AND NOT EXISTS (
+           SELECT 1 FROM file_metadata s
+           WHERE s.workspace = p.workspace AND s.object_key = p.object_key
+             AND ${PROMOTED_SHADOW_STATUS_SQL}
+         )
        ORDER BY p.updated_at DESC, p.object_key ASC`,
     )
     .bind(workspace)

--- a/apps/api/src/file-search.ts
+++ b/apps/api/src/file-search.ts
@@ -98,6 +98,9 @@ export async function searchFilesByNameAndMeta(
     nameTerm?: string;
     prefix?: string;
     pageSize: number;
+    /** Drop promoted branch originals — the screenshots drill-in (see the
+     * `files/search?collapse=promoted` route). Only affects the metadata path. */
+    collapsePromotedShadows?: boolean;
   },
 ): Promise<{ matches: FileSearchMatch[]; truncated: boolean }> {
   const { nameTerm, pageSize, prefix } = opts;
@@ -109,6 +112,7 @@ export async function searchFilesByNameAndMeta(
     const found = await findObjectsByMetadata(env.DB, workspaceName, filters, {
       prefix,
       limit: fetchLimit,
+      collapsePromotedShadows: opts.collapsePromotedShadows,
     });
     // Truncation is about the D1 window, not the post-name-filter count —
     // a name term can drop every row in the window while more matching-meta

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -146,11 +146,17 @@ export const workspaceFiles = new Hono<DualAuthVars>()
     const rawLimit = Number(c.req.query("limit") ?? SEARCH_LIMIT) || SEARCH_LIMIT;
     const pageSize = Math.min(Math.max(1, Math.floor(rawLimit)), SEARCH_LIMIT);
     const cfg = await storageConfig(c.env, record);
+    // `collapse=promoted` drops promoted branch originals so the screenshots
+    // drill-in (?path=…) doesn't list a shot twice — once from its `branch/<b>/`
+    // key and once from the promoted `pull/<n>/` copy. Opt-in: a bare search
+    // (and the `find_files` tool) still returns every matching object.
+    const collapsePromotedShadows = c.req.query("collapse") === "promoted";
     const { matches, truncated } = await searchFilesByNameAndMeta(c.env, record, name, {
       filters: hasMeta ? filters : undefined,
       nameTerm,
       prefix: query.prefix,
       pageSize,
+      collapsePromotedShadows,
     });
 
     return c.json({

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -656,16 +656,16 @@ function ScreenshotsByPathInner({
     let cancelled = false;
     setDrill({ status: "loading" });
     onSession(() => {
-      void searchWorkspaceFiles(apiOrigin, workspace, [{ key: "path", value: view.path }]).then(
-        (result) => {
-          if (cancelled) return;
-          setDrill(
-            result.kind === "ok"
-              ? { status: "ready", items: result.items, truncated: result.truncated }
-              : { status: "error" },
-          );
-        },
-      );
+      void searchWorkspaceFiles(apiOrigin, workspace, [{ key: "path", value: view.path }], {
+        collapsePromoted: true,
+      }).then((result) => {
+        if (cancelled) return;
+        setDrill(
+          result.kind === "ok"
+            ? { status: "ready", items: result.items, truncated: result.truncated }
+            : { status: "error" },
+        );
+      });
     });
     return () => {
       cancelled = true;
@@ -696,21 +696,21 @@ function ScreenshotsByPathInner({
     }
     onSession(() => {
       for (const [path, projects] of projectsByPath) {
-        void searchWorkspaceFiles(apiOrigin, workspace, [{ key: "path", value: path }]).then(
-          (result) => {
-            // No cancellation guard: the cache is keyed by (project, path)
-            // independent of the current view, so a late response is never
-            // stale — dropping it would strand its group (started, no strip).
-            const items = result.kind === "ok" ? result.items : [];
-            setBackfill((prev) => {
-              const next = { ...prev };
-              for (const project of projects) {
-                next[`${project}\0${path}`] = shotsFromSearchItems(items, project);
-              }
-              return next;
-            });
-          },
-        );
+        void searchWorkspaceFiles(apiOrigin, workspace, [{ key: "path", value: path }], {
+          collapsePromoted: true,
+        }).then((result) => {
+          // No cancellation guard: the cache is keyed by (project, path)
+          // independent of the current view, so a late response is never
+          // stale — dropping it would strand its group (started, no strip).
+          const items = result.kind === "ok" ? result.items : [];
+          setBackfill((prev) => {
+            const next = { ...prev };
+            for (const project of projects) {
+              next[`${project}\0${path}`] = shotsFromSearchItems(items, project);
+            }
+            return next;
+          });
+        });
       }
     });
     // `backfill` in the deps chains passes: each resolved batch re-runs the

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -830,10 +830,14 @@ export async function searchWorkspaceFiles(
   apiOrigin: string,
   name: string,
   filters: MetaFilter[],
-  opts: { name?: string } = {},
+  opts: { name?: string; collapsePromoted?: boolean } = {},
 ): Promise<SearchFilesResult> {
   const params = new URLSearchParams(buildSearchQuery(filters));
   if (opts.name) params.set("name", opts.name);
+  // Collapse promoted branch originals into their canonical pull/<n> copy so a
+  // screenshot isn't listed twice (server-side; the API leaves general search
+  // untouched).
+  if (opts.collapsePromoted) params.set("collapse", "promoted");
   const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/search?${params.toString()}`;
   const result = await fetchWithTimeout(url, { credentials: "include", cache: "no-store" });
   if (result.kind === "unavailable") return result;


### PR DESCRIPTION
## Problem

On the Screenshots page, a single logical screenshot shows up **twice** whenever it was branch‑staged and then promoted to a PR — once from `…/branch/<b>/<file>` and once from `…/pull/<n>/<file>`.

Promotion is deliberately non‑destructive: it copies the staged shot to the canonical `pull/<n>/` key and tags the branch original `gh.status=promoted`, but never deletes it ([`github-promote.ts`](https://github.com/buildinternet/uploads/blob/main/apps/api/src/github-promote.ts)). The branch original keeps its `path`/`state` metadata, and the pull copy inherits `path`/`state` too via content‑hash inheritance (both keys are in `INHERITABLE_META_KEYS`). The by‑path feed lists **every** `path`‑tagged object, so both copies appear.

Example (prod): `pull/703/bot-comment-footer-after.webp` (`gh.kind=pull`, no `gh.status`) and its twin `branch/feat-comment-add-media-pr-number/bot-comment-footer-after.webp` (`gh.kind=branch`, `gh.status=promoted`, `gh.promoted-to=buildinternet/uploads#703`) both render in the `/github-comment` group.

## Fix

The grouping is server‑side, so the dedupe lives in the backing API — the client just renders what it gets.

- **Overview grouping** — `groupObjectsByPath` now excludes `gh.status=promoted` rows, so group thumbnails, counts, `catalog`, and the Recent feed drop the branch duplicate at the source.
- **Drill‑in + strip search** (the `?path=` view) — added an **opt‑in** `collapse=promoted` flag to the shared `files/search` route, threaded through `findObjectsByMetadata` / `searchFilesByNameAndMeta`. The Screenshots page passes it; a bare search and the `find_files` tool are unchanged, so `find_files({ "gh.status": "promoted" })` still returns the branch copies.

Still‑**staged** (pre‑PR) branch shots have no pull twin and are kept. Before/after pairing works again because only the canonical `pull/<n>` before+after remain and pair within one prefix.

### Why it's safe to drop the branch copy

A promoted shot's `pull/<n>` twin always carries `path` (content‑hash inheritance merges `path`/`state`/`repo` onto the promoted copy — see `INHERITABLE_META_KEYS` + the full‑replace merge in `files-core.ts`), so excluding the branch original never hides a shot from the feed.

## Tests

- New cases in `file-metadata-facets.test.ts`: dedupe in `groupObjectsByPath`, staged‑branch kept, and the `findObjectsByMetadata` collapse opt‑in on/off (single‑filter + INTERSECT).
- Full suites green: **2007** apps/api + **748** apps/web tests, `tsc` clean, oxfmt/oxlint clean.
- No changeset — `@uploads/api`/`@uploads/web` are private and in the changesets `ignore` list (deployed via Workers Builds).

## Notes

- I couldn't attach a real before/after screenshot: the duplicates only exist in prod and this fix isn't deployed yet, and local can't easily seed promoted pairs. The unit tests are written against the real prod metadata shapes.
- Follow‑ups tracked separately: persisting PR merge state (`gh.merged`) so shots can be filtered to "merged to main", and surfacing PR status + upload time in the image hover pop‑over.
