### PR TITLE
feat(web): show PR status + upload time in the screenshots pop-over

### DIFF
--- a/apps/api/src/file-metadata-facets.test.ts
+++ b/apps/api/src/file-metadata-facets.test.ts
@@ -6,6 +6,7 @@ import {
   facetKeys,
   facetValues,
   findObjectsByMetadata,
+  getObjectUpdatedAt,
   groupObjectsByPath,
   projectLabelFromMeta,
   BY_PATH_CATALOG_LIMIT,
@@ -505,6 +506,40 @@ describe("findObjectsByMetadata", () => {
       { collapsePromotedShadows: true },
     );
     expect(found.map((f) => f.key)).toEqual(["gh/o/r/pull/703/shot.webp"]);
+  });
+});
+
+describe("getObjectUpdatedAt", () => {
+  it("returns the newest updated_at per object key", async () => {
+    const database = new DatabaseSync(":memory:");
+    database.exec(
+      readFileSync(
+        fileURLToPath(
+          new NodeURL("../migrations/20260713210559_file_metadata.sql", import.meta.url),
+        ),
+        "utf8",
+      ),
+    );
+    const insert = database.prepare(
+      "INSERT INTO file_metadata (workspace, object_key, meta_key, meta_value, updated_at) VALUES (?, ?, ?, ?, ?)",
+    );
+    // Two rows for a.png with different times — MAX wins.
+    insert.run("acme", "a.png", "path", "/x", "2026-08-01T00:00:01.000Z");
+    insert.run("acme", "a.png", "gh.ref", "o/r#7", "2026-08-01T00:00:05.000Z");
+    insert.run("acme", "b.png", "path", "/y", "2026-08-01T00:00:03.000Z");
+    insert.run("other", "c.png", "path", "/z", "2026-08-01T00:00:09.000Z");
+    const dbh = new SQLiteD1(database) as unknown as D1Database;
+
+    const map = await getObjectUpdatedAt(dbh, "acme", ["a.png", "b.png", "c.png"]);
+    expect(map.get("a.png")).toBe("2026-08-01T00:00:05.000Z");
+    expect(map.get("b.png")).toBe("2026-08-01T00:00:03.000Z");
+    // Other workspace's key is never returned; a missing key is simply absent.
+    expect(map.has("c.png")).toBe(false);
+  });
+
+  it("returns an empty map for no keys", async () => {
+    const map = await getObjectUpdatedAt(db([]), "acme", []);
+    expect(map.size).toBe(0);
   });
 });
 

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -994,6 +994,41 @@ export async function getMetadataForKeys(
 }
 
 /**
+ * Newest `updated_at` per object key (its `MAX(updated_at)` across all metadata
+ * rows) — a stand-in for "when this object was last written". A screenshot
+ * writes all its metadata in one shot at capture (and promotion rewrites its
+ * `path`/`state`/`gh.*` rows together), so this matches the `path`-row time the
+ * by-path `latest` feed already reports as `uploadedAt`. Keys with no metadata
+ * rows are simply absent. Chunked like `getMetadataForKeys` to stay under D1's
+ * bound-parameter limit.
+ */
+export async function getObjectUpdatedAt(
+  db: D1Database,
+  workspace: string,
+  keys: string[],
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (keys.length === 0) return out;
+
+  const chunkSize = metadataLookupChunk(1); // workspace bind rides along
+  for (let i = 0; i < keys.length; i += chunkSize) {
+    const chunk = keys.slice(i, i + chunkSize);
+    const placeholders = chunk.map(() => "?").join(", ");
+    const result = await db
+      .prepare(
+        `SELECT object_key, MAX(updated_at) AS updated_at FROM file_metadata
+         WHERE workspace = ? AND object_key IN (${placeholders})
+         GROUP BY object_key`,
+      )
+      .bind(workspace, ...chunk)
+      .all<{ object_key: string; updated_at: string }>();
+    for (const row of result.results) out.set(row.object_key, row.updated_at);
+  }
+
+  return out;
+}
+
+/**
  * Upsert server-owned metadata (`video.*`) without touching user rows.
  * Deliberately not `replaceFileMetadata`: that is delete-then-insert, and this
  * runs *after* it on the upload path — a full replace here would wipe the

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1651,7 +1651,7 @@ describe("GET /me/workspaces/:name/files/search", () => {
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      items: { key: string; url: string; metadata: Record<string, string> }[];
+      items: { key: string; url: string; metadata: Record<string, string>; updatedAt?: string }[];
       truncated: boolean;
     };
     expect(body.truncated).toBe(false);
@@ -1660,6 +1660,8 @@ describe("GET /me/workspaces/:name/files/search", () => {
       key: "f/x/shot.png",
       url: "https://storage.uploads.sh/acme/f/x/shot.png",
     });
+    // Upload time rides along so the screenshots drill-in pop-over can show it.
+    expect(typeof body.items[0]!.updatedAt).toBe("string");
   });
 
   it("rejects a repeated filter key with file_metadata_duplicate_filter", async () => {
@@ -1809,7 +1811,13 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
       {
         workspace: "acme",
         key: "shots/a.png",
-        meta: { path: "/settings", state: "after", "gh.kind": "pull", "gh.number": "42" },
+        meta: {
+          path: "/settings",
+          state: "after",
+          "gh.kind": "pull",
+          "gh.number": "42",
+          "gh.ref": "acme/web#42",
+        },
       },
       { workspace: "acme", key: "shots/b.png", meta: { path: "/settings" } },
       { workspace: "acme", key: "shots/c.png", meta: { app: "web" } },
@@ -1829,6 +1837,8 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
           state?: string;
           ghKind?: string;
           ghNumber?: string;
+          ghRef?: string;
+          updatedAt?: string;
         }[];
       }[];
       catalog: { project: string; path: string; count: number; lastUpdated: string }[];
@@ -1849,11 +1859,16 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
       state: "after",
       ghKind: "pull",
       ghNumber: "42",
+      ghRef: "acme/web#42",
     });
+    // Every shot carries an upload time for the pop-over.
+    expect(typeof byKey["shots/a.png"]!.updatedAt).toBe("string");
+    expect(typeof byKey["shots/b.png"]!.updatedAt).toBe("string");
     // `state` / gh fields are present only when set — no empty-string placeholder.
     expect(byKey["shots/b.png"]).not.toHaveProperty("state");
     expect(byKey["shots/b.png"]).not.toHaveProperty("ghKind");
     expect(byKey["shots/b.png"]).not.toHaveProperty("ghNumber");
+    expect(byKey["shots/b.png"]).not.toHaveProperty("ghRef");
   });
 
   it("labels groups with a project and returns the projects summary", async () => {

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -38,7 +38,12 @@ import {
 } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
 import { badKey, deleteObject, listObjects, setObjectVisibility } from "../files-core";
-import { getMetadataForKeys, groupObjectsByPath, listFacets } from "../file-metadata";
+import {
+  getMetadataForKeys,
+  getObjectUpdatedAt,
+  groupObjectsByPath,
+  listFacets,
+} from "../file-metadata";
 import {
   normalizeSearchName,
   parseMetaQueryFilters,
@@ -158,11 +163,25 @@ export const workspaceFiles = new Hono<DualAuthVars>()
       pageSize,
       collapsePromotedShadows,
     });
+    // Upload time per match so the screenshots drill-in pop-over can show it
+    // (the grouped by-path route surfaces the same via `updatedAt`).
+    const updatedByKey = await getObjectUpdatedAt(
+      c.env.DB,
+      name,
+      matches.map((m) => m.key),
+    );
 
     return c.json({
       items: matches.map((match) => {
         const urls = objectPublicUrls(c.env, cfg, match.key);
-        return { key: match.key, url: urls.url, embedUrl: urls.embedUrl, metadata: match.metadata };
+        const updatedAt = updatedByKey.get(match.key);
+        return {
+          key: match.key,
+          url: urls.url,
+          embedUrl: urls.embedUrl,
+          metadata: match.metadata,
+          ...(updatedAt !== undefined ? { updatedAt } : {}),
+        };
       }),
       truncated,
     });
@@ -188,12 +207,17 @@ export const workspaceFiles = new Hono<DualAuthVars>()
     const name = c.get("workspaceName");
     const { groups, catalog, projects, latest, truncated, catalogTruncated } =
       await groupObjectsByPath(c.env.DB, name);
-    const metaByKey = await getMetadataForKeys(
-      c.env.DB,
-      name,
-      [...groups.flatMap((group) => group.recent), ...latest.map((item) => item.key)],
-      { metaKeys: ["state", "gh.kind", "gh.number"] },
-    );
+    const shotKeys = [
+      ...groups.flatMap((group) => group.recent),
+      ...latest.map((item) => item.key),
+    ];
+    // `gh.ref` lets the pop-over resolve live PR/issue status via /github/titles;
+    // `updatedAt` gives it the shot's upload time (the `latest` feed already
+    // carries `uploadedAt`, this brings the same to the grouped `recent` strips).
+    const metaByKey = await getMetadataForKeys(c.env.DB, name, shotKeys, {
+      metaKeys: ["state", "gh.kind", "gh.number", "gh.ref"],
+    });
+    const updatedByKey = await getObjectUpdatedAt(c.env.DB, name, shotKeys);
     const cfg = await storageConfig(c.env, record);
     const shotItem = (key: string) => {
       const urls = objectPublicUrls(c.env, cfg, key);
@@ -201,6 +225,8 @@ export const workspaceFiles = new Hono<DualAuthVars>()
       const state = meta?.state;
       const ghKind = meta?.["gh.kind"];
       const ghNumber = meta?.["gh.number"];
+      const ghRef = meta?.["gh.ref"];
+      const updatedAt = updatedByKey.get(key);
       return {
         key,
         url: urls.url,
@@ -208,6 +234,8 @@ export const workspaceFiles = new Hono<DualAuthVars>()
         ...(state !== undefined ? { state } : {}),
         ...(ghKind !== undefined ? { ghKind } : {}),
         ...(ghNumber !== undefined ? { ghNumber } : {}),
+        ...(ghRef !== undefined ? { ghRef } : {}),
+        ...(updatedAt !== undefined ? { updatedAt } : {}),
       };
     };
 

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -27,9 +27,11 @@ import {
 } from "react";
 import { IslandErrorBoundary } from "./IslandErrorBoundary";
 import {
+  getGithubTitles,
   getWorkspaceFilesByPath,
   searchWorkspaceFiles,
   type FilesPathGroup,
+  type GithubTitleMap,
   type LatestShotItem,
   type PathCatalogEntry,
   type PathGroupItem,
@@ -227,6 +229,9 @@ function ShotThumb({
     state?: string;
     ghKind?: string;
     ghNumber?: string;
+    ghRef?: string;
+    updatedAt?: string;
+    uploadedAt?: string;
     metadata?: Record<string, string>;
   };
   /** True when a before/after counterpart sits in the same strip/grid. */
@@ -514,7 +519,15 @@ function FilterBar({
   );
 }
 
-type PreviewCaption = { name: string; pr?: string; kind?: string };
+type PreviewCaption = {
+  name: string;
+  pr?: string;
+  kind?: string;
+  /** `owner/repo#n` — key into the resolved titles map for live PR status. */
+  ref?: string;
+  /** ISO upload time, rendered as a relative "uploaded …" line. */
+  uploadedAt?: string;
+};
 
 type PreviewHandlers = {
   onPreviewEnter: (el: HTMLElement, src: string, caption: PreviewCaption) => void;
@@ -563,7 +576,14 @@ function ScreenshotsByPathInner({
     name: string;
     pr?: string;
     kind?: string;
+    ref?: string;
+    uploadedAt?: string;
   } | null>(null);
+  // Live PR/issue status (open/closed/merged + title) keyed by `owner/repo#n`,
+  // resolved lazily the first time a shot with that ref is hovered. A miss
+  // stays recorded so a null/outage isn't re-fetched on every hover.
+  const [titles, setTitles] = useState<GithubTitleMap>({});
+  const titleFetches = useRef(new Set<string>());
   const [drill, setDrill] = useState<DrillState>({ status: "idle" });
   const [drillRetryNonce, setDrillRetryNonce] = useState(0);
   const [ghState, setGhState] = useState<DrillState>({ status: "loading" });
@@ -766,9 +786,21 @@ function ScreenshotsByPathInner({
     previewTimer.current = null;
     setPreview(null);
   };
+  // Resolve a ref's live PR/issue status once; the pop-over reads `titles`.
+  const ensureTitle = (ref: string | undefined) => {
+    if (!ref || ref in titles || titleFetches.current.has(ref)) return;
+    titleFetches.current.add(ref);
+    void getGithubTitles(apiOrigin, workspace, [ref]).then((map) => {
+      const info = map?.[ref];
+      if (info) setTitles((prev) => ({ ...prev, [ref]: info }));
+    });
+  };
   const onPreviewEnter = (el: HTMLElement, src: string, caption: PreviewCaption) => {
     if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
     if (previewTimer.current !== null) window.clearTimeout(previewTimer.current);
+    // Prefetch the title now (not inside the timeout) so it's likely resolved
+    // by the time the pop-over appears.
+    ensureTitle(caption.ref);
     const delay = window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : 250;
     previewTimer.current = window.setTimeout(() => {
       const rect = el.getBoundingClientRect();
@@ -786,6 +818,8 @@ function ScreenshotsByPathInner({
         name: caption.name,
         pr: caption.pr,
         kind: caption.kind,
+        ref: caption.ref,
+        uploadedAt: caption.uploadedAt,
       });
     }, delay);
   };
@@ -867,6 +901,8 @@ function ScreenshotsByPathInner({
       onPickPath={(path) => setView({ ...view, path })}
     />
   ) : null;
+  const previewTitle = preview?.ref ? titles[preview.ref] : undefined;
+  const previewState = previewTitle?.state;
   const previewLayer = preview ? (
     <div
       className="wsp-preview"
@@ -878,7 +914,18 @@ function ScreenshotsByPathInner({
         <div className="wsp-preview__name">{preview.name}</div>
         {preview.pr && (
           <div className="wsp-preview__pr">
+            {previewState && (
+              <span className={`wsp-preview__status wsp-preview__status--${previewState}`}>
+                {previewState}
+              </span>
+            )}
             <GhKindIcon kind={preview.kind} /> {preview.pr}
+          </div>
+        )}
+        {previewTitle?.title && <div className="wsp-preview__title">{previewTitle.title}</div>}
+        {preview.uploadedAt && (
+          <div className="wsp-preview__time">
+            uploaded {lastUpdatedLabel(preview.uploadedAt, new Date())}
           </div>
         )}
       </div>

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -806,6 +806,8 @@ export interface SearchFileItem {
   metadata: Record<string, string>;
   /** Public `/f/` file-page URL when present (issue #308). */
   pageUrl?: string;
+  /** Newest metadata-write time — the shot's upload time for the pop-over. */
+  updatedAt?: string;
 }
 
 export type SearchFilesResult =
@@ -821,7 +823,8 @@ function isSearchFileItem(value: unknown): value is SearchFileItem {
     (item.embedUrl === null || typeof item.embedUrl === "string") &&
     typeof item.metadata === "object" &&
     item.metadata !== null &&
-    (item.pageUrl === undefined || typeof item.pageUrl === "string")
+    (item.pageUrl === undefined || typeof item.pageUrl === "string") &&
+    (item.updatedAt === undefined || typeof item.updatedAt === "string")
   );
 }
 
@@ -868,6 +871,10 @@ export interface PathGroupItem {
   /** Present only when the file is attached to a GitHub PR/issue. */
   ghKind?: string;
   ghNumber?: string;
+  /** `owner/repo#n` — lets the pop-over resolve live PR/issue status. */
+  ghRef?: string;
+  /** Newest metadata-write time — the shot's upload time for the pop-over. */
+  updatedAt?: string;
 }
 
 /** One `path` metadata value with its recent uploads. */
@@ -922,7 +929,9 @@ function isPathGroupItem(value: unknown): value is PathGroupItem {
     (item.embedUrl === null || typeof item.embedUrl === "string") &&
     (item.state === undefined || typeof item.state === "string") &&
     (item.ghKind === undefined || typeof item.ghKind === "string") &&
-    (item.ghNumber === undefined || typeof item.ghNumber === "string")
+    (item.ghNumber === undefined || typeof item.ghNumber === "string") &&
+    (item.ghRef === undefined || typeof item.ghRef === "string") &&
+    (item.updatedAt === undefined || typeof item.updatedAt === "string")
   );
 }
 

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -98,6 +98,50 @@ describe("lastUpdatedLabel", () => {
   });
 });
 
+describe("shotPreviewCaption", () => {
+  it("returns just the filename for a non-GitHub shot", () => {
+    expect(shotPreviewCaption({ key: "gh/o/r/pull/7/home.webp" })).toEqual({ name: "home.webp" });
+  });
+
+  it("adds a PR line + ref + upload time from top-level fields", () => {
+    expect(
+      shotPreviewCaption({
+        key: "gh/o/r/pull/7/home.webp",
+        ghKind: "pull",
+        ghNumber: "7",
+        ghRef: "o/r#7",
+        updatedAt: "2026-08-01T00:00:00.000Z",
+      }),
+    ).toEqual({
+      name: "home.webp",
+      pr: "PR #7",
+      ref: "o/r#7",
+      uploadedAt: "2026-08-01T00:00:00.000Z",
+    });
+  });
+
+  it("reads gh.* from metadata and reconstructs a missing ref from repo+number", () => {
+    expect(
+      shotPreviewCaption({
+        key: "gh/o/r/pull/7/home.webp",
+        metadata: { "gh.kind": "pull", "gh.number": "7", "gh.repo": "o/r" },
+      }),
+    ).toMatchObject({ pr: "PR #7", ref: "o/r#7" });
+  });
+
+  it("prefers updatedAt over uploadedAt, and omits ref when there is no PR", () => {
+    const cap = shotPreviewCaption({
+      key: "shot.webp",
+      ghRef: "o/r#7",
+      updatedAt: "2026-08-02T00:00:00.000Z",
+      uploadedAt: "2026-08-01T00:00:00.000Z",
+    });
+    expect(cap.uploadedAt).toBe("2026-08-02T00:00:00.000Z");
+    expect(cap.ref).toBeUndefined();
+    expect(cap.pr).toBeUndefined();
+  });
+});
+
 describe("projectLabelFromItemMeta", () => {
   // Pinned to the same cases as apps/api projectLabelFromMeta — keep in sync.
   it("prefers repo over gh.repo over url origin", () => {

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -115,16 +115,31 @@ export function shotPreviewCaption(item: {
   key: string;
   ghKind?: string;
   ghNumber?: string;
+  ghRef?: string;
+  updatedAt?: string;
+  uploadedAt?: string;
   metadata?: Record<string, string>;
-}): { name: string; pr?: string } {
+}): { name: string; pr?: string; ref?: string; uploadedAt?: string } {
   const kind = item.ghKind ?? item.metadata?.["gh.kind"];
   const number = item.ghNumber ?? item.metadata?.["gh.number"];
+  const repo = item.metadata?.["gh.repo"];
+  // Prefer the stored `gh.ref` (already `owner/repo#n`); fall back to
+  // reconstructing it so a shot with only repo+number still resolves a title.
+  const ref =
+    item.ghRef ?? item.metadata?.["gh.ref"] ?? (repo && number ? `${repo}#${number}` : undefined);
+  const uploadedAt = item.updatedAt ?? item.uploadedAt;
   let pr: string | undefined;
   if (number) {
     if (kind === "pull") pr = `PR #${number}`;
     else if (kind === "issue" || kind === "issues") pr = `Issue #${number}`;
   }
-  return pr ? { name: leafName(item.key), pr } : { name: leafName(item.key) };
+  const caption: { name: string; pr?: string; ref?: string; uploadedAt?: string } = {
+    name: leafName(item.key),
+  };
+  if (pr) caption.pr = pr;
+  if (pr && ref) caption.ref = ref;
+  if (uploadedAt) caption.uploadedAt = uploadedAt;
+  return caption;
 }
 
 export function pairedShotKeys(items: Array<{ key: string; state?: string }>): Set<string> {

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -2289,6 +2289,48 @@ button.wft-card__name:focus-visible {
   color: var(--muted);
   font: 11.5px var(--mono);
 }
+/* Live PR/issue status pill (open/merged/closed) with a leading dot. */
+.wsp-preview__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 6px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+  font: 600 10px var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  vertical-align: 1px;
+}
+.wsp-preview__status::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.wsp-preview__status--open {
+  color: oklch(0.72 0.17 150);
+}
+.wsp-preview__status--merged {
+  color: oklch(0.66 0.18 300);
+}
+.wsp-preview__status--closed {
+  color: oklch(0.65 0.2 25);
+}
+.wsp-preview__title {
+  color: var(--fg);
+  font: 11.5px var(--body);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: min(560px, calc(100vw - 24px));
+}
+.wsp-preview__time {
+  color: var(--muted);
+  font: 11px var(--mono);
+}
 @media (prefers-reduced-motion: no-preference) {
   .wsp-preview {
     animation: wsp-preview-in 150ms ease-out;


### PR DESCRIPTION
## What

The screenshots hover pop-over showed only the filename and a plain `PR #n` label. It now also surfaces:

- the pull request's **live status** — an `open` / `merged` / `closed` pill — with its **title**, and
- **when the shot was uploaded** ("uploaded 3d ago").

```
┌───────────────────────────┐
│  [ screenshot preview ]   │
│ bot-comment-footer-after  │
│ ● merged · PR #703        │
│ feat: fill the real PR…   │
│ uploaded 3 days ago       │
└───────────────────────────┘
```

Non-GitHub shots just get the upload-time line.

## How

**No new API capability was needed** — PR status reuses the existing `/v1/workspaces/:name/github/titles` endpoint (the files table already calls it, returns `{title, state, kind}`); upload time comes from D1, matching what the "Recent" feed already reports as `uploadedAt`.

**API** (`apps/api`)
- New `getObjectUpdatedAt` helper — `MAX(updated_at)` per key, chunked like `getMetadataForKeys`.
- `files/by-path` now enriches `gh.ref` and stamps `updatedAt` on every shot (grouped `recent` + `latest`).
- `files/search` (the `?path=` drill-in) stamps `updatedAt` per item.

**Web** (`apps/web`)
- `PathGroupItem` gains `ghRef`/`updatedAt`; `SearchFileItem` gains `updatedAt` (+ validators).
- `shotPreviewCaption` resolves a shot's `owner/repo#n` ref (stored `gh.ref`, else reconstructed from `gh.repo`+`gh.number`) and its upload time.
- The pop-over **lazily** resolves live status via `getGithubTitles` the first time a shot with a ref is hovered — prefetched on hover-enter, cached and deduped per ref, so a status pill + title appear by the time the preview shows. A status pill (green/purple/red) + title + "uploaded …" line render in `previewLayer`; CSS in `account-content.css`.

## Tests

- `getObjectUpdatedAt` unit tests (MAX-per-key, workspace isolation, empty).
- `shotPreviewCaption` unit tests (ref from `gh.ref` vs reconstructed, upload-time precedence, no ref without a PR).
- Route-level integration: the `by-path` test now asserts `ghRef` + `updatedAt` on `recent` items; the `files/search` test asserts `updatedAt` per item.
- Full suites green: **2009** apps/api + **752** apps/web tests, `tsc` clean both, oxfmt/oxlint clean. No changeset (`@uploads/api`/`@uploads/web` are private/ignored).

## Verification note

Local can't exercise this end-to-end (thumbnails render blank against prod storage, and `/github/titles` needs a GitHub App token to resolve `open/merged/closed`), so the logic is covered by unit + route tests. The live pill/title rendering is best eyeballed on the Workers preview this PR builds, or in prod after deploy — happy to drive that once the preview is up.

Builds on #728 (branch-shadow dedupe), already merged.
