### PR TITLE
feat(web): enable custom preview domains at *.preview.uploads.sh (#684)

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -115,6 +115,11 @@ these normal.
   spirit of Better Auth or OpenRouter. This also means avoiding user-seat
   limitations wherever possible: agents are the primary user, and agents
   support workspaces, not seats.
+- **Sign in with uploads.sh.** The hosted service as an identity provider —
+  for self-hosted deployments that would rather not run their own auth, and
+  for signed-in features on a customer's own custom domain. A companion
+  idea: narrow, short-lived review sessions for preview and review surfaces,
+  scoped to those surfaces alone and never a production session.
 - **Release management.** From per-PR evidence to per-release narrative:
   assembling the captures from a stream of merged PRs into the raw material
   for release notes, changelogs, and launch visuals.

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -64,6 +64,22 @@
       "pattern": "uploads.sh",
       "custom_domain": true,
     },
+    // Preview custom domain (#684, unblocked by #731's host-only session
+    // cookie: uploads.sh no longer shares the cookie with subdomains, so a
+    // preview origin under it receives no session). Dedicated
+    // `preview.uploads.sh` subdomain rather than a `previews_enabled` flag on
+    // the production route above — the apex already carries real subdomains
+    // (auth., api., storage., …), so Cloudflare's "wildcard would collide"
+    // guidance points at the dedicated-subdomain form. `previews_enabled`
+    // here provisions the wildcard DNS + cert for `<branch>.preview.uploads.sh`
+    // (see docs/previews.md); it does NOT itself gate access — Cloudflare
+    // Access must stay in front of the wildcard, same as the workers.dev
+    // preview tier today.
+    {
+      "pattern": "preview.uploads.sh",
+      "custom_domain": true,
+      "previews_enabled": true,
+    },
   ],
   // Workers Previews (`npx wrangler preview` from a branch — branch-scoped
   // environments, distinct from the legacy `preview_urls` version URLs above).

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -9,6 +9,25 @@ the Build Internet account (Cloudflare docs:
 Preview URLs are gated by Cloudflare Access. Sign in with a Cloudflare account
 that is a member of the Build Internet account and you pass straight through.
 
+`uploads-web` previews resolve at two URLs: the workers.dev one, and — since
+#684 — a custom domain, `<preview-name>.preview.uploads.sh`. The custom
+domain is safe post-#731: the production session cookie is host-only on
+`uploads.sh`, so no `*.preview.uploads.sh` hostname ever receives it, and
+previews stay signed out either way (see the GitHub-login/dev-session note
+below). The wildcard DNS record and certificate for `*.preview.uploads.sh`
+are auto-provisioned by Cloudflare on the first preview deploy after this
+merges — certificate issuance can lag the DNS record by a few minutes, so a
+brand-new preview name may fail TLS briefly before it's usable.
+
+Access must stay in front of both preview URL forms. Cloudflare's docs say
+the auto-created per-worker Access application covers workers.dev preview
+URLs and custom-domain preview URLs alike, but treat that as unverified until
+checked: after the first deploy under `*.preview.uploads.sh`, confirm in Zero
+Trust → Access → Applications that the wildcard is actually gated. If it
+isn't, add an Access app for `*.preview.uploads.sh` matching the existing
+preview setup (Cloudflare IdP, restricted to Build Internet account members,
+instant auth).
+
 Do not confuse a Preview with the Workers Builds bot's "Branch Preview URL"
 comment on PRs. That URL is the legacy aliased-version mechanism
 (`preview_urls: true`) and runs against **production bindings**. Only
@@ -97,8 +116,15 @@ the preview base config.
 
 ## Decisions of record
 
-- Previews stay on workers.dev URLs. Hostnames under `uploads.sh` would
-  receive the `.uploads.sh`-scoped production session cookie, handing live
-  sessions to unreviewed branch code. Revisit tracked in
-  [issue #684](https://github.com/buildinternet/uploads/issues/684).
+- `uploads-web` previews resolve at `*.preview.uploads.sh` (custom domain,
+  `previews_enabled` in `apps/web/wrangler.jsonc`) as well as workers.dev
+  (#684). This was on hold until #731 made the session cookie host-only on
+  `uploads.sh` — before that, a `uploads.sh` subdomain would have received
+  the production session cookie. Only the web worker has this; `uploads-api`
+  and `uploads-auth` stay workers.dev-only previews.
+- Previews stay signed out regardless of URL form: GitHub OAuth's callback is
+  pinned to the production origin (won't complete against a preview URL),
+  and the dev-session escape hatch doesn't exist outside local dev. This is
+  by design, not a gap to fix — see the "Which app to preview" table above
+  for what "realistic, signed out" means for UI review.
 - The legacy `preview_urls: true` flags stay during the transition.


### PR DESCRIPTION
Unblocked by #731: the session cookie is host-only on `uploads.sh`, so preview hostnames under the zone receive no session. Adds a dedicated `preview.uploads.sh` custom domain with `previews_enabled` on the web worker (production route untouched; api/auth stay workers.dev-only), updates docs/previews.md, and adds the identity-direction roadmap bullet to VISION.md.

Trust surfaces verified unchanged: `isTrustedOrigin`'s production path is exact-match only and its dev regexes can't match `*.preview.uploads.sh`; api CORS is exact-equality against `WEB_ORIGIN`. Preview origins stay untrusted and Access stays in front.

**After merge, two manual checks:**
1. First `wrangler preview` deploy auto-provisions the `*.preview.uploads.sh` wildcard DNS + cert (issuance can lag a few minutes). I'll run a throwaway preview to exercise this and delete it.
2. Verify in Zero Trust → Access → Applications that `*.preview.uploads.sh` is gated by the preview Access app; if not, add one (Cloudflare IdP, account members, instant auth).

Closes #684