### PR TITLE
feat(web): same-origin auth proxy infrastructure (#731 phase A)

### DIFF
--- a/apps/web/src/lib/auth-proxy.test.ts
+++ b/apps/web/src/lib/auth-proxy.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { proxyAuthRequest, serverGetSession } from "./auth-proxy";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Minimal binding fake — records the forwarded request and returns a canned response. */
+function fakeAuthBinding(response: Response) {
+  const fetch = vi.fn(async (_req: Request) => response);
+  return { AUTH: { fetch }, fetchMock: fetch };
+}
+
+describe("proxyAuthRequest — binding transport", () => {
+  it("forwards the request over env.AUTH with redirect: manual", async () => {
+    const { AUTH, fetchMock } = fakeAuthBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/auth/get-session", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    await proxyAuthRequest({ AUTH }, request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://uploads.sh/api/auth/get-session");
+    expect(forwarded.redirect).toBe("manual");
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
+  });
+
+  it("passes a 302 + Location through unmodified", async () => {
+    const upstream = new Response(null, {
+      status: 302,
+      headers: { location: "https://uploads.sh/login" },
+    });
+    const { AUTH } = fakeAuthBinding(upstream);
+    const request = new Request("https://uploads.sh/api/auth/sign-in/social");
+
+    const response = await proxyAuthRequest({ AUTH }, request);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://uploads.sh/login");
+  });
+});
+
+describe("proxyAuthRequest — HTTP fallback transport", () => {
+  it("rewrites only the origin, keeping path/query/method/headers/body", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const req = input as Request;
+      expect(req.url).toBe("http://127.0.0.1:8788/api/auth/sign-in/magic-link?x=1");
+      expect(req.method).toBe("POST");
+      expect(req.redirect).toBe("manual");
+      expect(req.headers.get("content-type")).toBe("application/json");
+      expect(await req.text()).toBe('{"email":"a@b.com"}');
+      return Response.json({ ok: true });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new Request("https://uploads.sh/api/auth/sign-in/magic-link?x=1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"email":"a@b.com"}',
+    });
+
+    await proxyAuthRequest({}, request);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to http://127.0.0.1:8788 when UPLOADS_AUTH_ORIGIN is unset", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect((input as Request).url).toMatch(/^http:\/\/127\.0\.0\.1:8788\//);
+      return Response.json(null);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await proxyAuthRequest({}, new Request("https://uploads.sh/api/auth/get-session"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses UPLOADS_AUTH_ORIGIN when provided", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect((input as Request).url).toBe("https://auth.uploads.localhost/api/auth/get-session");
+      return Response.json(null);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await proxyAuthRequest(
+      { UPLOADS_AUTH_ORIGIN: "https://auth.uploads.localhost" },
+      new Request("https://uploads.localhost/api/auth/get-session"),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("proxyAuthRequest — legacy cookie clearing", () => {
+  it("appends the clearing Set-Cookie when host-only session cookie is set on uploads.sh", async () => {
+    const upstream = new Response(null, {
+      status: 200,
+      headers: {
+        "set-cookie":
+          "__Secure-better-auth.session_token=xyz; Path=/; Secure; HttpOnly; SameSite=Lax",
+      },
+    });
+    const { AUTH } = fakeAuthBinding(upstream);
+    const request = new Request("https://uploads.sh/api/auth/sign-in/magic-link", {
+      method: "POST",
+    });
+
+    const response = await proxyAuthRequest({ AUTH }, request);
+    const setCookies = response.headers.getSetCookie();
+
+    expect(setCookies).toContain(
+      "__Secure-better-auth.session_token=; Path=/; Domain=.uploads.sh; Max-Age=0; Secure; HttpOnly; SameSite=Lax",
+    );
+    expect(setCookies).toHaveLength(2);
+  });
+
+  it("does NOT append when the Set-Cookie has a Domain attribute", async () => {
+    const upstream = new Response(null, {
+      status: 200,
+      headers: {
+        "set-cookie":
+          "__Secure-better-auth.session_token=xyz; Path=/; Domain=.uploads.sh; Secure; HttpOnly; SameSite=Lax",
+      },
+    });
+    const { AUTH } = fakeAuthBinding(upstream);
+    const request = new Request("https://uploads.sh/api/auth/sign-in/magic-link", {
+      method: "POST",
+    });
+
+    const response = await proxyAuthRequest({ AUTH }, request);
+    expect(response.headers.getSetCookie()).toHaveLength(1);
+  });
+
+  it("does NOT append for a non-session Set-Cookie", async () => {
+    const upstream = new Response(null, {
+      status: 200,
+      headers: { "set-cookie": "some_other_cookie=1; Path=/" },
+    });
+    const { AUTH } = fakeAuthBinding(upstream);
+    const request = new Request("https://uploads.sh/api/auth/sign-in/magic-link", {
+      method: "POST",
+    });
+
+    const response = await proxyAuthRequest({ AUTH }, request);
+    expect(response.headers.getSetCookie()).toHaveLength(1);
+  });
+
+  it("does NOT append when the request host is uploads.localhost", async () => {
+    const upstream = new Response(null, {
+      status: 200,
+      headers: {
+        "set-cookie":
+          "__Secure-better-auth.session_token=xyz; Path=/; Secure; HttpOnly; SameSite=Lax",
+      },
+    });
+    const { AUTH } = fakeAuthBinding(upstream);
+    const request = new Request("https://uploads.localhost/api/auth/sign-in/magic-link", {
+      method: "POST",
+    });
+
+    const response = await proxyAuthRequest({ AUTH }, request);
+    expect(response.headers.getSetCookie()).toHaveLength(1);
+  });
+
+  it("does NOT append when there is no Set-Cookie at all", async () => {
+    const upstream = new Response(null, { status: 200 });
+    const { AUTH } = fakeAuthBinding(upstream);
+    const request = new Request("https://uploads.sh/api/auth/get-session");
+
+    const response = await proxyAuthRequest({ AUTH }, request);
+    expect(response.headers.getSetCookie()).toHaveLength(0);
+  });
+});
+
+describe("serverGetSession", () => {
+  it("forwards the incoming cookie header and targets /api/auth/get-session on the request's own origin", async () => {
+    const { AUTH, fetchMock } = fakeAuthBinding(Response.json(null));
+    const request = new Request("https://uploads.sh/account/profile", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    await serverGetSession({ AUTH }, request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://uploads.sh/api/auth/get-session");
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
+  });
+
+  it("sends an empty cookie header when the incoming request has none", async () => {
+    const { AUTH, fetchMock } = fakeAuthBinding(Response.json(null));
+    const request = new Request("https://uploads.sh/account/profile");
+
+    await serverGetSession({ AUTH }, request);
+
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.headers.get("cookie")).toBe("");
+  });
+});

--- a/apps/web/src/lib/auth-proxy.ts
+++ b/apps/web/src/lib/auth-proxy.ts
@@ -1,0 +1,88 @@
+/**
+ * Same-origin auth proxy (#731 phase A).
+ *
+ * Web serves `uploads.sh/api/auth/*` and forwards to the auth worker, so a
+ * later phase can move browser auth traffic off `auth.uploads.sh` onto this
+ * origin (killing the cross-subdomain cookie). This phase only stands the
+ * transport up — nothing calls it yet, so the deploy is inert.
+ *
+ * Two transports:
+ *  - `env.AUTH` service binding (production/preview): a direct worker-to-
+ *    worker call, no public network hop.
+ *  - HTTP fallback against `UPLOADS_AUTH_ORIGIN` (astro dev, which has no
+ *    service bindings to sibling wrangler processes).
+ *
+ * Both transports use `redirect: "manual"` — Better Auth's OAuth callback
+ * 302s must reach the browser unfollowed, not be resolved inside the worker.
+ */
+
+export interface AuthProxyEnv {
+  AUTH?: { fetch(req: Request): Promise<Response> };
+  UPLOADS_AUTH_ORIGIN?: string;
+}
+
+const LOCAL_AUTH_ORIGIN_DEFAULT = "http://127.0.0.1:8788";
+
+/**
+ * Appended when a same-origin (host-only) session cookie is set for
+ * `uploads.sh` — clears the pre-Phase-C wide `Domain=.uploads.sh` cookie so
+ * the browser's jar doesn't carry both. Before Phase C the upstream
+ * `Set-Cookie` still carries `Domain=.uploads.sh`, so the guard below never
+ * fires; this is dead code until the auth worker's `BETTER_AUTH_URL` flips.
+ */
+const LEGACY_CLEAR_COOKIE =
+  "__Secure-better-auth.session_token=; Path=/; Domain=.uploads.sh; Max-Age=0; Secure; HttpOnly; SameSite=Lax";
+
+/** Forwards `request` to the auth worker (binding, else HTTP fallback). */
+export async function proxyAuthRequest(env: AuthProxyEnv, request: Request): Promise<Response> {
+  const forwarded = new Request(request, { redirect: "manual" });
+  const upstream = env.AUTH
+    ? await env.AUTH.fetch(forwarded)
+    : await fetch(rewriteOrigin(forwarded, env.UPLOADS_AUTH_ORIGIN ?? LOCAL_AUTH_ORIGIN_DEFAULT));
+  return withLegacyCookieCleared(upstream, request);
+}
+
+/** Rebuilds `request` against `origin`, keeping method/headers/body/redirect. */
+function rewriteOrigin(request: Request, origin: string): Request {
+  const url = new URL(request.url);
+  const target = new URL(origin.replace(/\/$/, ""));
+  url.protocol = target.protocol;
+  url.host = target.host;
+  return new Request(url.toString(), request);
+}
+
+/**
+ * Appends the legacy-cookie clearing header only when BOTH hold: the
+ * request's host is exactly `uploads.sh`, AND the upstream response sets a
+ * `*session_token` cookie with no `Domain=` attribute (host-only — the
+ * Phase-C shape). Never fires for `uploads.localhost` or any other host.
+ */
+function withLegacyCookieCleared(upstream: Response, request: Request): Response {
+  if (new URL(request.url).hostname !== "uploads.sh") return upstream;
+
+  const setCookies = upstream.headers.getSetCookie();
+  const setsHostOnlySessionCookie = setCookies.some((cookie) => {
+    const nameValue = cookie.split(";")[0] ?? "";
+    const name = nameValue.split("=")[0]?.trim() ?? "";
+    return name.endsWith("session_token") && !/;\s*domain=/i.test(cookie);
+  });
+  if (!setsHostOnlySessionCookie) return upstream;
+
+  const response = new Response(upstream.body, upstream);
+  response.headers.append("Set-Cookie", LEGACY_CLEAR_COOKIE);
+  return response;
+}
+
+/**
+ * SSR helper (consumed starting Phase B): resolves the current session by
+ * forwarding the incoming request's `cookie` header to `/api/auth/get-
+ * session` on the request's own origin, over the same transport as
+ * `proxyAuthRequest`. A server-to-server fetch has no cookie jar of its own,
+ * so the header must be forwarded explicitly.
+ */
+export async function serverGetSession(env: AuthProxyEnv, request: Request): Promise<Response> {
+  const getSessionRequest = new Request(new URL("/api/auth/get-session", request.url), {
+    headers: { cookie: request.headers.get("cookie") ?? "" },
+  });
+  return proxyAuthRequest(env, getSessionRequest);
+}

--- a/apps/web/src/lib/worker-env.ts
+++ b/apps/web/src/lib/worker-env.ts
@@ -1,0 +1,12 @@
+/**
+ * Re-exports the Workers runtime `env` singleton from a non-hidden directory.
+ *
+ * oxlint's type-aware checker (typeAware/typeCheck in .oxlintrc.json) fails
+ * to resolve the ambient `cloudflare:workers` module for any file that lives
+ * directly under a dot-directory (e.g. `src/pages/.well-known/**`), even
+ * though `tsc`/`astro check` resolve it fine — verified by reproducing with
+ * an otherwise-identical file outside `.well-known`. Well-known route files
+ * import `env` from here instead of `cloudflare:workers` directly to avoid
+ * that lint false-positive.
+ */
+export { env } from "cloudflare:workers";

--- a/apps/web/src/pages/.well-known/oauth-authorization-server/[...path].ts
+++ b/apps/web/src/pages/.well-known/oauth-authorization-server/[...path].ts
@@ -1,0 +1,18 @@
+/**
+ * Same-origin RFC 8414 discovery proxy (#731 phase A): forwards
+ * `uploads.sh/.well-known/oauth-authorization-server[/...]` (e.g. the
+ * `/api/auth`-suffixed variant) to the auth worker, which already rewrites
+ * these well-known aliases to Better Auth's real paths (see
+ * apps/auth/src/index.ts). The issuer value in the response follows
+ * `BETTER_AUTH_URL` and is correct both before and after the phase C flip.
+ *
+ * A sibling `index.ts` handles the bare (no sub-path) route in case Astro's
+ * rest-param matching doesn't cover it.
+ */
+import type { APIRoute } from "astro";
+import { proxyAuthRequest } from "../../../lib/auth-proxy";
+import { env } from "../../../lib/worker-env";
+
+export const prerender = false;
+
+export const ALL: APIRoute = ({ request }) => proxyAuthRequest(env, request);

--- a/apps/web/src/pages/.well-known/oauth-authorization-server/index.ts
+++ b/apps/web/src/pages/.well-known/oauth-authorization-server/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Bare `/.well-known/oauth-authorization-server` (no sub-path). See the
+ * sibling `[...path].ts` for the general case and rationale.
+ */
+import type { APIRoute } from "astro";
+import { proxyAuthRequest } from "../../../lib/auth-proxy";
+import { env } from "../../../lib/worker-env";
+
+export const prerender = false;
+
+export const ALL: APIRoute = ({ request }) => proxyAuthRequest(env, request);

--- a/apps/web/src/pages/.well-known/openid-configuration.ts
+++ b/apps/web/src/pages/.well-known/openid-configuration.ts
@@ -1,0 +1,13 @@
+/**
+ * Same-origin RFC 8414 discovery proxy (#731 phase A):
+ * `uploads.sh/.well-known/openid-configuration` forwards to the auth worker.
+ * See `.well-known/oauth-authorization-server/[...path].ts` for the sibling
+ * discovery route and rationale.
+ */
+import type { APIRoute } from "astro";
+import { proxyAuthRequest } from "../../lib/auth-proxy";
+import { env } from "../../lib/worker-env";
+
+export const prerender = false;
+
+export const ALL: APIRoute = ({ request }) => proxyAuthRequest(env, request);

--- a/apps/web/src/pages/api/auth/[...path].ts
+++ b/apps/web/src/pages/api/auth/[...path].ts
@@ -1,0 +1,12 @@
+/**
+ * Same-origin auth proxy (#731 phase A): `uploads.sh/api/auth/*` forwards
+ * unchanged to the auth worker. Route stays thin — all logic lives in
+ * `../../../lib/auth-proxy`.
+ */
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { proxyAuthRequest } from "../../../lib/auth-proxy";
+
+export const prerender = false;
+
+export const ALL: APIRoute = ({ request }) => proxyAuthRequest(env, request);

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -24,6 +24,14 @@
     // see src/lib/console-mode.ts for the resolution order.
     "CONSOLE_MODE": "linked-only",
   },
+  // Same-origin auth proxy (#731 phase A): lets server code call the auth
+  // and api workers directly instead of over the public internet. Astro dev
+  // has no service bindings to sibling wrangler processes, so proxy code
+  // falls back to UPLOADS_AUTH_ORIGIN (vars above) when these are absent.
+  "services": [
+    { "binding": "AUTH", "service": "uploads-auth" },
+    { "binding": "API", "service": "uploads-api" },
+  ],
   // Flagship feature flags (app "uploads"). Runtime override for CONSOLE_MODE
   // without a redeploy. Self-hosters without Flagship can delete this block —
   // everything falls back to the CONSOLE_MODE var above.
@@ -73,6 +81,15 @@
       "UPLOADS_AUTH_ORIGIN": "https://auth.uploads.sh",
       "CONSOLE_MODE": "linked-only",
     },
+    // Same-origin auth proxy (#731 phase A), duplicated here because bindings
+    // do not inherit into the previews block (see the top-level "services"
+    // comment above). Points at the same production auth/api workers as
+    // production, matching this block's existing "vars-only against prod"
+    // stance.
+    "services": [
+      { "binding": "AUTH", "service": "uploads-auth" },
+      { "binding": "API", "service": "uploads-api" },
+    ],
     // The Astro Cloudflare adapter's generated config (dist/server/wrangler.json,
     // via the .wrangler/deploy redirect) injects an id-less SESSION KV binding.
     // Wrangler normally auto-provisions an omitted id and writes it back to


### PR DESCRIPTION
Phase A of #731 (same-origin auth migration). Deploy is inert — nothing calls the new paths yet; every client still uses `auth.uploads.sh`.

## What this adds

- **`AUTH` + `API` service bindings** on the web worker (top-level and duplicated in the `previews` block, which does not inherit).
- **`/api/auth/[...path]`** — forwards unchanged to the auth worker over the `AUTH` binding, with an HTTP fallback to `UPLOADS_AUTH_ORIGIN` for astro dev (no service bindings to sibling wrangler processes there). `redirect: "manual"` on both transports so Better Auth's OAuth-callback 302s reach the browser unfollowed.
- **Discovery proxies** for the future issuer: `/.well-known/oauth-authorization-server` (bare + RFC 8414 path-inserted) and `/.well-known/openid-configuration`.
- **Legacy-cookie clearing**: when a *host-only* `session_token` Set-Cookie passes through on host `uploads.sh` (the post-flip shape — can't happen until the phase C config change), one clearing `Set-Cookie` for the old `Domain=.uploads.sh` cookie is appended so browser jars don't carry both. Self-sequencing: today's wide `Set-Cookie` carries `Domain=`, so the guard never fires.
- `serverGetSession(env, request)` — SSR session resolution over the same transport, consumed starting phase B.

## Verification

- 12 new unit tests (`auth-proxy.test.ts`); full web suite 766 tests, root suite 4687 tests, typecheck clean.
- Live on the raw local stack: `GET /api/auth/get-session` → 200 `null` through the proxy; both discovery forms serve the issuer; `openid-configuration` forwards the auth worker's existing 404.

## Notes

- Well-known route files import `env` via a `lib/worker-env.ts` re-export: oxlint's type-aware checker can't resolve ambient `cloudflare:workers` for files directly under a dot-directory (tsc/astro check are fine). Rationale documented in the file.
- Next: phase B moves browser auth XHR to these same-origin paths; phase C flips `BETTER_AUTH_URL` (host-only cookie + issuer move, coordinated deploy).

Refs #731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added same-origin authentication endpoints for sign-in, session, and related auth requests.
  * Added OAuth and OpenID Connect discovery endpoints for improved authentication-provider compatibility.
  * Authentication requests now support secure service communication and local development fallback.
  * Session cookies and redirects are preserved across proxied authentication requests.

* **Bug Fixes**
  * Added cleanup for legacy host-only session cookies on the primary site domain.

* **Tests**
  * Added coverage for authentication forwarding, session retrieval, redirects, cookies, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->