### PR TITLE
feat(auth,mcp): host-only session cookie and uploads.sh issuer (#731 phase C)

### DIFF
--- a/apps/auth/.dev.vars.example
+++ b/apps/auth/.dev.vars.example
@@ -7,15 +7,28 @@
 # Without it, /api/auth/* answers 503 locally. Any string >= 32 chars works.
 BETTER_AUTH_SECRET_DEV=
 
-# Local origin for this worker (port pinned in wrangler.jsonc). Use the
-# 127.0.0.1 IP literal, not localhost: GitHub's OAuth docs recommend loopback
-# IP literals for redirect URLs, and Better Auth derives redirect_uri from
-# this value — the dev GitHub app's callback is
-# http://127.0.0.1:8788/api/auth/callback/github. localhost and 127.0.0.1 are
-# also *different sites* for cookies, so keep the web app on 127.0.0.1 too
+# #731 phase C: this worker's own origin is pinned in wrangler.jsonc (dev
+# port 8788), but BETTER_AUTH_URL is set to the WEB app's origin, not this
+# worker's — same-origin mode, mirroring production (auth served through
+# web's /api/auth proxy). This is what makes deriveCookieDomain (src/auth.ts)
+# emit a host-only cookie locally instead of a `.uploads.sh`-style shared
+# domain. `pnpm dev:stack` also passes this explicitly at runtime, so this
+# value only matters when running `wrangler dev` on this worker directly.
+#
+# Use the 127.0.0.1 IP literal, not localhost: localhost and 127.0.0.1 are
+# *different sites* for cookies, so keep the web app on 127.0.0.1 too
 # (browse http://127.0.0.1:4321, not localhost:4321) or the session cookie
 # becomes cross-site.
-BETTER_AUTH_URL=http://127.0.0.1:8788
+#
+# Caveat: Better Auth derives GitHub's redirect_uri from BETTER_AUTH_URL, so
+# with this value GitHub sign-in would redirect to
+# http://127.0.0.1:4321/api/auth/callback/github — NOT the dev GitHub OAuth
+# app's actual registered callback (http://127.0.0.1:8788/api/auth/callback/
+# github, GitHub OAuth apps allow only one). Rarely exercised locally because
+# the dev-session bypass (LOCAL_STACK, set only by `pnpm dev:stack`) covers
+# most sign-in testing; to exercise real GitHub OAuth locally, temporarily
+# override this back to http://127.0.0.1:8788 (see docs/local-dev.md).
+BETTER_AUTH_URL=http://127.0.0.1:4321
 
 # Web app origin this worker trusts for CORS + magic-link emails.
 WEB_ORIGIN=http://127.0.0.1:4321

--- a/apps/auth/src/auth.test.ts
+++ b/apps/auth/src/auth.test.ts
@@ -18,13 +18,19 @@ describe("isCliSessionUserAgent", () => {
 });
 
 describe("deriveCookieDomain", () => {
+  // Legacy (differing-host) derivation — pinned with an explicit webOrigin
+  // that differs from betterAuthUrl, so these keep covering the
+  // cross-subdomain-sharing behavior untouched by the #731 same-origin
+  // short-circuit below.
   it("shares the whole apex host for a 2-label domain (no public-suffix leak)", () => {
-    expect(deriveCookieDomain("https://uploads.sh")).toBe(".uploads.sh");
+    expect(deriveCookieDomain("https://uploads.sh", "https://web.uploads.sh")).toBe(".uploads.sh");
   });
 
   it("strips the first label for a 3+-label host", () => {
-    expect(deriveCookieDomain("https://auth.uploads.sh")).toBe(".uploads.sh");
-    expect(deriveCookieDomain("https://api.auth.uploads.sh")).toBe(".auth.uploads.sh");
+    expect(deriveCookieDomain("https://auth.uploads.sh", "https://uploads.sh")).toBe(".uploads.sh");
+    expect(deriveCookieDomain("https://api.auth.uploads.sh", "https://uploads.sh")).toBe(
+      ".auth.uploads.sh",
+    );
   });
 
   it("returns undefined for localhost", () => {
@@ -36,18 +42,30 @@ describe("deriveCookieDomain", () => {
   });
 
   it("anchors the real-TLD portless zone parent across worktree prefixes", () => {
-    expect(deriveCookieDomain("https://auth.uploads.local.buildinternet.dev")).toBe(
-      ".uploads.local.buildinternet.dev",
-    );
-    expect(deriveCookieDomain("https://fix-ui.auth.uploads.local.buildinternet.dev")).toBe(
-      ".uploads.local.buildinternet.dev",
-    );
+    expect(
+      deriveCookieDomain(
+        "https://auth.uploads.local.buildinternet.dev",
+        "https://uploads.local.buildinternet.dev",
+      ),
+    ).toBe(".uploads.local.buildinternet.dev");
+    expect(
+      deriveCookieDomain(
+        "https://fix-ui.auth.uploads.local.buildinternet.dev",
+        "https://uploads.local.buildinternet.dev",
+      ),
+    ).toBe(".uploads.local.buildinternet.dev");
   });
 
   it("shares the last-two-label parent for portless *.localhost hosts", () => {
-    expect(deriveCookieDomain("https://auth.uploads.localhost")).toBe(".uploads.localhost");
-    expect(deriveCookieDomain("http://auth.uploads.localhost:1355")).toBe(".uploads.localhost");
-    expect(deriveCookieDomain("https://fix-ui.auth.uploads.localhost")).toBe(".uploads.localhost");
+    expect(deriveCookieDomain("https://auth.uploads.localhost", "https://uploads.localhost")).toBe(
+      ".uploads.localhost",
+    );
+    expect(
+      deriveCookieDomain("http://auth.uploads.localhost:1355", "http://uploads.localhost:1355"),
+    ).toBe(".uploads.localhost");
+    expect(
+      deriveCookieDomain("https://fix-ui.auth.uploads.localhost", "https://uploads.localhost"),
+    ).toBe(".uploads.localhost");
   });
 
   it("returns undefined for an IP host", () => {
@@ -60,6 +78,22 @@ describe("deriveCookieDomain", () => {
 
   it("returns undefined when the URL is undefined", () => {
     expect(deriveCookieDomain(undefined)).toBeUndefined();
+  });
+
+  // #731 Phase C: same-origin short-circuit.
+  it("returns undefined (host-only) when auth and web share a host", () => {
+    expect(deriveCookieDomain("https://uploads.sh", "https://uploads.sh")).toBeUndefined();
+    expect(
+      deriveCookieDomain("https://uploads.localhost", "https://uploads.localhost"),
+    ).toBeUndefined();
+  });
+
+  it("keeps cross-subdomain behavior when hosts differ", () => {
+    expect(deriveCookieDomain("https://auth.uploads.sh", "https://uploads.sh")).toBe(".uploads.sh");
+  });
+
+  it("ignores an unparseable webOrigin and falls through to legacy derivation", () => {
+    expect(deriveCookieDomain("https://auth.uploads.sh", "not-a-url")).toBe(".uploads.sh");
   });
 });
 

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -350,9 +350,29 @@ export async function upsertGithubLogin(
  * A 2-label apex host (e.g. `uploads.sh`) shares the whole host instead of
  * stripping the first label — stripping would yield a bare public suffix
  * (`.sh`), which browsers reject as a cookie domain.
+ *
+ * #731 Phase C: `webOrigin` is the web app's origin (env.WEB_ORIGIN). When it
+ * resolves to the SAME hostname as `betterAuthUrl` — auth is being served
+ * through the web origin's same-origin proxy — the cookie needs no domain
+ * scoping at all; a host-only cookie is both sufficient and strictly safer.
+ * This short-circuits before all the legacy derivation below, which still
+ * governs every differing-host case (auth.uploads.sh serving uploads.sh, the
+ * portless dev stack, etc).
  */
-export function deriveCookieDomain(betterAuthUrl: string | undefined): string | undefined {
+export function deriveCookieDomain(
+  betterAuthUrl: string | undefined,
+  webOrigin?: string,
+): string | undefined {
   if (!betterAuthUrl) return undefined;
+  if (webOrigin) {
+    try {
+      if (new URL(betterAuthUrl).hostname === new URL(webOrigin).hostname) {
+        return undefined; // same-origin mode: host-only session cookie
+      }
+    } catch {
+      // Unparseable webOrigin — fall through to legacy derivation below.
+    }
+  }
   let host: string;
   try {
     host = new URL(betterAuthUrl).hostname;
@@ -393,7 +413,7 @@ function buildAuth(
   const db = drizzle(env.DB, { schema });
   const betterAuthUrl = env.BETTER_AUTH_URL || "https://auth.uploads.sh";
   const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
-  const cookieDomain = deriveCookieDomain(betterAuthUrl);
+  const cookieDomain = deriveCookieDomain(betterAuthUrl, webOrigin);
   const isProduction = env.ENVIRONMENT === "production";
 
   return betterAuth({

--- a/apps/auth/src/index.test.ts
+++ b/apps/auth/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { app } from "./index";
 import { ROBOTS_TXT } from "./robots";
 import type { AuthEnv } from "./auth";
-import { LOCAL_STACK_AUTH_ORIGIN, LOCAL_STACK_WEB_ORIGIN } from "./local-demo";
+import { LOCAL_STACK_WEB_ORIGIN } from "./local-demo";
 import { createFakeD1 } from "./test/fake-d1";
 
 function envWithoutSecret(): AuthEnv {
@@ -14,13 +14,17 @@ function envWithoutSecret(): AuthEnv {
   };
 }
 
+// #731 phase C: the dev stack always runs the auth worker in same-origin
+// mode now (BETTER_AUTH_URL === WEB_ORIGIN, mirroring production — see
+// scripts/dev-stack.mjs), so the default local-stack shape here is the raw
+// stack's pinned loopback web origin used for BOTH fields.
 function localEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
   return {
     DB: createFakeD1(),
     BETTER_AUTH_SECRET_DEV: "x".repeat(32),
     LOCAL_STACK: "true",
     ENVIRONMENT: "development",
-    BETTER_AUTH_URL: LOCAL_STACK_AUTH_ORIGIN,
+    BETTER_AUTH_URL: LOCAL_STACK_WEB_ORIGIN,
     WEB_ORIGIN: LOCAL_STACK_WEB_ORIGIN,
     ...overrides,
   };
@@ -120,7 +124,8 @@ describe("local demo session", () => {
     for (const env of [
       localEnv({ LOCAL_STACK: undefined }),
       localEnv({ ENVIRONMENT: "production" }),
-      localEnv({ BETTER_AUTH_URL: "http://localhost:8788" }),
+      // #731 phase C: same-origin mode requires BETTER_AUTH_URL === WEB_ORIGIN.
+      localEnv({ BETTER_AUTH_URL: "http://localhost:4321" }),
       localEnv({ WEB_ORIGIN: "http://localhost:4321" }),
     ]) {
       const res = await app.request(
@@ -139,20 +144,16 @@ describe("local demo session", () => {
     expect(wrongOrigin.status).toBe(404);
   });
 
-  it("is absent for non-loopback or mismatched portless-style origins", async () => {
+  it("is absent for a same-origin pair that isn't a recognized local-stack web-origin shape", async () => {
     for (const env of [
-      // Real TLD, not `.localhost` — never enables the bypass.
+      // Real TLD, not `.localhost` and not the pinned loopback port — never
+      // enables the bypass, even though BETTER_AUTH_URL === WEB_ORIGIN here.
       localEnv({
-        BETTER_AUTH_URL: "https://auth.local.uploads.sh",
+        BETTER_AUTH_URL: "https://local.uploads.sh",
         WEB_ORIGIN: "https://local.uploads.sh",
       }),
-      // Bare `.localhost` auth host has no shareable parent.
-      localEnv({ BETTER_AUTH_URL: "https://auth.localhost", WEB_ORIGIN: "https://web.localhost" }),
-      // Web host outside the auth host's `.uploads.localhost` parent.
-      localEnv({
-        BETTER_AUTH_URL: "https://auth.uploads.localhost",
-        WEB_ORIGIN: "https://other.localhost",
-      }),
+      // Bare `.localhost` (no subdomain) doesn't match the portless shape.
+      localEnv({ BETTER_AUTH_URL: "https://localhost", WEB_ORIGIN: "https://localhost" }),
     ]) {
       const res = await app.request(
         "/api/auth/dev-session",
@@ -163,17 +164,16 @@ describe("local demo session", () => {
     }
   });
 
-  it("is available for a matched portless *.localhost pair", async () => {
-    const env = localEnv({
-      BETTER_AUTH_URL: "https://auth.uploads.localhost",
-      WEB_ORIGIN: "https://uploads.localhost",
-    });
-    const res = await app.request(
-      "/api/auth/dev-session",
-      { method: "POST", headers: { Origin: "https://uploads.localhost" } },
-      env,
-    );
-    expect(res.status).toBe(200);
+  it("is available for a same-origin portless *.localhost pair, including worktree-prefixed", async () => {
+    for (const webOrigin of ["https://uploads.localhost", "https://fix-ui.uploads.localhost"]) {
+      const env = localEnv({ BETTER_AUTH_URL: webOrigin, WEB_ORIGIN: webOrigin });
+      const res = await app.request(
+        "/api/auth/dev-session",
+        { method: "POST", headers: { Origin: webOrigin } },
+        env,
+      );
+      expect(res.status).toBe(200);
+    }
   });
 
   it("seeds an ordinary member and issues a standard Better Auth session", async () => {

--- a/apps/auth/src/local-demo.ts
+++ b/apps/auth/src/local-demo.ts
@@ -12,34 +12,35 @@ import { and, eq } from "drizzle-orm";
 import type { AuthEnv } from "./auth";
 import * as schema from "./schema";
 
-export const LOCAL_STACK_AUTH_ORIGIN = "http://127.0.0.1:8788";
+/**
+ * The raw (non-portless) local stack's pinned loopback web origin
+ * (scripts/dev-stack.mjs, `PORTLESS=0`). #731 phase C: the auth worker's own
+ * `LOCAL_STACK_AUTH_ORIGIN` (http://127.0.0.1:8788) constant is gone — the
+ * stack now runs the auth worker's `BETTER_AUTH_URL` as this same web
+ * origin (same-origin mode), even though the worker process itself still
+ * listens on its own pinned port. See `isLocalStackWebOrigin` below.
+ */
 export const LOCAL_STACK_WEB_ORIGIN = "http://127.0.0.1:4321";
 
 /**
- * Portless dev origins (see the `portless` skill): the stack runs at
- * https://auth.<name>.localhost / https://<name>.localhost (optionally
- * worktree-prefixed, optionally on the sudo-less proxy port, e.g.
- * http://uploads.localhost:1355). Accept the pair only when the auth host has
- * a shareable `.<name>.localhost` parent and the web host lives under that
- * same parent — the exact property the shared session cookie depends on.
- * `.localhost` names resolve to loopback by spec, so this stays as local-only
- * as the IP-literal pair above.
+ * True for a local-stack WEB origin shape: the raw stack's pinned loopback
+ * port, or a portless `*.localhost` origin (see the `portless` skill —
+ * optionally worktree-prefixed, optionally on the sudo-less proxy port, e.g.
+ * `http://uploads.localhost:1355`). `.localhost` names resolve to loopback
+ * by spec, so this stays as local-only as the IP-literal case.
  */
-function portlessLocalStackOrigins(authUrl: string | undefined, webOrigin: string | undefined) {
-  if (!authUrl || !webOrigin) return false;
-  let auth: URL;
+function isLocalStackWebOrigin(webOrigin: string | undefined): boolean {
+  if (!webOrigin) return false;
+  if (webOrigin === LOCAL_STACK_WEB_ORIGIN) return true;
   let web: URL;
   try {
-    auth = new URL(authUrl);
     web = new URL(webOrigin);
   } catch {
     return false;
   }
-  if (!/^https?:$/.test(auth.protocol) || !/^https?:$/.test(web.protocol)) return false;
-  const parts = auth.hostname.split(".");
-  if (parts.length < 3 || parts.at(-1) !== "localhost") return false;
-  const base = parts.slice(-2).join(".");
-  return web.hostname === base || web.hostname.endsWith("." + base);
+  if (!/^https?:$/.test(web.protocol)) return false;
+  const parts = web.hostname.split(".");
+  return parts.length >= 2 && parts.at(-1) === "localhost";
 }
 
 const DEMO_USER = {
@@ -51,19 +52,18 @@ const DEMO_ORGANIZATION = { id: "local-dev-demo-org", slug: "dev-demo", name: "D
 
 /**
  * The route is deliberately unavailable unless the lifecycle runner explicitly
- * opts in. Loopback-only origin shapes (exact IP-literal pair, or a matched
- * portless `*.localhost` pair) avoid accidentally enabling an identity bypass
- * on a public preview, a real-TLD alias, or a partially configured environment.
+ * opts in. #731 phase C: the dev stack now always runs the auth worker in
+ * same-origin mode (`BETTER_AUTH_URL === WEB_ORIGIN`, mirroring production —
+ * see scripts/dev-stack.mjs), so this requires that equality PLUS a
+ * recognized local-stack web-origin shape (the raw stack's pinned loopback
+ * port, or a portless `*.localhost` origin) — a real-TLD or otherwise
+ * unrecognized origin never enables the bypass, even if it happens to be
+ * same-origin.
  */
 export function localDemoEnabled(env: AuthEnv): boolean {
   if (env.LOCAL_STACK !== "true" || env.ENVIRONMENT !== "development") return false;
-  if (
-    env.BETTER_AUTH_URL === LOCAL_STACK_AUTH_ORIGIN &&
-    env.WEB_ORIGIN === LOCAL_STACK_WEB_ORIGIN
-  ) {
-    return true;
-  }
-  return portlessLocalStackOrigins(env.BETTER_AUTH_URL, env.WEB_ORIGIN);
+  if (!env.BETTER_AUTH_URL || env.BETTER_AUTH_URL !== env.WEB_ORIGIN) return false;
+  return isLocalStackWebOrigin(env.WEB_ORIGIN);
 }
 
 async function ensureDemoIdentity(env: AuthEnv) {

--- a/apps/auth/src/oauth.test.ts
+++ b/apps/auth/src/oauth.test.ts
@@ -17,7 +17,7 @@ function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
   return {
     DB: createFakeD1(),
     WEB_ORIGIN: "https://uploads.sh",
-    BETTER_AUTH_URL: "https://auth.uploads.sh",
+    BETTER_AUTH_URL: "https://uploads.sh",
     ENVIRONMENT: "development",
     BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
     ...overrides,
@@ -80,17 +80,33 @@ describe("root discovery aliases", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
     const body = (await res.json()) as { issuer?: string };
-    expect(body.issuer).toBe("https://auth.uploads.sh/api/auth");
+    expect(body.issuer).toBe("https://uploads.sh/api/auth");
   });
 
   it("serves the RFC 8414 path-inserted form", async () => {
     // The path a client actually derives from our issuer
-    // (https://auth.uploads.sh/api/auth) per RFC 8414 §3.1.
+    // (https://uploads.sh/api/auth) per RFC 8414 §3.1.
     const res = await app.request("/.well-known/oauth-authorization-server/api/auth", {}, dbEnv());
     expect(res.status).toBe(200);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
     const body = (await res.json()) as { issuer?: string };
-    expect(body.issuer).toBe("https://auth.uploads.sh/api/auth");
+    expect(body.issuer).toBe("https://uploads.sh/api/auth");
+  });
+
+  // #731 phase C: auth.uploads.sh keeps serving this alias for old clients
+  // that never migrate off it — but the issuer it returns follows
+  // BETTER_AUTH_URL, so it now points them at the NEW (uploads.sh) issuer.
+  // This is the deprecation path, not a bug: an old client's discovery still
+  // resolves, and lands on the same authorization server as everyone else.
+  it("the root discovery alias serves the new issuer once BETTER_AUTH_URL is uploads.sh (deprecation path for old clients hitting auth.uploads.sh)", async () => {
+    const res = await app.request(
+      "/.well-known/oauth-authorization-server",
+      {},
+      dbEnv({ BETTER_AUTH_URL: "https://uploads.sh" }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { issuer?: string };
+    expect(body.issuer).toBe("https://uploads.sh/api/auth");
   });
 
   it("forwards /.well-known/openid-configuration with CORS * (404: no `openid` scope, no OIDC id_token — honest metadata)", async () => {

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -12,8 +12,14 @@
   // cookies consistent.
   "dev": { "port": 8788 },
   "vars": {
-    // Better Auth's own baseURL — also this worker's public origin.
-    "BETTER_AUTH_URL": "https://auth.uploads.sh",
+    // Better Auth's own baseURL. #731 phase C: set to the WEB origin, not
+    // this worker's own public origin — auth is served same-origin through
+    // apps/web's /api/auth proxy, and this is what makes deriveCookieDomain
+    // (auth.ts) emit a host-only session cookie and the OAuth issuer resolve
+    // to https://uploads.sh/api/auth. auth.uploads.sh keeps serving (CLI
+    // bearer flows, the old-issuer discovery alias) — it just isn't the
+    // value baked into cookies/tokens anymore.
+    "BETTER_AUTH_URL": "https://uploads.sh",
     // Web app origin; credentialed CORS on /api/auth/* and the magic-link
     // email template both derive from this.
     "WEB_ORIGIN": "https://uploads.sh",
@@ -146,7 +152,10 @@
   //   wrangler d1 migrations apply uploads-auth-preview --remote -c apps/auth/wrangler.preview.jsonc
   "previews": {
     "vars": {
-      "BETTER_AUTH_URL": "https://auth.uploads.sh",
+      // #731 phase C: mirrors the top-level flip above (previews blocks do
+      // not inherit). A preview build can override this to the preview
+      // web origin instead — see docs/previews.md.
+      "BETTER_AUTH_URL": "https://uploads.sh",
       "WEB_ORIGIN": "https://uploads.sh",
       "ENVIRONMENT": "preview",
       "STRIPE_CHECKOUT_TOS_CONSENT": "true",

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -55,7 +55,10 @@ const OAUTH_AUDIENCES = ["https://agents.uploads.sh/mcp", "https://mcp.uploads.s
 const validator = new CfWorkerJsonSchemaValidator();
 
 function authOriginOf(env: Env): string {
-  return (env.AUTH_ORIGIN || "https://auth.uploads.sh").replace(/\/+$/, "");
+  // #731 phase C: falls back to the WEB origin (issuer now lives at
+  // uploads.sh/api/auth) — kept in lockstep with the AUTH_ORIGIN var in
+  // wrangler.jsonc.
+  return (env.AUTH_ORIGIN || "https://uploads.sh").replace(/\/+$/, "");
 }
 
 function bearerFrom(header: string | undefined): string {

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -61,6 +61,19 @@ function authOriginOf(env: Env): string {
   return (env.AUTH_ORIGIN || "https://uploads.sh").replace(/\/+$/, "");
 }
 
+/**
+ * The pre-#731-phase-C issuer — tokens minted before the cookie/issuer flip
+ * still carry this `iss` and remain valid until they expire naturally.
+ * `oauthAuth` accepts both this and the current issuer so those tokens keep
+ * working through the migration window; RFC 9728 discovery
+ * (`respondProtectedResource`) advertises ONLY the current issuer — new
+ * authorizations always mint against the new one. Remove this constant (and
+ * the array in `oauthAuth`) once phase E confirms no live legacy-issued
+ * tokens remain (they carry a bounded expiry, so this is safe to drop after
+ * one token lifetime has passed since the flip).
+ */
+const LEGACY_OAUTH_ISSUER = "https://auth.uploads.sh/api/auth";
+
 function bearerFrom(header: string | undefined): string {
   // RFC 9110 §11.1: auth scheme names are case-insensitive.
   return header?.match(/^Bearer +(.+)$/i)?.[1] ?? "";
@@ -88,8 +101,12 @@ async function oauthAuth(
   token: string,
   pathWorkspace: string | undefined,
 ): Promise<Response | null> {
+  const currentIssuer = `${authOriginOf(c.env)}/api/auth`;
   const verified = await verifyOAuthJwt(token, {
-    issuer: `${authOriginOf(c.env)}/api/auth`,
+    // Accept both the current and the legacy pre-flip issuer during the
+    // #731 phase C migration window — see LEGACY_OAUTH_ISSUER's comment.
+    // De-duped for the (non-prod) case where they happen to coincide.
+    issuer: [...new Set([currentIssuer, LEGACY_OAUTH_ISSUER])],
     audience: OAUTH_AUDIENCES,
   });
   if (!verified) return invalidTokenChallenge(c.req.url);

--- a/apps/mcp/src/oauth.ts
+++ b/apps/mcp/src/oauth.ts
@@ -121,18 +121,29 @@ export interface VerifiedOAuthToken {
 }
 
 export interface OAuthJwtConfig {
-  /** Expected `iss` — `${AUTH_ORIGIN}/api/auth`. jose does an exact match. */
-  issuer: string;
+  /**
+   * Expected `iss` — `${AUTH_ORIGIN}/api/auth`. jose does an exact match
+   * against any of the given values when an array is passed (used during
+   * the #731 phase C migration window to accept both the current and the
+   * legacy pre-flip issuer — see `LEGACY_OAUTH_ISSUER` in index.ts).
+   */
+  issuer: string | string[];
   /** Acceptable `aud` values — this resource's canonical URIs. */
   audience: string[];
-  /** JWKS endpoint. Defaults to `${issuer origin}/api/auth/jwks`. */
+  /** JWKS endpoint. Defaults to `${primary issuer origin}/api/auth/jwks`. */
   jwksUrl?: string;
   /** Test seam: skip the network fetch and cache, verify against this fetcher. */
   jwksFetcher?: JwksFetcher;
 }
 
-function defaultJwksUrl(issuer: string): string {
-  return new URL("/api/auth/jwks", issuer).href;
+/**
+ * JWKS lives at the primary (current) issuer's origin — the signing key
+ * material is shared regardless of which origin minted a given token, so a
+ * legacy-issuer token still verifies against the current JWKS endpoint.
+ */
+function defaultJwksUrl(issuer: string | string[]): string {
+  const primary = Array.isArray(issuer) ? issuer[0] : issuer;
+  return new URL("/api/auth/jwks", primary).href;
 }
 
 /**

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -11,7 +11,7 @@ const TOKEN = "up_test-ws_legacy-token-value";
 const ALPHA_TOKEN = "up_alpha_gallery-test";
 const BETA_TOKEN = "up_beta_gallery-test";
 
-const OAUTH_ISSUER = "https://auth.uploads.sh/api/auth";
+const OAUTH_ISSUER = "https://uploads.sh/api/auth";
 const OAUTH_AUDIENCE = "https://agents.uploads.sh/mcp";
 const OAUTH_KID = "test-key";
 
@@ -568,7 +568,7 @@ describe("mcp worker", () => {
       // Only apps/mcp advertises an AS (issue #224) — it's the only resource
       // server that verifies uploads-auth OAuth JWTs. Defaults to the prod
       // issuer when AUTH_ORIGIN isn't set on the test env.
-      expect(body.authorization_servers).toEqual(["https://auth.uploads.sh/api/auth"]);
+      expect(body.authorization_servers).toEqual(["https://uploads.sh/api/auth"]);
     }
   });
 

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1824,6 +1824,39 @@ describe("OAuth JWT bearer (issue #224)", () => {
     );
   });
 
+  // #731 phase C (C-1): the issuer moved from auth.uploads.sh to uploads.sh —
+  // tokens minted under the old issuer before the flip must keep working
+  // until they expire naturally.
+  it("accepts a JWT minted under the legacy pre-flip issuer (auth.uploads.sh)", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken(
+      { sub: "user-1", workspace: "test-ws", workspaces: ["test-ws"], scope: "files:read" },
+      { issuer: "https://auth.uploads.sh/api/auth" },
+    );
+    const response = await rpc(
+      env,
+      { jsonrpc: "2.0", id: 1, method: "initialize" },
+      jwt,
+      "https://agents.uploads.sh/mcp",
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it("still accepts a JWT minted under the current issuer (uploads.sh)", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken(
+      { sub: "user-1", workspace: "test-ws", workspaces: ["test-ws"], scope: "files:read" },
+      { issuer: OAUTH_ISSUER },
+    );
+    const response = await rpc(
+      env,
+      { jsonrpc: "2.0", id: 1, method: "initialize" },
+      jwt,
+      "https://agents.uploads.sh/mcp",
+    );
+    expect(response.status).toBe(200);
+  });
+
   it("401s with a discovery challenge for a bad-audience JWT", async () => {
     const { env } = await makeEnv();
     const jwt = await signOAuthToken(

--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -8,10 +8,13 @@
     "WEB_ORIGIN": "https://uploads.sh",
     // OAuth 2.1 authorization server this worker verifies access-token JWTs
     // against (issue #224) — issuer is `${AUTH_ORIGIN}/api/auth`, JWKS at
-    // `${AUTH_ORIGIN}/api/auth/jwks`. See src/oauth.ts. Override locally via
-    // .dev.vars (AUTH_ORIGIN=http://127.0.0.1:8788, matching apps/auth's
-    // pinned dev port).
-    "AUTH_ORIGIN": "https://auth.uploads.sh",
+    // `${AUTH_ORIGIN}/api/auth/jwks`. See src/oauth.ts. #731 phase C: this is
+    // the WEB origin — the issuer now lives at uploads.sh/api/auth (served
+    // same-origin through apps/web's proxy), matching BETTER_AUTH_URL in
+    // apps/auth/wrangler.jsonc. Override locally via .dev.vars
+    // (AUTH_ORIGIN=http://127.0.0.1:8788, matching apps/auth's pinned dev
+    // port).
+    "AUTH_ORIGIN": "https://uploads.sh",
     // GitHub App identity for the hosted put/comment path (#392) — the same
     // App uploads-api uses; postManagedComment runs in-process on this
     // worker, so it needs its own copy of the config. GITHUB_APP_PRIVATE_KEY
@@ -114,7 +117,7 @@
   "previews": {
     "vars": {
       "WEB_ORIGIN": "https://uploads.sh",
-      "AUTH_ORIGIN": "https://auth.uploads.sh",
+      "AUTH_ORIGIN": "https://uploads.sh",
       "GITHUB_APP_ID": "4346270",
       "GITHUB_APP_HOME_INSTALLATION_ID": "147814297",
     },

--- a/apps/web/src/lib/api-proxy.test.ts
+++ b/apps/web/src/lib/api-proxy.test.ts
@@ -236,3 +236,20 @@ describe("serverApiFetchImpl", () => {
     expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
   });
 });
+
+describe("serverApiFetchImpl", () => {
+  it("adapts serverApiFetch to a fetch(input, init) shape for api-client's fetchImpl", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ workspaces: [] }));
+    const request = new Request("https://uploads.sh/account/workspaces", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    const fetchImpl = serverApiFetchImpl({ API }, request);
+    const response = await fetchImpl("/api/me/workspaces", { cache: "no-store" });
+
+    expect(await response.json()).toEqual({ workspaces: [] });
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://uploads.sh/me/workspaces");
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
+  });
+});

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -721,25 +721,39 @@ describe("setOAuthWorkspaceChoice", () => {
 });
 
 describe("isLocalDemoStack", () => {
-  it("matches only the exact loopback pair", () => {
-    expect(isLocalDemoStack("http://127.0.0.1:8788", "http://127.0.0.1:4321")).toBe(true);
-    expect(isLocalDemoStack("http://127.0.0.1:8788/", "http://127.0.0.1:4321/")).toBe(true);
-    expect(isLocalDemoStack("http://localhost:8788", "http://127.0.0.1:4321")).toBe(false);
-    expect(isLocalDemoStack("http://127.0.0.1:8788", "http://localhost:4321")).toBe(false);
-    expect(isLocalDemoStack("https://auth.uploads.sh", "https://uploads.sh")).toBe(false);
+  // #731 phase C: gates on the PAGE origin alone — same-origin mode means
+  // the browser never learns the auth worker's own origin (authOrigin is
+  // always "" post Phase B), so the old auth-origin+page-origin pair check
+  // was permanently false. See the function's doc comment.
+  it("matches the raw stack's pinned loopback web origin", () => {
+    expect(isLocalDemoStack("http://127.0.0.1:4321")).toBe(true);
+    expect(isLocalDemoStack("http://127.0.0.1:4321/")).toBe(true);
+    expect(isLocalDemoStack("http://localhost:4321")).toBe(false);
+  });
+
+  it("matches a portless *.localhost web origin, including worktree-prefixed", () => {
+    expect(isLocalDemoStack("https://uploads.localhost")).toBe(true);
+    expect(isLocalDemoStack("https://fix-ui.uploads.localhost")).toBe(true);
+    expect(isLocalDemoStack("http://uploads.localhost:1355")).toBe(true);
+  });
+
+  it("rejects production and other non-local-stack origins", () => {
+    expect(isLocalDemoStack("https://uploads.sh")).toBe(false);
+    expect(isLocalDemoStack("https://auth.uploads.sh")).toBe(false);
+    expect(isLocalDemoStack("not-a-url")).toBe(false);
   });
 });
 
 describe("startLocalDemoSession", () => {
-  it("uses the gated loopback endpoint only for the exact local stack", async () => {
+  it("uses the gated loopback endpoint only for a recognized local-stack page origin", async () => {
     const fetcher = vi.fn(async () => new Response(null, { status: 200 }));
     vi.stubGlobal("fetch", fetcher);
 
-    await expect(
-      startLocalDemoSession("http://127.0.0.1:8788", "http://127.0.0.1:4321"),
-    ).resolves.toEqual({ kind: "started" });
+    await expect(startLocalDemoSession("", "http://127.0.0.1:4321")).resolves.toEqual({
+      kind: "started",
+    });
     expect(fetcher).toHaveBeenCalledWith(
-      "http://127.0.0.1:8788/api/auth/dev-session",
+      "/api/auth/dev-session",
       expect.objectContaining({
         credentials: "include",
         method: "POST",
@@ -748,9 +762,9 @@ describe("startLocalDemoSession", () => {
       }),
     );
 
-    await expect(
-      startLocalDemoSession("http://localhost:8788", "http://127.0.0.1:4321"),
-    ).resolves.toEqual({ kind: "not_enabled" });
+    await expect(startLocalDemoSession("", "http://localhost:4321")).resolves.toEqual({
+      kind: "not_enabled",
+    });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
@@ -760,9 +774,10 @@ describe("startLocalDemoSession", () => {
       vi.fn(async () => new Response(null, { status: 503 })),
     );
 
-    await expect(
-      startLocalDemoSession("http://127.0.0.1:8788", "http://127.0.0.1:4321"),
-    ).resolves.toEqual({ kind: "unavailable", reason: "server" });
+    await expect(startLocalDemoSession("", "http://127.0.0.1:4321")).resolves.toEqual({
+      kind: "unavailable",
+      reason: "server",
+    });
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -110,15 +110,37 @@ export type SessionResult =
   | { kind: "signed_out" }
   | { kind: "unavailable"; reason: RequestFailure | "server" | "malformed" };
 
-const LOCAL_STACK_AUTH_ORIGIN = "http://127.0.0.1:8788";
 const LOCAL_STACK_WEB_ORIGIN = "http://127.0.0.1:4321";
 
-/** True only on the exact loopback pair that may mint a local demo session. */
-export function isLocalDemoStack(authOriginValue: string, pageOrigin: string): boolean {
-  return (
-    authOrigin(authOriginValue) === LOCAL_STACK_AUTH_ORIGIN &&
-    pageOrigin.replace(/\/$/, "") === LOCAL_STACK_WEB_ORIGIN
-  );
+/**
+ * True only when `pageOrigin` is a recognized local-stack web origin: the
+ * raw stack's pinned loopback port, or a portless `*.localhost` origin
+ * (optionally worktree-prefixed, e.g. `https://fix-ui.uploads.localhost`).
+ *
+ * #731 phase C: this used to compare the injected auth origin against its
+ * own pinned loopback port, but Phase B made every injected auth origin `""`
+ * (same-origin) in every environment — that comparison was permanently
+ * false, silently disabling the local demo session everywhere. Same-origin
+ * mode means the browser never learns the auth worker's own origin at all,
+ * so the only signal left to gate on is the PAGE's origin. This is a
+ * convenience check to avoid probing the endpoint outside dev; the auth
+ * worker's `/api/auth/dev-session` route (`apps/auth/src/index.ts`) is the
+ * real, authoritative enforcement — it re-validates the request `Origin`
+ * against `env.WEB_ORIGIN` and `localDemoEnabled`'s own env gate
+ * server-side regardless of what this returns.
+ */
+export function isLocalDemoStack(pageOrigin: string): boolean {
+  const normalized = pageOrigin.replace(/\/$/, "");
+  if (normalized === LOCAL_STACK_WEB_ORIGIN) return true;
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
+    return false;
+  }
+  if (!/^https?:$/.test(url.protocol)) return false;
+  const parts = url.hostname.split(".");
+  return parts.length >= 2 && parts.at(-1) === "localhost";
 }
 
 type LocalDemoSessionStart =
@@ -187,7 +209,7 @@ export async function startLocalDemoSession(
   pageOrigin: string,
 ): Promise<LocalDemoSessionStart> {
   const normalizedOrigin = authOrigin(origin);
-  if (!isLocalDemoStack(normalizedOrigin, pageOrigin)) {
+  if (!isLocalDemoStack(pageOrigin)) {
     return { kind: "not_enabled" };
   }
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -9,15 +9,17 @@
  */
 import { defineMiddleware } from "astro:middleware";
 import { isLocalDemoStack } from "./lib/auth-client";
-import { resolveSignedInOrigins, signedInShellLoginRedirect } from "./lib/signed-in-page";
+import { signedInShellLoginRedirect } from "./lib/signed-in-page";
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname, search, origin } = context.url;
-  const { authOrigin } = resolveSignedInOrigins();
   const target = signedInShellLoginRedirect({
     pathname,
     search,
-    allowLocalDemo: isLocalDemoStack(authOrigin, origin),
+    // #731 phase C: same-origin mode means the browser never learns the
+    // auth worker's own origin (authOrigin is always "") — gate on the
+    // request's own origin instead (see isLocalDemoStack's doc comment).
+    allowLocalDemo: isLocalDemoStack(origin),
     hasCookie: Boolean(context.request.headers.get("cookie")?.trim()),
     sessionKind: null,
   });

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -21,20 +21,24 @@ pnpm typecheck        # wrangler types + tsc across workspaces
 `pnpm dev:stack` runs through [portless](https://npmjs.com/portless), so the
 stack gets stable named `.localhost` origins instead of bare ports:
 
-| Service | URL                              |
-| ------- | -------------------------------- |
-| web     | `https://uploads.localhost`      |
-| auth    | `https://auth.uploads.localhost` |
-| api     | `https://api.uploads.localhost`  |
+| Service | URL                              | Browser-visible?                                            |
+| ------- | -------------------------------- | ----------------------------------------------------------- |
+| web     | `https://uploads.localhost`      | yes — the only origin the browser talks to                  |
+| auth    | `https://auth.uploads.localhost` | no — internal upstream behind web's `/api/auth` proxy       |
+| api     | `https://api.uploads.localhost`  | not yet (phase D moves browser api traffic same-origin too) |
 
-The shared `.uploads.localhost` parent makes local auth work like prod. The
-auth worker sets a Better Auth session cookie, and the browser sends it to web
-and api the same way it sends `.uploads.sh` cookies. So signed-in pages
-(`/account/*`, `/admin/*`) just work in a local browser, including agent browser
-panels. In a linked git worktree, portless prefixes the branch name
-(`fix-ui.uploads.localhost` / `fix-ui.auth.uploads.localhost`); the cookie
-parent still anchors on the last two labels, so nothing else changes.
-`dev:stack` prints the resolved `previewUrl` when ready, and
+All three processes still run — auth and api each get their own named origin
+— but since #731 phase C the browser only ever talks to `uploads.localhost`:
+auth is served same-origin through web's `/api/auth` proxy (mirroring
+production), so `auth.uploads.localhost` is now an internal upstream the web
+worker forwards to, not something a signed-in page's own requests hit
+directly. The Better Auth session cookie is host-only on `uploads.localhost`
+(no shared `.uploads.localhost` parent needed anymore — same shape as prod's
+host-only `uploads.sh` cookie), and signed-in pages (`/account/*`, `/admin/*`)
+just work in a local browser, including agent browser panels. In a linked git
+worktree, portless prefixes the branch name (`fix-ui.uploads.localhost` /
+`fix-ui.auth.uploads.localhost` for the internal upstream); nothing else
+changes. `dev:stack` prints the resolved `previewUrl` when ready, and
 `pnpm dev:stack:check --json` reports it too.
 
 Notes:
@@ -44,16 +48,25 @@ Notes:
   handles both. `pnpm exec portless doctor` diagnoses routing/CA issues, and
   `pnpm exec portless service install` keeps the proxy across reboots.
 - `pnpm dev:stack:raw` (or `PORTLESS=0 pnpm dev:stack`) restores the legacy
-  pinned loopback ports (`127.0.0.1:4321/8787/8788`). This is also the path
-  to use when testing the dev GitHub OAuth app, whose callback is pinned to
-  `http://127.0.0.1:8788/api/auth/callback/github`. The `stack-raw` launch
-  config (.claude/launch.json) boots the same thing with a port-based
-  preview; in portless mode the web port is dynamic, so open the printed
-  `previewUrl` directly instead.
+  pinned loopback ports (`127.0.0.1:4321/8787/8788`) — same-origin mode there
+  too (the auth worker's `BETTER_AUTH_URL` is set to the web origin,
+  `http://127.0.0.1:4321`, even though the worker process itself still
+  listens on its own pinned `:8788`). This raw mode is also the path to use
+  when testing the dev GitHub OAuth app, whose callback is pinned to
+  `http://127.0.0.1:8788/api/auth/callback/github` — note that pinned
+  callback is now a DIFFERENT origin than `BETTER_AUTH_URL`
+  (`http://127.0.0.1:4321`), so Better Auth's derived `redirect_uri` won't
+  match it; day-to-day GitHub sign-in testing should stay on the
+  `dev-session` bypass below, or temporarily point `BETTER_AUTH_URL` back at
+  `http://127.0.0.1:8788` (see `apps/auth/.dev.vars.example`) to exercise the
+  real GitHub OAuth flow. The `stack-raw` launch config (.claude/launch.json)
+  boots the same thing with a port-based preview; in portless mode the web
+  port is dynamic, so open the printed `previewUrl` directly instead.
 - `pnpm dev:stack:oauth` is the named alias for the real-TLD mode below.
 - The zero-input `/api/auth/dev-session` bypass stays fail-closed: it only
-  enables for the exact loopback pair or a matched `*.localhost` pair — never
-  for real-TLD origins.
+  enables for a recognized local-stack web-origin shape (the exact loopback
+  pair or a matched `*.localhost` origin) — never for real-TLD origins, even
+  when they happen to be same-origin.
 
 ### Real-TLD mode for OAuth (`*.uploads.local.buildinternet.dev`)
 
@@ -86,8 +99,12 @@ both TLDs: `sudo portless proxy stop && sudo portless proxy start --https
 `portless service install --tld localhost --tld dev`).
 
 These origins are trusted by the auth worker outside production (https only).
-Register the provider's redirect URI as
-`https://auth.uploads.local.buildinternet.dev/api/auth/callback/<provider>`.
+Same-origin mode applies here too (`BETTER_AUTH_URL` is the web origin), so
+register the provider's redirect URI as
+`https://uploads.local.buildinternet.dev/api/auth/callback/<provider>` — NOT
+the `auth.` subdomain, even though that's where the auth worker's own process
+listens; `auth.uploads.local.buildinternet.dev` is now only the internal
+upstream web forwards `/api/auth/*` to.
 Note the `dev-session` bypass is intentionally unavailable in this mode —
 sign in through the real provider flow you're testing. GitHub accepts
 loopback callbacks, so day-to-day GitHub testing can stay on `PORTLESS=0`

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -40,12 +40,12 @@ diverged.
 Cross-service references (service bindings, origin vars) point at production
 by default, so one preview usually suffices:
 
-| Change                | Preview                | Everything else                                                                                                              |
-| --------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Web UI                | `uploads-web` only     | Talks to prod api/auth — realistic, signed out                                                                               |
-| API                   | `uploads-api` only     | Hit its URL with curl or the CLI; writes land in the preview tier; sessions verify against prod auth                         |
-| Cross-app (web + api) | Both                   | Override the web preview's `UPLOADS_API_ORIGIN` var to the api preview's URL                                                 |
-| Auth                  | `uploads-auth`, rarely | Needs a per-preview `BETTER_AUTH_URL` override; magic-link flows only — GitHub OAuth callbacks only cover production origins |
+| Change                | Preview                | Everything else                                                                                                                                                                                                  |
+| --------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Web UI                | `uploads-web` only     | Talks to prod api/auth — realistic, signed out                                                                                                                                                                   |
+| API                   | `uploads-api` only     | Hit its URL with curl or the CLI; writes land in the preview tier; sessions verify against prod auth                                                                                                             |
+| Cross-app (web + api) | Both                   | Override the web preview's `UPLOADS_API_ORIGIN` var to the api preview's URL                                                                                                                                     |
+| Auth                  | `uploads-auth`, rarely | Needs a per-preview `BETTER_AUTH_URL` override to the WEB preview's origin (#731: same-origin mode — see apps/auth/wrangler.jsonc); magic-link flows only — GitHub OAuth callbacks only cover production origins |
 
 Platform rules that shape this: service bindings always call the bound
 worker's production deployment, and cron triggers, queue consumers, and

--- a/scripts/dev-stack-common.mjs
+++ b/scripts/dev-stack-common.mjs
@@ -192,6 +192,27 @@ export async function runSmoke() {
     throw new Error("demo membership did not resolve only the expected dev-demo workspace");
   }
 
+  // #731 phase C (C-2): the two direct-origin checks above prove the
+  // workers themselves are healthy; these two cheaply prove the same-origin
+  // proxy routes web actually serves in prod (uploads.sh/api/auth/*,
+  // uploads.sh/api/*) also work, using the same cookie jar — a regression in
+  // either proxy route wouldn't otherwise be caught by this smoke.
+  const proxiedSession = await request(`${WEB_ORIGIN}/api/auth/get-session`, {}, jar);
+  await requireOk(proxiedSession, "web /api/auth/get-session proxy");
+  const proxiedSessionBody = await proxiedSession.json();
+  if (proxiedSessionBody?.user?.email !== "dev-demo@uploads.local") {
+    throw new Error("web's /api/auth proxy did not return the local demo user");
+  }
+
+  const proxiedWorkspaces = await request(`${WEB_ORIGIN}/api/me/workspaces`, {}, jar);
+  await requireOk(proxiedWorkspaces, "web /api/me/workspaces proxy");
+  const proxiedNames = (await proxiedWorkspaces.json())?.workspaces?.map(
+    (workspace) => workspace.workspace,
+  );
+  if (!Array.isArray(proxiedNames) || !proxiedNames.includes(DEMO_WORKSPACE)) {
+    throw new Error("web's /api proxy did not resolve the expected dev-demo workspace");
+  }
+
   const files = await request(
     `${API_ORIGIN}/me/workspaces/${DEMO_WORKSPACE}/files`,
     { headers: { Origin: WEB_ORIGIN } },

--- a/scripts/dev-stack.mjs
+++ b/scripts/dev-stack.mjs
@@ -127,9 +127,15 @@ async function main() {
   const portlessWrap = (name, script) =>
     USE_PORTLESS ? ["exec", "portless", "run", "--name", name, "sh", "-c", script] : null;
 
+  // #731 phase C: BETTER_AUTH_URL is the WEB origin, not this worker's own
+  // AUTH_ORIGIN — the auth worker still binds/listens on AUTH_ORIGIN (see
+  // waitFor below and UPLOADS_AUTH_ORIGIN passed to web further down), but
+  // Better Auth is configured as if it's served through web's same-origin
+  // proxy, so deriveCookieDomain (auth.ts) emits a host-only cookie locally
+  // the same way it will in production.
   const authVars =
     `--var LOCAL_STACK:true --var ENVIRONMENT:development ` +
-    `--var BETTER_AUTH_URL:${AUTH_ORIGIN} --var WEB_ORIGIN:${WEB_ORIGIN}`;
+    `--var BETTER_AUTH_URL:${WEB_ORIGIN} --var WEB_ORIGIN:${WEB_ORIGIN}`;
   start(
     "auth",
     portlessWrap(
@@ -151,7 +157,7 @@ async function main() {
       "--var",
       "ENVIRONMENT:development",
       "--var",
-      `BETTER_AUTH_URL:${AUTH_ORIGIN}`,
+      `BETTER_AUTH_URL:${WEB_ORIGIN}`,
       "--var",
       `WEB_ORIGIN:${WEB_ORIGIN}`,
     ],


### PR DESCRIPTION
Phase C of #731 — **the flip**. Do not merge unattended: the deploy needs the manual GitHub OAuth callback step below, timed right after it goes out.

## Changes

- `deriveCookieDomain(betterAuthUrl, webOrigin?)` gains a same-origin short-circuit: equal hostnames → `undefined` → **host-only session cookie**. All differing-host derivations (legacy prod shape, portless dev) unchanged and still covered by tests.
- `BETTER_AUTH_URL` → `https://uploads.sh` in `apps/auth/wrangler.jsonc` (top-level + previews). This is what moves the OAuth issuer to `https://uploads.sh/api/auth` and makes the cookie host-only.
- `AUTH_ORIGIN` → `https://uploads.sh` in `apps/mcp/wrangler.jsonc` (both blocks) plus its in-code fallback, keeping the RFC 9728 metadata on `agents.uploads.sh` pointing at the new issuer.
- The auth worker's root-level discovery aliases now serve the **new** issuer from the old origin — that is the deprecation path for clients still discovering via `auth.uploads.sh` (test added).
- Dev stack: `BETTER_AUTH_URL` is the web origin locally too, so local cookies are host-only the same way prod's will be; `local-demo` gating reworked for the same-origin shape (worker gate + the client pre-check that phase B had orphaned). `docs/local-dev.md` and `docs/previews.md` updated. Known dev caveat: real GitHub OAuth sign-in on the raw stack needs a documented manual override (dev callback is pinned to `:8788`); the dev-session flow is unaffected.

## Verified on the raw local stack

Issuer `…/api/auth` on the web origin **and** via the old auth-origin alias; session `Set-Cookie` with no `Domain` attribute (host-only); signed-in SSR intact; local-demo gate restored.

## Deploy runbook (merge = deploy via Workers Builds)

1. Merge (with #733 below it). Auth + mcp redeploy with the new vars.
2. **Immediately after**: update the production GitHub OAuth app's Authorization callback URL to `https://uploads.sh/api/auth/callback/github`. GitHub OAuth apps take a single callback URL, so expect ≤1 minute where GitHub sign-in fails; existing sessions are unaffected.
3. Repoint the `@better-auth/infra` dashboard at `https://uploads.sh` (see apps/auth/README.md).
4. Verify: `curl -s https://uploads.sh/.well-known/oauth-authorization-server | jq .issuer` → `https://uploads.sh/api/auth`; same via `auth.uploads.sh`; a fresh sign-in sets a host-only cookie plus one clearing `Set-Cookie` for the legacy `.uploads.sh` domain; the MCP OAuth flow against agents.uploads.sh completes.

Old wide cookies keep authenticating (same cookie name, still sent to `uploads.sh`); the #732 proxy clears them on the next sign-in.

Refs #731
