### PR TITLE
fix(web): keep screenshots and files chrome from flashing to a skeleton

### DIFF
--- a/apps/web/src/components/ScreenshotsByPath.test.ts
+++ b/apps/web/src/components/ScreenshotsByPath.test.ts
@@ -82,6 +82,16 @@ describe("ScreenshotsByPath seed contract — initialSearch provided", () => {
       merged: false,
     });
   });
+
+  it("a deep-linked merged-only view seeds merged true (SSR overview uses this)", () => {
+    expect(readScreenshotsView("?merged=1")).toEqual({
+      project: "",
+      path: "",
+      q: "",
+      feed: "grouped",
+      merged: true,
+    });
+  });
 });
 
 describe("ScreenshotsByPath seed contract — no initialSearch prop (props-less mount)", () => {

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -579,6 +579,10 @@ function ScreenshotsByPathInner({
     () => initialOverview ?? { status: "loading" },
   );
   const [overviewRetryNonce, setOverviewRetryNonce] = useState(0);
+  // In-place refetch (Merged only) — keeps the last ready overview so the
+  // filter bar stays mounted. Distinct from `overview.status === "loading"`,
+  // which is the full-page skeleton for workspace/retry.
+  const [overviewRefreshing, setOverviewRefreshing] = useState(false);
   // `readScreenshotsView` derives purely from the URL search string (no
   // localStorage involved anywhere in this module — unlike the files tab's
   // `resolveFilesView`), so there's no stored-preference divergence to guard
@@ -609,12 +613,24 @@ function ScreenshotsByPathInner({
   // doesn't fire a duplicate search.
   const [backfill, setBackfill] = useState<Record<string, PathGroupItem[]>>({});
   const backfillStarted = useRef(new Set<string>());
+  // Scope of the last overview fetch that is allowed to replace the page with
+  // the full-page skeleton. `view.merged` is deliberately excluded: toggling
+  // Merged only refetches the same workspace, and dropping a ready overview
+  // unmounts the filter bar (Grouped/Recent is a client-side layout switch
+  // on the same payload, so it never hits this path).
+  const overviewScopeRef = useRef(`${apiOrigin}\0${workspace}\0${overviewRetryNonce}`);
+  // SSR already fetched the overview for this search string (including
+  // `?merged=1`). Skip the first client fetch so hydrate doesn't mark the
+  // seeded groups busy and immediately replace them with the same payload.
+  const skipSeededOverviewFetch = useRef(initialOverview?.status === "ready");
 
   // Workspace-level facts (hasPublicUrl), gated behind session resolution —
   // same pattern as WorkspaceFileTable.
   useEffect(() => {
     let cancelled = false;
-    setInfo({ status: "loading" });
+    // Don't flash the full-page skeleton over SSR-seeded info on hydrate.
+    // Retry (nonce) still goes through loading because prev is not ready.
+    setInfo((prev) => (prev.status === "ready" ? prev : { status: "loading" }));
     onSession(() => {
       void loadWorkspaces(apiOrigin).then((result) => {
         if (cancelled) return;
@@ -629,10 +645,23 @@ function ScreenshotsByPathInner({
   // Overview fetch, once per mount/workspace/retry/merged-toggle.
   useEffect(() => {
     let cancelled = false;
-    setOverview({ status: "loading" });
+    const scope = `${apiOrigin}\0${workspace}\0${overviewRetryNonce}`;
+    const scopeChanged = overviewScopeRef.current !== scope;
+    overviewScopeRef.current = scope;
+    if (skipSeededOverviewFetch.current) {
+      skipSeededOverviewFetch.current = false;
+      return;
+    }
+    if (scopeChanged) {
+      setOverview({ status: "loading" });
+      setOverviewRefreshing(false);
+    } else {
+      setOverviewRefreshing(true);
+    }
     onSession(() => {
       void getWorkspaceFilesByPath(apiOrigin, workspace, { merged: view.merged }).then((result) => {
         if (cancelled) return;
+        setOverviewRefreshing(false);
         setOverview(
           result.kind === "ok"
             ? {
@@ -996,7 +1025,7 @@ function ScreenshotsByPathInner({
     }
 
     return (
-      <div className="wsp">
+      <div className="wsp" aria-busy={overviewRefreshing || undefined}>
         {filterBar}
         <button type="button" className="text-btn" onClick={() => setView({ ...view, path: "" })}>
           {view.project ? `← ${view.project}` : "← all projects"}
@@ -1064,7 +1093,7 @@ function ScreenshotsByPathInner({
     });
     const latestPaired = pairedShotKeys(latestItems);
     return (
-      <div className="wsp">
+      <div className="wsp" aria-busy={overviewRefreshing || undefined}>
         {filterBar}
         {latestItems.length === 0 ? (
           !view.merged && overview.latest.length === 0 && overview.catalog.length === 0 ? (
@@ -1153,7 +1182,7 @@ function ScreenshotsByPathInner({
   }
 
   return (
-    <div className="wsp">
+    <div className="wsp" aria-busy={overviewRefreshing || undefined}>
       {filterBar}
       {isEmptyWorkspace ? (
         <EmptyShotsCta title="No screenshots yet" />

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -615,6 +615,10 @@ function WorkspaceFileTableInner({
   // against markup neither side disagrees on.
   const [view, setView] = useState<FilesView>(() => resolveFilesView(seedSearch, null));
   const githubTitlesGeneration = useRef(0);
+  // SSR already fetched the default-browse listing for this workspace.
+  // Skip the first client fetch so hydrate doesn't swap the seeded rows
+  // for the in-table skeleton. Folder/filter changes still refetch.
+  const skipSeededListingFetch = useRef(initialListing?.status === "ok");
   // In-flight guards (refs, not state — must not trigger re-renders) so a
   // second call issued while the first is still pending (every keystroke on
   // a `key=` draft, or a rapid blur/refocus) doesn't re-request the same key.
@@ -681,7 +685,9 @@ function WorkspaceFileTableInner({
   // gated behind the layout's session resolution like the rail (workspace-rail.ts).
   useEffect(() => {
     let cancelled = false;
-    setInfo({ status: "loading" });
+    // Don't flash the full-page skeleton over SSR-seeded info on hydrate.
+    // Retry (nonce) still goes through loading because prev is not ready.
+    setInfo((prev) => (prev.status === "ready" ? prev : { status: "loading" }));
     onSession(() => {
       void getMyWorkspaces(apiOrigin).then((result) => {
         if (cancelled) return;
@@ -697,6 +703,10 @@ function WorkspaceFileTableInner({
   // lost-access status renders in place of the table instead — see below).
   useEffect(() => {
     if (info.status !== "ready") return;
+    if (skipSeededListingFetch.current) {
+      skipSeededListingFetch.current = false;
+      return;
+    }
     let cancelled = false;
     githubTitlesGeneration.current += 1;
     setGithubTitles(null);
@@ -732,8 +742,10 @@ function WorkspaceFileTableInner({
     // filtersKey stands in for `filters` (serialized): the array identity
     // changes on every render, so depending on it directly would refetch in a
     // loop. The serialized key changes only when a filter actually changes.
+    // `info.status` (not `info`) so a same-status identity change after the
+    // hydrate refetch does not drop the seeded rows into the row skeleton.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiOrigin, workspace, info, filtered, filtersKey, nameTerm, prefix]);
+  }, [apiOrigin, workspace, info.status, filtered, filtersKey, nameTerm, prefix]);
 
   // Resolve connected-work titles once per listing. The generation guard keeps
   // a slower, superseded listing from repainting the current banner or rail.

--- a/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
@@ -19,12 +19,12 @@
  *
  * Unlike the files tab's `listWorkspaceFolder` (which depends on the current
  * folder, so plan 005 only seeds it for the plain root browse),
- * `getWorkspaceFilesByPath` always returns the same complete by-path overview
- * regardless of the URL — `?project=`/`?q=` only change how
- * `ScreenshotsByPath` filters that same data (project + path query), and
- * `?path=` switches to a *different* client-side fetch (drill-in search).
- * So the overview seed below is unconditional, not gated to a "default
- * view" URL the way plan 005's listing seed is.
+ * `getWorkspaceFilesByPath` returns the by-path overview for the current
+ * merge filter (`?merged=1` or the default unfiltered catalog). `?project=`
+ * and `?q=` only change how `ScreenshotsByPath` filters that same payload,
+ * and `?path=` switches to a *different* client-side fetch (drill-in search).
+ * The seed below always runs when a session cookie is present, not gated to
+ * a "default view" URL the way plan 005's listing seed is.
  */
 import { env } from "cloudflare:workers";
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
@@ -34,6 +34,7 @@ import { serverApiFetchImpl } from "../../../../lib/api-proxy";
 import { resolveSignedInOrigins } from "../../../../lib/signed-in-page";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
 import type { WorkspaceInfoStatus } from "../../../../lib/workspace-file-row";
+import { readScreenshotsView } from "../../../../lib/workspace-screenshots";
 
 export const prerender = false;
 
@@ -50,6 +51,7 @@ const tip = {
 const { apiOrigin } = resolveSignedInOrigins();
 const cookie = Astro.request.headers.get("cookie") ?? "";
 const initialSearch = Astro.url.search;
+const { merged: mergedOnly } = readScreenshotsView(initialSearch);
 
 let initialInfo: WorkspaceInfoStatus | undefined;
 let initialOverview: OverviewState | undefined;
@@ -58,7 +60,11 @@ if (cookie.trim()) {
   const fetchImpl = serverApiFetchImpl(env, Astro.request);
   const [summary, overview] = await Promise.all([
     getWorkspaceSummary(apiOrigin, workspace, { cookie, fetchImpl }),
-    getWorkspaceFilesByPath(apiOrigin, workspace, { cookie, fetchImpl }),
+    getWorkspaceFilesByPath(apiOrigin, workspace, {
+      cookie,
+      fetchImpl,
+      merged: mergedOnly,
+    }),
   ]);
 
   if (summary.kind === "success") {


### PR DESCRIPTION
## In plain terms

Clicking **Merged only** on the screenshots page was tearing the whole layout down and putting the loading skeleton back up. Grouped and Recent never did that, because they only switch layout on data already on the page. The files tab had the same kind of flash after JavaScript booted: SSR-painted rows and the filter bar vanished into a skeleton, then came back.

The chrome now stays on screen. Merged only still refetches; the gallery updates when the filtered data arrives. The files tab keeps its seeded toolbar and rows through hydrate.

## What it does / what it is not

- **Does:** keep the last ready screenshots overview while `?merged=1` refetches, so the filter bar does not unmount.
- **Does:** skip the redundant first client fetch when SSR already seeded the screenshots overview or the files listing.
- **Does:** seed the screenshots overview with `?merged=1` on the server, so a reload with the toggle on paints the filtered catalog first.
- **Does:** stop the files tab from clobbering SSR-ready workspace info (and from refetching the listing just because that info object got a new identity).
- **Does not:** change Grouped/Recent, files list/grid, or folder/filter navigation. Folder changes still skeleton the rows and keep the toolbar.
- **Does not:** keep stale drill-in tiles while Merged only is on a path view — that grid still shows a content skeleton, with the filter bar in place.

## How to try it

On a workspace that has screenshots:

1. Open the screenshots tab.
2. Click **Merged only**. The filter bar should stay. Only the shots should change.
3. Toggle **Grouped** / **Recent**. That should still be instant, same as before.
4. Reload with Merged only on (`?merged=1`). First paint should already be the filtered catalog.

On the files tab, load the default browse. The filter bar and rows should not flash to a skeleton after the page becomes interactive.

## Technical notes

Both islands had the same early return: `status === "loading"` replaced the whole tree, toolbar included. Merged only put `view.merged` on the overview fetch, so a toggle set loading. The files listing effect depended on the whole `info` object, so the hydrate refetch of workspace info dropped seeded rows even when the listing itself had not changed.

Retry and workspace change still go through the full-page skeleton. Those are a different scope, not a filter toggle.

## Test plan

- [x] `pnpm --filter @uploads/web test` (814 tests)
- [x] oxlint on the touched TS/TSX files
- [ ] Click **Merged only** on a signed-in screenshots page and confirm the filter bar stays
- [ ] Load the files tab and confirm no toolbar/row skeleton flash after hydrate
- [ ] Folder click on files still skeletons the rows and keeps the toolbar