### PR TITLE
feat(api,web): persisted PR merge-state tagging for GitHub screenshots

### DIFF
--- a/apps/api/src/file-metadata-facets.test.ts
+++ b/apps/api/src/file-metadata-facets.test.ts
@@ -399,6 +399,27 @@ describe("groupObjectsByPath", () => {
     });
   });
 
+  // Persisted PR merge-state tagging: opts.mergedOnly keeps only objects
+  // stamped gh.merged=true, and leaves the default (no opts) response
+  // unfiltered — mirrors the promoted-shadow NOT EXISTS clause's shape as an
+  // EXISTS counterpart.
+  it("opts.mergedOnly keeps only gh.merged=true objects; omitted returns all", async () => {
+    const rows = db([
+      { workspace: "acme", key: "a.png", meta: { path: "/p", "gh.merged": "true" } },
+      { workspace: "acme", key: "b.png", meta: { path: "/p" } },
+    ]);
+
+    const unfiltered = await groupObjectsByPath(rows, "acme");
+    expect(unfiltered.groups).toHaveLength(1);
+    expect(unfiltered.groups[0]).toMatchObject({ path: "/p", count: 2 });
+
+    const filtered = await groupObjectsByPath(rows, "acme", { mergedOnly: true });
+    expect(filtered.groups).toHaveLength(1);
+    expect(filtered.groups[0]).toMatchObject({ path: "/p", count: 1 });
+    expect(filtered.groups[0]!.recent).toEqual(["a.png"]);
+    expect(filtered.catalog).toEqual([expect.objectContaining({ path: "/p", count: 1 })]);
+  });
+
   it("splits the same path across projects and summarizes projects", async () => {
     const result = await groupObjectsByPath(
       db([

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -518,6 +518,22 @@ const PREFIX_FILTER_SQL = `substr(object_key, 1, length(?)) = ?`;
 const PROMOTED_SHADOW_STATUS_SQL = `s.meta_key = 'gh.status' AND s.meta_value = 'promoted'`;
 
 /**
+ * Predicate matching an object stamped `gh.merged=true` — written by
+ * github-webhook.ts's `pull_request` `closed` handling when the PR's
+ * `merged` field is true. A merge is a terminal, durable fact (unlike
+ * open/closed, which stay transient and are already resolved live by the KV
+ * title cache in github-titles.ts), so `gh.merged` is the only PR
+ * lifecycle fact this codebase persists as metadata — there is deliberately
+ * no `gh.pr-state` key that would imply the full lifecycle is tracked.
+ * Mirrors `PROMOTED_SHADOW_STATUS_SQL`'s shape but as an EXISTS (not NOT
+ * EXISTS) predicate; written against a subquery alias `s2` (distinct from
+ * `PROMOTED_SHADOW_STATUS_SQL`'s `s` so both can be composed in one query,
+ * as `groupObjectsByPath`'s opt-in `mergedOnly` filter does) — the caller
+ * supplies how to reach the outer row.
+ */
+const MERGED_STATUS_SQL = `s2.meta_key = 'gh.merged' AND s2.meta_value = 'true'`;
+
+/**
  * Finds objects whose metadata matches ALL `filters` (ANDed equality), with
  * an optional key-prefix and result limit. Returns each match's key plus its
  * full metadata map (not just the matched pairs).
@@ -740,10 +756,17 @@ export type ProjectSummary = { label: string; count: number; lastUpdated: string
  * original is never deleted, so without this filter every promoted shot would
  * show twice — once from `branch/<b>/` and once from `pull/<n>/`. Still-staged
  * (`gh.status=staged`) branch shots have no pull twin yet and are kept.
+ *
+ * `opts.mergedOnly` (opt-in, off by default — issue "persisted PR merge-state
+ * tagging") adds an EXISTS counterpart to the NOT EXISTS promoted-shadow
+ * clause above, keeping only objects stamped `gh.merged=true`
+ * (`MERGED_STATUS_SQL`). Applies to the single underlying query, so `groups`,
+ * `catalog`, `projects`, and `latest` all reflect the same filtered rows.
  */
 export async function groupObjectsByPath(
   db: D1Database,
   workspace: string,
+  opts: { mergedOnly?: boolean } = {},
 ): Promise<{
   groups: PathGroup[];
   catalog: PathCatalogEntry[];
@@ -752,6 +775,13 @@ export async function groupObjectsByPath(
   truncated: boolean;
   catalogTruncated: boolean;
 }> {
+  const mergedFilterSql = opts.mergedOnly
+    ? `AND EXISTS (
+           SELECT 1 FROM file_metadata s2
+           WHERE s2.workspace = p.workspace AND s2.object_key = p.object_key
+             AND ${MERGED_STATUS_SQL}
+         )`
+    : "";
   const result = await db
     .prepare(
       `SELECT p.meta_value AS path, p.object_key AS object_key, p.updated_at AS updated_at,
@@ -766,6 +796,7 @@ export async function groupObjectsByPath(
            WHERE s.workspace = p.workspace AND s.object_key = p.object_key
              AND ${PROMOTED_SHADOW_STATUS_SQL}
          )
+         ${mergedFilterSql}
        ORDER BY p.updated_at DESC, p.object_key ASC`,
     )
     .bind(workspace)

--- a/apps/api/src/github-webhook-merge.test.ts
+++ b/apps/api/src/github-webhook-merge.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Persisted PR merge-state tagging (`pull_request` `closed` handling in
+ * github-webhook.ts): a real merge stamps `gh.merged=true` on the PR's
+ * screenshots; a close-without-merge, an unbound repo, and a fork PR are all
+ * no-ops. Same `handleWebhook`-direct-call shape as
+ * github-webhook-auto-promote.test.ts, so every assertion below is
+ * deterministic without draining a `waitUntil` queue.
+ */
+import { describe, expect, it } from "vitest";
+import { handleWebhook } from "./github-webhook";
+import { getFileMetadata, replaceFileMetadata } from "./file-metadata";
+import { recordRepoLink } from "./github-repo-links";
+import { sha256Hex, type WorkspaceRecord } from "./workspace";
+import { FakeKv } from "../test/fake-kv";
+import { FakeR2Bucket } from "../test/fake-r2";
+import { UsageFakeD1 } from "../test/usage-fake-d1";
+import { GITHUB_APP_CFG_ENV } from "../test/github-app-env";
+
+const WS = "acme";
+const PREFIX = "acme/";
+const REPO = "acme/web";
+const NUM = 12;
+const REF = "acme/web#12";
+
+function shotKey(filename: string): string {
+  return `gh/acme/web/pull/${NUM}/${filename}`;
+}
+
+async function baseEnv(): Promise<{ env: Env; db: UsageFakeD1; bucket: FakeR2Bucket }> {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: PREFIX,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex("unused"), createdAt: new Date().toISOString() }],
+  };
+  const registry = {
+    get: (async (key: string) =>
+      key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  const githubCache = new FakeKv();
+  const env = {
+    REGISTRY: registry,
+    DB: db,
+    UPLOADS_DEFAULT: bucket,
+    GITHUB_CACHE: githubCache,
+    ...GITHUB_APP_CFG_ENV,
+  } as unknown as Env;
+  return { env, db, bucket };
+}
+
+/** Seed one already-promoted PR screenshot, tagged like `promoteBranchAttachments` leaves it. */
+async function seedPrShot(env: Env, filename: string, extra: Record<string, string> = {}) {
+  const key = shotKey(filename);
+  await replaceFileMetadata(env.DB, WS, key, {
+    "gh.repo": REPO,
+    "gh.kind": "pull",
+    "gh.number": String(NUM),
+    "gh.ref": REF,
+    ...extra,
+  });
+  return key;
+}
+
+function closedPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: "closed",
+    repository: { full_name: REPO },
+    pull_request: {
+      number: NUM,
+      merged: true,
+      head: { ref: "feat-x", repo: { full_name: REPO } },
+    },
+    ...overrides,
+  };
+}
+
+describe("handleWebhook pull_request closed merge-tagging", () => {
+  it("stamps gh.merged=true on the PR's screenshots when merged: true", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    const keyA = await seedPrShot(env, "hero.png");
+    const keyB = await seedPrShot(env, "footer.png");
+
+    await handleWebhook(env, "pull_request", closedPayload());
+
+    expect((await getFileMetadata(env.DB, WS, keyA))["gh.merged"]).toBe("true");
+    expect((await getFileMetadata(env.DB, WS, keyB))["gh.merged"]).toBe("true");
+  });
+
+  it("does not disturb existing gh.* tags (merge write)", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    const key = await seedPrShot(env, "hero.png", { "gh.promoted-at": "2026-08-01T00:00:00.000Z" });
+
+    await handleWebhook(env, "pull_request", closedPayload());
+
+    const meta = await getFileMetadata(env.DB, WS, key);
+    expect(meta["gh.merged"]).toBe("true");
+    expect(meta["gh.promoted-at"]).toBe("2026-08-01T00:00:00.000Z");
+    expect(meta["gh.repo"]).toBe(REPO);
+  });
+
+  it("finds shots by metadata, not key prefix, so private-prefix keys are stamped too", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    // A key that does NOT match the plain gh/<owner>/<repo>/pull/<n>/ shape —
+    // stands in for a private-repo gh/private/<hex>/... key. Findable only
+    // because the lookup below is metadata-driven (gh.ref + gh.kind).
+    const key = "gh/private/deadbeefdeadbeefdeadbeefdeadbeef/pull/12/hero.png";
+    await replaceFileMetadata(env.DB, WS, key, {
+      "gh.repo": REPO,
+      "gh.kind": "pull",
+      "gh.number": String(NUM),
+      "gh.ref": REF,
+    });
+
+    await handleWebhook(env, "pull_request", closedPayload());
+
+    expect((await getFileMetadata(env.DB, WS, key))["gh.merged"]).toBe("true");
+  });
+
+  it("does nothing when closed without merging (merged: false)", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    const key = await seedPrShot(env, "hero.png");
+
+    await handleWebhook(
+      env,
+      "pull_request",
+      closedPayload({
+        pull_request: {
+          number: NUM,
+          merged: false,
+          head: { ref: "feat-x", repo: { full_name: REPO } },
+        },
+      }),
+    );
+
+    expect((await getFileMetadata(env.DB, WS, key))["gh.merged"]).toBeUndefined();
+  });
+
+  it("does nothing when merged is absent entirely", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    const key = await seedPrShot(env, "hero.png");
+
+    await handleWebhook(
+      env,
+      "pull_request",
+      closedPayload({
+        pull_request: { number: NUM, head: { ref: "feat-x", repo: { full_name: REPO } } },
+      }),
+    );
+
+    expect((await getFileMetadata(env.DB, WS, key))["gh.merged"]).toBeUndefined();
+  });
+
+  it("no-ops when the repo has no binding", async () => {
+    const { env } = await baseEnv();
+    const key = await seedPrShot(env, "hero.png");
+
+    await handleWebhook(env, "pull_request", closedPayload());
+
+    // No binding was ever recorded, so the shot was seeded straight into D1
+    // with WS as its workspace — nothing should touch it.
+    expect((await getFileMetadata(env.DB, WS, key))["gh.merged"]).toBeUndefined();
+  });
+
+  it("applies the same fork guard as promote: a fork PR's merge is not tagged", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    const key = await seedPrShot(env, "hero.png");
+
+    await handleWebhook(
+      env,
+      "pull_request",
+      closedPayload({
+        pull_request: {
+          number: NUM,
+          merged: true,
+          head: { ref: "feat-x", repo: { full_name: "someone-else/fork" } },
+        },
+      }),
+    );
+
+    expect((await getFileMetadata(env.DB, WS, key))["gh.merged"]).toBeUndefined();
+  });
+
+  it("cleans up the link and no-ops when the bound workspace is gone", async () => {
+    const { env, db } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, "ghost-workspace", "promote");
+
+    await handleWebhook(env, "pull_request", closedPayload());
+
+    expect(db.repoLinks.has(REPO)).toBe(false);
+  });
+
+  it("logs and never throws when a per-shot metadata write fails (best-effort tagging)", async () => {
+    const { env, db } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedPrShot(env, "hero.png");
+
+    const realBatch = db.batch.bind(db);
+    db.batch = (() => {
+      throw new Error("boom");
+    }) as typeof db.batch;
+    try {
+      await expect(handleWebhook(env, "pull_request", closedPayload())).resolves.toBeUndefined();
+    } finally {
+      db.batch = realBatch;
+    }
+  });
+});

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -209,6 +209,32 @@ async function gatherAndUpsert(env: Env, link: RepoLink, target: GhTarget): Prom
 }
 
 /**
+ * Resolve a repo's bound workspace, or null after cleaning up a stale link —
+ * the shared front half of `autoPromoteAndComment` and
+ * `stampMergedScreenshots` (#326 read/delete-only policy). No link → null; a
+ * missing/tombstoned linked workspace → delete the stale link (so
+ * first-claim-wins never blocks a future claim forever) and return null.
+ * Never creates a link.
+ */
+async function resolveLinkedWorkspaceOrCleanup(
+  env: Env,
+  repo: string,
+): Promise<{
+  link: RepoLink;
+  ws: NonNullable<Awaited<ReturnType<typeof loadWorkspaceRecord>>>;
+} | null> {
+  const link = await findRepoLinkStrict(env.DB, repo);
+  if (!link) return null;
+
+  const ws = await loadWorkspaceRecord(env, link.workspaceName);
+  if (!ws) {
+    await deleteRepoLink(env.DB, repo);
+    return null;
+  }
+  return { link, ws };
+}
+
+/**
  * Webhook-driven auto-promotion for one bound repo/PR. No-ops on: no repo
  * link or a missing/tombstoned linked workspace. Downstream promote/gather/
  * comment failures THROW — the caller decides whether that means a queue
@@ -223,14 +249,9 @@ async function autoPromoteAndComment(
   num: number,
   branch: string,
 ): Promise<void> {
-  const link = await findRepoLinkStrict(env.DB, repo);
-  if (!link) return;
-
-  const ws = await loadWorkspaceRecord(env, link.workspaceName);
-  if (!ws) {
-    await deleteRepoLink(env.DB, repo);
-    return;
-  }
+  const resolved = await resolveLinkedWorkspaceOrCleanup(env, repo);
+  if (!resolved) return;
+  const { link, ws } = resolved;
 
   await promoteBranchAttachments(env, ws, link.workspaceName, { repo, num, branch });
 
@@ -244,8 +265,8 @@ async function autoPromoteAndComment(
 /**
  * Webhook-driven merge tagging for one bound repo/PR (see the module doc
  * above for the `gh.merged`-only, no-`gh.pr-state` rationale). No-ops on: no
- * repo link or a missing/tombstoned linked workspace — same binding
- * resolution and stale-link cleanup as `autoPromoteAndComment`. Finds the
+ * repo link or a missing/tombstoned linked workspace — shares
+ * `resolveLinkedWorkspaceOrCleanup` with `autoPromoteAndComment`. Finds the
  * PR's screenshots by metadata (`gh.ref`/`gh.kind`), not by key prefix, so
  * this covers private-repo `gh/private/<hex>/...` keys too. Stamping is
  * best-effort per shot (log, never throw) — mirrors
@@ -254,14 +275,9 @@ async function autoPromoteAndComment(
  * `autoPromoteAndComment`, so the queue consumer retries the event.
  */
 async function stampMergedScreenshots(env: Env, repo: string, num: number): Promise<void> {
-  const link = await findRepoLinkStrict(env.DB, repo);
-  if (!link) return;
-
-  const ws = await loadWorkspaceRecord(env, link.workspaceName);
-  if (!ws) {
-    await deleteRepoLink(env.DB, repo);
-    return;
-  }
+  const resolved = await resolveLinkedWorkspaceOrCleanup(env, repo);
+  if (!resolved) return;
+  const { link } = resolved;
 
   const [owner, name] = repo.split("/");
   const ref = `${owner}/${name}#${num}`.toLowerCase();

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -25,6 +25,22 @@
  * gather+upsert. Same `ctx.waitUntil`/degrade-safe doctrine as above; never
  * creates a repo binding, only consumes `findRepoLink`.
  *
+ * Merge tagging (`pull_request` `closed` with `merged: true` — persisted
+ * PR merge-state tagging, 2026-08-21): stamps every one of the merged PR's
+ * already-tagged screenshots with `gh.merged=true` (found via metadata —
+ * `gh.ref`/`gh.kind` — not by key prefix, so this also covers private-repo
+ * `gh/private/<hex>/...` keys). A merge is a terminal, durable fact — unlike
+ * open/closed, which stay transient and are already resolved live by the KV
+ * title cache (github-titles.ts) — so `gh.merged` is deliberately the ONLY
+ * PR lifecycle fact this codebase persists as metadata; there is no
+ * `gh.pr-state` key, which would wrongly imply the full lifecycle is
+ * tracked. `closed` with `merged: false` (closed without merging) is a
+ * no-op. Same repo→workspace binding resolution, stale-link cleanup, and
+ * fork guard as auto-promotion; per-shot tagging failures are logged and
+ * swallowed (mirrors `promoteBranchAttachments`'s tagging doctrine), while a
+ * D1 outage resolving the binding still throws so the queue consumer
+ * retries.
+ *
  * Queue ingestion (issue #287): payload parsing is split into a pure
  * `extractWebhookEvent` (delivery → compact `WebhookEvent` or null) and an
  * effectful `processWebhookEvent` (KV deletes + promote/reconcile). When the
@@ -41,6 +57,7 @@ import { hasUserAttachmentUrl } from "./github-attachment-extract";
 import { cacheRepoPrivacy, githubAppConfig, installationForRepo } from "./github-app";
 import { commentCacheKey, gatherCommentBody, upsertBotComment } from "./github-comment";
 import { ATTACHMENTS_MARKER } from "./github-comment-render";
+import { findObjectsByMetadata, setFileMetadata } from "./file-metadata";
 import type { GhTarget } from "./github-comment-render";
 import { ingestForWebhook, type IngestSourceRef } from "./github-ingest";
 import {
@@ -134,6 +151,9 @@ interface PullRequestPayload {
   repository?: { full_name?: unknown; private?: unknown };
   pull_request?: {
     number?: unknown;
+    /** Only meaningful on `action: "closed"` — true iff the PR was merged
+     * (vs. closed without merging). */
+    merged?: unknown;
     head?: { ref?: unknown; repo?: { full_name?: unknown } };
   };
 }
@@ -221,6 +241,52 @@ async function autoPromoteAndComment(
   await gatherAndUpsert(env, link, target);
 }
 
+/**
+ * Webhook-driven merge tagging for one bound repo/PR (see the module doc
+ * above for the `gh.merged`-only, no-`gh.pr-state` rationale). No-ops on: no
+ * repo link or a missing/tombstoned linked workspace — same binding
+ * resolution and stale-link cleanup as `autoPromoteAndComment`. Finds the
+ * PR's screenshots by metadata (`gh.ref`/`gh.kind`), not by key prefix, so
+ * this covers private-repo `gh/private/<hex>/...` keys too. Stamping is
+ * best-effort per shot (log, never throw) — mirrors
+ * `promoteBranchAttachments`'s tagging-failure doctrine — but a D1 outage
+ * resolving the binding or listing matches still throws, same as
+ * `autoPromoteAndComment`, so the queue consumer retries the event.
+ */
+async function stampMergedScreenshots(env: Env, repo: string, num: number): Promise<void> {
+  const link = await findRepoLinkStrict(env.DB, repo);
+  if (!link) return;
+
+  const ws = await loadWorkspaceRecord(env, link.workspaceName);
+  if (!ws) {
+    await deleteRepoLink(env.DB, repo);
+    return;
+  }
+
+  const [owner, name] = repo.split("/");
+  const ref = `${owner}/${name}#${num}`.toLowerCase();
+  const matches = await findObjectsByMetadata(env.DB, link.workspaceName, {
+    "gh.ref": ref,
+    "gh.kind": "pull",
+  });
+
+  for (const match of matches) {
+    try {
+      await setFileMetadata(env.DB, link.workspaceName, match.key, { "gh.merged": "true" });
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          message: "webhook: failed to stamp gh.merged",
+          repo,
+          num,
+          key: match.key,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
+  }
+}
+
 /** Substring shared by every managed-comment marker variant (legacy + the
  * per-workspace `ws=<slug>` namespaced form) — cheap to test for without
  * parsing which marker it is. Derived from `ATTACHMENTS_MARKER` so there is
@@ -306,6 +372,9 @@ export interface WebhookEvent {
   promote?: { repo: string; num: number; branch: string };
   /** Gated issue_comment edited/deleted → heal the managed comment. */
   reconcile?: { repo: string; num: number; kind: GhTarget["kind"] };
+  /** Same-repo PR closed with `merged: true` → stamp its screenshots
+   * `gh.merged=true` (persisted PR merge-state tagging). */
+  merge?: { repo: string; num: number };
   /** Opt-in GitHub-native attachment ingest (spec 2026-08-11). Source ref only —
    * the consumer re-fetches current text, so this stays queue-compact. */
   ingest?: IngestSourceRef;
@@ -396,6 +465,20 @@ export function extractWebhookEvent(eventType: string, payload: unknown): Webhoo
       pr.head.repo.full_name.toLowerCase() === repo.toLowerCase()
     ) {
       ev.promote = { repo, num: pr.number, branch: pr.head.ref };
+    } else if (
+      // Merge tagging (persisted PR merge-state, 2026-08-21): closed WITHOUT
+      // `merged: true` (i.e. closed without merging) is deliberately a no-op
+      // — only a real merge is a terminal, durable fact worth persisting.
+      action === "closed" &&
+      pr?.merged === true &&
+      typeof repo === "string" &&
+      typeof pr.number === "number" &&
+      typeof pr.head?.repo?.full_name === "string" &&
+      // Same fork guard as promote above: a fork PR's screenshots (if any)
+      // live under the fork's own workspace context, not this repo's binding.
+      pr.head.repo.full_name.toLowerCase() === repo.toLowerCase()
+    ) {
+      ev.merge = { repo, num: pr.number };
     }
   } else if (eventType === "issue_comment") {
     // isReconcilableCommentEvent's cheap payload-only check runs here, before
@@ -444,7 +527,13 @@ export function extractWebhookEvent(eventType: string, payload: unknown): Webhoo
   }
   // ping and unknown events fall through with no work.
 
-  return ev.keys.length || ev.promote || ev.reconcile || ev.ingest || ev.adopt || ev.privacy
+  return ev.keys.length ||
+    ev.promote ||
+    ev.reconcile ||
+    ev.ingest ||
+    ev.adopt ||
+    ev.merge ||
+    ev.privacy
     ? ev
     : null;
 }
@@ -489,6 +578,9 @@ export async function processWebhookEvent(env: Env, ev: WebhookEvent): Promise<v
   if (ev.adopt) {
     await adoptLinkedFilesForWebhook(env, ev.adopt);
   }
+  if (ev.merge) {
+    await stampMergedScreenshots(env, ev.merge.repo, ev.merge.num);
+  }
 }
 
 /** `processWebhookEvent` with every failure caught and logged — the inline
@@ -504,6 +596,7 @@ async function processInline(env: Env, ev: WebhookEvent): Promise<void> {
         reconcile: ev.reconcile ?? null,
         ingest: ev.ingest ?? null,
         adopt: ev.adopt ?? null,
+        merge: ev.merge ?? null,
         error: err instanceof Error ? err.message : String(err),
       }),
     );

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1664,6 +1664,28 @@ describe("GET /me/workspaces/:name/files/search", () => {
     expect(typeof body.items[0]!.updatedAt).toBe("string");
   });
 
+  // Persisted PR merge-state tagging: gh.merged is a normal queryable value —
+  // meta.gh.merged=true must filter like any other meta.* equality filter.
+  it("filters by meta.gh.merged=true like any other metadata filter", async () => {
+    const db = metadataDb([
+      {
+        workspace: "acme",
+        key: "shots/merged.png",
+        meta: { "gh.kind": "pull", "gh.merged": "true" },
+      },
+      { workspace: "acme", key: "shots/open.png", meta: { "gh.kind": "pull" } },
+    ]);
+    const env = memberEnv({ workspace: "acme", db, bucket: new FakeR2Bucket(), record: R2_RECORD });
+    const res = await app().request(
+      "/me/workspaces/acme/files/search?meta.gh.merged=true",
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: { key: string }[] };
+    expect(body.items.map((i) => i.key)).toEqual(["shots/merged.png"]);
+  });
+
   it("rejects a repeated filter key with file_metadata_duplicate_filter", async () => {
     const env = memberEnv({ workspace: "acme", db: metadataDb([]), record: R2_RECORD });
     const res = await app().request(
@@ -1946,6 +1968,40 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
     const res = await app().request("/me/workspaces/other/files/by-path", {}, env);
     expect(res.status).toBe(404);
   });
+
+  // Persisted PR merge-state tagging: the opt-in `?merged=1` param filters to
+  // objects stamped `gh.merged=true`, without changing the default (no-param)
+  // response — the flag is opt-in only, general by-path browsing is unfiltered.
+  it("returns every path-tagged shot without ?merged, and only gh.merged=true ones with it", async () => {
+    const db = metadataDb([
+      {
+        workspace: "acme",
+        key: "shots/merged.png",
+        meta: { path: "/settings", "gh.kind": "pull", "gh.merged": "true" },
+      },
+      {
+        workspace: "acme",
+        key: "shots/open.png",
+        meta: { path: "/settings", "gh.kind": "pull" },
+      },
+    ]);
+    const env = memberEnv({ workspace: "acme", db, bucket: new FakeR2Bucket(), record: R2_RECORD });
+
+    const unfiltered = await app().request("/me/workspaces/acme/files/by-path", {}, env);
+    expect(unfiltered.status).toBe(200);
+    const unfilteredBody = (await unfiltered.json()) as { groups: { count: number }[] };
+    expect(unfilteredBody.groups).toHaveLength(1);
+    expect(unfilteredBody.groups[0]).toMatchObject({ count: 2 });
+
+    const filtered = await app().request("/me/workspaces/acme/files/by-path?merged=1", {}, env);
+    expect(filtered.status).toBe(200);
+    const filteredBody = (await filtered.json()) as {
+      groups: { count: number; recent: { key: string }[] }[];
+    };
+    expect(filteredBody.groups).toHaveLength(1);
+    expect(filteredBody.groups[0]).toMatchObject({ count: 1 });
+    expect(filteredBody.groups[0]!.recent.map((r) => r.key)).toEqual(["shots/merged.png"]);
+  });
 });
 
 describe("GET /me/workspaces/:name/files/facets", () => {
@@ -1962,6 +2018,37 @@ describe("GET /me/workspaces/:name/files/facets", () => {
         { key: "gh.repo", count: 2, distinctValues: 1 },
         { key: "app", count: 1, distinctValues: 1 },
       ],
+      truncated: false,
+    });
+  });
+
+  // Persisted PR merge-state tagging: gh.merged is a plain, client-visible
+  // metadata key — it must show up as a facet like any other, with its one
+  // stored value ("true").
+  it("lists gh.merged as a facet key and its value", async () => {
+    const db = metadataDb([
+      { workspace: "acme", key: "a.png", meta: { "gh.kind": "pull", "gh.merged": "true" } },
+    ]);
+    const env = memberEnv({ workspace: "acme", db, record: R2_RECORD });
+    const keysRes = await app().request("/me/workspaces/acme/files/facets", {}, env);
+    expect(keysRes.status).toBe(200);
+    expect(await keysRes.json()).toEqual({
+      keys: [
+        { key: "gh.kind", count: 1, distinctValues: 1 },
+        { key: "gh.merged", count: 1, distinctValues: 1 },
+      ],
+      truncated: false,
+    });
+
+    const valuesRes = await app().request(
+      "/me/workspaces/acme/files/facets?key=gh.merged",
+      {},
+      env,
+    );
+    expect(valuesRes.status).toBe(200);
+    expect(await valuesRes.json()).toEqual({
+      key: "gh.merged",
+      values: [{ value: "true", count: 1 }],
       truncated: false,
     });
   });

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -205,8 +205,12 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   .get("/:workspace/files/by-path", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
     const record = c.get("workspace");
     const name = c.get("workspaceName");
+    // Opt-in "Merged only" filter (Screenshots page toggle) — leaves the
+    // default (unfiltered) overview and general `meta.gh.merged=` search
+    // semantics untouched.
+    const mergedOnly = c.req.query("merged") === "1";
     const { groups, catalog, projects, latest, truncated, catalogTruncated } =
-      await groupObjectsByPath(c.env.DB, name);
+      await groupObjectsByPath(c.env.DB, name, { mergedOnly });
     const shotKeys = [
       ...groups.flatMap((group) => group.recent),
       ...latest.map((item) => item.key),

--- a/apps/web/src/components/ScreenshotsByPath.test.ts
+++ b/apps/web/src/components/ScreenshotsByPath.test.ts
@@ -44,7 +44,13 @@ import { readScreenshotsView } from "../lib/workspace-screenshots";
  */
 describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
   it("a default overview (empty search) seeds an empty project, path, and q", () => {
-    expect(readScreenshotsView("")).toEqual({ project: "", path: "", q: "", feed: "grouped" });
+    expect(readScreenshotsView("")).toEqual({
+      project: "",
+      path: "",
+      q: "",
+      feed: "grouped",
+      merged: false,
+    });
   });
 
   it("a deep-linked project view seeds that project, no path", () => {
@@ -53,6 +59,7 @@ describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
       path: "",
       q: "",
       feed: "grouped",
+      merged: false,
     });
   });
 
@@ -62,6 +69,7 @@ describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
       path: "/admin",
       q: "",
       feed: "grouped",
+      merged: false,
     });
   });
 
@@ -71,6 +79,7 @@ describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
       path: "",
       q: "/catalog",
       feed: "grouped",
+      merged: false,
     });
   });
 });
@@ -90,6 +99,7 @@ describe("ScreenshotsByPath seed contract — no initialSearch prop (props-less 
       path: "",
       q: "",
       feed: "grouped",
+      merged: false,
     });
   });
 });

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -368,18 +368,22 @@ function FilterBar({
   q,
   path,
   feed,
+  merged,
   projects,
   catalog,
   onProject,
   onQuery,
   onFeed,
   onPickPath,
+  onMerged,
 }: {
   project: string;
   q: string;
   /** Exact drill-in path, shown in the input so editing it widens the filter. */
   path: string;
   feed: ScreenshotsFeed;
+  /** "Merged only" toggle (persisted PR merge-state tagging). */
+  merged: boolean;
   projects: string[];
   /** Path catalog backing the input's autocomplete suggestions. */
   catalog: PathCatalogEntry[];
@@ -387,6 +391,7 @@ function FilterBar({
   onQuery: (q: string) => void;
   onFeed: (feed: ScreenshotsFeed) => void;
   onPickPath: (path: string) => void;
+  onMerged: (merged: boolean) => void;
 }) {
   const options = project && !projects.includes(project) ? [...projects, project] : projects;
   const [suggestOpen, setSuggestOpen] = useState(false);
@@ -515,6 +520,18 @@ function FilterBar({
           Recent
         </button>
       </div>
+      {/* Persisted PR merge-state tagging: filters both the drill-in
+          (meta.gh.merged=true) and the grouped overview (?merged=1). */}
+      <div className="wsp-toggle" role="group" aria-label="Merge filter">
+        <button
+          type="button"
+          className="wsp-toggle__opt"
+          aria-pressed={merged}
+          onClick={() => onMerged(!merged)}
+        >
+          Merged only
+        </button>
+      </div>
     </div>
   );
 }
@@ -609,12 +626,12 @@ function ScreenshotsByPathInner({
     };
   }, [apiOrigin, workspace, infoRetryNonce]);
 
-  // Overview fetch, once per mount/workspace/retry.
+  // Overview fetch, once per mount/workspace/retry/merged-toggle.
   useEffect(() => {
     let cancelled = false;
     setOverview({ status: "loading" });
     onSession(() => {
-      void getWorkspaceFilesByPath(apiOrigin, workspace).then((result) => {
+      void getWorkspaceFilesByPath(apiOrigin, workspace, { merged: view.merged }).then((result) => {
         if (cancelled) return;
         setOverview(
           result.kind === "ok"
@@ -634,7 +651,7 @@ function ScreenshotsByPathInner({
     return () => {
       cancelled = true;
     };
-  }, [apiOrigin, workspace, overviewRetryNonce]);
+  }, [apiOrigin, workspace, overviewRetryNonce, view.merged]);
 
   // GitHub-mirrored screenshots ("From GitHub" section), fetched in parallel
   // with the by-path overview. A failure here must never block or break the
@@ -667,7 +684,8 @@ function ScreenshotsByPathInner({
     history.replaceState(
       null,
       "",
-      window.location.pathname + screenshotsSearch(view.project, view.path, view.q, view.feed),
+      window.location.pathname +
+        screenshotsSearch(view.project, view.path, view.q, view.feed, view.merged),
     );
     if (!view.path) {
       setDrill({ status: "idle" });
@@ -676,9 +694,17 @@ function ScreenshotsByPathInner({
     let cancelled = false;
     setDrill({ status: "loading" });
     onSession(() => {
-      void searchWorkspaceFiles(apiOrigin, workspace, [{ key: "path", value: view.path }], {
-        collapsePromoted: true,
-      }).then((result) => {
+      void searchWorkspaceFiles(
+        apiOrigin,
+        workspace,
+        [
+          { key: "path", value: view.path },
+          // "Merged only" toggle (persisted PR merge-state tagging): gh.merged
+          // is a normal ANDed metadata filter, same as any other meta.* term.
+          ...(view.merged ? [{ key: "gh.merged", value: "true" }] : []),
+        ],
+        { collapsePromoted: true },
+      ).then((result) => {
         if (cancelled) return;
         setDrill(
           result.kind === "ok"
@@ -690,7 +716,16 @@ function ScreenshotsByPathInner({
     return () => {
       cancelled = true;
     };
-  }, [apiOrigin, workspace, view.project, view.path, view.q, view.feed, drillRetryNonce]);
+  }, [
+    apiOrigin,
+    workspace,
+    view.project,
+    view.path,
+    view.q,
+    view.feed,
+    view.merged,
+    drillRetryNonce,
+  ]);
 
   // Thumb backfill for groups past the overview's 50-group thumbed cap:
   // filtering (especially by project) surfaces catalog paths whose group got
@@ -871,6 +906,7 @@ function ScreenshotsByPathInner({
   const setProject = (project: string) => setView({ ...view, project, path: "" });
   const setQuery = (q: string) => setView({ ...view, path: "", q });
   const setFeed = (feed: ScreenshotsFeed) => setView({ ...view, path: "", feed });
+  const setMerged = (merged: boolean) => setView({ ...view, merged });
 
   // GitHub items bucketed by project label, for both the overview's
   // per-project strips and the project view's full "From GitHub" section.
@@ -886,19 +922,25 @@ function ScreenshotsByPathInner({
     (label) => !overview.projects.some((p) => p.label === label),
   );
   const projectLabels = [...overview.projects.map((p) => p.label), ...ghOnlyLabels];
-  const showFilter = projectLabels.length > 0 || overview.catalog.length > 0;
+  // `view.merged` keeps the bar (and its toggle) visible even when the
+  // merged-only filter itself narrows the catalog to nothing — otherwise a
+  // workspace with no merged shots would hide the only control that can turn
+  // the filter back off.
+  const showFilter = projectLabels.length > 0 || overview.catalog.length > 0 || view.merged;
   const filterBar = showFilter ? (
     <FilterBar
       project={view.project}
       q={view.q}
       path={view.path}
       feed={view.feed}
+      merged={view.merged}
       projects={projectLabels}
       catalog={overview.catalog}
       onProject={setProject}
       onQuery={setQuery}
       onFeed={setFeed}
       onPickPath={(path) => setView({ ...view, path })}
+      onMerged={setMerged}
     />
   ) : null;
   const previewTitle = preview?.ref ? titles[preview.ref] : undefined;
@@ -1025,12 +1067,14 @@ function ScreenshotsByPathInner({
       <div className="wsp">
         {filterBar}
         {latestItems.length === 0 ? (
-          overview.latest.length === 0 && overview.catalog.length === 0 ? (
+          !view.merged && overview.latest.length === 0 && overview.catalog.length === 0 ? (
             <EmptyShotsCta title="No screenshots yet" />
           ) : (
             <p className="wft-end">
               {overview.latest.length === 0
-                ? "No recent uploads to show."
+                ? view.merged
+                  ? "No merged uploads to show."
+                  : "No recent uploads to show."
                 : "No recent uploads match this filter."}
             </p>
           )
@@ -1094,9 +1138,14 @@ function ScreenshotsByPathInner({
     ].filter(sectionHasContent);
   }
 
-  const isEmptyWorkspace = overview.catalog.length === 0 && ghByProject.size === 0;
+  // `view.merged` excluded from `isEmptyWorkspace`: an empty catalog under
+  // the merged-only filter means "no merged shots yet", not "no screenshots
+  // ever uploaded" — that's the filtered-empty message below, not the CLI CTA.
+  const isEmptyWorkspace = !view.merged && overview.catalog.length === 0 && ghByProject.size === 0;
   const isEmptyFilter = !isEmptyWorkspace && sectionLabels.length === 0;
-  let emptyFilterMessage = "No screenshots for this project.";
+  let emptyFilterMessage = view.merged
+    ? "No merged screenshots for this project yet."
+    : "No screenshots for this project.";
   if (qTrim) {
     emptyFilterMessage = overview.catalogTruncated
       ? `No paths matching ${qTrim} in the most active set.`

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -671,6 +671,25 @@ describe("getWorkspaceFilesByPath", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(seenInit?.headers).toBeUndefined();
   });
+
+  // Persisted PR merge-state tagging: opts.merged is opt-in — sent as
+  // `?merged=1` only when true, omitted (not `merged=0`) otherwise.
+  it("appends ?merged=1 only when opts.merged is true", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
+      Response.json({ groups: [], projects: [], truncated: false }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getWorkspaceFilesByPath("https://api.uploads.sh", "acme", { merged: true });
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "https://api.uploads.sh/v1/workspaces/acme/files/by-path?merged=1",
+    );
+
+    await getWorkspaceFilesByPath("https://api.uploads.sh", "acme", { merged: false });
+    expect(fetchMock.mock.calls[1]![0]).toBe(
+      "https://api.uploads.sh/v1/workspaces/acme/files/by-path",
+    );
+  });
 });
 
 describe("getWorkspaceFacets", () => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -993,9 +993,13 @@ function catalogFromGroups(groups: FilesPathGroup[]): PathCatalogEntry[] {
 export async function getWorkspaceFilesByPath(
   apiOrigin: string,
   name: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; merged?: boolean },
 ): Promise<FilesByPathResult> {
-  const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/by-path`;
+  // Opt-in "Merged only" filter (persisted PR merge-state tagging) — omitted
+  // entirely rather than sent as `merged=0`/`false`, so a default call's URL
+  // is unchanged.
+  const query = opts?.merged ? "?merged=1" : "";
+  const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/by-path${query}`;
   const result = await fetchWithTimeout(url, sessionFetchInit(opts?.cookie));
   if (result.kind === "unavailable") return result;
   const { response } = result;

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -184,6 +184,7 @@ describe("screenshots view URL state", () => {
       path: "/admin",
       q: "/cat",
       feed: "grouped",
+      merged: false,
     });
     expect(screenshotsSearch("acme/web", "/admin", "/cat")).toBe(
       "?project=acme%2Fweb&path=%2Fadmin&q=%2Fcat",
@@ -206,8 +207,20 @@ describe("screenshots view URL state", () => {
       path: "/admin",
       q: "",
       feed: "grouped",
+      merged: false,
     });
     expect(screenshotsSearch("", "/admin")).toBe("?path=%2Fadmin");
+  });
+
+  it("round-trips the merged-only toggle, defaulting to false", () => {
+    expect(readScreenshotsView("?merged=1").merged).toBe(true);
+    expect(readScreenshotsView("?merged=0").merged).toBe(false);
+    expect(readScreenshotsView("").merged).toBe(false);
+    expect(screenshotsSearch("", "", "", "grouped", true)).toBe("?merged=1");
+    expect(screenshotsSearch("", "", "", "grouped", false)).toBe("");
+    expect(screenshotsSearch("acme/web", "", "", "recent", true)).toBe(
+      "?project=acme%2Fweb&view=recent&merged=1",
+    );
   });
 });
 

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -175,9 +175,13 @@ export interface ScreenshotsView {
   path: string;
   q: string;
   feed: ScreenshotsFeed;
+  /** "Merged only" toggle (persisted PR merge-state tagging) — filters both
+   * the grouped overview (`?merged=1` on files/by-path) and the drill-in
+   * (`meta.gh.merged=true`). */
+  merged: boolean;
 }
 
-/** `?project=` / `?path=` / `?q=` / `?view=` state, ""/grouped when absent. */
+/** `?project=` / `?path=` / `?q=` / `?view=` / `?merged=` state, ""/grouped/false when absent. */
 export function readScreenshotsView(search: string): ScreenshotsView {
   const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
   return {
@@ -185,6 +189,7 @@ export function readScreenshotsView(search: string): ScreenshotsView {
     path: params.get("path") ?? "",
     q: params.get("q") ?? "",
     feed: params.get("view") === "recent" ? "recent" : "grouped",
+    merged: params.get("merged") === "1",
   };
 }
 
@@ -194,12 +199,14 @@ export function screenshotsSearch(
   path: string,
   q = "",
   feed: ScreenshotsFeed = "grouped",
+  merged = false,
 ): string {
   const params = new URLSearchParams();
   if (project) params.set("project", project);
   if (path) params.set("path", path);
   if (q) params.set("q", q);
   if (feed === "recent") params.set("view", "recent");
+  if (merged) params.set("merged", "1");
   const qs = params.toString();
   return qs ? `?${qs}` : "";
 }


### PR DESCRIPTION
## What

When a GitHub PR is merged, stamp that PR's screenshots with a queryable
metadata tag so the Screenshots page can filter to "merged to main" shots.

Tag: **`gh.merged` = `"true"`** (a merge write, not a replace). There is
deliberately **no `gh.pr-state` key** — we only ever learn and persist the
*merged* fact (a merge is terminal and durable); open/closed stay transient
and are already resolved live by the KV title cache
(`github-titles.ts`, reused by #729's pop-over). A `pr-state` key would
falsely imply the full lifecycle is tracked. Documented in
`apps/api/src/github-webhook.ts`'s module doc comment and above
`MERGED_STATUS_SQL` in `file-metadata.ts`.

## How

**Webhook (`apps/api/src/github-webhook.ts`)**
- New `pull_request` `closed` branch: when `payload.pull_request.merged ===
  true`, resolves the repo's bound workspace the same way auto-promotion
  does (`findRepoLinkStrict` → `loadWorkspaceRecord`, cleaning up a stale
  link the same way), then finds the PR's shots via
  `findObjectsByMetadata(db, workspace, { "gh.ref": ref, "gh.kind": "pull" })`
  — metadata-driven, not key-prefix, so private-repo `gh/private/<hex>/...`
  keys are covered too. Each match is merge-written with
  `setFileMetadata(db, workspace, key, { "gh.merged": "true" })`,
  best-effort per shot (log-and-never-throw, mirroring
  `promoteBranchAttachments`'s tagging doctrine). `closed` without merging
  is a no-op. Same fork guard as auto-promotion (head repo must match base
  repo).

**Filterability**
- `gh.merged` is a plain metadata value — it shows up in `facetKeys`/
  `facetValues` and `meta.gh.merged=true` filters through the existing
  `files/search` route and `find_files` MCP tool like any other key. No
  special-casing needed or added.
- `groupObjectsByPath` (`file-metadata.ts`) gains an opt-in
  `opts.mergedOnly` filter — an `EXISTS` counterpart to the existing
  promoted-shadow `NOT EXISTS` clause (`PROMOTED_SHADOW_STATUS_SQL` /
  `MERGED_STATUS_SQL`), applied to the same underlying query so `groups`,
  `catalog`, `projects`, and `latest` all reflect the same filtered rows.
  `routes/workspace-files.ts`'s `GET files/by-path` threads an opt-in
  `?merged=1` query param into it.

**Web (`ScreenshotsByPath.tsx`)**
- A "Merged only" toggle in the `FilterBar`, stored in `ScreenshotsView`
  and round-tripped through the URL as `?merged=1` (alongside the existing
  `?view=recent` toggle). Filters both the drill-in (adds
  `{ key: "gh.merged", value: "true" }` to the search filters) and the
  grouped overview (`getWorkspaceFilesByPath(..., { merged: true })` →
  `?merged=1`). The filter bar stays visible (so the toggle can be turned
  back off) and empty-state copy distinguishes "no merged shots yet" from
  "no screenshots at all" when the toggle narrows a workspace to zero
  results.

## Backfill (not implemented — follow-up)

Existing already-merged PRs won't carry `gh.merged` retroactively. A
one-time backfill would iterate merged `pull/<n>` refs (the title cache in
`github-titles.ts` already resolves merged state) and stamp them. Left as a
follow-up issue.

## Tests

- `apps/api/src/github-webhook-merge.test.ts` (new, 9 tests): merged
  stamping, merge-write doesn't disturb existing `gh.*` tags, private-prefix
  keys found by metadata, `merged: false`/absent is a no-op, no binding is a
  no-op, fork guard, stale-link cleanup, best-effort per-shot failure
  handling.
- `apps/api/src/file-metadata-facets.test.ts`: `groupObjectsByPath`'s
  `opts.mergedOnly` unit test.
- `apps/api/src/routes/me.test.ts`: `?merged=1` on `files/by-path`, `gh.merged`
  as a facet key/value, `meta.gh.merged=true` search filter.
- `apps/web/src/lib/workspace-screenshots.test.ts` +
  `apps/web/src/components/ScreenshotsByPath.test.ts`: the toggle's URL/state
  round-trip (pure helpers only — this package's vitest can't import `.tsx`).
- `apps/web/src/lib/api-client.test.ts`: `?merged=1` only sent when
  `opts.merged` is true.

All green: API `tsc --noEmit` + `vitest run` (2022 tests), Web `tsc --noEmit`
+ `vitest run` (754 tests).

## Note

This branch was rebased onto `main` after #729 (PR status + upload time in
the pop-over) merged — both touched `ScreenshotsByPath.tsx`,
`workspace-screenshots.ts`, `api-client.ts`, `file-metadata.ts`, and
`routes/workspace-files.ts`. The rebase is already done here (one conflict,
in the `files/by-path` handler, resolved by keeping both changes side by
side), so this PR applies cleanly on top of current `main`.
