### PR TITLE
feat(web): browser auth traffic via same-origin /api/auth (#731 phase B)

### DIFF
--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -74,9 +74,12 @@ const MENU_ITEMS = [
     if (!root || !slot || root.dataset.booted === "1") return;
     root.dataset.booted = "1";
 
-    const origin =
-      (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__ ||
-      "https://auth.uploads.sh";
+    // Same-origin (#731 phase B): "" is a deliberate value meaning
+    // window.__UPLOADS_AUTH_ORIGIN__ was explicitly set to same-origin, not
+    // "unset" — so this must not `||`-fallback over an empty string.
+    const injectedOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
+      .__UPLOADS_AUTH_ORIGIN__;
+    const origin = injectedOrigin === undefined ? "https://auth.uploads.sh" : injectedOrigin;
     const menuItems =
       (
         window as unknown as {

--- a/apps/web/src/components/SiteHeader.astro
+++ b/apps/web/src/components/SiteHeader.astro
@@ -59,7 +59,12 @@ const stars = await githubStarCount();
         <span class="star-cta__label">Star on GitHub</span>
         {stars === null ? null : <span class="count">{formatStars(stars)}</span>}
       </a>
-      {authOrigin ? <AuthIndicator authOrigin={authOrigin} /> : null}
+      {
+        // `authOrigin` can legitimately be `""` (same-origin, #731 phase B) —
+        // check for the prop's absence explicitly rather than truthiness, or
+        // every same-origin page would silently drop its AuthIndicator.
+        authOrigin !== undefined ? <AuthIndicator authOrigin={authOrigin} /> : null
+      }
       <slot name="end" />
     </div>
   </div>

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -10,7 +10,8 @@
  * re-boot on `astro:page-load` (ClientRouter).
  */
 import { env } from "cloudflare:workers";
-import { getSession } from "../lib/auth-client";
+import { sessionResultFromResponse, type SessionResult } from "../lib/auth-client";
+import { serverGetSession } from "../lib/auth-proxy";
 import {
   applyAuthSecurityHeaders,
   resolveSignedInOrigins,
@@ -85,7 +86,13 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
 const sessionCookie = Astro.request.headers.get("cookie") ?? "";
 let serverSessionUserJson: string | null = null;
 if (sessionCookie.trim()) {
-  const session = await getSession(authOrigin, { cookie: sessionCookie });
+  // #731 phase B: resolved over the AUTH binding (env.AUTH, or the HTTP
+  // fallback in astro dev) instead of a fetch to the auth origin — the
+  // binding forwards this request's cookie header itself (see
+  // serverGetSession), so no cookie option is passed here.
+  const session = await serverGetSession(env, Astro.request)
+    .then(sessionResultFromResponse)
+    .catch((): SessionResult => ({ kind: "unavailable", reason: "network" }));
   if (session.kind === "signed_in") {
     // Serialized as a JS object literal (not a quoted string) so names/emails
     // with apostrophes need no quote-escaping; `<` is escaped so a stray

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -31,9 +31,9 @@ interface Props {
 }
 const { title, description, path, heading, tagline, active, toc, ogType = "website" } = Astro.props;
 
-// Static page (no `prerender = false`) — auth origin is baked at build time,
-// not read from request-time env. See src/lib/auth-client.ts.
-const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
+// Same-origin (#731 phase B): browser auth traffic goes through this origin's
+// /api/auth proxy, not a configured auth-worker origin.
+const authOrigin = "";
 
 // Left-nav sections. The four subject pages plus the standalone agent guide.
 const DOCS_NAV = [

--- a/apps/web/src/layouts/ErrorLayout.astro
+++ b/apps/web/src/layouts/ErrorLayout.astro
@@ -18,8 +18,9 @@ interface Props {
 
 const { status, title, message, hint } = Astro.props;
 
-// Static page — auth origin baked at build time (see LegalLayout / landing).
-const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
+// Same-origin (#731 phase B): browser auth traffic goes through this origin's
+// /api/auth proxy, not a configured auth-worker origin.
+const authOrigin = "";
 ---
 
 <html lang="en">

--- a/apps/web/src/layouts/LegalLayout.astro
+++ b/apps/web/src/layouts/LegalLayout.astro
@@ -13,8 +13,9 @@ interface Props {
 }
 const { title, description, path } = Astro.props;
 
-// Static page — auth origin is baked at build time (see src/lib/auth-client.ts).
-const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
+// Same-origin (#731 phase B): browser auth traffic goes through this origin's
+// /api/auth proxy, not a configured auth-worker origin.
+const authOrigin = "";
 ---
 
 <html lang="en">

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  authOrigin,
   banUser,
   getAccountInfo,
   getOAuthPublicClient,
@@ -35,6 +36,21 @@ const timeoutFetch: typeof fetch = async (_input, init) =>
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
+});
+
+describe("authOrigin", () => {
+  it("treats an empty string as same-origin (#731 phase B), not a fallback trigger", () => {
+    expect(authOrigin("")).toBe("");
+  });
+
+  it("still falls back to the auth worker's public origin when unset", () => {
+    expect(authOrigin()).toBe("https://auth.uploads.sh");
+    expect(authOrigin(undefined)).toBe("https://auth.uploads.sh");
+  });
+
+  it("strips a trailing slash from a configured origin", () => {
+    expect(authOrigin("https://auth.uploads.sh/")).toBe("https://auth.uploads.sh");
+  });
 });
 
 describe("fetchWithTimeout", () => {
@@ -114,6 +130,17 @@ describe("getSession", () => {
     await getSession("http://127.0.0.1:8788");
     const init = fetcher.mock.calls[0]?.[1];
     expect(init && "headers" in init ? init.headers : undefined).toBeUndefined();
+  });
+
+  it('hits the same-origin relative path when authOrigin resolves to "" (#731 phase B)', async () => {
+    const fetcher = vi.fn(async () => Response.json(null));
+    vi.stubGlobal("fetch", fetcher);
+
+    await expect(getSession("")).resolves.toEqual({ kind: "signed_out" });
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/auth/get-session",
+      expect.objectContaining({ cache: "no-store", credentials: "include" }),
+    );
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -18,10 +18,19 @@
  */
 import { fetchWithTimeout, type RequestFailure } from "./request";
 
-/** Public origin of the auth worker. Falls back to the documented local dev
+/**
+ * Public origin of the auth worker. Falls back to the documented local dev
  * origin (apps/auth's pinned wrangler dev port — see apps/auth/wrangler.jsonc
- * and .dev.vars.example) when UPLOADS_AUTH_ORIGIN isn't set. */
+ * and .dev.vars.example) when unset (`undefined`/omitted).
+ *
+ * `""` is a distinct, deliberate value (#731 phase B): same-origin. Every
+ * caller in this file templates `` `${authOrigin(origin)}/api/auth/...` ``,
+ * so `""` turns that into a same-origin relative URL (`/api/auth/...`) that
+ * hits this origin's `/api/auth/[...path]` proxy instead of the auth worker
+ * directly.
+ */
 export function authOrigin(configuredOrigin?: string): string {
+  if (configuredOrigin === "") return "";
   return (configuredOrigin || "https://auth.uploads.sh").replace(/\/$/, "");
 }
 
@@ -108,9 +117,31 @@ type LocalDemoSessionStart =
   | { kind: "unavailable"; reason: RequestFailure | "server" };
 
 /**
- * GET /api/auth/get-session. A valid no-session response is distinct from an
- * auth timeout, network failure, 503, or malformed response so protected
+ * Parses a get-session HTTP response into the `SessionResult` union: a valid
+ * no-session response (`401`, or a `200` with a `null` body) is distinct from
+ * an outage (non-2xx server error) or a malformed `200` body, so protected
  * pages never send a user to sign in when the service is merely unavailable.
+ *
+ * Shared by `getSession` (browser path, over `fetchWithTimeout`) and
+ * `serverSessionFromRequest` (SSR path, over the `AUTH` binding via
+ * `serverGetSession` — see auth-proxy.ts) so both keep this distinction
+ * identically rather than each parsing the response their own way.
+ */
+export async function sessionResultFromResponse(response: Response): Promise<SessionResult> {
+  if (response.status === 401) return { kind: "signed_out" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const body = (await response.json().catch(() => undefined)) as SessionResponse | null | undefined;
+  if (body === null) return { kind: "signed_out" };
+  if (!body || !body.user) return { kind: "unavailable", reason: "malformed" };
+  // Ban clears sessions; if a banned flag still appears, treat as signed out
+  // so shells never paint account chrome for a deactivated user.
+  if (body.user.banned === true) return { kind: "signed_out" };
+  return { kind: "signed_in", session: body };
+}
+
+/**
+ * GET /api/auth/get-session. See `sessionResultFromResponse` for the result
+ * shape and why "no session" and "unavailable" stay distinct.
  *
  * `opts.cookie` lets an Astro frontmatter resolve the session during the
  * server render by forwarding the incoming request's cookie header — a
@@ -128,16 +159,7 @@ export async function getSession(
     ...(opts?.cookie ? { headers: { cookie: opts.cookie } } : {}),
   });
   if (result.kind === "unavailable") return result;
-  const { response } = result;
-  if (response.status === 401) return { kind: "signed_out" };
-  if (!response.ok) return { kind: "unavailable", reason: "server" };
-  const body = (await response.json().catch(() => undefined)) as SessionResponse | null | undefined;
-  if (body === null) return { kind: "signed_out" };
-  if (!body || !body.user) return { kind: "unavailable", reason: "malformed" };
-  // Ban clears sessions; if a banned flag still appears, treat as signed out
-  // so shells never paint account chrome for a deactivated user.
-  if (body.user.banned === true) return { kind: "signed_out" };
-  return { kind: "signed_in", session: body };
+  return sessionResultFromResponse(result.response);
 }
 
 /**

--- a/apps/web/src/lib/billing-ui.test.ts
+++ b/apps/web/src/lib/billing-ui.test.ts
@@ -103,6 +103,43 @@ describe("loadBillingPageData", () => {
     expect(result.billing).toBeNull();
     expect(result.proPrice).toBeNull();
   });
+
+  it("passes the given authFetchImpl through to the price fetch only (#731 phase B)", async () => {
+    const globalFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            workspace: "acme",
+            organization: { id: "org_1", slug: "acme", name: "Acme" },
+            plan: "free",
+            available: true,
+            planApplied: true,
+            limits: {},
+            usage: null,
+            planSource: "none",
+            subscription: null,
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", globalFetch);
+    const authFetchImpl = vi.fn(async () =>
+      Response.json({ prices: { pro: { unitAmount: 1000, currency: "usd", interval: "month" } } }),
+    );
+
+    const result = await loadBillingPageData(
+      "https://api.uploads.sh",
+      "",
+      "acme",
+      "better-auth.session=abc",
+      authFetchImpl,
+    );
+
+    expect(authFetchImpl).toHaveBeenCalledWith("/billing/prices", expect.anything());
+    expect(result.proPrice).toEqual({ unitAmount: 1000, currency: "usd", interval: "month" });
+    // getWorkspaceBilling still goes through global fetch, not authFetchImpl.
+    expect(globalFetch).toHaveBeenCalled();
+  });
 });
 
 describe("planLabel", () => {

--- a/apps/web/src/lib/billing-ui.ts
+++ b/apps/web/src/lib/billing-ui.ts
@@ -35,11 +35,12 @@ export async function loadBillingPageData(
   authOrigin: string,
   workspace: string,
   cookie: string,
+  authFetchImpl?: typeof fetch,
 ): Promise<BillingPageData> {
   if (!cookie.trim()) return { billing: null, proPrice: null };
   const [billingResult, proPrice] = await Promise.all([
     getWorkspaceBilling(apiOrigin, workspace, { cookie }),
-    fetchProPrice(authOrigin),
+    fetchProPrice(authOrigin, authFetchImpl),
   ]);
   return {
     billing: billingResult.kind === "ok" ? billingResult.billing : null,

--- a/apps/web/src/lib/client-router-boot.test.ts
+++ b/apps/web/src/lib/client-router-boot.test.ts
@@ -81,7 +81,8 @@ describe("Error page chrome", () => {
     expect(src).toContain("<Footer");
     // Full footer (not compact-only under the card) — same chrome as legal pages.
     expect(src).not.toMatch(/<Footer\s+compact/);
-    expect(src).toContain("PUBLIC_UPLOADS_AUTH_ORIGIN");
+    // Same-origin (#731 phase B): no configured-origin fallback chain anymore.
+    expect(src).toContain('const authOrigin = "";');
   });
 
   it("404 and 500 use ErrorLayout", () => {

--- a/apps/web/src/lib/plan-prices.test.ts
+++ b/apps/web/src/lib/plan-prices.test.ts
@@ -44,6 +44,28 @@ describe("fetchProPrice", () => {
     await expect(fetchProPrice("https://auth.uploads.sh")).resolves.toBeNull();
   });
 
+  it("uses the provided fetchImpl instead of global fetch when given (#731 phase B SSR)", async () => {
+    const globalFetch = vi.fn();
+    vi.stubGlobal("fetch", globalFetch);
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        prices: { pro: { unitAmount: 500, currency: "usd", interval: "month" } },
+      }),
+    });
+
+    await expect(fetchProPrice("", fetchImpl)).resolves.toEqual({
+      unitAmount: 500,
+      currency: "usd",
+      interval: "month",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "/billing/prices",
+      expect.not.objectContaining({ credentials: "include" }),
+    );
+    expect(globalFetch).not.toHaveBeenCalled();
+  });
+
   it("returns null on a malformed body", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/web/src/lib/plan-prices.ts
+++ b/apps/web/src/lib/plan-prices.ts
@@ -8,6 +8,14 @@
  * `unitAmount` in minor units (e.g. cents). This endpoint is being added by a
  * concurrent lane and may 404 until that lands — treated identically to a
  * `null` price so the page never blocks on it or shows a lie ("$NaN").
+ *
+ * `authOrigin` is the same-origin sentinel from `resolveSignedInOrigins`
+ * (#731 phase B) — `""` in the browser (relative `/billing/prices`, served
+ * by this app's own `pages/billing/prices.ts` proxy) or an absolute origin
+ * for any other caller. A browser's own `fetch` resolves a relative URL
+ * against the page origin fine, but a Workers SSR `fetch` has no ambient
+ * origin to resolve against, so SSR callers must pass `fetchImpl` (e.g. a
+ * `proxyAuthRequest`-backed adapter) rather than rely on the default.
  */
 
 export interface PlanPrice {
@@ -47,9 +55,12 @@ function isPlanPrice(value: unknown): value is PlanPrice {
  * it outright, which silently produced this exact "Pro card never shows a
  * price" bug.
  */
-export async function fetchProPrice(authOrigin: string): Promise<PlanPrice | null> {
+export async function fetchProPrice(
+  authOrigin: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<PlanPrice | null> {
   try {
-    const res = await fetch(`${authOrigin.replace(/\/$/, "")}/billing/prices`, {
+    const res = await fetchImpl(`${authOrigin.replace(/\/$/, "")}/billing/prices`, {
       cache: "no-store",
     });
     if (!res.ok) return null;

--- a/apps/web/src/lib/signed-in-page.test.ts
+++ b/apps/web/src/lib/signed-in-page.test.ts
@@ -9,12 +9,29 @@ import {
   INVITE_CSP,
   loginHref,
   loginReturnPath,
+  resolveSignedInOrigins,
   signedInCsp,
   signedInShellLoginRedirect,
 } from "./signed-in-page";
 
 const AUTH = "https://auth.uploads.sh";
 const API = "https://api.uploads.sh";
+
+describe("resolveSignedInOrigins", () => {
+  it("always resolves the auth origin to same-origin (#731 phase B), regardless of env", () => {
+    expect(resolveSignedInOrigins({}).authOrigin).toBe("");
+    expect(
+      resolveSignedInOrigins({ UPLOADS_API_ORIGIN: "https://api.uploads.sh" }).authOrigin,
+    ).toBe("");
+  });
+
+  it("leaves apiOrigin resolution untouched (flips in phase D, not now)", () => {
+    expect(resolveSignedInOrigins({}).apiOrigin).toBe("https://api.uploads.sh");
+    expect(resolveSignedInOrigins({ UPLOADS_API_ORIGIN: "https://api.uploads.sh" }).apiOrigin).toBe(
+      "https://api.uploads.sh",
+    );
+  });
+});
 
 describe("signedInShellLoginRedirect", () => {
   const search = "?path=/settings";
@@ -135,6 +152,28 @@ describe("signed-in / auth CSP builders", () => {
     const authCsp = authPageCsp(AUTH);
     const expectedDeviceCsp = authCsp.replace(`connect-src ${AUTH}`, `connect-src ${AUTH} ${API}`);
     expect(devicePageCsp(AUTH, API)).toBe(expectedDeviceCsp);
+  });
+
+  it("authPageCsp collapses a same-origin auth origin to 'self' (#731 phase B)", () => {
+    const csp = authPageCsp("");
+    expect(csp).toContain("connect-src 'self' https://cloudflareinsights.com");
+    expect(csp).not.toContain("connect-src  ");
+  });
+
+  it("devicePageCsp collapses a same-origin auth origin to 'self', keeps the API origin", () => {
+    const csp = devicePageCsp("", API);
+    expect(csp).toContain(`connect-src 'self' ${API} https://cloudflareinsights.com`);
+  });
+
+  it("signedInCsp collapses a same-origin auth origin to 'self', keeps the API origin", () => {
+    const csp = signedInCsp("", API);
+    expect(csp).toContain(`connect-src 'self' ${API} https://cloudflareinsights.com`);
+  });
+
+  it("de-dupes connect-src to a single 'self' when both origins are same-origin", () => {
+    const csp = signedInCsp("", "");
+    expect(csp).toContain("connect-src 'self' https://cloudflareinsights.com");
+    expect(csp).not.toContain("'self' 'self'");
   });
 
   it("INVITE_CSP targets prod API and keeps frame-ancestors", () => {

--- a/apps/web/src/lib/signed-in-page.ts
+++ b/apps/web/src/lib/signed-in-page.ts
@@ -11,8 +11,9 @@ import { resolveConsoleMode } from "./console-mode";
 import { CF_RUM_CONNECT_SRC, CF_RUM_SCRIPT_SRC, STYLE_SRC_SELF_AND_INLINE } from "./csp";
 import { safeSameOriginPath } from "./workspace-ui";
 
+// UPLOADS_AUTH_ORIGIN isn't read here (auth is same-origin, #731 phase B) —
+// only the API origin still varies by environment.
 type OriginEnv = {
-  UPLOADS_AUTH_ORIGIN?: string;
   UPLOADS_API_ORIGIN?: string;
 };
 
@@ -69,14 +70,13 @@ export function resolveSignedInOrigins(env: OriginEnv): {
   // supervisor's values in dev so the CSP and clients point at the workers
   // that are actually running; production is untouched (PUBLIC_* is unset
   // there, so the runtime-env chain below still decides).
-  const devAuth = import.meta.env.DEV ? import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN : undefined;
   const devApi = import.meta.env.DEV ? import.meta.env.PUBLIC_UPLOADS_API_ORIGIN : undefined;
   return {
-    authOrigin:
-      devAuth ??
-      env.UPLOADS_AUTH_ORIGIN ??
-      import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
-      "https://auth.uploads.sh",
+    // Same-origin (#731 phase B): browser auth traffic goes through this
+    // origin's /api/auth proxy, not a configured auth-worker origin. The
+    // cookie's Domain scope is unchanged in this phase — only where the
+    // browser sends requests.
+    authOrigin: "",
     apiOrigin:
       devApi ??
       env.UPLOADS_API_ORIGIN ??
@@ -85,11 +85,29 @@ export function resolveSignedInOrigins(env: OriginEnv): {
   };
 }
 
+/**
+ * `origin` for a `connect-src` token: `""` means same-origin (#731 phase B),
+ * which CSP expresses as `'self'` rather than an origin literal.
+ */
+function connectSrcToken(origin: string): string {
+  return origin === "" ? "'self'" : origin;
+}
+
+/**
+ * Builds a `connect-src` directive from one or more origins plus the RUM
+ * allowance, de-duping tokens — `origin === ""` and `CF_RUM_CONNECT_SRC`'s own
+ * `'self'` would otherwise both land in the list.
+ */
+function connectSrc(...origins: string[]): string {
+  const tokens = [...origins.map(connectSrcToken), ...CF_RUM_CONNECT_SRC.split(" ")];
+  return `connect-src ${[...new Set(tokens)].join(" ")}`;
+}
+
 /** Strict CSP used by /account/* and /admin/* (session + API fetches only). */
 export function signedInCsp(authOrigin: string, apiOrigin: string): string {
   return [
     "default-src 'none'",
-    `connect-src ${authOrigin} ${apiOrigin} ${CF_RUM_CONNECT_SRC}`,
+    connectSrc(authOrigin, apiOrigin),
     `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
     `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
     "font-src 'self'",
@@ -108,7 +126,7 @@ export function signedInCsp(authOrigin: string, apiOrigin: string): string {
 export function authPageCsp(authOrigin: string): string {
   return [
     "default-src 'none'",
-    `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
+    connectSrc(authOrigin),
     // 'self' covers Astro-bundled /_astro/*.js; CF RUM is edge-injected.
     `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
     `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
@@ -130,7 +148,7 @@ export function authPageCsp(authOrigin: string): string {
 export function devicePageCsp(authOrigin: string, apiOrigin: string): string {
   return [
     "default-src 'none'",
-    `connect-src ${authOrigin} ${apiOrigin} ${CF_RUM_CONNECT_SRC}`,
+    connectSrc(authOrigin, apiOrigin),
     `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
     `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
     "font-src 'self'",

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -1,5 +1,4 @@
 ---
-import { env } from "cloudflare:workers";
 import { applyAuthSecurityHeaders, authPageCsp } from "../../lib/signed-in-page";
 import BaseHead from "../../components/BaseHead.astro";
 import Brand from "../../components/Brand.astro";
@@ -8,10 +7,9 @@ import LegalConsent from "../../components/LegalConsent.astro";
 
 export const prerender = false;
 
-const authOrigin =
-  env.UPLOADS_AUTH_ORIGIN ??
-  import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
-  "https://auth.uploads.sh";
+// Same-origin (#731 phase B): browser auth traffic goes through this origin's
+// /api/auth proxy, not a configured auth-worker origin.
+const authOrigin = "";
 
 const { id } = Astro.params;
 

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -11,6 +11,7 @@
 import { env } from "cloudflare:workers";
 import { PLANS } from "@uploads/billing";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
+import { proxyAuthRequest, type AuthProxyEnv } from "../../../../lib/auth-proxy";
 import {
   loadBillingPageData,
   renderPlanCardBodyHtml,
@@ -37,7 +38,18 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 // "own region" rule as the galleries/people pages).
 const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
 const cookie = Astro.request.headers.get("cookie") ?? "";
-const initial = await loadBillingPageData(apiOrigin, authOrigin, workspace, cookie);
+// `fetchProPrice`'s relative `/billing/prices` URL (authOrigin === "", #731
+// phase B) has no ambient origin for a Workers SSR `fetch` to resolve
+// against, unlike a browser's own `fetch`. Route the SSR call through the
+// same auth-proxy transport the browser hits (`pages/billing/prices.ts`)
+// by resolving the relative path against this request's own origin and
+// forwarding it over `proxyAuthRequest`.
+const authFetchImpl: typeof fetch = (input, init) =>
+  proxyAuthRequest(
+    env as AuthProxyEnv,
+    new Request(new URL(String(input), Astro.request.url), init),
+  );
+const initial = await loadBillingPageData(apiOrigin, authOrigin, workspace, cookie, authFetchImpl);
 const { billing } = initial;
 const proPriceCopy = formatPrice(initial.proPrice);
 const cta: BillingCtaState = billing

--- a/apps/web/src/pages/billing/prices.ts
+++ b/apps/web/src/pages/billing/prices.ts
@@ -1,0 +1,17 @@
+/**
+ * Same-origin proxy for the auth worker's public `/billing/prices` (#731
+ * phase B). `plan-prices.ts`'s `fetchProPrice` hits this relative path (its
+ * `authOrigin` sentinel is `""`) rather than `auth.uploads.sh` directly.
+ *
+ * This route lives outside `.well-known` (unlike the discovery proxies), so
+ * it can import `cloudflare:workers`'s `env` directly instead of going
+ * through `lib/worker-env` — see that module's comment for the oxlint
+ * dot-directory quirk this route doesn't hit.
+ */
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { proxyAuthRequest } from "../../lib/auth-proxy";
+
+export const prerender = false;
+
+export const ALL: APIRoute = ({ request }) => proxyAuthRequest(env, request);

--- a/apps/web/src/pages/changelog.astro
+++ b/apps/web/src/pages/changelog.astro
@@ -14,8 +14,9 @@ const pageTitle = "Changelog";
 const pageDescription =
   "What's new in uploads.sh — platform updates and CLI releases, newest first.";
 
-// Static page — auth origin is baked at build time (see src/lib/auth-client.ts).
-const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
+// Same-origin (#731 phase B): browser auth traffic goes through this origin's
+// /api/auth proxy, not a configured auth-worker origin.
+const authOrigin = "";
 
 const formatDate = (iso: string) =>
   new Date(iso).toLocaleDateString("en-US", {

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -22,10 +22,9 @@ if (consoleMode === "off") {
 }
 
 const API_DEFAULT = "https://api.uploads.sh";
-const authOrigin =
-  env.UPLOADS_AUTH_ORIGIN ??
-  import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
-  "https://auth.uploads.sh";
+// Same-origin (#731 phase B): browser auth traffic goes through this origin's
+// /api/auth proxy, not a configured auth-worker origin.
+const authOrigin = "";
 ---
 
 <html lang="en">

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -13,9 +13,9 @@ const pageTitle = "uploads.sh — the missing upload command for coding agents";
 const pageDescription =
   "GitHub has no API for file uploads, so agents can't include screenshots in pull requests and issues. Uploads gives agents a way to host files and show their work. When the pull request opens, all screenshots appear in one tidy comment that updates automatically on each revision.";
 
-// Static page (no `prerender = false`) — auth origin is baked at build time,
-// not read from request-time env. See src/lib/auth-client.ts.
-const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
+// Same-origin (#731 phase B): browser auth traffic goes through this origin's
+// /api/auth proxy, not a configured auth-worker origin.
+const authOrigin = "";
 
 // The agent setup prompt: copied via button, never rendered in full on the page.
 const agentPrompt = `Help me set up the uploads CLI (uploads.sh) and attach my first screenshot to a GitHub pull request.
@@ -859,9 +859,12 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         // Optimistic: same sessionStorage cache as the header auth indicator.
         if (readCachedSessionUser()) paintHomeCta(true);
 
-        const origin =
-          (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__ ||
-          "https://auth.uploads.sh";
+        // Same-origin (#731 phase B): "" is a deliberate value meaning
+        // window.__UPLOADS_AUTH_ORIGIN__ was explicitly set to same-origin,
+        // not "unset" — so this must not `||`-fallback over an empty string.
+        const injectedOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
+          .__UPLOADS_AUTH_ORIGIN__;
+        const origin = injectedOrigin === undefined ? "https://auth.uploads.sh" : injectedOrigin;
 
         void getSession(origin).then((result) => {
           if (cta.dataset.booted !== "1" || !document.contains(cta)) return;

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -1,5 +1,4 @@
 ---
-import { env } from "cloudflare:workers";
 import { applyAuthSecurityHeaders, authPageCsp } from "../lib/signed-in-page";
 import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
@@ -9,10 +8,9 @@ import LegalConsent from "../components/LegalConsent.astro";
 
 export const prerender = false;
 
-const authOrigin =
-  env.UPLOADS_AUTH_ORIGIN ??
-  import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
-  "https://auth.uploads.sh";
+// Same-origin (#731 phase B): browser auth traffic goes through this origin's
+// /api/auth proxy, not a configured auth-worker origin.
+const authOrigin = "";
 
 // Header (not meta): frame-ancestors is ignored on meta CSP.
 applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -1,5 +1,4 @@
 ---
-import { env } from "cloudflare:workers";
 import { applyAuthSecurityHeaders, authPageCsp } from "../../lib/signed-in-page";
 import BaseHead from "../../components/BaseHead.astro";
 import Brand from "../../components/Brand.astro";
@@ -7,10 +6,9 @@ import Footer from "../../components/Footer.astro";
 
 export const prerender = false;
 
-const authOrigin =
-  env.UPLOADS_AUTH_ORIGIN ??
-  import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
-  "https://auth.uploads.sh";
+// Same-origin (#731 phase B): browser auth traffic goes through this origin's
+// /api/auth proxy, not a configured auth-worker origin.
+const authOrigin = "";
 
 // Header (not meta): frame-ancestors is ignored on meta CSP.
 applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));


### PR DESCRIPTION
Phase B of #731 (stack: #733 → #737 → #734, on top of the merged #732).

Browser auth traffic moves from `https://auth.uploads.sh` to the same-origin `/api/auth/*` proxy that #732 stood up. **Cookie scope is unchanged in this phase** — only where the browser sends requests.

## Changes

- `authOrigin("")` returns `""`, turning every existing `` `${authOrigin(o)}/api/auth/...` `` template into a same-origin relative URL; `resolveSignedInOrigins` now always returns `authOrigin: ""`.
- All `window.__UPLOADS_AUTH_ORIGIN__` injections and `PUBLIC_UPLOADS_AUTH_ORIGIN` fallback chains flip to `""` (layouts, login/consent/device/accept-invitation pages, admin inline scripts).
- SSR session resolution in `AccountLayout.astro` goes through the `AUTH` service binding (`serverGetSession` from #732) instead of a public-origin fetch; the response parsing is extracted to a shared `sessionResultFromResponse` so browser and SSR paths keep the "valid no-session" vs "unavailable" distinction identically.
- CSP: `connect-src` collapses the auth origin to `'self'` (deduped against the RUM allowance).
- Two truthy-check fixes surfaced by making `""` a real value: `SiteHeader` would have dropped the AuthIndicator on same-origin pages, and `AuthIndicator`/`index.astro` `||`-fallbacks would have overridden `""` with the old cross-origin default.

## Verified on the raw local stack

Same-origin `get-session`, CSP `connect-src 'self'`, unsigned `/account` redirect, dev-session sign-in through the proxy, and signed-in SSR (session user injected server-side).

## Known temporary gap (fixed later in this stack)

`/account/profile`'s SSR data load builds relative auth URLs that Workers `fetch` can't resolve, so its first paint degrades to the client-side fill between this PR and #735, which fixes it via the binding (`serverAuthFetchImpl`). No error surfaces; the page still works.

Refs #731
