### PR TITLE
feat(web): browser api traffic via same-origin /api proxy (#731 phase D)

### DIFF
--- a/apps/web/src/components/ReportAbuse.astro
+++ b/apps/web/src/components/ReportAbuse.astro
@@ -4,6 +4,11 @@
  * Posts to POST /v1/abuse on the API origin.
  */
 interface Props {
+  /**
+   * Absolute origin, or the same-origin "/api" prefix (#731 phase D) — either
+   * way a bare string prefix, never fed through `new URL(path, apiOrigin)`
+   * (that constructor requires an absolute base and would throw on "/api").
+   */
   apiOrigin: string;
   pageUrl: string;
   workspace: string;
@@ -120,7 +125,7 @@ const REASONS = [
       status.textContent = "Sending…";
 
       try {
-        const res = await fetch(new URL("/v1/abuse", apiOrigin), {
+        const res = await fetch(apiOrigin.replace(/\/$/, "") + "/v1/abuse", {
           method: "POST",
           headers: { "content-type": "application/json", accept: "application/json" },
           body: JSON.stringify({

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -65,7 +65,7 @@ const settingsSubpage =
 const workspaceBase = workspace ? `/account/workspaces/${encodeURIComponent(workspace)}` : "";
 const switcherHeading = workspace || "workspaces";
 
-const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
+const { authOrigin, apiOrigin } = resolveSignedInOrigins();
 // Header (not meta): frame-ancestors is ignored on meta CSP. Also sets
 // Cache-Control: no-store, so the per-request session reveal below is never
 // cached and served to another visitor.

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -39,7 +39,7 @@ const titles: Record<AdminSection, string> = {
 const docTitle = `${titles[section]} · uploads.sh`;
 
 const showConsoleLinks = await resolveShowConsoleLinks(env);
-const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
+const { authOrigin, apiOrigin } = resolveSignedInOrigins();
 // Header (not meta): frame-ancestors is ignored on meta CSP.
 applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
 

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -13,6 +13,7 @@ import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
 import SiteHeader from "../components/SiteHeader.astro";
 import ViewTransitions from "../components/ViewTransitions.astro";
+import { SAME_ORIGIN_AUTH_BASE } from "../lib/auth-client";
 import { OG_DEFAULT_IMAGE, OG_SITE_NAME } from "../lib/og";
 
 interface TocEntry {
@@ -31,9 +32,7 @@ interface Props {
 }
 const { title, description, path, heading, tagline, active, toc, ogType = "website" } = Astro.props;
 
-// Same-origin (#731 phase B): browser auth traffic goes through this origin's
-// /api/auth proxy, not a configured auth-worker origin.
-const authOrigin = "";
+const authOrigin = SAME_ORIGIN_AUTH_BASE;
 
 // Left-nav sections. The four subject pages plus the standalone agent guide.
 const DOCS_NAV = [

--- a/apps/web/src/layouts/ErrorLayout.astro
+++ b/apps/web/src/layouts/ErrorLayout.astro
@@ -7,6 +7,7 @@
 import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
 import SiteHeader from "../components/SiteHeader.astro";
+import { SAME_ORIGIN_AUTH_BASE } from "../lib/auth-client";
 
 interface Props {
   status: number;
@@ -18,9 +19,7 @@ interface Props {
 
 const { status, title, message, hint } = Astro.props;
 
-// Same-origin (#731 phase B): browser auth traffic goes through this origin's
-// /api/auth proxy, not a configured auth-worker origin.
-const authOrigin = "";
+const authOrigin = SAME_ORIGIN_AUTH_BASE;
 ---
 
 <html lang="en">

--- a/apps/web/src/layouts/LegalLayout.astro
+++ b/apps/web/src/layouts/LegalLayout.astro
@@ -5,6 +5,7 @@
 import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
 import SiteHeader from "../components/SiteHeader.astro";
+import { SAME_ORIGIN_AUTH_BASE } from "../lib/auth-client";
 
 interface Props {
   title: string;
@@ -13,9 +14,7 @@ interface Props {
 }
 const { title, description, path } = Astro.props;
 
-// Same-origin (#731 phase B): browser auth traffic goes through this origin's
-// /api/auth proxy, not a configured auth-worker origin.
-const authOrigin = "";
+const authOrigin = SAME_ORIGIN_AUTH_BASE;
 ---
 
 <html lang="en">

--- a/apps/web/src/lib/account-profile-ui.test.ts
+++ b/apps/web/src/lib/account-profile-ui.test.ts
@@ -149,6 +149,29 @@ describe("loadProfilePageData", () => {
     }
   });
 
+  it("routes every fetch through a caller-supplied fetchImpl (SSR binding transport)", async () => {
+    const user = { id: "u1", email: "z@example.com", name: "Zach", role: "member" };
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const url = String(input);
+      if (url.includes("get-session")) return Response.json({ user, session: {} });
+      if (url.includes("list-accounts")) return Response.json([]);
+      if (url.includes("list-sessions")) return Response.json([]);
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    const globalFetch = vi.fn();
+    vi.stubGlobal("fetch", globalFetch);
+
+    const data = await loadProfilePageData(
+      "https://auth.uploads.sh",
+      "better-auth.session_token=abc",
+      fetchImpl,
+    );
+
+    expect(data.user).toEqual(user);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(globalFetch).not.toHaveBeenCalled();
+  });
+
   it("skips the account-info lookup when no github account is linked", async () => {
     const fetcher = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/apps/web/src/lib/account-profile-ui.ts
+++ b/apps/web/src/lib/account-profile-ui.ts
@@ -39,15 +39,16 @@ export interface ProfilePageData {
 export async function loadProfilePageData(
   authOrigin: string,
   cookie: string,
+  fetchImpl?: typeof fetch,
 ): Promise<ProfilePageData> {
   if (!cookie.trim()) {
     return { user: null, currentToken: null, accounts: null, githubInfo: null, sessions: null };
   }
 
   const [sessionResult, accounts, sessions] = await Promise.all([
-    getSession(authOrigin, { cookie }),
-    listAccounts(authOrigin, { cookie }),
-    listSessions(authOrigin, { cookie }),
+    getSession(authOrigin, { cookie, fetchImpl }),
+    listAccounts(authOrigin, { cookie, fetchImpl }),
+    listSessions(authOrigin, { cookie, fetchImpl }),
   ]);
 
   const user = sessionResult.kind === "signed_in" ? sessionResult.session.user : null;
@@ -62,6 +63,7 @@ export async function loadProfilePageData(
         providerId: "github",
         accountId: github.accountId,
         cookie,
+        fetchImpl,
       })
     : null;
 

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -33,6 +33,29 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+describe("apiOrigin same-origin contract (#731 phase D)", () => {
+  it("builds a same-origin /api/... URL when apiOrigin is the '/api' sentinel", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) => Response.json({ workspaces: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getMyWorkspaces("/api");
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/me/workspaces");
+  });
+
+  it("routes the fetch through a caller-supplied fetchImpl (SSR binding transport)", async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL) => Response.json({ workspaces: [] }));
+    const globalFetch = vi.fn();
+    vi.stubGlobal("fetch", globalFetch);
+
+    await getMyWorkspaces("/api", { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe("/api/me/workspaces");
+    expect(globalFetch).not.toHaveBeenCalled();
+  });
+});
+
 describe("getMyWorkspaces", () => {
   it("preserves a successful empty workspace list", async () => {
     vi.stubGlobal(

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -9,6 +9,17 @@
 import { fetchWithTimeout, type RequestFailure } from "./request";
 import { buildSearchQuery, type MetaFilter } from "./workspace-search-url";
 
+/**
+ * `apiOrigin` is either an absolute origin (`https://api.uploads.sh`, or a
+ * dev override) or the same-origin path prefix `"/api"` that
+ * `resolveSignedInOrigins` returns in-app (#731 phase D — `signed-in-
+ * page.ts`). Unlike `authOrigin("")` → `""` (auth's templates already bake
+ * in `/api/auth/...`), every template here is a bare `${trimOrigin(apiOrigin)}/v1/...`
+ * with no prefix of its own, so the same-origin sentinel has to carry the
+ * `/api` prefix itself — an empty string would build a request against this
+ * origin's own `/v1/...` route, not the proxy. `trimOrigin` only strips a
+ * trailing slash either way, so `"/api"` needs no special-casing here.
+ */
 function trimOrigin(origin: string): string {
   return origin.replace(/\/$/, "");
 }
@@ -112,11 +123,13 @@ export function parseWorkspaceCreateQuota(value: unknown): WorkspaceCreateQuota 
 /** GET /me/workspaces, preserving an outage rather than rendering it as an empty account. */
 export async function getMyWorkspaces(
   apiOrigin: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<WorkspacesResult> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/me/workspaces`,
     sessionFetchInit(opts?.cookie),
+    undefined,
+    opts?.fetchImpl,
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -186,11 +199,13 @@ export type WorkspaceSummaryResult =
 export async function getWorkspaceSummary(
   apiOrigin: string,
   name: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<WorkspaceSummaryResult> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/summary`,
     sessionFetchInit(opts?.cookie),
+    undefined,
+    opts?.fetchImpl,
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -217,11 +232,13 @@ async function fetchWorkspaceList<T>(
   segment: string,
   key: string,
   isValid: (value: unknown) => value is T,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<T[]> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/${segment}`,
     sessionFetchInit(opts?.cookie),
+    undefined,
+    opts?.fetchImpl,
   );
   if (result.kind === "unavailable" || !result.response.ok) return [];
   const body = (await result.response.json().catch(() => null)) as Record<string, unknown> | null;
@@ -288,7 +305,7 @@ function isGallerySummary(value: unknown): value is GallerySummary {
 export function getMyWorkspaceGalleries(
   apiOrigin: string,
   name: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<GallerySummary[]> {
   return fetchWorkspaceList(apiOrigin, name, "galleries", "galleries", isGallerySummary, opts);
 }
@@ -480,11 +497,13 @@ export type WorkspacePeopleResult =
 export async function getWorkspacePeople(
   apiOrigin: string,
   name: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<WorkspacePeopleResult> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/people`,
     sessionFetchInit(opts?.cookie),
+    undefined,
+    opts?.fetchImpl,
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -556,11 +575,13 @@ export type WorkspaceBillingResult =
 export async function getWorkspaceBilling(
   apiOrigin: string,
   name: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<WorkspaceBillingResult> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/billing`,
     sessionFetchInit(opts?.cookie),
+    undefined,
+    opts?.fetchImpl,
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -993,14 +1014,19 @@ function catalogFromGroups(groups: FilesPathGroup[]): PathCatalogEntry[] {
 export async function getWorkspaceFilesByPath(
   apiOrigin: string,
   name: string,
-  opts?: { cookie?: string; merged?: boolean },
+  opts?: { cookie?: string; merged?: boolean; fetchImpl?: typeof fetch },
 ): Promise<FilesByPathResult> {
   // Opt-in "Merged only" filter (persisted PR merge-state tagging) — omitted
   // entirely rather than sent as `merged=0`/`false`, so a default call's URL
   // is unchanged.
   const query = opts?.merged ? "?merged=1" : "";
   const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/by-path${query}`;
-  const result = await fetchWithTimeout(url, sessionFetchInit(opts?.cookie));
+  const result = await fetchWithTimeout(
+    url,
+    sessionFetchInit(opts?.cookie),
+    undefined,
+    opts?.fetchImpl,
+  );
   if (result.kind === "unavailable") return result;
   const { response } = result;
   if (!response.ok) return { kind: "unavailable", reason: "server" };
@@ -1316,11 +1342,13 @@ function sessionFetchInit(cookie?: string): RequestInit {
 /** GET /v1/tokens — workspaces the signed-in user can mint a token for. */
 export async function listMintableWorkspaces(
   apiOrigin: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<MintableWorkspace[] | null> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/tokens`,
     sessionFetchInit(opts?.cookie),
+    undefined,
+    opts?.fetchImpl,
   );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = await result.response.json().catch(() => undefined);
@@ -1330,11 +1358,13 @@ export async function listMintableWorkspaces(
 /** GET /v1/tokens/issued — tokens this session user minted. */
 export async function listIssuedWorkspaceTokens(
   apiOrigin: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<IssuedWorkspaceToken[] | null> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/tokens/issued`,
     sessionFetchInit(opts?.cookie),
+    undefined,
+    opts?.fetchImpl,
   );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = await result.response.json().catch(() => undefined);
@@ -1482,7 +1512,13 @@ function toWorkspaceFolderFile(raw: Record<string, unknown>): WorkspaceFolderFil
 export async function listWorkspaceFolder(
   apiOrigin: string,
   workspace: string,
-  opts: { prefix?: string; cursor?: string; limit?: number; cookie?: string } = {},
+  opts: {
+    prefix?: string;
+    cursor?: string;
+    limit?: number;
+    cookie?: string;
+    fetchImpl?: typeof fetch;
+  } = {},
 ): Promise<WorkspaceFolderListing> {
   const params = new URLSearchParams();
   // Always list one folder level at a time — without the delimiter the API
@@ -1494,7 +1530,12 @@ export async function listWorkspaceFolder(
   const query = params.toString();
   const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(workspace)}/files${query ? `?${query}` : ""}`;
 
-  const result = await fetchWithTimeout(url, sessionFetchInit(opts.cookie));
+  const result = await fetchWithTimeout(
+    url,
+    sessionFetchInit(opts.cookie),
+    undefined,
+    opts.fetchImpl,
+  );
   if (result.kind === "unavailable" || !result.response.ok) return emptyFolderListing();
 
   const body = (await result.response.json().catch(() => null)) as {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -128,8 +128,7 @@ export async function getMyWorkspaces(
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/me/workspaces`,
     sessionFetchInit(opts?.cookie),
-    undefined,
-    opts?.fetchImpl,
+    { fetchImpl: opts?.fetchImpl },
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -204,8 +203,7 @@ export async function getWorkspaceSummary(
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/summary`,
     sessionFetchInit(opts?.cookie),
-    undefined,
-    opts?.fetchImpl,
+    { fetchImpl: opts?.fetchImpl },
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -237,8 +235,7 @@ async function fetchWorkspaceList<T>(
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/${segment}`,
     sessionFetchInit(opts?.cookie),
-    undefined,
-    opts?.fetchImpl,
+    { fetchImpl: opts?.fetchImpl },
   );
   if (result.kind === "unavailable" || !result.response.ok) return [];
   const body = (await result.response.json().catch(() => null)) as Record<string, unknown> | null;
@@ -502,8 +499,7 @@ export async function getWorkspacePeople(
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/people`,
     sessionFetchInit(opts?.cookie),
-    undefined,
-    opts?.fetchImpl,
+    { fetchImpl: opts?.fetchImpl },
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -580,8 +576,7 @@ export async function getWorkspaceBilling(
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/billing`,
     sessionFetchInit(opts?.cookie),
-    undefined,
-    opts?.fetchImpl,
+    { fetchImpl: opts?.fetchImpl },
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -1021,12 +1016,9 @@ export async function getWorkspaceFilesByPath(
   // is unchanged.
   const query = opts?.merged ? "?merged=1" : "";
   const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/files/by-path${query}`;
-  const result = await fetchWithTimeout(
-    url,
-    sessionFetchInit(opts?.cookie),
-    undefined,
-    opts?.fetchImpl,
-  );
+  const result = await fetchWithTimeout(url, sessionFetchInit(opts?.cookie), {
+    fetchImpl: opts?.fetchImpl,
+  });
   if (result.kind === "unavailable") return result;
   const { response } = result;
   if (!response.ok) return { kind: "unavailable", reason: "server" };
@@ -1347,8 +1339,7 @@ export async function listMintableWorkspaces(
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/tokens`,
     sessionFetchInit(opts?.cookie),
-    undefined,
-    opts?.fetchImpl,
+    { fetchImpl: opts?.fetchImpl },
   );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = await result.response.json().catch(() => undefined);
@@ -1363,8 +1354,7 @@ export async function listIssuedWorkspaceTokens(
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/tokens/issued`,
     sessionFetchInit(opts?.cookie),
-    undefined,
-    opts?.fetchImpl,
+    { fetchImpl: opts?.fetchImpl },
   );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = await result.response.json().catch(() => undefined);
@@ -1530,12 +1520,9 @@ export async function listWorkspaceFolder(
   const query = params.toString();
   const url = `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(workspace)}/files${query ? `?${query}` : ""}`;
 
-  const result = await fetchWithTimeout(
-    url,
-    sessionFetchInit(opts.cookie),
-    undefined,
-    opts.fetchImpl,
-  );
+  const result = await fetchWithTimeout(url, sessionFetchInit(opts.cookie), {
+    fetchImpl: opts.fetchImpl,
+  });
   if (result.kind === "unavailable" || !result.response.ok) return emptyFolderListing();
 
   const body = (await result.response.json().catch(() => null)) as {

--- a/apps/web/src/lib/api-proxy.test.ts
+++ b/apps/web/src/lib/api-proxy.test.ts
@@ -73,6 +73,36 @@ describe("proxyApiRequest — binding transport", () => {
     expect(response.status).toBe(404);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("404s an encoded /auth further down the path (/api/%61uth/...), never reaching env.API", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/%61uth/enrollments/xyz");
+
+    const response = await proxyApiRequest({ API }, request);
+
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("404s an encoded /api boundary slash (/api%2Fauth/...), never reaching env.API", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api%2Fauth/enrollments/xyz");
+
+    const response = await proxyApiRequest({ API }, request);
+
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("404s a malformed percent-escape rather than guessing", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/v1/workspaces/acme/files/%");
+
+    const response = await proxyApiRequest({ API }, request);
+
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("proxyApiRequest — HTTP fallback transport", () => {
@@ -173,6 +203,20 @@ describe("serverApiFetch", () => {
     const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
     expect(forwarded.method).toBe("DELETE");
     expect(forwarded.url).toBe("https://uploads.sh/v1/workspaces/acme/storage");
+  });
+
+  it("does not overwrite a cookie header the caller's init already set (matches serverAuthFetch)", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/account/workspaces", {
+      headers: { cookie: "better-auth.session_token=incoming" },
+    });
+
+    await serverApiFetch({ API }, request, "/api/me/workspaces", {
+      headers: { cookie: "better-auth.session_token=caller-set" },
+    });
+
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=caller-set");
   });
 });
 

--- a/apps/web/src/lib/api-proxy.test.ts
+++ b/apps/web/src/lib/api-proxy.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { proxyApiRequest, serverApiFetch } from "./api-proxy";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Minimal binding fake — records the forwarded request and returns a canned response. */
+function fakeApiBinding(response: Response) {
+  const fetch = vi.fn(async (_req: Request) => response);
+  return { API: { fetch }, fetchMock: fetch };
+}
+
+describe("proxyApiRequest — binding transport", () => {
+  it("strips the leading /api and forwards over env.API with redirect: manual", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/me/workspaces", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    await proxyApiRequest({ API }, request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://uploads.sh/me/workspaces");
+    expect(forwarded.redirect).toBe("manual");
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
+  });
+
+  it("preserves the query string", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/v1/workspaces/acme/files?prefix=a%2Fb");
+
+    await proxyApiRequest({ API }, request);
+
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://uploads.sh/v1/workspaces/acme/files?prefix=a%2Fb");
+  });
+
+  it("forwards method and body untouched", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/v1/tokens", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"grants":[]}',
+    });
+
+    await proxyApiRequest({ API }, request);
+
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.method).toBe("POST");
+    expect(forwarded.headers.get("content-type")).toBe("application/json");
+    expect(await forwarded.text()).toBe('{"grants":[]}');
+  });
+
+  it("passes the upstream response through untouched", async () => {
+    const upstream = Response.json({ hello: "world" }, { status: 201 });
+    const { API } = fakeApiBinding(upstream);
+    const request = new Request("https://uploads.sh/api/v1/tokens", { method: "POST" });
+
+    const response = await proxyApiRequest({ API }, request);
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({ hello: "world" });
+  });
+
+  it("404s a stripped path starting with /auth, never reaching env.API", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/auth/enrollments/xyz");
+
+    const response = await proxyApiRequest({ API }, request);
+
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("proxyApiRequest — HTTP fallback transport", () => {
+  it("rewrites only the origin, stripping /api and keeping path/query/method/headers/body", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const req = input as Request;
+      expect(req.url).toBe("http://127.0.0.1:8787/v1/workspaces/acme/files?prefix=x");
+      expect(req.method).toBe("POST");
+      expect(req.redirect).toBe("manual");
+      expect(req.headers.get("content-type")).toBe("application/json");
+      expect(await req.text()).toBe('{"name":"acme"}');
+      return Response.json({ ok: true });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new Request("https://uploads.sh/api/v1/workspaces/acme/files?prefix=x", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"name":"acme"}',
+    });
+
+    await proxyApiRequest({}, request);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to http://127.0.0.1:8787 when UPLOADS_API_ORIGIN is unset", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect((input as Request).url).toMatch(/^http:\/\/127\.0\.0\.1:8787\//);
+      return Response.json(null);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await proxyApiRequest({}, new Request("https://uploads.sh/api/me/workspaces"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses UPLOADS_API_ORIGIN when provided", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect((input as Request).url).toBe("https://api.uploads.localhost/me/workspaces");
+      return Response.json(null);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await proxyApiRequest(
+      { UPLOADS_API_ORIGIN: "https://api.uploads.localhost" },
+      new Request("https://uploads.localhost/api/me/workspaces"),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("404s a stripped path starting with /auth without touching the network", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await proxyApiRequest(
+      {},
+      new Request("https://uploads.sh/api/auth/enrollments/xyz"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("serverApiFetch", () => {
+  it("targets the given path on the request's own origin and forwards its cookie header", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ workspaces: [] }));
+    const request = new Request("https://uploads.sh/account/workspaces", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    await serverApiFetch({ API }, request, "/api/me/workspaces");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://uploads.sh/me/workspaces");
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
+  });
+
+  it("sends an empty cookie header when the incoming request has none", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json(null));
+    const request = new Request("https://uploads.sh/account/workspaces");
+
+    await serverApiFetch({ API }, request, "/api/me/workspaces");
+
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.headers.get("cookie")).toBe("");
+  });
+
+  it("passes method/init through", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/account/workspaces/acme/settings");
+
+    await serverApiFetch({ API }, request, "/api/v1/workspaces/acme/storage", {
+      method: "DELETE",
+    });
+
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.method).toBe("DELETE");
+    expect(forwarded.url).toBe("https://uploads.sh/v1/workspaces/acme/storage");
+  });
+});

--- a/apps/web/src/lib/api-proxy.test.ts
+++ b/apps/web/src/lib/api-proxy.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { proxyApiRequest, serverApiFetch } from "./api-proxy";
+import { proxyApiRequest, serverApiFetch, serverApiFetchImpl } from "./api-proxy";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -173,5 +173,22 @@ describe("serverApiFetch", () => {
     const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
     expect(forwarded.method).toBe("DELETE");
     expect(forwarded.url).toBe("https://uploads.sh/v1/workspaces/acme/storage");
+  });
+});
+
+describe("serverApiFetchImpl", () => {
+  it("adapts serverApiFetch to a fetch(input, init) shape for api-client's fetchImpl", async () => {
+    const { API, fetchMock } = fakeApiBinding(Response.json({ workspaces: [] }));
+    const request = new Request("https://uploads.sh/account/workspaces", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    const fetchImpl = serverApiFetchImpl({ API }, request);
+    const response = await fetchImpl("/api/me/workspaces", { cache: "no-store" });
+
+    expect(await response.json()).toEqual({ workspaces: [] });
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://uploads.sh/me/workspaces");
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
   });
 });

--- a/apps/web/src/lib/api-proxy.ts
+++ b/apps/web/src/lib/api-proxy.ts
@@ -9,10 +9,14 @@
  * more specific `/api/auth/[...path]` static segment), but the guard below
  * 404s it anyway rather than trusting routing order — the api worker has its
  * own unrelated `/auth/enrollments/*` surface (console enroll codes) that a
- * misrouted `/api/auth/*` request must never reach.
+ * misrouted `/api/auth/*` request must never reach. The guard checks the
+ * percent-decoded pathname (see `decodedStrippedPathForGuard`) so an
+ * encoded `/auth` (`/api/%61uth/...`, `/api%2Fauth/...`) can't slip past it
+ * only to be decoded and routed to `/auth/...` by the api worker's Hono
+ * router upstream.
  */
 
-import { rewriteOrigin } from "./proxy-transport";
+import { rewriteOrigin, withInheritedCookie } from "./proxy-transport";
 
 export interface ApiProxyEnv {
   API?: { fetch(req: Request): Promise<Response> };
@@ -27,14 +31,38 @@ function stripApiPrefix(pathname: string): string {
   return stripped === "" ? "/" : stripped;
 }
 
+/**
+ * Decodes the FULL pathname (not just the part after `/api`) for the
+ * `/auth` guard check below — a bypass can hide in the `/api` boundary
+ * itself (`/api%2Fauth/...`, the encoded slash decoding to the one
+ * `stripApiPrefix`'s regex expects) just as easily as further down the path
+ * (`/api/%61uth/...`). Hono (the api worker's router) decodes
+ * percent-escapes when matching routes, so either shape reaches `/auth/...`
+ * upstream even though the raw, still-encoded pathname doesn't literally
+ * contain it. Guarding on the fully-decoded, then re-stripped form closes
+ * both. Returns `null` for a malformed escape sequence — treated as 404 by
+ * the caller rather than guessing.
+ */
+function decodedStrippedPathForGuard(pathname: string): string | null {
+  try {
+    return stripApiPrefix(decodeURIComponent(pathname));
+  } catch {
+    return null;
+  }
+}
+
 /** Forwards `request` to the api worker (binding, else HTTP fallback), `/api` prefix stripped. */
 export async function proxyApiRequest(env: ApiProxyEnv, request: Request): Promise<Response> {
   const url = new URL(request.url);
-  const strippedPath = stripApiPrefix(url.pathname);
-  if (strippedPath === "/auth" || strippedPath.startsWith("/auth/")) {
+  const decodedPath = decodedStrippedPathForGuard(url.pathname);
+  if (decodedPath === null || decodedPath === "/auth" || decodedPath.startsWith("/auth/")) {
     return new Response("Not found", { status: 404 });
   }
 
+  // The guard runs on the decoded form above; the request forwarded
+  // upstream keeps the original (still-encoded where applicable) pathname
+  // unchanged, `/api` prefix stripped literally rather than re-encoded.
+  const strippedPath = stripApiPrefix(url.pathname);
   const manual = new Request(request, { redirect: "manual" });
   url.pathname = strippedPath;
   const forwarded = new Request(url.toString(), manual);
@@ -47,9 +75,12 @@ export async function proxyApiRequest(env: ApiProxyEnv, request: Request): Promi
 /**
  * SSR helper (Task D2): resolves one api call from Astro frontmatter over the
  * same transport as `proxyApiRequest`, forwarding the incoming request's
- * `cookie` header — a server-to-server fetch has no cookie jar of its own.
- * `pathAndQuery` is the same `/api/...`-prefixed path the browser would hit
- * (e.g. `/api/v1/workspaces/acme/summary`); `init` carries method/body/etc.
+ * `cookie` header when `init` doesn't already carry one (see
+ * `withInheritedCookie` in `proxy-transport.ts` — the same rule
+ * `serverAuthFetch` applies) — a server-to-server fetch has no cookie jar of
+ * its own. `pathAndQuery` is the same `/api/...`-prefixed path the browser
+ * would hit (e.g. `/api/v1/workspaces/acme/summary`); `init` carries
+ * method/body/etc.
  */
 export async function serverApiFetch(
   env: ApiProxyEnv,
@@ -58,8 +89,7 @@ export async function serverApiFetch(
   init: RequestInit = {},
 ): Promise<Response> {
   const target = new URL(pathAndQuery, request.url);
-  const headers = new Headers(init.headers);
-  headers.set("cookie", request.headers.get("cookie") ?? "");
+  const headers = withInheritedCookie(new Headers(init.headers), request);
   return proxyApiRequest(env, new Request(target, { ...init, headers }));
 }
 

--- a/apps/web/src/lib/api-proxy.ts
+++ b/apps/web/src/lib/api-proxy.ts
@@ -1,0 +1,64 @@
+/**
+ * Same-origin api proxy (#731 phase D): `uploads.sh/api/<path>` forwards to
+ * the api worker's `/<path>` (the `/api` prefix stripped, query string kept).
+ * Mirrors `auth-proxy.ts`'s transport shape — see that file for the binding
+ * vs. HTTP-fallback rationale — but carries no cookie-clearing logic; that's
+ * an auth-worker-only concern.
+ *
+ * `/api/auth/*` never legitimately reaches this route (Astro prefers the
+ * more specific `/api/auth/[...path]` static segment), but the guard below
+ * 404s it anyway rather than trusting routing order — the api worker has its
+ * own unrelated `/auth/enrollments/*` surface (console enroll codes) that a
+ * misrouted `/api/auth/*` request must never reach.
+ */
+
+import { rewriteOrigin } from "./proxy-transport";
+
+export interface ApiProxyEnv {
+  API?: { fetch(req: Request): Promise<Response> };
+  UPLOADS_API_ORIGIN?: string;
+}
+
+const LOCAL_API_ORIGIN_DEFAULT = "http://127.0.0.1:8787";
+
+/** Strips a leading `/api` from `pathname`, keeping the rest (including a bare `/api` → `/`). */
+function stripApiPrefix(pathname: string): string {
+  const stripped = pathname.replace(/^\/api(?=\/|$)/, "");
+  return stripped === "" ? "/" : stripped;
+}
+
+/** Forwards `request` to the api worker (binding, else HTTP fallback), `/api` prefix stripped. */
+export async function proxyApiRequest(env: ApiProxyEnv, request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const strippedPath = stripApiPrefix(url.pathname);
+  if (strippedPath === "/auth" || strippedPath.startsWith("/auth/")) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const manual = new Request(request, { redirect: "manual" });
+  url.pathname = strippedPath;
+  const forwarded = new Request(url.toString(), manual);
+
+  return env.API
+    ? env.API.fetch(forwarded)
+    : fetch(rewriteOrigin(forwarded, env.UPLOADS_API_ORIGIN ?? LOCAL_API_ORIGIN_DEFAULT));
+}
+
+/**
+ * SSR helper (Task D2): resolves one api call from Astro frontmatter over the
+ * same transport as `proxyApiRequest`, forwarding the incoming request's
+ * `cookie` header — a server-to-server fetch has no cookie jar of its own.
+ * `pathAndQuery` is the same `/api/...`-prefixed path the browser would hit
+ * (e.g. `/api/v1/workspaces/acme/summary`); `init` carries method/body/etc.
+ */
+export async function serverApiFetch(
+  env: ApiProxyEnv,
+  request: Request,
+  pathAndQuery: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const target = new URL(pathAndQuery, request.url);
+  const headers = new Headers(init.headers);
+  headers.set("cookie", request.headers.get("cookie") ?? "");
+  return proxyApiRequest(env, new Request(target, { ...init, headers }));
+}

--- a/apps/web/src/lib/api-proxy.ts
+++ b/apps/web/src/lib/api-proxy.ts
@@ -62,3 +62,15 @@ export async function serverApiFetch(
   headers.set("cookie", request.headers.get("cookie") ?? "");
   return proxyApiRequest(env, new Request(target, { ...init, headers }));
 }
+
+/**
+ * A `fetch`-shaped adapter over {@link serverApiFetch}, for api-client.ts's
+ * `opts.fetchImpl` — every api-client URL is already the same
+ * `"/api/..."`-prefixed string `serverApiFetch` expects (api-client's
+ * `apiOrigin` is `resolveSignedInOrigins`'s `"/api"` sentinel in this same
+ * request), so no path translation is needed here.
+ */
+export function serverApiFetchImpl(env: ApiProxyEnv, request: Request): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) =>
+    serverApiFetch(env, request, String(input), init)) as typeof fetch;
+}

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -151,13 +151,18 @@ export async function sessionResultFromResponse(response: Response): Promise<Ses
  */
 export async function getSession(
   origin: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<SessionResult> {
-  const result = await fetchWithTimeout(`${authOrigin(origin)}/api/auth/get-session`, {
-    credentials: "include",
-    cache: "no-store",
-    ...(opts?.cookie ? { headers: { cookie: opts.cookie } } : {}),
-  });
+  const result = await fetchWithTimeout(
+    `${authOrigin(origin)}/api/auth/get-session`,
+    {
+      credentials: "include",
+      cache: "no-store",
+      ...(opts?.cookie ? { headers: { cookie: opts.cookie } } : {}),
+    },
+    undefined,
+    opts?.fetchImpl,
+  );
   if (result.kind === "unavailable") return result;
   return sessionResultFromResponse(result.response);
 }
@@ -504,13 +509,18 @@ export async function acceptInvitation(
 async function getAuthArray(
   origin: string,
   path: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<unknown[] | null> {
-  const result = await fetchWithTimeout(`${authOrigin(origin)}${path}`, {
-    credentials: "include",
-    cache: "no-store",
-    ...(opts?.cookie ? { headers: { cookie: opts.cookie } } : {}),
-  });
+  const result = await fetchWithTimeout(
+    `${authOrigin(origin)}${path}`,
+    {
+      credentials: "include",
+      cache: "no-store",
+      ...(opts?.cookie ? { headers: { cookie: opts.cookie } } : {}),
+    },
+    undefined,
+    opts?.fetchImpl,
+  );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = (await result.response.json().catch(() => undefined)) as unknown;
   return Array.isArray(body) ? body : null;
@@ -523,7 +533,7 @@ async function getAuthArray(
  */
 export async function listSessions(
   origin: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<AuthSession[] | null> {
   const body = await getAuthArray(origin, "/api/auth/list-sessions", opts);
   if (!body) return null;
@@ -731,7 +741,7 @@ export function isBannedAuthError(input: {
  */
 export async function listAccounts(
   origin: string,
-  opts?: { cookie?: string },
+  opts?: { cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<LinkedAccount[] | null> {
   const body = await getAuthArray(origin, "/api/auth/list-accounts", opts);
   if (!body) return null;
@@ -771,17 +781,22 @@ export async function listAccounts(
  */
 export async function getAccountInfo(
   origin: string,
-  opts: { providerId: string; accountId: string; cookie?: string },
+  opts: { providerId: string; accountId: string; cookie?: string; fetchImpl?: typeof fetch },
 ): Promise<ProviderAccountInfo | null> {
   const params = new URLSearchParams({
     providerId: opts.providerId,
     accountId: opts.accountId,
   });
-  const result = await fetchWithTimeout(`${authOrigin(origin)}/api/auth/account-info?${params}`, {
-    credentials: "include",
-    cache: "no-store",
-    ...(opts.cookie ? { headers: { cookie: opts.cookie } } : {}),
-  });
+  const result = await fetchWithTimeout(
+    `${authOrigin(origin)}/api/auth/account-info?${params}`,
+    {
+      credentials: "include",
+      cache: "no-store",
+      ...(opts.cookie ? { headers: { cookie: opts.cookie } } : {}),
+    },
+    undefined,
+    opts.fetchImpl,
+  );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = (await result.response.json().catch(() => undefined)) as
     | { user?: unknown; data?: unknown }

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -19,15 +19,25 @@
 import { fetchWithTimeout, type RequestFailure } from "./request";
 
 /**
+ * Same-origin (#731 phase B): browser auth traffic goes through this
+ * origin's `/api/auth` proxy, not a configured auth-worker origin. Every
+ * page that injects a browser-facing auth origin (layouts, login, device,
+ * console, oauth/consent, accept-invitation, the static-layout fallbacks)
+ * uses this constant rather than a copy-pasted `const authOrigin = "";` so
+ * the one same-origin decision lives in one place.
+ */
+export const SAME_ORIGIN_AUTH_BASE = "";
+
+/**
  * Public origin of the auth worker. Falls back to the documented local dev
  * origin (apps/auth's pinned wrangler dev port — see apps/auth/wrangler.jsonc
  * and .dev.vars.example) when unset (`undefined`/omitted).
  *
- * `""` is a distinct, deliberate value (#731 phase B): same-origin. Every
- * caller in this file templates `` `${authOrigin(origin)}/api/auth/...` ``,
- * so `""` turns that into a same-origin relative URL (`/api/auth/...`) that
- * hits this origin's `/api/auth/[...path]` proxy instead of the auth worker
- * directly.
+ * `""` (`SAME_ORIGIN_AUTH_BASE`) is a distinct, deliberate value (#731 phase
+ * B): same-origin. Every caller in this file templates
+ * `` `${authOrigin(origin)}/api/auth/...` ``, so `""` turns that into a
+ * same-origin relative URL (`/api/auth/...`) that hits this origin's
+ * `/api/auth/[...path]` proxy instead of the auth worker directly.
  */
 export function authOrigin(configuredOrigin?: string): string {
   if (configuredOrigin === "") return "";
@@ -160,8 +170,7 @@ export async function getSession(
       cache: "no-store",
       ...(opts?.cookie ? { headers: { cookie: opts.cookie } } : {}),
     },
-    undefined,
-    opts?.fetchImpl,
+    { fetchImpl: opts?.fetchImpl },
   );
   if (result.kind === "unavailable") return result;
   return sessionResultFromResponse(result.response);
@@ -518,8 +527,7 @@ async function getAuthArray(
       cache: "no-store",
       ...(opts?.cookie ? { headers: { cookie: opts.cookie } } : {}),
     },
-    undefined,
-    opts?.fetchImpl,
+    { fetchImpl: opts?.fetchImpl },
   );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = (await result.response.json().catch(() => undefined)) as unknown;
@@ -794,8 +802,7 @@ export async function getAccountInfo(
       cache: "no-store",
       ...(opts.cookie ? { headers: { cookie: opts.cookie } } : {}),
     },
-    undefined,
-    opts.fetchImpl,
+    { fetchImpl: opts.fetchImpl },
   );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = (await result.response.json().catch(() => undefined)) as

--- a/apps/web/src/lib/auth-proxy.test.ts
+++ b/apps/web/src/lib/auth-proxy.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { proxyAuthRequest, serverGetSession } from "./auth-proxy";
+import {
+  proxyAuthRequest,
+  serverAuthFetch,
+  serverAuthFetchImpl,
+  serverGetSession,
+} from "./auth-proxy";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -195,5 +200,73 @@ describe("serverGetSession", () => {
 
     const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
     expect(forwarded.headers.get("cookie")).toBe("");
+  });
+});
+
+describe("serverAuthFetch", () => {
+  it("resolves a relative path against the request's own origin and forwards its cookie header", async () => {
+    const { AUTH, fetchMock } = fakeAuthBinding(Response.json(null));
+    const request = new Request("https://uploads.sh/account/profile", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    await serverAuthFetch({ AUTH }, request, "/api/auth/list-sessions");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://uploads.sh/api/auth/list-sessions");
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
+  });
+
+  it("sends an empty cookie header when the incoming request has none", async () => {
+    const { AUTH, fetchMock } = fakeAuthBinding(Response.json(null));
+    const request = new Request("https://uploads.sh/account/profile");
+
+    await serverAuthFetch({ AUTH }, request, "/api/auth/list-accounts");
+
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.headers.get("cookie")).toBe("");
+  });
+
+  it("does not overwrite a cookie header the caller's init already set", async () => {
+    const { AUTH, fetchMock } = fakeAuthBinding(Response.json(null));
+    const request = new Request("https://uploads.sh/account/profile", {
+      headers: { cookie: "better-auth.session_token=from-request" },
+    });
+
+    await serverAuthFetch({ AUTH }, request, "/api/auth/get-session", {
+      headers: { cookie: "better-auth.session_token=from-caller" },
+    });
+
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=from-caller");
+  });
+
+  it("passes method/init through", async () => {
+    const { AUTH, fetchMock } = fakeAuthBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/account/profile");
+
+    await serverAuthFetch({ AUTH }, request, "/api/auth/sign-out", { method: "POST" });
+
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.method).toBe("POST");
+    expect(forwarded.url).toBe("https://uploads.sh/api/auth/sign-out");
+  });
+});
+
+describe("serverAuthFetchImpl", () => {
+  it("adapts serverAuthFetch to a fetch(input, init) shape for auth-client's fetchImpl", async () => {
+    const { AUTH, fetchMock } = fakeAuthBinding(Response.json({ user: { id: "1" } }));
+    const request = new Request("https://uploads.sh/account/profile", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    const fetchImpl = serverAuthFetchImpl({ AUTH }, request);
+    const response = await fetchImpl("/api/auth/get-session", { cache: "no-store" });
+
+    expect(await response.json()).toEqual({ user: { id: "1" } });
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://uploads.sh/api/auth/get-session");
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
   });
 });

--- a/apps/web/src/lib/auth-proxy.ts
+++ b/apps/web/src/lib/auth-proxy.ts
@@ -16,6 +16,8 @@
  * 302s must reach the browser unfollowed, not be resolved inside the worker.
  */
 
+import { rewriteOrigin } from "./proxy-transport";
+
 export interface AuthProxyEnv {
   AUTH?: { fetch(req: Request): Promise<Response> };
   UPLOADS_AUTH_ORIGIN?: string;
@@ -40,15 +42,6 @@ export async function proxyAuthRequest(env: AuthProxyEnv, request: Request): Pro
     ? await env.AUTH.fetch(forwarded)
     : await fetch(rewriteOrigin(forwarded, env.UPLOADS_AUTH_ORIGIN ?? LOCAL_AUTH_ORIGIN_DEFAULT));
   return withLegacyCookieCleared(upstream, request);
-}
-
-/** Rebuilds `request` against `origin`, keeping method/headers/body/redirect. */
-function rewriteOrigin(request: Request, origin: string): Request {
-  const url = new URL(request.url);
-  const target = new URL(origin.replace(/\/$/, ""));
-  url.protocol = target.protocol;
-  url.host = target.host;
-  return new Request(url.toString(), request);
 }
 
 /**

--- a/apps/web/src/lib/auth-proxy.ts
+++ b/apps/web/src/lib/auth-proxy.ts
@@ -79,3 +79,42 @@ export async function serverGetSession(env: AuthProxyEnv, request: Request): Pro
   });
   return proxyAuthRequest(env, getSessionRequest);
 }
+
+/**
+ * SSR helper (#731 phase D follow-up): resolves one auth-client call from
+ * Astro frontmatter over the same transport as `proxyAuthRequest`.
+ * `pathAndQuery` is resolved against the incoming request's own origin, so a
+ * relative auth-client URL (`authOrigin("")` → `/api/auth/...`) becomes an
+ * absolute one a Worker can actually fetch — plain `fetch("/api/auth/...")`
+ * has no ambient origin to resolve against outside a browser.
+ *
+ * Forwards the incoming request's `cookie` header only when `init` doesn't
+ * already carry one — auth-client's `opts.cookie` callers already set it
+ * themselves (mirrors `getSession`'s own conditional-header shape), so this
+ * only fills the gap for a caller that didn't.
+ */
+export async function serverAuthFetch(
+  env: AuthProxyEnv,
+  request: Request,
+  pathAndQuery: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const target = new URL(pathAndQuery, request.url);
+  const headers = new Headers(init.headers);
+  if (!headers.has("cookie")) {
+    headers.set("cookie", request.headers.get("cookie") ?? "");
+  }
+  return proxyAuthRequest(env, new Request(target, { ...init, headers }));
+}
+
+/**
+ * A `fetch`-shaped adapter over {@link serverAuthFetch}, for auth-client.ts's
+ * `opts.fetchImpl` (mirrors `api-proxy.ts`'s `serverApiFetchImpl`) — every
+ * auth-client URL is already the same relative `"/api/auth/..."` string
+ * `serverAuthFetch` expects when `authOrigin("")` resolves to `""`, so no
+ * path translation is needed here.
+ */
+export function serverAuthFetchImpl(env: AuthProxyEnv, request: Request): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) =>
+    serverAuthFetch(env, request, String(input), init)) as typeof fetch;
+}

--- a/apps/web/src/lib/auth-proxy.ts
+++ b/apps/web/src/lib/auth-proxy.ts
@@ -16,7 +16,7 @@
  * 302s must reach the browser unfollowed, not be resolved inside the worker.
  */
 
-import { rewriteOrigin } from "./proxy-transport";
+import { rewriteOrigin, withInheritedCookie } from "./proxy-transport";
 
 export interface AuthProxyEnv {
   AUTH?: { fetch(req: Request): Promise<Response> };
@@ -100,10 +100,7 @@ export async function serverAuthFetch(
   init: RequestInit = {},
 ): Promise<Response> {
   const target = new URL(pathAndQuery, request.url);
-  const headers = new Headers(init.headers);
-  if (!headers.has("cookie")) {
-    headers.set("cookie", request.headers.get("cookie") ?? "");
-  }
+  const headers = withInheritedCookie(new Headers(init.headers), request);
   return proxyAuthRequest(env, new Request(target, { ...init, headers }));
 }
 

--- a/apps/web/src/lib/billing-ui.test.ts
+++ b/apps/web/src/lib/billing-ui.test.ts
@@ -132,6 +132,7 @@ describe("loadBillingPageData", () => {
       "",
       "acme",
       "better-auth.session=abc",
+      undefined,
       authFetchImpl,
     );
 

--- a/apps/web/src/lib/billing-ui.ts
+++ b/apps/web/src/lib/billing-ui.ts
@@ -35,11 +35,12 @@ export async function loadBillingPageData(
   authOrigin: string,
   workspace: string,
   cookie: string,
+  apiFetchImpl?: typeof fetch,
   authFetchImpl?: typeof fetch,
 ): Promise<BillingPageData> {
   if (!cookie.trim()) return { billing: null, proPrice: null };
   const [billingResult, proPrice] = await Promise.all([
-    getWorkspaceBilling(apiOrigin, workspace, { cookie }),
+    getWorkspaceBilling(apiOrigin, workspace, { cookie, fetchImpl: apiFetchImpl }),
     fetchProPrice(authOrigin, authFetchImpl),
   ]);
   return {

--- a/apps/web/src/lib/client-router-boot.test.ts
+++ b/apps/web/src/lib/client-router-boot.test.ts
@@ -82,7 +82,7 @@ describe("Error page chrome", () => {
     // Full footer (not compact-only under the card) — same chrome as legal pages.
     expect(src).not.toMatch(/<Footer\s+compact/);
     // Same-origin (#731 phase B): no configured-origin fallback chain anymore.
-    expect(src).toContain('const authOrigin = "";');
+    expect(src).toContain("const authOrigin = SAME_ORIGIN_AUTH_BASE;");
   });
 
   it("404 and 500 use ErrorLayout", () => {

--- a/apps/web/src/lib/developers-ui.ts
+++ b/apps/web/src/lib/developers-ui.ts
@@ -13,11 +13,12 @@ import { escapeHtml } from "./workspace-ui";
 export async function loadDevelopersPageData(
   apiOrigin: string,
   cookie: string,
+  fetchImpl?: typeof fetch,
 ): Promise<{ workspaces: MintableWorkspace[] | null; tokens: IssuedWorkspaceToken[] | null }> {
   if (!cookie.trim()) return { workspaces: null, tokens: null };
   const [workspaces, tokens] = await Promise.all([
-    listMintableWorkspaces(apiOrigin, { cookie }),
-    listIssuedWorkspaceTokens(apiOrigin, { cookie }),
+    listMintableWorkspaces(apiOrigin, { cookie, fetchImpl }),
+    listIssuedWorkspaceTokens(apiOrigin, { cookie, fetchImpl }),
   ]);
   return { workspaces, tokens };
 }

--- a/apps/web/src/lib/proxy-transport.test.ts
+++ b/apps/web/src/lib/proxy-transport.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { withInheritedCookie } from "./proxy-transport";
+
+describe("withInheritedCookie", () => {
+  it("fills the cookie header from the request when init carries none", () => {
+    const request = new Request("https://uploads.sh/account/profile", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    const headers = withInheritedCookie(new Headers(), request);
+
+    expect(headers.get("cookie")).toBe("better-auth.session_token=abc");
+  });
+
+  it("fills an empty cookie header when the request has none", () => {
+    const request = new Request("https://uploads.sh/account/profile");
+
+    const headers = withInheritedCookie(new Headers(), request);
+
+    expect(headers.get("cookie")).toBe("");
+  });
+
+  it("does not overwrite a cookie header already present on the given headers", () => {
+    const request = new Request("https://uploads.sh/account/profile", {
+      headers: { cookie: "better-auth.session_token=incoming" },
+    });
+
+    const headers = withInheritedCookie(
+      new Headers({ cookie: "better-auth.session_token=caller-set" }),
+      request,
+    );
+
+    expect(headers.get("cookie")).toBe("better-auth.session_token=caller-set");
+  });
+
+  it("mutates and returns the same Headers instance it was given", () => {
+    const request = new Request("https://uploads.sh/account/profile", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+    const headers = new Headers();
+
+    expect(withInheritedCookie(headers, request)).toBe(headers);
+  });
+});

--- a/apps/web/src/lib/proxy-transport.ts
+++ b/apps/web/src/lib/proxy-transport.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared transport bit for the same-origin proxies (#731): `auth-proxy.ts`
+ * (phase A) and `api-proxy.ts` (phase D) both rebuild an incoming request
+ * against a different origin for their astro-dev HTTP fallback. Pulled out
+ * once both existed rather than duplicated.
+ */
+
+/** Rebuilds `request` against `origin`, keeping method/headers/body/redirect. */
+export function rewriteOrigin(request: Request, origin: string): Request {
+  const url = new URL(request.url);
+  const target = new URL(origin.replace(/\/$/, ""));
+  url.protocol = target.protocol;
+  url.host = target.host;
+  return new Request(url.toString(), request);
+}

--- a/apps/web/src/lib/proxy-transport.ts
+++ b/apps/web/src/lib/proxy-transport.ts
@@ -13,3 +13,22 @@ export function rewriteOrigin(request: Request, origin: string): Request {
   url.host = target.host;
   return new Request(url.toString(), request);
 }
+
+/**
+ * The one cookie-forwarding rule both `serverApiFetch` (api-proxy.ts) and
+ * `serverAuthFetch` (auth-proxy.ts) apply when building a server-to-server
+ * request from Astro frontmatter: fill the `cookie` header from the
+ * incoming request only when `init` doesn't already carry one — a caller
+ * that already set its own `cookie` header (e.g. api-client.ts's
+ * `sessionFetchInit(opts.cookie)`) is left alone rather than overwritten.
+ * Behavior-neutral for every current caller: every SSR call site passes the
+ * same `Astro.request.headers.get("cookie")` value both as its own
+ * `opts.cookie` and as the incoming request's header, so filling vs.
+ * overwriting produces an identical header either way.
+ */
+export function withInheritedCookie(headers: Headers, request: Request): Headers {
+  if (!headers.has("cookie")) {
+    headers.set("cookie", request.headers.get("cookie") ?? "");
+  }
+  return headers;
+}

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -56,6 +56,12 @@ describe("public file headers", () => {
     expect(headers.get("Cache-Control")).toBe("no-store");
   });
 
+  it("publicFileCsp collapses the same-origin '/api' prefix to 'self' (#731 phase D)", () => {
+    const csp = publicFileCsp("/api");
+    expect(csp).toContain("connect-src 'self' https://cloudflareinsights.com");
+    expect(csp).not.toContain("/api");
+  });
+
   it("widens script-src on the ok branch for copy + report controls", () => {
     expect(PUBLIC_FILE_CSP).toContain(
       "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -1,4 +1,5 @@
-import { CF_RUM_CONNECT_SRC, CF_RUM_SCRIPT_SRC, STYLE_SRC_SELF_AND_INLINE } from "./csp";
+import { CF_RUM_SCRIPT_SRC, STYLE_SRC_SELF_AND_INLINE } from "./csp";
+import { connectSrc } from "./signed-in-page";
 
 // Client model for the standalone public file page (issue #135). Fetched
 // server-side from the API's `GET /public/files/:workspace/:key` — apps/web has
@@ -109,14 +110,11 @@ export function fileDownloadUrl(origin: string, workspace: string, key: string):
  *
  * `apiOrigin` is either an absolute origin or the same-origin `"/api"` prefix
  * (#731 phase D, `resolveSignedInOrigins`'s `SAME_ORIGIN_API_BASE`) — the
- * latter collapses to `'self'` here, same rule as `signed-in-page.ts`'s
- * `connectSrcToken`.
+ * latter collapses to `'self'` via `connectSrc`, same rule
+ * `signed-in-page.ts`'s own CSP builders apply (shared rather than
+ * duplicated here).
  */
 export function publicFileCsp(apiOrigin: string): string {
-  const connectApiToken = apiOrigin === "" || apiOrigin.startsWith("/") ? "'self'" : apiOrigin;
-  // CF_RUM_CONNECT_SRC already carries its own 'self' — de-dupe rather than
-  // emit "'self' 'self'" when the api origin also collapses to 'self'.
-  const connectTokens = [...new Set([connectApiToken, ...CF_RUM_CONNECT_SRC.split(" ")])].join(" ");
   return [
     "default-src 'none'",
     "img-src https: data:",
@@ -124,7 +122,7 @@ export function publicFileCsp(apiOrigin: string): string {
     "font-src 'self'",
     `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
     `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
-    `connect-src ${connectTokens}`,
+    connectSrc(apiOrigin),
     "base-uri 'none'",
     "form-action 'none'",
     "frame-ancestors 'none'",

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -106,8 +106,17 @@ export function fileDownloadUrl(origin: string, workspace: string, key: string):
 /**
  * File-page CSP. Inline script for Copy-as / Report; `connect-src` includes
  * the API origin for `/v1/abuse` and the auth_required session probe.
+ *
+ * `apiOrigin` is either an absolute origin or the same-origin `"/api"` prefix
+ * (#731 phase D, `resolveSignedInOrigins`'s `SAME_ORIGIN_API_BASE`) — the
+ * latter collapses to `'self'` here, same rule as `signed-in-page.ts`'s
+ * `connectSrcToken`.
  */
 export function publicFileCsp(apiOrigin: string): string {
+  const connectApiToken = apiOrigin === "" || apiOrigin.startsWith("/") ? "'self'" : apiOrigin;
+  // CF_RUM_CONNECT_SRC already carries its own 'self' — de-dupe rather than
+  // emit "'self' 'self'" when the api origin also collapses to 'self'.
+  const connectTokens = [...new Set([connectApiToken, ...CF_RUM_CONNECT_SRC.split(" ")])].join(" ");
   return [
     "default-src 'none'",
     "img-src https: data:",
@@ -115,7 +124,7 @@ export function publicFileCsp(apiOrigin: string): string {
     "font-src 'self'",
     `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
     `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
-    `connect-src ${apiOrigin} ${CF_RUM_CONNECT_SRC}`,
+    `connect-src ${connectTokens}`,
     "base-uri 'none'",
     "form-action 'none'",
     "frame-ancestors 'none'",

--- a/apps/web/src/lib/request.ts
+++ b/apps/web/src/lib/request.ts
@@ -10,11 +10,12 @@ export async function fetchWithTimeout(
   input: RequestInfo | URL,
   init: RequestInit = {},
   timeoutMs = BROWSER_REQUEST_TIMEOUT_MS,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<RequestResult> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(input, { ...init, signal: controller.signal });
+    const response = await fetchImpl(input, { ...init, signal: controller.signal });
     return { kind: "response", response };
   } catch (err) {
     return {

--- a/apps/web/src/lib/request.ts
+++ b/apps/web/src/lib/request.ts
@@ -6,12 +6,17 @@ export type RequestResult =
   | { kind: "response"; response: Response }
   | { kind: "unavailable"; reason: RequestFailure };
 
+export interface FetchWithTimeoutOptions {
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
 export async function fetchWithTimeout(
   input: RequestInfo | URL,
   init: RequestInit = {},
-  timeoutMs = BROWSER_REQUEST_TIMEOUT_MS,
-  fetchImpl: typeof fetch = fetch,
+  opts: FetchWithTimeoutOptions = {},
 ): Promise<RequestResult> {
+  const { timeoutMs = BROWSER_REQUEST_TIMEOUT_MS, fetchImpl = fetch } = opts;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {

--- a/apps/web/src/lib/signed-in-page.test.ts
+++ b/apps/web/src/lib/signed-in-page.test.ts
@@ -25,10 +25,10 @@ describe("resolveSignedInOrigins", () => {
     ).toBe("");
   });
 
-  it("leaves apiOrigin resolution untouched (flips in phase D, not now)", () => {
-    expect(resolveSignedInOrigins({}).apiOrigin).toBe("https://api.uploads.sh");
+  it("always resolves the api origin to the same-origin '/api' prefix (#731 phase D), regardless of env", () => {
+    expect(resolveSignedInOrigins({}).apiOrigin).toBe("/api");
     expect(resolveSignedInOrigins({ UPLOADS_API_ORIGIN: "https://api.uploads.sh" }).apiOrigin).toBe(
-      "https://api.uploads.sh",
+      "/api",
     );
   });
 });
@@ -172,6 +172,18 @@ describe("signed-in / auth CSP builders", () => {
 
   it("de-dupes connect-src to a single 'self' when both origins are same-origin", () => {
     const csp = signedInCsp("", "");
+    expect(csp).toContain("connect-src 'self' https://cloudflareinsights.com");
+    expect(csp).not.toContain("'self' 'self'");
+  });
+
+  it("collapses the same-origin api '/api' prefix to 'self' too (#731 phase D)", () => {
+    const csp = devicePageCsp("", "/api");
+    expect(csp).toContain("connect-src 'self' https://cloudflareinsights.com");
+    expect(csp).not.toContain("/api");
+  });
+
+  it("de-dupes connect-src to one 'self' when authOrigin is '' and apiOrigin is '/api'", () => {
+    const csp = signedInCsp("", "/api");
     expect(csp).toContain("connect-src 'self' https://cloudflareinsights.com");
     expect(csp).not.toContain("'self' 'self'");
   });

--- a/apps/web/src/lib/signed-in-page.test.ts
+++ b/apps/web/src/lib/signed-in-page.test.ts
@@ -18,18 +18,12 @@ const AUTH = "https://auth.uploads.sh";
 const API = "https://api.uploads.sh";
 
 describe("resolveSignedInOrigins", () => {
-  it("always resolves the auth origin to same-origin (#731 phase B), regardless of env", () => {
-    expect(resolveSignedInOrigins({}).authOrigin).toBe("");
-    expect(
-      resolveSignedInOrigins({ UPLOADS_API_ORIGIN: "https://api.uploads.sh" }).authOrigin,
-    ).toBe("");
+  it("always resolves the auth origin to same-origin (#731 phase B)", () => {
+    expect(resolveSignedInOrigins().authOrigin).toBe("");
   });
 
-  it("always resolves the api origin to the same-origin '/api' prefix (#731 phase D), regardless of env", () => {
-    expect(resolveSignedInOrigins({}).apiOrigin).toBe("/api");
-    expect(resolveSignedInOrigins({ UPLOADS_API_ORIGIN: "https://api.uploads.sh" }).apiOrigin).toBe(
-      "/api",
-    );
+  it("always resolves the api origin to the same-origin '/api' prefix (#731 phase D)", () => {
+    expect(resolveSignedInOrigins().apiOrigin).toBe("/api");
   });
 });
 

--- a/apps/web/src/lib/signed-in-page.ts
+++ b/apps/web/src/lib/signed-in-page.ts
@@ -11,11 +11,6 @@ import { resolveConsoleMode } from "./console-mode";
 import { CF_RUM_CONNECT_SRC, CF_RUM_SCRIPT_SRC, STYLE_SRC_SELF_AND_INLINE } from "./csp";
 import { safeSameOriginPath } from "./workspace-ui";
 
-// UPLOADS_AUTH_ORIGIN isn't read here (auth is same-origin, #731 phase B).
-type OriginEnv = {
-  UPLOADS_API_ORIGIN?: string;
-};
-
 /**
  * Same-origin sentinel `resolveSignedInOrigins` returns for `apiOrigin`
  * (#731 phase D). Unlike `authOrigin("")` → `""` (auth's own templates
@@ -74,7 +69,7 @@ export function signedInShellLoginRedirect(opts: {
   return null;
 }
 
-export function resolveSignedInOrigins(env: OriginEnv): {
+export function resolveSignedInOrigins(): {
   authOrigin: string;
   apiOrigin: string;
 } {
@@ -99,17 +94,20 @@ export function resolveSignedInOrigins(env: OriginEnv): {
  * same-origin (#731 phases B/D), which CSP expresses as `'self'` rather than
  * an origin literal — any other relative (`/`-leading) path is same-origin
  * too, so treat that generally rather than hard-coding just these two.
+ * Exported for `public-file.ts`'s `publicFileCsp`, which applies the same
+ * rule to its own (single) api origin rather than duplicating it.
  */
-function connectSrcToken(origin: string): string {
+export function connectSrcToken(origin: string): string {
   return origin === "" || origin.startsWith("/") ? "'self'" : origin;
 }
 
 /**
  * Builds a `connect-src` directive from one or more origins plus the RUM
  * allowance, de-duping tokens — `origin === ""` and `CF_RUM_CONNECT_SRC`'s own
- * `'self'` would otherwise both land in the list.
+ * `'self'` would otherwise both land in the list. Exported for the same
+ * reason as `connectSrcToken`.
  */
-function connectSrc(...origins: string[]): string {
+export function connectSrc(...origins: string[]): string {
   const tokens = [...origins.map(connectSrcToken), ...CF_RUM_CONNECT_SRC.split(" ")];
   return `connect-src ${[...new Set(tokens)].join(" ")}`;
 }

--- a/apps/web/src/lib/signed-in-page.ts
+++ b/apps/web/src/lib/signed-in-page.ts
@@ -11,11 +11,25 @@ import { resolveConsoleMode } from "./console-mode";
 import { CF_RUM_CONNECT_SRC, CF_RUM_SCRIPT_SRC, STYLE_SRC_SELF_AND_INLINE } from "./csp";
 import { safeSameOriginPath } from "./workspace-ui";
 
-// UPLOADS_AUTH_ORIGIN isn't read here (auth is same-origin, #731 phase B) —
-// only the API origin still varies by environment.
+// UPLOADS_AUTH_ORIGIN isn't read here (auth is same-origin, #731 phase B).
 type OriginEnv = {
   UPLOADS_API_ORIGIN?: string;
 };
+
+/**
+ * Same-origin sentinel `resolveSignedInOrigins` returns for `apiOrigin`
+ * (#731 phase D). Unlike `authOrigin("")` → `""` (auth's own templates
+ * already bake in `/api/auth/...`), api-client's templates are bare
+ * `${apiOrigin}/v1/...` with no prefix — and a good many browser call sites
+ * (admin pages, inline `<script>`s, WorkspaceFileTable, file-opener,
+ * workspace-rail, gh-context) build URLs the same bare way directly off
+ * `window.__UPLOADS_API_ORIGIN__`, never through a shared "" → "/api"
+ * mapping helper. Returning `""` here would silently 404 every one of them
+ * against this origin's own routes instead of the api proxy. Returning the
+ * concrete `"/api"` prefix instead means every existing `${apiOrigin}${path}`
+ * template — inside api-client.ts and outside it — keeps working unmodified.
+ */
+export const SAME_ORIGIN_API_BASE = "/api";
 
 /**
  * Same-origin path we'll send the user back to after login. Rejects `/login`
@@ -64,33 +78,30 @@ export function resolveSignedInOrigins(env: OriginEnv): {
   authOrigin: string;
   apiOrigin: string;
 } {
-  // In dev, the stack supervisor (scripts/dev-stack.mjs) injects the live
-  // portless origins as PUBLIC_* process env — but the Cloudflare adapter's
-  // runtime env lets a stale apps/web/.dev.vars shadow them. Prefer the
-  // supervisor's values in dev so the CSP and clients point at the workers
-  // that are actually running; production is untouched (PUBLIC_* is unset
-  // there, so the runtime-env chain below still decides).
-  const devApi = import.meta.env.DEV ? import.meta.env.PUBLIC_UPLOADS_API_ORIGIN : undefined;
   return {
     // Same-origin (#731 phase B): browser auth traffic goes through this
     // origin's /api/auth proxy, not a configured auth-worker origin. The
     // cookie's Domain scope is unchanged in this phase — only where the
     // browser sends requests.
     authOrigin: "",
-    apiOrigin:
-      devApi ??
-      env.UPLOADS_API_ORIGIN ??
-      import.meta.env.PUBLIC_UPLOADS_API_ORIGIN ??
-      "https://api.uploads.sh",
+    // Same-origin (#731 phase D): browser api traffic goes through this
+    // origin's /api proxy — see SAME_ORIGIN_API_BASE for why this is "/api"
+    // and not "". env.UPLOADS_API_ORIGIN / PUBLIC_UPLOADS_API_ORIGIN no
+    // longer drive the browser-facing value; they still back the api proxy's
+    // own astro-dev HTTP fallback (api-proxy.ts) and any SSR call site that
+    // still needs a real absolute origin (e.g. public-file.ts's server fetch).
+    apiOrigin: SAME_ORIGIN_API_BASE,
   };
 }
 
 /**
- * `origin` for a `connect-src` token: `""` means same-origin (#731 phase B),
- * which CSP expresses as `'self'` rather than an origin literal.
+ * `origin` for a `connect-src` token: `""` (auth) or `"/api"` (api) both mean
+ * same-origin (#731 phases B/D), which CSP expresses as `'self'` rather than
+ * an origin literal — any other relative (`/`-leading) path is same-origin
+ * too, so treat that generally rather than hard-coding just these two.
  */
 function connectSrcToken(origin: string): string {
-  return origin === "" ? "'self'" : origin;
+  return origin === "" || origin.startsWith("/") ? "'self'" : origin;
 }
 
 /**

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -8,13 +8,12 @@
  * resolves the session for first paint).
  */
 import { defineMiddleware } from "astro:middleware";
-import { env } from "cloudflare:workers";
 import { isLocalDemoStack } from "./lib/auth-client";
 import { resolveSignedInOrigins, signedInShellLoginRedirect } from "./lib/signed-in-page";
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname, search, origin } = context.url;
-  const { authOrigin } = resolveSignedInOrigins(env);
+  const { authOrigin } = resolveSignedInOrigins();
   const target = signedInShellLoginRedirect({
     pathname,
     search,

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -1,4 +1,5 @@
 ---
+import { SAME_ORIGIN_AUTH_BASE } from "../../lib/auth-client";
 import { applyAuthSecurityHeaders, authPageCsp } from "../../lib/signed-in-page";
 import BaseHead from "../../components/BaseHead.astro";
 import Brand from "../../components/Brand.astro";
@@ -7,9 +8,7 @@ import LegalConsent from "../../components/LegalConsent.astro";
 
 export const prerender = false;
 
-// Same-origin (#731 phase B): browser auth traffic goes through this origin's
-// /api/auth proxy, not a configured auth-worker origin.
-const authOrigin = "";
+const authOrigin = SAME_ORIGIN_AUTH_BASE;
 
 const { id } = Astro.params;
 

--- a/apps/web/src/pages/account/developers.astro
+++ b/apps/web/src/pages/account/developers.astro
@@ -1,6 +1,7 @@
 ---
 import { env } from "cloudflare:workers";
 import AccountLayout from "../../layouts/AccountLayout.astro";
+import { serverApiFetchImpl } from "../../lib/api-proxy";
 import {
   loadDevelopersPageData,
   renderIssuedTokenListHtml,
@@ -12,7 +13,11 @@ import { renderDetailListPlaceholderHtml } from "../../lib/workspace-ui";
 export const prerender = false;
 
 const { apiOrigin } = resolveSignedInOrigins(env);
-const initial = await loadDevelopersPageData(apiOrigin, Astro.request.headers.get("cookie") ?? "");
+const initial = await loadDevelopersPageData(
+  apiOrigin,
+  Astro.request.headers.get("cookie") ?? "",
+  serverApiFetchImpl(env, Astro.request),
+);
 const workspaceNames = initial.workspaces?.map((row) => row.workspace) ?? [];
 const hasWorkspaces = workspaceNames.length > 0;
 const knownEmpty = initial.workspaces !== null && !hasWorkspaces;

--- a/apps/web/src/pages/account/developers.astro
+++ b/apps/web/src/pages/account/developers.astro
@@ -12,7 +12,7 @@ import { renderDetailListPlaceholderHtml } from "../../lib/workspace-ui";
 
 export const prerender = false;
 
-const { apiOrigin } = resolveSignedInOrigins(env);
+const { apiOrigin } = resolveSignedInOrigins();
 const initial = await loadDevelopersPageData(
   apiOrigin,
   Astro.request.headers.get("cookie") ?? "",

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -12,7 +12,7 @@ import { renderDetailListPlaceholderHtml } from "../../lib/workspace-ui";
 
 export const prerender = false;
 
-const { authOrigin } = resolveSignedInOrigins(env);
+const { authOrigin } = resolveSignedInOrigins();
 const initial = await loadProfilePageData(
   authOrigin,
   Astro.request.headers.get("cookie") ?? "",

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -6,13 +6,18 @@ import {
   renderSessionsHtml,
   renderSignInMethodsHtml,
 } from "../../lib/account-profile-ui";
+import { serverAuthFetchImpl } from "../../lib/auth-proxy";
 import { resolveSignedInOrigins } from "../../lib/signed-in-page";
 import { renderDetailListPlaceholderHtml } from "../../lib/workspace-ui";
 
 export const prerender = false;
 
 const { authOrigin } = resolveSignedInOrigins(env);
-const initial = await loadProfilePageData(authOrigin, Astro.request.headers.get("cookie") ?? "");
+const initial = await loadProfilePageData(
+  authOrigin,
+  Astro.request.headers.get("cookie") ?? "",
+  serverAuthFetchImpl(env, Astro.request),
+);
 const accountsReady = initial.accounts !== null;
 const sessionsReady = initial.sessions !== null;
 // A signed-in profile view always has at least the current session, so this

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -8,6 +8,7 @@
 import { env } from "cloudflare:workers";
 import AccountLayout from "../../layouts/AccountLayout.astro";
 import { getMyWorkspaces } from "../../lib/api-client";
+import { serverApiFetchImpl } from "../../lib/api-proxy";
 import { resolveSignedInOrigins } from "../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../lib/workspace-browse-url";
 import { renderWorkspacesPlaceholderHtml } from "../../lib/workspace-ui";
@@ -38,7 +39,10 @@ if (!managing) {
   const { apiOrigin } = resolveSignedInOrigins(env);
   const cookie = Astro.request.headers.get("cookie") ?? "";
   if (cookie.trim()) {
-    const result = await getMyWorkspaces(apiOrigin, { cookie });
+    const result = await getMyWorkspaces(apiOrigin, {
+      cookie,
+      fetchImpl: serverApiFetchImpl(env, Astro.request),
+    });
     if (result.kind === "success" && result.workspaces.length === 1) {
       const only = result.workspaces[0].workspace;
       const to = new URLSearchParams(Astro.url.search).get("to");

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -36,7 +36,7 @@ if (isBrowseWorkspace(legacyWs)) {
 // ?manage=1, empty, and unavailable all fall through to the client script.
 const managing = new URLSearchParams(Astro.url.search).get("manage") === "1";
 if (!managing) {
-  const { apiOrigin } = resolveSignedInOrigins(env);
+  const { apiOrigin } = resolveSignedInOrigins();
   const cookie = Astro.request.headers.get("cookie") ?? "";
   if (cookie.trim()) {
     const result = await getMyWorkspaces(apiOrigin, {

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -37,7 +37,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 // succeeded — a failed/absent fetch falls back to the same skeleton as
 // before and the client script paints the correct real/error state (same
 // "own region" rule as the galleries/people pages).
-const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
+const { authOrigin, apiOrigin } = resolveSignedInOrigins();
 const cookie = Astro.request.headers.get("cookie") ?? "";
 // `fetchProPrice`'s relative `/billing/prices` URL (authOrigin === "", #731
 // phase B) has no ambient origin for a Workers SSR `fetch` to resolve

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -12,6 +12,7 @@ import { env } from "cloudflare:workers";
 import { PLANS } from "@uploads/billing";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { proxyAuthRequest, type AuthProxyEnv } from "../../../../lib/auth-proxy";
+import { serverApiFetchImpl } from "../../../../lib/api-proxy";
 import {
   loadBillingPageData,
   renderPlanCardBodyHtml,
@@ -49,7 +50,14 @@ const authFetchImpl: typeof fetch = (input, init) =>
     env as AuthProxyEnv,
     new Request(new URL(String(input), Astro.request.url), init),
   );
-const initial = await loadBillingPageData(apiOrigin, authOrigin, workspace, cookie, authFetchImpl);
+const initial = await loadBillingPageData(
+  apiOrigin,
+  authOrigin,
+  workspace,
+  cookie,
+  serverApiFetchImpl(env, Astro.request),
+  authFetchImpl,
+);
 const { billing } = initial;
 const proPriceCopy = formatPrice(initial.proPrice);
 const cta: BillingCtaState = billing

--- a/apps/web/src/pages/account/workspaces/[name]/files.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/files.astro
@@ -32,6 +32,7 @@ import { env } from "cloudflare:workers";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { WorkspaceFileTable, type ListingState } from "../../../../components/WorkspaceFileTable";
 import { getWorkspaceSummary, listWorkspaceFolder } from "../../../../lib/api-client";
+import { serverApiFetchImpl } from "../../../../lib/api-proxy";
 import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace, readBrowseLocation } from "../../../../lib/workspace-browse-url";
 import { readSearchFilters, readSearchName } from "../../../../lib/workspace-search-url";
@@ -66,9 +67,12 @@ if (cookie.trim()) {
     readSearchFilters(initialSearch).length === 0 &&
     !readSearchName(initialSearch);
 
+  const fetchImpl = serverApiFetchImpl(env, Astro.request);
   const [summary, listing] = await Promise.all([
-    getWorkspaceSummary(apiOrigin, workspace, { cookie }),
-    isDefaultBrowse ? listWorkspaceFolder(apiOrigin, workspace, { cookie }) : Promise.resolve(null),
+    getWorkspaceSummary(apiOrigin, workspace, { cookie, fetchImpl }),
+    isDefaultBrowse
+      ? listWorkspaceFolder(apiOrigin, workspace, { cookie, fetchImpl })
+      : Promise.resolve(null),
   ]);
 
   if (summary.kind === "success") {

--- a/apps/web/src/pages/account/workspaces/[name]/files.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/files.astro
@@ -48,7 +48,7 @@ const tip = {
   body: "Attach uploads to a pull request with <code>uploads put ./shot.png --pr 123</code> — they collect into one managed comment.",
 };
 
-const { apiOrigin } = resolveSignedInOrigins(env);
+const { apiOrigin } = resolveSignedInOrigins();
 const cookie = Astro.request.headers.get("cookie") ?? "";
 const initialSearch = Astro.url.search;
 

--- a/apps/web/src/pages/account/workspaces/[name]/galleries.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/galleries.astro
@@ -42,7 +42,7 @@ const tip = {
 // list when there IS data — getMyWorkspaceGalleries conflates empty and error,
 // so an empty/failed result falls back to the placeholder and the client script
 // paints the correct empty-state or error.
-const { apiOrigin } = resolveSignedInOrigins(env);
+const { apiOrigin } = resolveSignedInOrigins();
 const cookie = Astro.request.headers.get("cookie") ?? "";
 let ssrGalleriesHtml: string | null = null;
 if (cookie.trim()) {

--- a/apps/web/src/pages/account/workspaces/[name]/galleries.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/galleries.astro
@@ -10,6 +10,7 @@
 import { env } from "cloudflare:workers";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { getMyWorkspaceGalleries, getWorkspaceSummary } from "../../../../lib/api-client";
+import { serverApiFetchImpl } from "../../../../lib/api-proxy";
 import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
 import { resolveGalleriesView } from "../../../../lib/workspace-galleries-view";
@@ -45,9 +46,10 @@ const { apiOrigin } = resolveSignedInOrigins(env);
 const cookie = Astro.request.headers.get("cookie") ?? "";
 let ssrGalleriesHtml: string | null = null;
 if (cookie.trim()) {
+  const fetchImpl = serverApiFetchImpl(env, Astro.request);
   const [summary, galleries] = await Promise.all([
-    getWorkspaceSummary(apiOrigin, workspace, { cookie }),
-    getMyWorkspaceGalleries(apiOrigin, workspace, { cookie }),
+    getWorkspaceSummary(apiOrigin, workspace, { cookie, fetchImpl }),
+    getMyWorkspaceGalleries(apiOrigin, workspace, { cookie, fetchImpl }),
   ]);
   if (summary.kind === "success" && galleries.length > 0) {
     ssrGalleriesHtml = renderGalleriesHtml(galleries, ssrView);

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -27,7 +27,7 @@ const tip = {
 // real teammates. Controls, the "you" badge, and pending invites are added by
 // the client re-render (they need viewer identity, which the server gate does
 // not expose). Rows are identical between the two renders → no layout jump.
-const { apiOrigin } = resolveSignedInOrigins(env);
+const { apiOrigin } = resolveSignedInOrigins();
 const cookie = Astro.request.headers.get("cookie") ?? "";
 let ssrMembersHtml: string | null = null;
 if (cookie.trim()) {

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -7,6 +7,7 @@
 import { env } from "cloudflare:workers";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { getWorkspacePeople } from "../../../../lib/api-client";
+import { serverApiFetchImpl } from "../../../../lib/api-proxy";
 import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
 import { renderMembersHtml, renderMembersPlaceholderHtml } from "../../../../lib/workspace-ui";
@@ -30,7 +31,10 @@ const { apiOrigin } = resolveSignedInOrigins(env);
 const cookie = Astro.request.headers.get("cookie") ?? "";
 let ssrMembersHtml: string | null = null;
 if (cookie.trim()) {
-  const people = await getWorkspacePeople(apiOrigin, workspace, { cookie });
+  const people = await getWorkspacePeople(apiOrigin, workspace, {
+    cookie,
+    fetchImpl: serverApiFetchImpl(env, Astro.request),
+  });
   if (people.kind === "ok" && people.members.length > 0) {
     ssrMembersHtml = renderMembersHtml(people.members, {
       canManage: false,

--- a/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
@@ -47,7 +47,7 @@ const tip = {
   linkLabel: "How grouping works",
 };
 
-const { apiOrigin } = resolveSignedInOrigins(env);
+const { apiOrigin } = resolveSignedInOrigins();
 const cookie = Astro.request.headers.get("cookie") ?? "";
 const initialSearch = Astro.url.search;
 

--- a/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
@@ -30,6 +30,7 @@ import { env } from "cloudflare:workers";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { ScreenshotsByPath, type OverviewState } from "../../../../components/ScreenshotsByPath";
 import { getWorkspaceFilesByPath, getWorkspaceSummary } from "../../../../lib/api-client";
+import { serverApiFetchImpl } from "../../../../lib/api-proxy";
 import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
 import type { WorkspaceInfoStatus } from "../../../../lib/workspace-file-row";
@@ -54,9 +55,10 @@ let initialInfo: WorkspaceInfoStatus | undefined;
 let initialOverview: OverviewState | undefined;
 
 if (cookie.trim()) {
+  const fetchImpl = serverApiFetchImpl(env, Astro.request);
   const [summary, overview] = await Promise.all([
-    getWorkspaceSummary(apiOrigin, workspace, { cookie }),
-    getWorkspaceFilesByPath(apiOrigin, workspace, { cookie }),
+    getWorkspaceSummary(apiOrigin, workspace, { cookie, fetchImpl }),
+    getWorkspaceFilesByPath(apiOrigin, workspace, { cookie, fetchImpl }),
   ]);
 
   if (summary.kind === "success") {

--- a/apps/web/src/pages/api/[...path].ts
+++ b/apps/web/src/pages/api/[...path].ts
@@ -1,0 +1,12 @@
+/**
+ * Same-origin api proxy (#731 phase D): `uploads.sh/api/<path>` forwards to
+ * the api worker's `/<path>`. Route stays thin — all logic lives in
+ * `../../lib/api-proxy`.
+ */
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { proxyApiRequest } from "../../lib/api-proxy";
+
+export const prerender = false;
+
+export const ALL: APIRoute = ({ request }) => proxyApiRequest(env, request);

--- a/apps/web/src/pages/changelog.astro
+++ b/apps/web/src/pages/changelog.astro
@@ -5,6 +5,7 @@
 import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
 import SiteHeader from "../components/SiteHeader.astro";
+import { SAME_ORIGIN_AUTH_BASE } from "../lib/auth-client";
 import { loadChangelogEntries } from "../lib/changelog";
 import { OG_DEFAULT_IMAGE, OG_SITE_NAME } from "../lib/og";
 
@@ -14,9 +15,7 @@ const pageTitle = "Changelog";
 const pageDescription =
   "What's new in uploads.sh — platform updates and CLI releases, newest first.";
 
-// Same-origin (#731 phase B): browser auth traffic goes through this origin's
-// /api/auth proxy, not a configured auth-worker origin.
-const authOrigin = "";
+const authOrigin = SAME_ORIGIN_AUTH_BASE;
 
 const formatDate = (iso: string) =>
   new Date(iso).toLocaleDateString("en-US", {

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -2,6 +2,7 @@
 // Minimal operator console: paste a bearer token, list usage + files via the public API.
 // No server-side secrets — token stays in the browser. Scaffold toward a fuller files-sdk UI.
 import { env } from "cloudflare:workers";
+import { SAME_ORIGIN_AUTH_BASE } from "../lib/auth-client";
 import { resolveConsoleMode } from "../lib/console-mode";
 import Brand from "../components/Brand.astro";
 import BaseHead from "../components/BaseHead.astro";
@@ -22,9 +23,7 @@ if (consoleMode === "off") {
 }
 
 const API_DEFAULT = "https://api.uploads.sh";
-// Same-origin (#731 phase B): browser auth traffic goes through this origin's
-// /api/auth proxy, not a configured auth-worker origin.
-const authOrigin = "";
+const authOrigin = SAME_ORIGIN_AUTH_BASE;
 ---
 
 <html lang="en">

--- a/apps/web/src/pages/device.astro
+++ b/apps/web/src/pages/device.astro
@@ -15,7 +15,7 @@ export const prerender = false;
 
 // The API origin is needed because a first-run account can create its
 // workspace inline here (issue #362).
-const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
+const { authOrigin, apiOrigin } = resolveSignedInOrigins();
 
 // Header (not meta): frame-ancestors is ignored on meta CSP.
 applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOrigin));

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -45,7 +45,7 @@ const result = await fetchPublicFile(workspace, key, { origin });
 // Browser-facing: the delete/file-url probe below and ReportAbuse's fetch are
 // credentialed(-ish) calls a real visitor's browser makes, so they go through
 // the same-origin /api proxy rather than api.uploads.sh directly (#731 phase D).
-const { apiOrigin: browserApiOrigin } = resolveSignedInOrigins(env);
+const { apiOrigin: browserApiOrigin } = resolveSignedInOrigins();
 
 applyPublicFileHeaders(Astro.response.headers, { csp: publicFileCsp(browserApiOrigin) });
 
@@ -693,6 +693,14 @@ const ogImage = file
         authRequired: result.status === "auth_required",
       }}
     >
+      // Base `/v1/workspaces/:name/files` endpoint (apiOrigin/workspace come
+      // in via define:vars above) shared by the three call sites below —
+      // this inline script can't import api-client.ts's trimOrigin/URL
+      // builders, so the one local helper stands in for it.
+      function filesEndpoint(suffix) {
+        return `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files${suffix}`;
+      }
+
       // Progressive-enhancement, client-side authorization path — a second
       // gate parallel to the server-side one this page already applied via
       // fetchPublicFile()/objectVisibility (apps/api's GET /public/files/...,
@@ -704,9 +712,7 @@ const ogImage = file
         if (!authRequired) return;
         const checking = document.getElementById("auth-checking");
         try {
-          const endpoint =
-            `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url` +
-            `?key=${encodeURIComponent(key)}`;
+          const endpoint = filesEndpoint(`/file-url?key=${encodeURIComponent(key)}`);
           if (checking) checking.hidden = false;
           const response = await fetch(endpoint, {
             credentials: "include",
@@ -734,9 +740,7 @@ const ogImage = file
       (async function () {
         const zone = document.getElementById("delete-zone");
         if (!zone) return;
-        const endpoint =
-          `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url` +
-          `?key=${encodeURIComponent(key)}`;
+        const endpoint = filesEndpoint(`/file-url?key=${encodeURIComponent(key)}`);
         try {
           const probe = await fetch(endpoint, {
             credentials: "include",
@@ -808,7 +812,7 @@ const ogImage = file
             // in sync. The old query-param form (?key=) matched no /v1 route and
             // fell through to the bearer-only guard, 401ing session users.
             const keyPath = key.split("/").map(encodeURIComponent).join("/");
-            const target = `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/${keyPath}`;
+            const target = filesEndpoint(`/${keyPath}`);
             const response = await fetch(target, { method: "DELETE", credentials: "include" });
             if (!response.ok) throw new Error(String(response.status));
             // Swap the page to the deleted state.

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -27,19 +27,27 @@ import {
 import { oembedDiscoveryHref } from "../../../lib/oembed";
 import { OG_DEFAULT_IMAGE, OG_SITE_NAME, ogImageFor } from "../../../lib/og";
 import { env } from "cloudflare:workers";
+import { resolveSignedInOrigins } from "../../../lib/signed-in-page";
 import { workspaceHomePath } from "../../../lib/workspaces-nav";
 
 export const prerender = false;
 
 const workspace = Astro.params.workspace ?? "";
 const key = Astro.params.key ?? "";
+// SSR-only, absolute — fetchPublicFile validates this is a real https:/loopback
+// origin and fetches it directly (server-to-server, no browser cookie jar
+// involved), so it stays independent of the browser-facing same-origin value
+// below (#731 phase D).
 const origin =
   env.UPLOADS_API_ORIGIN ?? import.meta.env.PUBLIC_UPLOADS_API_ORIGIN ?? "https://api.uploads.sh";
 const result = await fetchPublicFile(workspace, key, { origin });
 
-// Always allow connect-src → API: Report a problem (public) and the
-// auth_required session probe both POST/GET against the API origin.
-applyPublicFileHeaders(Astro.response.headers, { csp: publicFileCsp(origin) });
+// Browser-facing: the delete/file-url probe below and ReportAbuse's fetch are
+// credentialed(-ish) calls a real visitor's browser makes, so they go through
+// the same-origin /api proxy rather than api.uploads.sh directly (#731 phase D).
+const { apiOrigin: browserApiOrigin } = resolveSignedInOrigins(env);
+
+applyPublicFileHeaders(Astro.response.headers, { csp: publicFileCsp(browserApiOrigin) });
 
 const file = result.status === "ok" ? result.file : null;
 if (result.status === "unavailable") Astro.response.status = 503;
@@ -625,7 +633,7 @@ const ogImage = file
                 </div>
               </div>
               <ReportAbuse
-                apiOrigin={origin}
+                apiOrigin={browserApiOrigin}
                 pageUrl={canonical}
                 workspace={workspace}
                 objectKey={key}
@@ -679,7 +687,7 @@ const ogImage = file
     -->
     <script
       define:vars={{
-        apiOrigin: origin,
+        apiOrigin: browserApiOrigin,
         workspace,
         key,
         authRequired: result.status === "auth_required",
@@ -696,11 +704,9 @@ const ogImage = file
         if (!authRequired) return;
         const checking = document.getElementById("auth-checking");
         try {
-          const endpoint = new URL(
-            `/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url`,
-            apiOrigin,
-          );
-          endpoint.searchParams.set("key", key);
+          const endpoint =
+            `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url` +
+            `?key=${encodeURIComponent(key)}`;
           if (checking) checking.hidden = false;
           const response = await fetch(endpoint, {
             credentials: "include",
@@ -728,11 +734,9 @@ const ogImage = file
       (async function () {
         const zone = document.getElementById("delete-zone");
         if (!zone) return;
-        const endpoint = new URL(
-          `/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url`,
-          apiOrigin,
-        );
-        endpoint.searchParams.set("key", key);
+        const endpoint =
+          `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/file-url` +
+          `?key=${encodeURIComponent(key)}`;
         try {
           const probe = await fetch(endpoint, {
             credentials: "include",
@@ -804,10 +808,7 @@ const ogImage = file
             // in sync. The old query-param form (?key=) matched no /v1 route and
             // fell through to the bearer-only guard, 401ing session users.
             const keyPath = key.split("/").map(encodeURIComponent).join("/");
-            const target = new URL(
-              `/v1/workspaces/${encodeURIComponent(workspace)}/files/${keyPath}`,
-              apiOrigin,
-            );
+            const target = `${apiOrigin.replace(/\/$/, "")}/v1/workspaces/${encodeURIComponent(workspace)}/files/${keyPath}`;
             const response = await fetch(target, { method: "DELETE", credentials: "include" });
             if (!response.ok) throw new Error(String(response.status));
             // Swap the page to the deleted state.

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -6,6 +6,7 @@ import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
 import GitHubMark from "../components/GitHubMark.astro";
 import SiteHeader from "../components/SiteHeader.astro";
+import { SAME_ORIGIN_AUTH_BASE } from "../lib/auth-client";
 import { GITHUB_APP_URL } from "../lib/github-app";
 import { OG_DEFAULT_IMAGE, OG_SITE_NAME } from "../lib/og";
 
@@ -13,9 +14,7 @@ const pageTitle = "uploads.sh — the missing upload command for coding agents";
 const pageDescription =
   "GitHub has no API for file uploads, so agents can't include screenshots in pull requests and issues. Uploads gives agents a way to host files and show their work. When the pull request opens, all screenshots appear in one tidy comment that updates automatically on each revision.";
 
-// Same-origin (#731 phase B): browser auth traffic goes through this origin's
-// /api/auth proxy, not a configured auth-worker origin.
-const authOrigin = "";
+const authOrigin = SAME_ORIGIN_AUTH_BASE;
 
 // The agent setup prompt: copied via button, never rendered in full on the page.
 const agentPrompt = `Help me set up the uploads CLI (uploads.sh) and attach my first screenshot to a GitHub pull request.

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -1,4 +1,5 @@
 ---
+import { SAME_ORIGIN_AUTH_BASE } from "../lib/auth-client";
 import { applyAuthSecurityHeaders, authPageCsp } from "../lib/signed-in-page";
 import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
@@ -8,9 +9,7 @@ import LegalConsent from "../components/LegalConsent.astro";
 
 export const prerender = false;
 
-// Same-origin (#731 phase B): browser auth traffic goes through this origin's
-// /api/auth proxy, not a configured auth-worker origin.
-const authOrigin = "";
+const authOrigin = SAME_ORIGIN_AUTH_BASE;
 
 // Header (not meta): frame-ancestors is ignored on meta CSP.
 applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -1,4 +1,5 @@
 ---
+import { SAME_ORIGIN_AUTH_BASE } from "../../lib/auth-client";
 import { applyAuthSecurityHeaders, authPageCsp } from "../../lib/signed-in-page";
 import BaseHead from "../../components/BaseHead.astro";
 import Brand from "../../components/Brand.astro";
@@ -6,9 +7,7 @@ import Footer from "../../components/Footer.astro";
 
 export const prerender = false;
 
-// Same-origin (#731 phase B): browser auth traffic goes through this origin's
-// /api/auth proxy, not a configured auth-worker origin.
-const authOrigin = "";
+const authOrigin = SAME_ORIGIN_AUTH_BASE;
 
 // Header (not meta): frame-ancestors is ignored on meta CSP.
 applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));


### PR DESCRIPTION
Phase D of #731. The browser's credentialed api traffic (`/me/*`, `/admin-ui/*`, session'd `/v1/workspaces*` and `/v1/tokens*`) moves behind the web origin — the BFF shape. After this, session cookies exist on exactly one host and `api.uploads.sh` sees only `Authorization`-header traffic from browsers-adjacent code paths (credentialed CORS retirement itself is phase E, gated a week behind this in prod).

## Changes

- New `/api/[...path]` route: `uploads.sh/api/<path>` → api worker `/<path>` (prefix stripped, query preserved, `redirect: "manual"`), over the `API` binding with the astro-dev HTTP fallback. A `/auth/*` guard 404s rather than trusting route precedence — the api worker has its own unrelated `/auth/enrollments` surface. Shared origin-rewrite extracted to `proxy-transport.ts` (auth-proxy refactored onto it, tests unchanged).
- `resolveSignedInOrigins` returns `apiOrigin: "/api"` (documented as `SAME_ORIGIN_API_BASE`): many call sites build bare `` `${apiOrigin}${path}` `` URLs, so a concrete prefix — not `""` — keeps every existing template correct. CSP builders collapse it to `'self'`.
- All `window.__UPLOADS_API_ORIGIN__` injections and api-origin fallbacks flip; SSR frontmatter api reads (workspaces, developers, files, billing, screenshots, galleries, people) route through the binding via a `fetchImpl` threaded into `api-client.ts` (`serverApiFetchImpl`).
- Fixes the phase-B profile gap: `loadProfilePageData`'s SSR auth calls now resolve via the AUTH binding (`serverAuthFetchImpl`) instead of unresolvable relative URLs.
- Deliberately untouched: `invite.astro` (documented prod-api hardcode), `console.astro` operator console, uncredentialed SSR-only fetches (`oembed`, gallery pages, `public-file.ts`), and everything about the public file-serving origins (`storage.`/`store.`/`embed.`).

## Verified on the raw local stack

`/api/me/workspaces` returns real data with the session cookie through the proxy; injected api base is `/api`; signed-in CSP is `connect-src 'self'` + RUM only; profile SSR renders session data server-side; workspace pages 200; `/api/auth` guard 404s; no new console errors.

Refs #731
