### PR TITLE
feat(ui,web): type scale tokens, a mono rule, and site-nav active state

### DIFF
--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -7,13 +7,13 @@
         "rule": "overused-font",
         "value": "geist",
         "createdAt": "2026-07-13T15:21:39.964Z",
-        "reason": "Zach confirmed mono-first terminal-native identity 2026-07-13; Geist retained deliberately for prose/headings"
+        "reason": "Zach confirmed the type direction 2026-08-21: Geist (sans) is the interface voice for prose, headings, and UI chrome. Retained deliberately, not by default."
       },
       {
         "rule": "overused-font",
         "value": "geist mono",
         "createdAt": "2026-07-13T15:21:39.994Z",
-        "reason": "Zach confirmed mono-first terminal-native identity 2026-07-13; Geist Mono is the brand's base face for a CLI-first product"
+        "reason": "Zach confirmed the type direction 2026-08-21: Geist Mono is no longer the base face. It is reserved for what it measures \u2014 commands, code, file keys, URLs, hashes, tabular figures \u2014 which is a real, ongoing use in a CLI-first product, so the face stays."
       },
       {
         "rule": "broken-image",
@@ -27,7 +27,7 @@
           "**/*.test.tsx"
         ],
         "createdAt": "2026-07-23T18:05:43.111Z",
-        "reason": "Waives broken-image for code that EMITS markup as strings rather than rendering it, plus test fixtures — the class this rule cannot distinguish. Covers the CLI/stdio MCP (packages/uploads/src), the hosted MCP worker and the API worker (headless JSON-RPC, no rendered surface; their <img> occurrences are GitHub-comment markdown builders and tool-schema prose), apps/web/src/lib (embed-snippet builders and UI label text, not components), and *.test.ts(x) (notably an XSS fixture, `caption: \"<img onerror=alert(1)>\"`, that must stay malformed). Scoped deliberately rather than disabled globally: the rule stays live on apps/web/src/components/**, apps/web/src/pages/**, and packages/ui/**, which all scan clean today and where a real `<img src=\"\">` would ship a broken box — verified 2026-07-23 that the detector parses .astro and catches that defect."
+        "reason": "Waives broken-image for code that EMITS markup as strings rather than rendering it, plus test fixtures \u2014 the class this rule cannot distinguish. Covers the CLI/stdio MCP (packages/uploads/src), the hosted MCP worker and the API worker (headless JSON-RPC, no rendered surface; their <img> occurrences are GitHub-comment markdown builders and tool-schema prose), apps/web/src/lib (embed-snippet builders and UI label text, not components), and *.test.ts(x) (notably an XSS fixture, `caption: \"<img onerror=alert(1)>\"`, that must stay malformed). Scoped deliberately rather than disabled globally: the rule stays live on apps/web/src/components/**, apps/web/src/pages/**, and packages/ui/**, which all scan clean today and where a real `<img src=\"\">` would ship a broken box \u2014 verified 2026-07-23 that the detector parses .astro and catches that defect."
       },
       {
         "rule": "broken-image",

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,72 +1,205 @@
 # Product
 
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
 ## Register
 
 product
 
-<!-- Split surface: the landing page, docs, and guides are brand register;
-     console/account/admin and packages/ui are product register. Product is the default. -->
+<!-- Split surface: the landing page, docs, guides, and changelog are brand
+     register; console/account/admin and packages/ui are product register.
+     Product is the default. -->
 
 ## Users
 
-Developers and the coding agents that work alongside them. The core workflow is
-CLI- and agent-first: one command takes a local file — a PR screenshot, an agent
-artifact, a quick share — and returns a stable, embeddable URL, usually landing in
-a GitHub PR or issue. Agents are first-class users, not an afterthought: they reach
-the product through the CLI, the agent skills, and the MCP server, and they can't
-drag-and-drop into GitHub the way a human can.
+**Primary: the coding agent.** Agents execute the loop — capture a visual the
+moment a change is visible, `uploads put` it, and let it land on the pull
+request. They reach the product through the CLI, the agent skills, the local
+stdio MCP server, and the hosted MCP at `agents.uploads.sh`. They are the
+primary actor because they are the ones structurally blocked without it: GitHub's
+native image hosting only works through a browser session, so an agent that just
+captured a before/after has nowhere to put it.
 
-The web surfaces serve two moments: deciding (a landing page and docs that explain
-the product) and managing (signed-in console, account, and admin pages for
-workspaces, keys, files, and galleries).
+**Owner: the developer.** The developer installs the CLI once, signs in, owns
+the workspace, sets its limits and keys, and reads the result on the PR. They
+also use the product directly for one-off shares and screenshot capture. Every
+surface an agent cannot see — console, account, admin, billing, the `/f/` share
+page — exists for them.
+
+The web surfaces serve two moments: **deciding** (landing page, docs, changelog,
+guides that explain the product) and **managing** (signed-in console, account,
+workspace, and admin pages for workspaces, keys, files, screenshots, galleries,
+people, storage, and billing).
 
 ## Product Purpose
 
 uploads.sh is purpose-built file hosting for development workflows — not generic
-"store anything" file hosting. It exists so that getting a file from a local machine
-into a PR, issue, or agent pipeline is one command instead of a drag-and-drop a
-robot can't perform. It is open source and runs as a hosted service; workspaces
-keep teams' files, limits, and tokens isolated from each other.
+"store anything" file hosting. It exists so that getting a file from a local
+machine into a PR, issue, or agent pipeline is one command instead of a
+drag-and-drop a robot cannot perform.
+
+The mechanism is the **staged loop**: on a branch, a bare `put` stages the file
+against that branch — no PR required, no flag to remember. Capture at every
+milestone and there is nothing to reassemble at the end; when the pull request
+opens, everything staged is promoted into one managed attachments comment that
+rewrites itself in place on every revision.
+
+It is open source (Apache 2.0), runs as a hosted service at uploads.sh, and
+workspaces keep teams' files, budgets, and tokens isolated from each other.
 
 Success looks like: the tool a developer installs once and stops thinking about,
 and the default way coding agents attach visual evidence to their work.
 
-## Brand Personality
+## Positioning
+
+Three things a neighboring product could not truthfully copy:
+
+1. **Staged-before-the-PR.** Files attach to a branch that has no pull request
+   yet and promote themselves when one opens. Competing tools require a target
+   that already exists.
+2. **One comment, rewritten in place.** Not a growing thread of attachments —
+   a single managed comment per PR/issue, deduped, that updates on each sync and
+   empties itself when the last attachment is removed. `--state before`/`after`
+   files pair into a side-by-side table.
+3. **Hash-free stable keys.** Re-uploading the same filename overwrites in place
+   and the URL never changes, so every existing embed updates at once.
+
+## Operating Context
+
+- The work happens in a terminal on a feature branch, mid-task, usually inside
+  an agent session rather than a browser tab.
+- GitHub is the destination for most files: PR descriptions, issue bodies,
+  PR/issue comments. `gh` (or the `uploads-sh` GitHub App) is how the product
+  reaches them; the App makes promotion instant, the local `gh` path is
+  first-class parity, not a fallback.
+- Agent runtimes are an install target of their own: `uploads install` wires in
+  the skills and MCP server; `npx skills add buildinternet/uploads` installs the
+  three skills (`github-screenshots`, `uploads-cli`, `annotate-screenshots`)
+  into any runtime without a checkout.
+- Everything hosted is a public URL. Private-repo attachments get non-guessable
+  capability links, but anyone holding a URL can view the file. The product
+  states this plainly rather than implying access control it does not have.
+- The project is under active development and says so; APIs including auth can
+  still change.
+
+## Capabilities and Constraints
+
+**Shipped surfaces:** REST API worker (`api.uploads.sh`), auth worker, remote
+MCP server (`agents.uploads.sh`), the Astro site at uploads.sh, and the
+`@buildinternet/uploads` CLI on npm. Each deploys separately on Cloudflare
+Workers. All storage goes through `createStorage()` in `packages/storage`, built
+on files-sdk, so the storage layer is provider-agnostic (R2 today).
+
+**Web routes in production:** marketing home, `/docs` hub with eight guides,
+`/changelog` (plus Atom feed), `/f/<workspace>/<key>` file share pages, `/g/<id>`
+public galleries, `/console`, `/account` (profile, developers, workspaces),
+per-workspace files / screenshots / galleries / people / invite / settings /
+storage / billing, `/admin` (users, oauth, email, metrics), and the auth flows
+(login, device, invite, accept-invitation, oauth consent).
+
+**Plans (both live).**
+
+|           | Free         | Pro                                       |
+| --------- | ------------ | ----------------------------------------- |
+| Storage   | 250 MB       | 10 GB                                     |
+| Max file  | 25 MB        | 100 MB                                    |
+| Max video | 8 MB         | 100 MB (same as file cap)                 |
+| Members   | 3 (marketed) | seatless; 25 is an unmarketed abuse guard |
+
+Free is available in perpetuity; Pro is purchased through Stripe Checkout. Seats
+and roles are deliberately not sold — they are reserved for a future Team tier.
+Self-serve signup is live (GitHub-gated, 3 free workspaces per user, paid users
+exempt); the invitation-only story is retired.
+
+**Bring your own bucket.** A workspace can point at its own Cloudflare R2 bucket
+instead of the shared `storage.uploads.sh` bucket. Available on both plans,
+gated per workspace by a `byoBucketEnabled` record flag, with its own docs page
+and a settings/storage connect wizard.
+
+**Terminology that must stay stable:** _staged_ (attached to a branch, not yet
+promoted), _promote_ (staged → the PR comment), _attach_ (upload + sync the
+managed comment), _managed comment_ (the single rewritten comment), _workspace_
+(the isolation boundary for files, limits, and tokens), _key_ (the hash-free
+path a file lives at), _state_ (`before`/`after` for pairing).
+
+**Constraints:** dark-only palette by construction (`color-scheme: dark`); the
+site ships no framework JavaScript on public pages (React only behind sign-in);
+Node ≥24 and pnpm ≥11 for local development.
+
+## Brand Commitments
+
+Name is **uploads** / **uploads.sh**; the bot and GitHub App are referred to in
+prose as the "`uploads-sh` bot".
 
 Terminal-native, precise, quietly playful. A developer's tool that takes craft
 seriously — mono-first typography, dark by construction, with one genuinely
-distinctive asset: Geist Pixel and its variable ELSH (element-shape) axis, used as
-the brand's signature rather than a wordmark-only garnish. Personality shows up in
-small, exact moments (pixel morphs, the chevron/upload motif), never in loudness.
+distinctive asset: Geist Pixel and its variable ELSH (element-shape) axis, used
+as the brand's signature rather than a wordmark-only garnish. Personality shows
+up in small, exact moments (pixel morphs, the chevron/upload motif), never in
+loudness.
+
+Three faces, defined once in `packages/ui/src/tokens.css`: Geist (sans, body and
+headings), Geist Mono (developer-console chrome — buttons, labels, metadata),
+Geist Pixel (display and brand moments).
+
+Voice: purpose-first and concrete. Legal and marketing copy never overpromises —
+no access-control claims about public URLs, no durability or uptime guarantees
+the service does not make.
 
 ## Anti-references
 
-- The generic "dark + purple dev tool" (Linear/Vercel-adjacent) rendered entirely
-  in stock defaults. The palette family is allowed; the tell is default-ness —
-  distinctiveness must come from owned assets and usage, not template chrome.
+- The generic "dark + purple dev tool" (Linear/Vercel-adjacent) rendered
+  entirely in stock defaults. The palette family is allowed; the tell is
+  default-ness — distinctiveness must come from owned assets and usage, not
+  template chrome.
 - SaaS landing-page grammar: hero-metric blocks, identical icon-card grids, tiny
   uppercase tracked eyebrows above every section, gradient text, glassmorphism.
 - Generic file-hosting framing (Dropbox-alike "store your files" pitches). The
   pitch is purpose-first: screenshots on PRs, artifacts from agents.
 
-## Design Principles
+## Evidence on Hand
 
-1. **The CLI is the hero.** Web surfaces demonstrate and manage what the CLI does;
-   show real commands, real output, real hosted files — not marketing abstractions.
+Real, usable, and already shipped — future work should reach for these rather
+than invent equivalents:
+
+- `docs/assets/readme-home.png`, `readme-comment.png`, `readme-screenshots.png`,
+  `readme-file-page.png` — real product captures.
+- A real managed comment on PR #436, linked from the README, that can be cited
+  as a live demonstration.
+- `VISION.md` — the open-source-first pledge and roadmap; marketing copy must
+  stay consistent with it.
+- Remotion social loops at `scripts/demos`.
+- OG cards under `apps/web/public/og/`, regenerated by `scripts/og/render-og.mjs`.
+- `/changelog` and its Atom feed are a live, self-updating proof surface.
+
+**Absences that must not be fabricated:** there are no customer testimonials,
+no named logos, no benchmark numbers, no uptime or durability SLA, and no
+usage/adoption figures cleared for public use. `/admin/metrics` is internal.
+
+## Product Principles
+
+1. **The CLI is the hero.** Web surfaces demonstrate and manage what the CLI
+   does; show real commands, real output, real hosted files — not marketing
+   abstractions.
 2. **One brand, one source of truth.** The design system (`@uploads/ui`) defines
    the visual language; the site consumes it. The two never drift.
 3. **Signature over decoration.** Distinctiveness comes from owned assets (Geist
-   Pixel's ELSH axis, the pixel chevron mark) used systematically — not added ornament.
-4. **Deliberate, not default.** Every visual value is either chosen or explicitly
-   kept with a recorded reason. No silent defaults.
-5. **Agent-legible craft.** Pages work without JavaScript where possible, degrade
-   cleanly, and stay fast at the edge — the audience includes headless agents and
-   curl, not just browsers.
+   Pixel's ELSH axis, the pixel chevron mark) used systematically — not added
+   ornament.
+4. **Deliberate, not default.** Every visual value is either chosen or
+   explicitly kept with a recorded reason. No silent defaults.
+5. **Agent-legible craft.** Pages work without JavaScript where possible,
+   degrade cleanly, and stay fast at the edge — the audience includes headless
+   agents and curl, not just browsers.
 
 ## Accessibility & Inclusion
 
 WCAG 2.1 AA. The dark-only palette must hold ≥4.5:1 contrast for all text,
-including muted metadata at small sizes. Full keyboard operability on the signed-in
-surfaces (file browser, forms, navigation). Every animation ships a
+including muted metadata at small sizes. Full keyboard operability on the
+signed-in surfaces (file browser, forms, navigation). Every animation ships a
 `prefers-reduced-motion` alternative. Touch targets sized for mobile use on the
 management surfaces.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -136,15 +136,22 @@ Name is **uploads** / **uploads.sh**; the bot and GitHub App are referred to in
 prose as the "`uploads-sh` bot".
 
 Terminal-native, precise, quietly playful. A developer's tool that takes craft
-seriously — mono-first typography, dark by construction, with one genuinely
-distinctive asset: Geist Pixel and its variable ELSH (element-shape) axis, used
-as the brand's signature rather than a wordmark-only garnish. Personality shows
-up in small, exact moments (pixel morphs, the chevron/upload motif), never in
-loudness.
+seriously — dark by construction, with one genuinely distinctive asset: Geist
+Pixel and its variable ELSH (element-shape) axis, used as the brand's signature
+rather than a wordmark-only garnish. Personality shows up in small, exact
+moments (pixel morphs, the chevron/upload motif), never in loudness.
 
-Three faces, defined once in `packages/ui/src/tokens.css`: Geist (sans, body and
-headings), Geist Mono (developer-console chrome — buttons, labels, metadata),
-Geist Pixel (display and brand moments).
+Three faces, defined once in `packages/ui/src/tokens.css`: Geist (sans — the
+interface voice: prose, headings, buttons, labels, navigation), Geist Mono
+(reserved for what it measures — commands, code, file keys, URLs, hashes, and
+tabular figures), Geist Pixel (display and brand moments).
+
+**The mono rule, decided 2026-08-21:** reach for mono when the characters are
+something a reader transcribes or compares column-to-column, never to make a
+word look technical. The terminal character comes from Geist Pixel, the chevron
+motif, and the density — not from setting every label in a typewriter. This
+replaces the earlier "mono-first typography" framing, under which Geist Mono was
+the base face for all product UI.
 
 Voice: purpose-first and concrete. Legal and marketing copy never overpromises —
 no access-control claims about public URLs, no durability or uptime guarantees

--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -273,15 +273,18 @@ const MENU_ITEMS = [
     background: var(--panel, #121214);
     border: 1px solid var(--line, #232327);
   }
-  .auth-indicator__muted {
-    font: 12px var(--mono, ui-monospace, monospace);
+  /* Injected by the client script (see the innerHTML above), so it needs the
+     same :global() escape every other injected class here uses — scoped, it
+     never matched and the text silently inherited the page body size. */
+  .auth-indicator :global(.auth-indicator__muted) {
+    font: var(--text-micro) / 1 var(--sans);
     color: var(--muted, #8a8a83);
   }
   .auth-indicator :global(.auth-indicator__signin) {
     text-decoration: none;
     white-space: nowrap;
     /* ul-btn--sm (9px vertical padding, 1.65 line-height) stands ~9px taller
-       than the sibling .star-cta (12.5px font + 6px padding + normal line
+       than the sibling .star-cta (--text-meta + 6px padding + normal line
        height, SiteHeader.astro) — match its vertical rhythm so the header
        controls read as one row. */
     padding-top: 6px;
@@ -316,7 +319,7 @@ const MENU_ITEMS = [
     background: var(--panel, #121214);
     border: 1px solid var(--line, #232327);
     color: var(--accent, #c27eff);
-    font: 600 11px/1 var(--mono, ui-monospace, monospace);
+    font: var(--weight-semibold) var(--text-micro) / 1 var(--sans);
     letter-spacing: 0.04em;
     user-select: none;
   }
@@ -345,7 +348,7 @@ const MENU_ITEMS = [
   }
   .auth-indicator :global(.auth-menu__email) {
     display: block;
-    font: 12px var(--mono, ui-monospace, monospace);
+    font: var(--text-micro) var(--sans);
     color: var(--muted, #8a8a83);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -372,7 +375,7 @@ const MENU_ITEMS = [
     border-radius: 6px;
     background: transparent;
     color: var(--fg, #ececea);
-    font: 13px var(--sans, system-ui, sans-serif);
+    font: var(--text-meta) var(--sans, system-ui, sans-serif);
     text-decoration: none;
     cursor: pointer;
   }

--- a/apps/web/src/components/CopyAsControls.astro
+++ b/apps/web/src/components/CopyAsControls.astro
@@ -188,7 +188,7 @@ const show = Boolean(downloadUrl) || formats.length > 0;
     border-radius: var(--radius-md);
     background: var(--panel);
     color: var(--fg);
-    font: 12px var(--mono);
+    font: var(--text-micro) var(--sans);
     text-decoration: none;
     margin-top: 0;
   }
@@ -208,7 +208,7 @@ const show = Boolean(downloadUrl) || formats.length > 0;
     color: var(--muted);
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    font: 11px var(--mono);
+    font: var(--text-micro) var(--sans);
     margin-bottom: 5px;
   }
   /* Stacked: format chooser on top, snippet row beneath — keeps every
@@ -241,7 +241,7 @@ const show = Boolean(downloadUrl) || formats.length > 0;
     min-width: 0;
     white-space: pre-wrap;
     overflow-wrap: anywhere;
-    font: 12px/1.5 var(--mono);
+    font: var(--text-micro)/1.5 var(--mono);
     color: var(--body);
     padding: 3px 0;
   }

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -113,7 +113,7 @@ const COLUMNS: FooterColumn[] = [
     margin-top: auto;
     border-top: 1px solid var(--line, #232327);
     color: var(--muted, #7d7d77);
-    font: 12px var(--mono, ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace);
+    font: var(--text-micro) var(--sans);
     letter-spacing: 0.01em;
     line-height: 1.7;
   }
@@ -133,7 +133,7 @@ const COLUMNS: FooterColumn[] = [
   }
   .site-footer.compact {
     margin-top: 26px;
-    font-size: 11.5px;
+    font-size: var(--text-micro);
   }
   .site-footer a {
     color: var(--muted, #7d7d77);
@@ -152,7 +152,7 @@ const COLUMNS: FooterColumn[] = [
     gap: 24px 32px;
   }
   .wordmark {
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     color: var(--fg, #e8e8e3);
   }
   .site-footer a.wordmark {
@@ -167,7 +167,7 @@ const COLUMNS: FooterColumn[] = [
     max-width: 30ch;
   }
   .col-title {
-    font-size: 10.5px;
+    font-size: var(--text-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     margin-bottom: 12px;
@@ -187,7 +187,7 @@ const COLUMNS: FooterColumn[] = [
     border-top: 1px solid var(--line, #232327);
     margin-top: 28px;
     padding: 16px 0 0;
-    font-size: 11.5px;
+    font-size: var(--text-micro);
   }
   .family p {
     margin: 0;

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -32,22 +32,30 @@ type FooterLink = { label: string; href: string };
 type FooterColumn = { title: string; links: FooterLink[] };
 
 // Adding a future link is a one-line edit here — no markup changes needed.
+// Grouped the way a reader scans a footer: what helps you use it, what the
+// project itself is, and the fine print. Sign in lives in the header only —
+// AuthIndicator already renders a primary CTA there when signed out, so a
+// second entry point down here was redundant.
 const COLUMNS: FooterColumn[] = [
   {
-    title: "Product",
+    title: "Resources",
     links: [
       { label: "Docs", href: "/docs" },
-      { label: "Changelog", href: "/changelog" },
-      { label: "GitHub App", href: "/docs/github-app" },
       { label: "Agent guide", href: "/github-screenshots" },
-      { label: "Sign in", href: "/login" },
+      { label: "GitHub App", href: "/docs/github-app" },
+      { label: "Changelog", href: "/changelog" },
     ],
   },
   {
-    title: "Project",
+    title: "Open source",
     links: [
       { label: "GitHub", href: REPO },
       { label: "Status", href: STATUS_URL },
+    ],
+  },
+  {
+    title: "Legal",
+    links: [
       { label: "Terms", href: "/terms" },
       { label: "Privacy", href: "/privacy" },
     ],
@@ -146,9 +154,10 @@ const COLUMNS: FooterColumn[] = [
   }
 
   /* ---- columned (default) variant ---- */
+  /* Brand blurb + one track per link column. */
   .cols {
     display: grid;
-    grid-template-columns: 1.4fr 1fr 1fr;
+    grid-template-columns: 1.4fr repeat(3, 1fr);
     gap: 24px 32px;
   }
   .wordmark {
@@ -191,6 +200,16 @@ const COLUMNS: FooterColumn[] = [
   }
   .family p {
     margin: 0;
+  }
+  /* Four tracks get tight before the stack breakpoint: drop the brand onto its
+     own row first and let the three link columns keep full width. */
+  @media (max-width: 900px) {
+    .cols {
+      grid-template-columns: repeat(3, 1fr);
+    }
+    .brand {
+      grid-column: 1 / -1;
+    }
   }
   @media (max-width: 560px) {
     .cols {

--- a/apps/web/src/components/GalleryReferences.astro
+++ b/apps/web/src/components/GalleryReferences.astro
@@ -191,10 +191,10 @@ const refsClass = isByline ? "refs refs--byline" : isHeaderMulti ? "refs refs--h
   .refs h2 {
     margin: 0 0 10px;
     color: var(--muted);
-    font: 11px var(--mono);
+    font: var(--text-micro) var(--sans);
     letter-spacing: 0.14em;
     text-transform: uppercase;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
 
   .rail-head {
@@ -206,7 +206,7 @@ const refsClass = isByline ? "refs refs--byline" : isHeaderMulti ? "refs refs--h
 
   .rail-label {
     color: var(--muted);
-    font-size: 10.5px;
+    font-size: var(--text-micro);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     white-space: nowrap;
@@ -242,7 +242,7 @@ const refsClass = isByline ? "refs refs--byline" : isHeaderMulti ? "refs refs--h
     row-gap: 2px;
     max-width: 100%;
     color: var(--muted);
-    font: 12.5px / 1.45 var(--mono);
+    font: var(--text-meta) / 1.45 var(--sans);
     text-decoration: none;
   }
 
@@ -288,7 +288,7 @@ const refsClass = isByline ? "refs refs--byline" : isHeaderMulti ? "refs refs--h
     border-radius: var(--radius-md);
     background: var(--panel);
     color: var(--fg);
-    font: 12px var(--mono);
+    font: var(--text-micro) var(--mono);
     text-decoration: none;
     max-width: 100%;
   }
@@ -317,12 +317,12 @@ const refsClass = isByline ? "refs refs--byline" : isHeaderMulti ? "refs refs--h
 
   .gh-chip-title {
     overflow-wrap: anywhere;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
 
   .gh-chip-ref {
     color: var(--muted);
-    font-size: 11px;
+    font-size: var(--text-micro);
     overflow-wrap: anywhere;
   }
 
@@ -332,7 +332,7 @@ const refsClass = isByline ? "refs refs--byline" : isHeaderMulti ? "refs refs--h
 
   .provider {
     color: var(--muted);
-    font: 11px var(--mono);
+    font: var(--text-micro) var(--sans);
     text-transform: lowercase;
   }
 </style>

--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -536,7 +536,7 @@ const counterpartUrl = compare?.src ?? null;
     border-radius: 999px;
     background: transparent;
     color: var(--muted);
-    font: 11px var(--mono);
+    font: var(--text-micro) var(--sans);
     letter-spacing: 0.02em;
     cursor: pointer;
     line-height: 1.2;
@@ -682,7 +682,7 @@ const counterpartUrl = compare?.src ?? null;
     border-radius: 999px;
     background: color-mix(in srgb, var(--panel) 82%, transparent);
     color: var(--muted);
-    font: 10.5px var(--mono);
+    font: var(--text-micro) var(--sans);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     pointer-events: none;
@@ -762,7 +762,7 @@ const counterpartUrl = compare?.src ?? null;
     .size-toggle button,
     .view-toggle button {
       padding: 4px 6px;
-      font-size: 9.5px;
+      font-size: var(--text-micro);
       letter-spacing: 0.01em;
     }
 

--- a/apps/web/src/components/LegalConsent.astro
+++ b/apps/web/src/components/LegalConsent.astro
@@ -37,7 +37,7 @@
   .legal-consent {
     margin: 18px 0 0;
     color: var(--body);
-    font-size: 12px;
+    font-size: var(--text-micro);
     line-height: 1.55;
     text-align: center;
   }

--- a/apps/web/src/components/MediaFallback.astro
+++ b/apps/web/src/components/MediaFallback.astro
@@ -40,7 +40,7 @@ const { title, body, href = null, filename, pending = false, compact = false } =
     padding: 60px 30px;
     text-align: center;
     color: var(--muted);
-    font: 13px/1.6 var(--mono);
+    font: var(--text-meta)/1.6 var(--sans);
     max-width: 28rem;
     line-height: 1.6;
   }
@@ -51,13 +51,13 @@ const { title, body, href = null, filename, pending = false, compact = false } =
     display: block;
     color: var(--fg);
     margin-bottom: 8px;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .media-fallback__body {
     display: block;
     margin: 0 0 12px;
     color: var(--body);
-    font: 0.92rem/1.55 var(--sans);
+    font: var(--text-body)/1.55 var(--sans);
     text-wrap: pretty;
   }
   .media-fallback a {

--- a/apps/web/src/components/MediaStage.astro
+++ b/apps/web/src/components/MediaStage.astro
@@ -163,7 +163,7 @@ const {
     border-radius: 999px;
     background: transparent;
     color: var(--muted);
-    font: 11px var(--mono);
+    font: var(--text-micro) var(--sans);
     letter-spacing: 0.02em;
     cursor: pointer;
     line-height: 1.2;

--- a/apps/web/src/components/ReportAbuse.astro
+++ b/apps/web/src/components/ReportAbuse.astro
@@ -172,7 +172,7 @@ const REASONS = [
     padding: 0;
     margin: 0;
     color: var(--muted);
-    font: 12px var(--mono);
+    font: var(--text-micro) var(--sans);
     text-decoration: underline;
     text-underline-offset: 3px;
     text-decoration-color: color-mix(in srgb, var(--muted) 55%, transparent);
@@ -205,7 +205,7 @@ const REASONS = [
   .report-lead {
     margin: 0;
     color: var(--muted);
-    font: 12px/1.45 var(--mono);
+    font: var(--text-micro)/1.45 var(--sans);
   }
   .field {
     display: flex;
@@ -215,7 +215,7 @@ const REASONS = [
   }
   .field-label {
     color: var(--muted);
-    font: 11px var(--mono);
+    font: var(--text-micro) var(--sans);
     letter-spacing: 0.06em;
     text-transform: uppercase;
   }
@@ -235,7 +235,7 @@ const REASONS = [
     border-radius: var(--radius-md);
     background: var(--panel);
     color: var(--body);
-    font: 12px/1.45 var(--mono);
+    font: var(--text-micro)/1.45 var(--sans);
   }
   .field textarea {
     resize: vertical;
@@ -256,7 +256,7 @@ const REASONS = [
   .report-cancel {
     appearance: none;
     border-radius: var(--radius-md);
-    font: 12px var(--mono);
+    font: var(--text-micro) var(--sans);
     cursor: pointer;
     padding: 8px 12px;
   }
@@ -288,7 +288,7 @@ const REASONS = [
   .report-status,
   .report-done {
     margin: 0;
-    font: 12px/1.4 var(--mono);
+    font: var(--text-micro)/1.4 var(--sans);
     color: var(--muted);
   }
   .report-status[data-tone="error"] {

--- a/apps/web/src/components/SiteHeader.astro
+++ b/apps/web/src/components/SiteHeader.astro
@@ -7,7 +7,11 @@
  *
  * Left: <Brand /> + optional badge.
  * Right (consistent on every surface): Screenshots (signed-in only) · Docs ·
- * Changelog · Star on GitHub · <AuthIndicator /> (Sign in CTA, or avatar menu).
+ * Star on GitHub · <AuthIndicator /> (Sign in CTA, or avatar menu).
+ *
+ * The nav stays this short on purpose. Changelog lives in the footer under
+ * Resources; it is a thing you go read occasionally, not a place you navigate
+ * to mid-task.
  *
  * The nav marks its own current section with aria-current="page", matching the
  * docs sidebar and the account rail — the header was the one nav on the site
@@ -66,11 +70,6 @@ const inSection = (base: string) => path === base || path.startsWith(base + "/")
           class="site-header__link"
           href="/docs"
           aria-current={inSection("/docs") ? "page" : undefined}>Docs</a
-        >
-        <a
-          class="site-header__link"
-          href="/changelog"
-          aria-current={inSection("/changelog") ? "page" : undefined}>Changelog</a
         >
       </nav>
       <a class="star-cta" href={REPO} aria-label="Star buildinternet/uploads on GitHub">

--- a/apps/web/src/components/SiteHeader.astro
+++ b/apps/web/src/components/SiteHeader.astro
@@ -37,9 +37,13 @@ const REPO = "https://github.com/buildinternet/uploads";
 const stars = await githubStarCount();
 
 // Section match, not exact match: /docs/agents should light up "Docs", and
-// /account/workspaces/acme/screenshots should light up "Screenshots". Trailing
-// slashes are normalized so /docs and /docs/ agree.
-const path = Astro.url.pathname.replace(/\/+$/, "") || "/";
+// /account/workspaces/acme/screenshots should light up "Screenshots".
+//
+// Normalize before comparing. Prerendered routes build to files, so at build
+// time this reads "/docs.html" rather than "/docs" — without stripping the
+// extension the section root is the one page that fails to mark itself, while
+// its own children match fine via the startsWith arm.
+const path = Astro.url.pathname.replace(/(?:\/index)?\.html$/, "").replace(/\/+$/, "") || "/";
 const inSection = (base: string) => path === base || path.startsWith(base + "/");
 ---
 

--- a/apps/web/src/components/SiteHeader.astro
+++ b/apps/web/src/components/SiteHeader.astro
@@ -6,8 +6,12 @@
  * page content below keeps its own max-width column.
  *
  * Left: <Brand /> + optional badge.
- * Right (consistent on every surface): Files (signed-in only) · Docs ·
- * Star on GitHub · <AuthIndicator /> (Sign in CTA, or avatar menu).
+ * Right (consistent on every surface): Screenshots (signed-in only) · Docs ·
+ * Changelog · Star on GitHub · <AuthIndicator /> (Sign in CTA, or avatar menu).
+ *
+ * The nav marks its own current section with aria-current="page", matching the
+ * docs sidebar and the account rail — the header was the one nav on the site
+ * that never told you where you were.
  *
  * Centered auth cards (login, device, invite, consent) omit this header.
  */
@@ -27,6 +31,12 @@ const REPO = "https://github.com/buildinternet/uploads";
 // Resolved server-side: no page CSP allows api.github.com in connect-src, so
 // the old client fetch was blocked everywhere. See lib/github-stars.
 const stars = await githubStarCount();
+
+// Section match, not exact match: /docs/agents should light up "Docs", and
+// /account/workspaces/acme/screenshots should light up "Screenshots". Trailing
+// slashes are normalized so /docs and /docs/ agree.
+const path = Astro.url.pathname.replace(/\/+$/, "") || "/";
+const inSection = (base: string) => path === base || path.startsWith(base + "/");
 ---
 
 <header class="site-header">
@@ -45,10 +55,23 @@ const stars = await githubStarCount();
           session cache). The workspaces index auto-opens on screenshots.
         */
         }
-        <a class="site-header__link" data-header-files href="/account/workspaces" hidden
-          >Screenshots</a
+        <a
+          class="site-header__link"
+          data-header-files
+          href="/account/workspaces"
+          aria-current={inSection("/account") ? "page" : undefined}
+          hidden>Screenshots</a
         >
-        <a class="site-header__link" href="/docs">Docs</a>
+        <a
+          class="site-header__link"
+          href="/docs"
+          aria-current={inSection("/docs") ? "page" : undefined}>Docs</a
+        >
+        <a
+          class="site-header__link"
+          href="/changelog"
+          aria-current={inSection("/changelog") ? "page" : undefined}>Changelog</a
+        >
       </nav>
       <a class="star-cta" href={REPO} aria-label="Star buildinternet/uploads on GitHub">
         <svg viewBox="0 0 16 16" aria-hidden="true">
@@ -110,20 +133,49 @@ const stars = await githubStarCount();
     gap: 14px;
   }
   .site-header__link {
+    position: relative;
     color: var(--muted, #7d7d77);
     text-decoration: none;
-    font: 12.5px var(--mono, ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace);
-    letter-spacing: 0.02em;
+    font: var(--weight-medium) var(--text-ui) / 1 var(--sans);
+    letter-spacing: var(--tracking-ui);
+    padding: 4px 0;
+    transition: color 0.15s cubic-bezier(0.22, 1, 0.36, 1);
   }
   .site-header__link:hover,
   .site-header__link:focus-visible {
-    color: var(--accent, #c27eff);
+    color: var(--fg, #e8e8e3);
     outline: none;
+  }
+  .site-header__link:focus-visible {
+    outline: 2px solid var(--accent, #c27eff);
+    outline-offset: 3px;
+    border-radius: 3px;
+  }
+  /* Current section: full-strength text plus a hairline under it. Anchored to
+     the link rather than the header's bottom border, so it survives the
+     tighter padding at the stack breakpoint. */
+  .site-header__link[aria-current="page"] {
+    color: var(--fg, #e8e8e3);
+  }
+  .site-header__link[aria-current="page"]::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -2px;
+    height: 1px;
+    background: var(--accent, #c27eff);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .site-header__link {
+      transition: none;
+    }
   }
   .site-header__badge {
     display: inline-block;
-    font-size: 11px;
-    letter-spacing: 0.08em;
+    font-size: var(--text-micro);
+    font-weight: var(--weight-medium);
+    letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
     color: var(--accent, #c27eff);
     border: 1px solid var(--line, #232327);
@@ -137,7 +189,7 @@ const stars = await githubStarCount();
     gap: 7px;
     color: var(--fg, #e8e8e3);
     text-decoration: none;
-    font: 12.5px var(--mono, ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace);
+    font: var(--weight-medium) var(--text-meta) / 1 var(--sans);
     border: 1px solid var(--line, #232327);
     border-radius: var(--radius-sm, 6px);
     padding: 6px 11px;

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -99,7 +99,7 @@ const fullTitle = `${title} · uploads.sh`;
         min-height: 100dvh;
         background: var(--bg);
         color: var(--fg);
-        font: 15.5px/1.7 var(--sans);
+        font: var(--text-body)/1.7 var(--sans);
         padding: 0;
         display: flex;
         flex-direction: column;
@@ -129,15 +129,15 @@ const fullTitle = `${title} · uploads.sh`;
         max-width: 720px;
       }
       main.docs-main > h1 {
-        font-size: clamp(26px, 5vw, 34px);
-        font-weight: 600;
+        font-size: var(--text-h1);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.015em;
         line-height: 1.25;
         margin: 4px 0 4px;
       }
       main.docs-main > .tagline {
         color: var(--muted);
-        font-size: 14px;
+        font-size: var(--text-ui);
         margin: 0 0 8px;
       }
 
@@ -156,7 +156,7 @@ const fullTitle = `${title} · uploads.sh`;
         margin-bottom: 0;
       }
       .docs-nav-title {
-        font: 11px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.14em;
         text-transform: uppercase;
         color: var(--muted);
@@ -175,7 +175,7 @@ const fullTitle = `${title} · uploads.sh`;
       .docs-side a,
       .docs-nav-m .panel a {
         display: block;
-        font: 13.5px/1.5 var(--sans);
+        font: var(--text-meta)/1.5 var(--sans);
         color: var(--muted);
         text-decoration: none;
         padding: 3px 0;
@@ -190,7 +190,7 @@ const fullTitle = `${title} · uploads.sh`;
       .docs-side a[aria-current="page"],
       .docs-nav-m .panel a[aria-current="page"] {
         color: var(--accent);
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
       }
 
       /* mobile: the left nav collapses to a dropdown (hidden on wider screens) */
@@ -207,7 +207,7 @@ const fullTitle = `${title} · uploads.sh`;
         align-self: flex-start;
       }
       .docs-toc .head {
-        font: 11px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.14em;
         text-transform: uppercase;
         color: var(--muted);
@@ -227,7 +227,7 @@ const fullTitle = `${title} · uploads.sh`;
         border-left: 1px solid transparent;
         margin-left: -1px;
         padding: 3px 0 3px 14px;
-        font: 13px/1.45 var(--sans);
+        font: var(--text-meta)/1.45 var(--sans);
         color: var(--muted);
         text-decoration: none;
       }
@@ -270,7 +270,7 @@ const fullTitle = `${title} · uploads.sh`;
           justify-content: space-between;
           gap: 8px;
           padding: 10px 14px;
-          font: 13.5px var(--sans);
+          font: var(--text-meta) var(--sans);
           color: var(--fg);
           cursor: pointer;
           list-style: none;
@@ -316,8 +316,8 @@ const fullTitle = `${title} · uploads.sh`;
       }
 
       .doc section h2 {
-        font-size: 19px;
-        font-weight: 600;
+        font-size: var(--text-h3);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.01em;
         margin: 40px 0 10px;
         padding-top: 24px;
@@ -329,7 +329,7 @@ const fullTitle = `${title} · uploads.sh`;
         color: color-mix(in srgb, var(--accent) 55%, transparent);
         text-decoration: none;
         margin-left: 8px;
-        font-weight: 400;
+        font-weight: var(--weight-regular);
       }
       .doc section h2 .anchor:hover,
       .doc section h2 .anchor:focus-visible {
@@ -343,13 +343,14 @@ const fullTitle = `${title} · uploads.sh`;
         margin-top: 22px;
       }
       .doc h3 {
-        font: 600 15px/1.4 var(--sans);
+        font: 600 var(--text-body)/1.4 var(--sans);
         margin: 22px 0 6px;
         color: var(--fg);
       }
       .doc p,
       .doc li {
         color: var(--body);
+        max-width: var(--measure);
       }
       .doc strong {
         color: var(--fg);
@@ -360,7 +361,7 @@ const fullTitle = `${title} · uploads.sh`;
         width: 100%;
         border-collapse: collapse;
         margin: 16px 0;
-        font-size: 14px;
+        font-size: var(--text-ui);
       }
       .doc table th,
       .doc table td {
@@ -372,11 +373,11 @@ const fullTitle = `${title} · uploads.sh`;
       .doc table thead th {
         background: var(--panel);
         color: var(--fg);
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
       }
       .doc table tbody th[scope="row"] {
         color: var(--fg);
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
         white-space: nowrap;
       }
 
@@ -386,7 +387,7 @@ const fullTitle = `${title} · uploads.sh`;
       }
       .doc .faq dt {
         color: var(--fg);
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
         margin-top: 18px;
       }
       .doc .faq dd {
@@ -404,7 +405,7 @@ const fullTitle = `${title} · uploads.sh`;
         border: 1px solid var(--line);
         border-radius: 5px;
         padding: 1px 6px;
-        font: 0.88em var(--mono);
+        font: var(--mono-optical) var(--mono);
       }
 
       /* copyable command rows */
@@ -418,7 +419,7 @@ const fullTitle = `${title} · uploads.sh`;
         border-radius: var(--radius-md);
         padding: 10px 12px;
         margin: 12px 0;
-        font: 13px var(--mono);
+        font: var(--text-meta) var(--mono);
       }
       .doc .cmd .text {
         color: var(--fg);
@@ -442,7 +443,7 @@ const fullTitle = `${title} · uploads.sh`;
         color: var(--muted);
       }
       .doc .cmd button {
-        font: 11px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.06em;
         color: var(--accent);
         background: none;
@@ -468,7 +469,7 @@ const fullTitle = `${title} · uploads.sh`;
         border-radius: var(--radius-md);
         padding: 12px 14px;
         margin: 12px 0;
-        font: 12.5px/1.6 var(--mono);
+        font: var(--text-meta)/1.6 var(--mono);
         color: var(--muted);
         overflow-x: auto;
       }
@@ -504,12 +505,12 @@ const fullTitle = `${title} · uploads.sh`;
         outline: none;
       }
       .doc .card h3 {
-        font: 600 14px var(--sans);
+        font: 600 var(--text-ui) var(--sans);
         color: var(--fg);
         margin: 0 0 4px;
       }
       .doc .card p {
-        font-size: 13px;
+        font-size: var(--text-meta);
         color: var(--muted);
         margin: 0;
       }
@@ -530,7 +531,7 @@ const fullTitle = `${title} · uploads.sh`;
         margin: 40px 0 0;
         padding-top: 20px;
         border-top: 1px solid var(--line);
-        font: 13px var(--sans);
+        font: var(--text-meta) var(--sans);
       }
       .doc .page-nav a {
         color: var(--body);
@@ -546,7 +547,7 @@ const fullTitle = `${title} · uploads.sh`;
       }
       .doc .page-nav .dir {
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.08em;
         text-transform: uppercase;
         display: block;
@@ -558,7 +559,7 @@ const fullTitle = `${title} · uploads.sh`;
         grid-template-columns: 40px 1fr;
         gap: 12px;
         margin: 18px 0;
-        font: 13px/1.5 var(--sans);
+        font: var(--text-meta)/1.5 var(--sans);
       }
       .doc .ghc .avatar {
         width: 40px;
@@ -604,10 +605,10 @@ const fullTitle = `${title} · uploads.sh`;
       }
       .doc .ghc .head .user {
         color: #e6edf3;
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
       }
       .doc .ghc .head .bot-chip {
-        font: 10px var(--sans);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.02em;
         color: #8b949e;
         border: 1px solid #30363d;
@@ -616,7 +617,7 @@ const fullTitle = `${title} · uploads.sh`;
         background: transparent;
       }
       .doc .ghc .head .badge {
-        font: 11px var(--mono);
+        font: var(--text-micro) var(--sans);
         color: #8b949e;
         border: 1px solid #30363d;
         border-radius: 999px;
@@ -628,7 +629,7 @@ const fullTitle = `${title} · uploads.sh`;
       }
       .doc .ghc .md-title {
         color: #e6edf3;
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
         margin: 0 0 10px;
       }
       .doc .ghc .imgs {
@@ -658,7 +659,7 @@ const fullTitle = `${title} · uploads.sh`;
         height: 42px;
       }
       .doc .ghc figcaption {
-        font: 11px var(--mono);
+        font: var(--text-micro) var(--sans);
         color: #8b949e;
         margin-top: 6px;
         display: flex;
@@ -692,7 +693,7 @@ const fullTitle = `${title} · uploads.sh`;
         border: 1px solid color-mix(in srgb, var(--green) 35%, transparent);
         border-radius: 8px;
         background: color-mix(in srgb, var(--green) 8%, transparent);
-        font-size: 14px;
+        font-size: var(--text-ui);
         line-height: 1.6;
       }
       .doc .installed strong {
@@ -705,7 +706,7 @@ const fullTitle = `${title} · uploads.sh`;
         border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
         border-radius: 8px;
         background: color-mix(in srgb, var(--accent) 6%, transparent);
-        font-size: 14px;
+        font-size: var(--text-ui);
         line-height: 1.6;
       }
       .doc .callout strong {
@@ -714,7 +715,7 @@ const fullTitle = `${title} · uploads.sh`;
       .doc .note {
         margin: 20px 0 0;
         color: var(--muted);
-        font-size: 13.5px;
+        font-size: var(--text-meta);
       }
       .doc .note a {
         color: var(--muted);

--- a/apps/web/src/layouts/ErrorLayout.astro
+++ b/apps/web/src/layouts/ErrorLayout.astro
@@ -37,7 +37,8 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         min-height: 100dvh;
         background: var(--bg);
         color: var(--fg);
-        font: 14.5px/1.65 var(--mono);
+        font: var(--text-body) / var(--leading-body) var(--sans);
+        letter-spacing: var(--tracking-body);
         display: flex;
         flex-direction: column;
       }
@@ -66,7 +67,7 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         color: var(--muted);
         font-family: var(--pixel);
         font-variation-settings: "ELSH" var(--pixel-shape, 1);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.05em;
       }
       .body {
@@ -74,23 +75,24 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
       }
       .status {
         margin: 0 0 6px;
-        font: 600 clamp(2.2rem, 8vw, 2.8rem)/1.1 var(--sans);
+        font: var(--weight-semibold) var(--text-display) / var(--leading-display) var(--sans);
+        letter-spacing: var(--tracking-display);
         letter-spacing: -0.015em;
         color: var(--accent);
       }
       h1 {
         margin: 0 0 12px;
-        font: 600 1rem/1.4 var(--sans);
+        font: 600 var(--text-body)/1.4 var(--sans);
         color: var(--fg);
       }
       p {
         margin: 0;
         color: var(--body);
-        font: 0.92rem/1.6 var(--sans);
+        font: var(--text-body)/1.6 var(--sans);
       }
       .hint {
         margin-top: 10px;
-        font-size: 0.85rem;
+        font-size: var(--text-ui);
         color: var(--muted);
       }
       .actions {
@@ -98,7 +100,7 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
       }
       .home {
         display: inline-block;
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
         color: var(--muted);
         background: var(--bg);
         border: 1px solid var(--line);

--- a/apps/web/src/layouts/LegalLayout.astro
+++ b/apps/web/src/layouts/LegalLayout.astro
@@ -32,7 +32,7 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         min-height: 100dvh;
         background: var(--bg);
         color: var(--fg);
-        font: 15.5px/1.7 var(--sans);
+        font: var(--text-body)/1.7 var(--sans);
         display: flex;
         flex-direction: column;
       }
@@ -44,34 +44,35 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         box-sizing: border-box;
       }
       h1 {
-        font-size: clamp(26px, 5vw, 34px);
-        font-weight: 600;
+        font-size: var(--text-h1);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.015em;
         line-height: 1.25;
         margin: 8px 0 4px;
       }
       .effective {
         color: var(--muted);
-        font-size: 13px;
+        font-size: var(--text-meta);
         margin: 0 0 36px;
       }
       article h2 {
-        font-size: 19px;
-        font-weight: 600;
+        font-size: var(--text-h3);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.01em;
         margin: 40px 0 10px;
         padding-top: 22px;
         border-top: 1px solid var(--line);
       }
       article h3 {
-        font-size: 15px;
-        font-weight: 600;
+        font-size: var(--text-body);
+        font-weight: var(--weight-semibold);
         color: var(--fg);
         margin: 24px 0 6px;
       }
       article p,
       article li {
         color: var(--body);
+        max-width: var(--measure);
       }
       article strong {
         color: var(--fg);
@@ -98,7 +99,7 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         border: 1px solid var(--line);
         border-radius: 5px;
         padding: 1px 6px;
-        font: 0.88em var(--mono);
+        font: var(--mono-optical) var(--mono);
         font-variant-ligatures: none;
         font-feature-settings:
           "calt" 0,

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -166,7 +166,7 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
     border: 0;
     color: var(--muted);
     font: inherit;
-    font-size: 11.5px;
+    font-size: var(--text-micro);
     cursor: pointer;
   }
   :global(.account-shell) .ws-rail :global(.ws-rail__more:hover),
@@ -201,8 +201,8 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
   }
   :global(.account-shell) .ws-rail :global(.ws-rail__connected-meta a) {
     color: var(--fg);
-    font-weight: 600;
-    font-size: 12.5px;
+    font-weight: var(--weight-semibold);
+    font-size: var(--text-meta);
     text-decoration: none;
   }
   :global(.account-shell) .ws-rail :global(.ws-rail__connected-meta a:hover),
@@ -234,18 +234,18 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
   .ws-rail__tip-body {
     margin: 0;
     color: var(--muted);
-    font-size: 12.5px;
+    font-size: var(--text-meta);
     line-height: 1.55;
     text-wrap: pretty;
   }
   .ws-rail__tip-body :global(code) {
-    font-size: 11.5px;
+    font-size: var(--text-micro);
   }
   .ws-rail__tip-link {
     display: inline-block;
     margin-top: 6px;
     color: var(--fg);
-    font-size: 12px;
+    font-size: var(--text-micro);
     text-decoration: none;
   }
   .ws-rail__tip-link:hover,
@@ -272,7 +272,7 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
     border-radius: 4px;
     color: var(--fg);
     text-decoration: none;
-    font-size: 12px;
+    font-size: var(--text-micro);
   }
   /* The class sets `display`, which outranks the UA `[hidden]` rule — without
      this, the rail's install-status suppression would have no visible effect. */
@@ -295,7 +295,7 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
   .ws-rail__invite {
     color: var(--muted);
     text-decoration: none;
-    font-size: 12px;
+    font-size: var(--text-micro);
   }
   .ws-rail__invite:hover,
   .ws-rail__invite:focus-visible {

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -32,7 +32,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         padding: 28px;
         background: var(--bg);
         color: var(--fg);
-        font: 14.5px/1.65 var(--mono);
+        font: var(--text-body) / var(--leading-body) var(--sans);
+        letter-spacing: var(--tracking-body);
       }
       main {
         width: min(var(--width-card, 480px), 100%);
@@ -48,8 +49,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       }
       h1 {
         margin: 0 0 8px;
-        font-size: clamp(21px, 5vw, 26px);
-        font-weight: 600;
+        font-size: var(--text-h2);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.015em;
         line-height: 1.25;
       }
@@ -66,7 +67,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         align-items: center;
         justify-content: center;
         gap: 10px;
-        font: 14px var(--mono);
+        font: var(--text-ui) var(--sans);
         letter-spacing: 0.02em;
         color: var(--fg);
         background: var(--bg);
@@ -86,7 +87,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         gap: 12px;
         margin: 22px 0;
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.08em;
         text-transform: uppercase;
       }
@@ -105,7 +106,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         display: grid;
         gap: 6px;
         color: var(--muted);
-        font-size: 10.5px;
+        font-size: var(--text-micro);
         letter-spacing: 0.1em;
         text-transform: uppercase;
       }
@@ -115,7 +116,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         border-radius: var(--radius-md);
         color: var(--fg);
         padding: 10px 12px;
-        font: 14px var(--mono);
+        font: var(--text-ui) var(--sans);
       }
       input:focus-visible {
         border-color: var(--accent);
@@ -123,7 +124,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       }
       button[type="submit"],
       button#accept-btn {
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.04em;
         color: var(--accent);
         background: var(--bg);

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -112,7 +112,7 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
     .account-rail-tip {
       margin: 0;
       color: var(--muted);
-      font-size: 12.5px;
+      font-size: var(--text-meta);
       line-height: 1.55;
       text-wrap: pretty;
     }

--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -287,7 +287,7 @@ const tip = {
     /* ---------- Comment settings rows ---------- */
     .cs-repo-banner {
       margin: 0 0 16px;
-      font-size: 12.5px;
+      font-size: var(--text-meta);
     }
 
     /* Install-App prompt: shown only when the workspace has no GitHub App
@@ -307,7 +307,7 @@ const tip = {
     .cs-install__body {
       margin: 0;
       max-width: 44ch;
-      font: 12.5px/1.55 var(--sans);
+      font: var(--text-meta)/1.55 var(--sans);
       color: var(--body);
       text-wrap: pretty;
     }
@@ -318,7 +318,7 @@ const tip = {
       border-radius: var(--radius-sm);
       background: var(--bg);
       color: var(--fg);
-      font: 600 12.5px var(--sans);
+      font: 600 var(--text-meta) var(--sans);
       text-decoration: none;
       white-space: nowrap;
     }
@@ -400,12 +400,12 @@ const tip = {
       flex-wrap: wrap;
     }
     .cs-row__label {
-      font: 600 13px var(--sans);
+      font: 600 var(--text-meta) var(--sans);
       color: var(--fg);
     }
     .cs-row__desc {
       margin: 4px 0 0;
-      font-size: 12.5px;
+      font-size: var(--text-meta);
       line-height: 1.55;
       color: var(--muted);
       max-width: 44ch;
@@ -439,14 +439,14 @@ const tip = {
     .cs-row__note-count {
       margin-left: auto;
       color: var(--muted);
-      font-size: 11px;
+      font-size: var(--text-micro);
     }
     .cs-row--note textarea {
       margin-top: 8px;
       width: 100%;
       box-sizing: border-box;
       resize: vertical;
-      font-size: 13px;
+      font-size: var(--text-meta);
       line-height: 1.5;
     }
 
@@ -458,7 +458,7 @@ const tip = {
       overflow: hidden;
     }
     .cs-seg__btn {
-      font: 12.5px var(--sans);
+      font: var(--text-meta) var(--sans);
       padding: 7px 13px;
       background: transparent;
       color: var(--muted);
@@ -514,7 +514,7 @@ const tip = {
       box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
     }
     .cs-savebar__msg {
-      font: 13px var(--sans);
+      font: var(--text-meta) var(--sans);
       color: var(--fg);
     }
     .cs-savebar__msg[data-state="ok"] {
@@ -528,7 +528,7 @@ const tip = {
       border: 0;
       background: none;
       color: var(--muted);
-      font: 12.5px var(--sans);
+      font: var(--text-meta) var(--sans);
       cursor: pointer;
     }
     .cs-savebar__reset:hover,
@@ -559,7 +559,7 @@ const tip = {
       background: var(--panel);
       border: 1px solid var(--line);
       border-radius: 7px;
-      font: 12.5px var(--mono);
+      font: var(--text-meta) var(--mono);
     }
     .cs-preview-footnote {
       margin-top: 10px;
@@ -598,14 +598,14 @@ const tip = {
       border-bottom: 1px solid var(--line);
       padding: 8px 14px;
       color: var(--muted);
-      font-size: 13px;
+      font-size: var(--text-meta);
     }
     .cs-ghc-user {
       color: var(--fg);
-      font-weight: 600;
+      font-weight: var(--weight-semibold);
     }
     .cs-ghc-bot-chip {
-      font-size: 10px;
+      font-size: var(--text-micro);
       letter-spacing: 0.02em;
       color: var(--muted);
       border: 1px solid var(--line);
@@ -615,7 +615,7 @@ const tip = {
 
     .cs-preview-body {
       padding: 14px 16px;
-      font-size: 13px;
+      font-size: var(--text-meta);
       line-height: 1.6;
       overflow-x: auto;
     }

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -271,11 +271,11 @@ if (!workspace) return Astro.redirect("/account/workspaces");
     .storage-summary__num {
       flex: none;
       color: var(--accent);
-      font-size: 12px;
+      font-size: var(--text-micro);
     }
     .storage-summary__body {
       min-width: 0;
-      font-size: 13px;
+      font-size: var(--text-meta);
     }
     .storage-summary__title {
       color: var(--fg);
@@ -283,7 +283,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
     .storage-summary__sub {
       margin-top: 2px;
       color: var(--muted);
-      font-size: 12px;
+      font-size: var(--text-micro);
     }
 
     .storage-instructions {
@@ -292,7 +292,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       display: flex;
       flex-direction: column;
       gap: 10px;
-      font-size: 13px;
+      font-size: var(--text-meta);
       line-height: 1.6;
       color: var(--muted);
     }
@@ -327,7 +327,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       gap: 8px;
     }
     .storage-check-hint {
-      font-size: 12px;
+      font-size: var(--text-micro);
       color: var(--muted);
     }
   </style>

--- a/apps/web/src/pages/account/workspaces/new.astro
+++ b/apps/web/src/pages/account/workspaces/new.astro
@@ -89,7 +89,7 @@ export const prerender = false;
       align-items: center;
       gap: 8px;
       margin-top: 10px;
-      font-size: 13px;
+      font-size: var(--text-meta);
     }
     .storage-byo-option input {
       margin: 0;

--- a/apps/web/src/pages/admin/oauth.astro
+++ b/apps/web/src/pages/admin/oauth.astro
@@ -77,7 +77,7 @@ export const prerender = false;
     </form>
     <div id="oauth-create-status" class="admin-status" role="status" hidden></div>
     <div id="oauth-create-result" hidden>
-      <p class="muted" style="margin:0;font-size:13px">New client ID (copy it now):</p>
+      <p class="muted" style="margin:0;font-size:var(--text-meta)">New client ID (copy it now):</p>
       <div class="oauth-copy-row">
         <input type="text" id="oauth-create-client-id" readonly aria-label="New client ID" />
         <button type="button" class="admin-btn" id="oauth-create-copy">Copy</button>

--- a/apps/web/src/pages/admin/oauth/[clientId].astro
+++ b/apps/web/src/pages/admin/oauth/[clientId].astro
@@ -59,7 +59,7 @@ if (!clientId) return Astro.redirect("/admin/oauth");
         <button type="button" class="admin-btn" id="oauth-disable-toggle"></button>
         <button type="button" class="admin-btn admin-btn--danger" id="oauth-delete">Delete</button>
       </div>
-      <p id="oauth-delete-hint" class="muted" style="font-size:12px;margin:0" hidden>
+      <p id="oauth-delete-hint" class="muted" style="font-size:var(--text-micro);margin:0" hidden>
         Remove the official flag to enable deletion.
       </p>
       <div id="oauth-action-status" class="admin-status" role="status" hidden></div>

--- a/apps/web/src/pages/changelog.astro
+++ b/apps/web/src/pages/changelog.astro
@@ -61,7 +61,7 @@ const formatDate = (iso: string) =>
         min-height: 100dvh;
         background: var(--bg);
         color: var(--fg);
-        font: 15.5px/1.7 var(--sans);
+        font: var(--text-body)/1.7 var(--sans);
         display: flex;
         flex-direction: column;
       }
@@ -72,20 +72,20 @@ const formatDate = (iso: string) =>
         flex: 1;
       }
       h1 {
-        font-size: clamp(26px, 5vw, 34px);
-        font-weight: 600;
+        font-size: var(--text-h1);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.015em;
         line-height: 1.25;
         margin: 8px 0 4px;
       }
       .lede {
         color: var(--muted);
-        font-size: 14px;
+        font-size: var(--text-ui);
         margin: 0 0 12px;
       }
       .feed-link {
         color: var(--muted);
-        font-size: 13px;
+        font-size: var(--text-meta);
         text-decoration: underline;
         text-underline-offset: 3px;
       }
@@ -97,14 +97,14 @@ const formatDate = (iso: string) =>
       .entry time {
         display: block;
         color: var(--muted);
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--mono);
         letter-spacing: 0.02em;
         text-transform: uppercase;
         margin-bottom: 6px;
       }
       .entry h2 {
-        font-size: 20px;
-        font-weight: 600;
+        font-size: var(--text-h3);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.01em;
         margin: 0 0 12px;
       }
@@ -117,7 +117,7 @@ const formatDate = (iso: string) =>
         text-underline-offset: 3px;
       }
       .entry--cli h2 {
-        font-size: 16px;
+        font-size: var(--text-body);
         color: var(--body);
       }
       .entry--cli .body {
@@ -139,7 +139,7 @@ const formatDate = (iso: string) =>
         border-radius: 8px;
       }
       .body :global(h3) {
-        font-size: 13px;
+        font-size: var(--text-meta);
         text-transform: uppercase;
         letter-spacing: 0.04em;
         color: var(--muted);
@@ -156,7 +156,7 @@ const formatDate = (iso: string) =>
         border: 1px solid var(--line);
         border-radius: 5px;
         padding: 1px 6px;
-        font: 0.88em var(--mono);
+        font: var(--mono-optical) var(--mono);
         font-variant-ligatures: none;
       }
       .body :global(pre) {

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -40,7 +40,8 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         min-height: 100dvh;
         background: var(--bg);
         color: var(--fg);
-        font: 14px/1.5 var(--mono);
+        font: var(--text-ui) / var(--leading-ui) var(--sans);
+        letter-spacing: var(--tracking-ui);
         font-variant-ligatures: none;
         font-feature-settings:
           "calt" 0,
@@ -59,20 +60,20 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         box-sizing: border-box;
       }
       h1 {
-        font-size: 1.15rem;
-        font-weight: 600;
+        font-size: var(--text-h3);
+        font-weight: var(--weight-semibold);
         margin: 0;
       }
       p.muted {
         color: var(--muted);
         margin: 0;
-        font-size: 0.9rem;
+        font-size: var(--text-ui);
       }
       label {
         display: grid;
         gap: 6px;
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.1em;
         text-transform: uppercase;
       }
@@ -82,7 +83,7 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         border-radius: var(--radius-md);
         color: var(--fg);
         padding: 10px 12px;
-        font: 14px var(--mono);
+        font: var(--text-ui) var(--sans);
       }
       input:focus-visible {
         border-color: var(--accent);
@@ -94,7 +95,7 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         gap: 10px;
       }
       button {
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.04em;
         color: var(--accent);
         background: var(--panel);
@@ -119,7 +120,7 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         white-space: pre-wrap;
         word-break: break-word;
         color: var(--body);
-        font-size: 12px;
+        font-size: var(--text-micro);
       }
       a {
         color: var(--fg);
@@ -144,7 +145,7 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
       }
       .sect-head {
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.14em;
         text-transform: uppercase;
         margin: 0;
@@ -176,7 +177,7 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         gap: 9px;
       }
       .pill {
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.08em;
         text-transform: uppercase;
         color: var(--accent);
@@ -186,10 +187,10 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         background: var(--bg);
       }
       .session-bar a {
-        font-size: 12px;
+        font-size: var(--text-micro);
       }
       .session-bar button {
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
         color: var(--accent);
         background: var(--panel);
         border: 1px solid var(--line);

--- a/apps/web/src/pages/device.astro
+++ b/apps/web/src/pages/device.astro
@@ -37,7 +37,8 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
         padding: 28px;
         background: var(--bg);
         color: var(--fg);
-        font: 14.5px/1.65 var(--mono);
+        font: var(--text-body) / var(--leading-body) var(--sans);
+        letter-spacing: var(--tracking-body);
       }
       main {
         width: min(var(--width-card, 480px), 100%);
@@ -53,8 +54,8 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
       }
       h1 {
         margin: 0 0 8px;
-        font-size: clamp(21px, 5vw, 26px);
-        font-weight: 600;
+        font-size: var(--text-h2);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.015em;
         line-height: 1.25;
       }
@@ -66,9 +67,9 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
         margin: 16px 0;
       }
       .code {
-        font-size: clamp(24px, 7vw, 32px);
+        font-size: var(--text-h1);
         letter-spacing: 0.28em;
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
         color: var(--fg);
         text-align: center;
         padding: 16px 10px;
@@ -83,7 +84,7 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
         align-items: center;
         justify-content: center;
         gap: 10px;
-        font: 14px var(--mono);
+        font: var(--text-ui) var(--sans);
         letter-spacing: 0.02em;
         color: var(--fg);
         background: var(--bg);
@@ -103,7 +104,7 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
         gap: 12px;
         margin: 22px 0;
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.08em;
         text-transform: uppercase;
       }
@@ -122,7 +123,7 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
         display: grid;
         gap: 6px;
         color: var(--muted);
-        font-size: 10.5px;
+        font-size: var(--text-micro);
         letter-spacing: 0.1em;
         text-transform: uppercase;
       }
@@ -132,7 +133,7 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
         border-radius: var(--radius-md);
         color: var(--fg);
         padding: 10px 12px;
-        font: 14px var(--mono);
+        font: var(--text-ui) var(--sans);
       }
       input:focus-visible {
         border-color: var(--accent);
@@ -148,13 +149,13 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
       .ws label {
         display: block;
         color: var(--muted);
-        font-size: 10.5px;
+        font-size: var(--text-micro);
         letter-spacing: 0.1em;
         text-transform: uppercase;
         margin-bottom: 6px;
       }
       .ws .fixed {
-        font: 14px var(--mono);
+        font: var(--text-ui) var(--mono);
         color: var(--fg);
         background: var(--bg);
         border: 1px solid var(--line);
@@ -163,7 +164,7 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
       }
       .ws .note {
         color: var(--muted);
-        font-size: 12px;
+        font-size: var(--text-micro);
         margin: 6px 0 0;
       }
       .ws-new {
@@ -182,7 +183,7 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
       button.secondary,
       button[type="submit"] {
         flex: 1;
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.04em;
         color: var(--accent);
         background: var(--bg);

--- a/apps/web/src/pages/docs/reference.astro
+++ b/apps/web/src/pages/docs/reference.astro
@@ -161,7 +161,7 @@ const REPO = "https://github.com/buildinternet/uploads";
       border-radius: var(--radius-md);
     }
     .shots figcaption {
-      font: 12px var(--mono);
+      font: var(--text-micro) var(--sans);
       color: var(--muted);
       margin-top: 8px;
     }

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -181,12 +181,12 @@ const ogImage = file
         align-items: center;
         justify-content: space-between;
         margin-bottom: 32px;
-        font: 13px var(--mono);
+        font: var(--text-meta) var(--mono);
         letter-spacing: 0.02em;
       }
       .public {
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.1em;
         text-transform: uppercase;
         border: 1px solid var(--line);
@@ -230,7 +230,7 @@ const ogImage = file
       .filetitle {
         margin: 0;
         color: var(--fg);
-        font: 600 17px var(--mono);
+        font: 600 var(--text-h3) var(--mono);
         letter-spacing: -0.01em;
         overflow-wrap: anywhere;
       }
@@ -244,7 +244,7 @@ const ogImage = file
         margin-top: 6px;
         max-width: 100%;
         color: var(--muted);
-        font: 12.5px/1.45 var(--mono);
+        font: var(--text-meta)/1.45 var(--sans);
         text-decoration: none;
       }
       .gh-byline:hover,
@@ -288,7 +288,7 @@ const ogImage = file
       }
       .rail-label {
         color: var(--muted);
-        font-size: 10.5px;
+        font-size: var(--text-micro);
         letter-spacing: 0.14em;
         text-transform: uppercase;
         white-space: nowrap;
@@ -303,13 +303,13 @@ const ogImage = file
         grid-template-columns: auto 1fr;
         gap: 6px 16px;
         margin: 0;
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--mono);
       }
       dl.meta dt {
         color: var(--muted);
         text-transform: uppercase;
         letter-spacing: 0.08em;
-        font-size: 11px;
+        font-size: var(--text-micro);
       }
       dl.meta dd {
         margin: 0;
@@ -321,7 +321,7 @@ const ogImage = file
       .footnote {
         margin: auto 0 0;
         color: var(--muted);
-        font: 11.5px/1.5 var(--mono);
+        font: var(--text-micro)/1.5 var(--sans);
       }
       /* Before/after counterpart (issue #420) — rail rows; the stage itself
          carries the comparison via ImagePreview's Compare mode. */
@@ -332,7 +332,7 @@ const ogImage = file
         display: flex;
         flex-direction: column;
         gap: 6px;
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--mono);
       }
       .pairrow {
         display: flex;
@@ -358,7 +358,7 @@ const ogImage = file
         color: var(--muted);
         text-transform: none;
         letter-spacing: normal;
-        font-size: 11.5px;
+        font-size: var(--text-micro);
       }
       .error {
         padding: 70px 24px;
@@ -380,7 +380,7 @@ const ogImage = file
         border-radius: var(--radius-md);
         background: var(--bg);
         color: var(--fg);
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
         text-decoration: none;
       }
       .error .signin:hover,
@@ -393,7 +393,7 @@ const ogImage = file
         display: block;
         margin-top: 14px;
         color: var(--muted);
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
       }
       a {
         color: var(--fg);
@@ -414,7 +414,7 @@ const ogImage = file
       }
       .danger-zone {
         position: relative;
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
       }
       .delete-link {
         appearance: none;
@@ -447,14 +447,14 @@ const ogImage = file
       .delete-pop__text {
         margin: 0 0 10px;
         color: var(--body);
-        font-size: 12px;
+        font-size: var(--text-micro);
         line-height: 1.5;
         overflow-wrap: anywhere;
       }
       .delete-pop__gh,
       .delete-pop__error {
         color: var(--muted);
-        font-size: 11.5px;
+        font-size: var(--text-micro);
       }
       .delete-pop__error {
         color: var(--red);
@@ -468,7 +468,7 @@ const ogImage = file
         border-radius: var(--radius-md);
         background: var(--bg);
         color: var(--red);
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
         cursor: pointer;
       }
       .delete-pop__btn[data-armed] {

--- a/apps/web/src/pages/g/[id].astro
+++ b/apps/web/src/pages/g/[id].astro
@@ -89,12 +89,12 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
         align-items: center;
         justify-content: space-between;
         margin-bottom: 40px;
-        font: 13px var(--mono);
+        font: var(--text-meta) var(--sans);
         letter-spacing: 0.02em;
       }
       .public {
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.1em;
         text-transform: uppercase;
         border: 1px solid var(--line);
@@ -108,14 +108,14 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
       }
       .eyebrow {
         color: var(--muted);
-        font: 11px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.14em;
         text-transform: uppercase;
       }
       h1 {
         margin: 10px 0 12px;
-        font-size: clamp(1.7rem, 4vw, 2.4rem);
-        font-weight: 600;
+        font-size: var(--text-h1);
+        font-weight: var(--weight-semibold);
         line-height: 1.2;
         letter-spacing: -0.015em;
         overflow-wrap: anywhere;
@@ -123,7 +123,7 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
       .desc {
         max-width: 640px;
         color: var(--body);
-        font-size: 15px;
+        font-size: var(--text-body);
         line-height: 1.65;
         white-space: pre-wrap;
       }
@@ -133,12 +133,12 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
         flex-wrap: wrap;
         margin-top: 18px;
         color: var(--muted);
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
       }
       .notice {
         margin: 22px 2px;
         color: var(--muted);
-        font: 13.5px/1.6 var(--sans);
+        font: var(--text-meta)/1.6 var(--sans);
       }
       .grid {
         display: grid;
@@ -179,7 +179,7 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
       }
       .filename {
         color: var(--fg);
-        font: 600 13px var(--mono);
+        font: var(--weight-semibold) var(--text-meta) / 1 var(--mono);
         overflow-wrap: anywhere;
       }
       .original {
@@ -187,7 +187,7 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
         margin-top: 10px;
         margin-right: 14px;
         color: var(--muted);
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
       }
       .media-link {
         display: contents;
@@ -200,7 +200,7 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
       .caption {
         margin-top: 8px;
         color: var(--body);
-        font-size: 14px;
+        font-size: var(--text-ui);
         line-height: 1.5;
         white-space: pre-wrap;
       }

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -146,12 +146,12 @@ const footnoteLine = footnoteParts.join(" · ");
         align-items: center;
         justify-content: space-between;
         margin-bottom: 32px;
-        font: 13px var(--mono);
+        font: var(--text-meta) var(--mono);
         letter-spacing: 0.02em;
       }
       .public {
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.1em;
         text-transform: uppercase;
         border: 1px solid var(--line);
@@ -191,7 +191,7 @@ const footnoteLine = footnoteParts.join(" · ");
       .crumbs {
         margin-bottom: 12px;
         color: var(--muted);
-        font: 13px var(--mono);
+        font: var(--text-meta) var(--mono);
         overflow-wrap: anywhere;
       }
       .crumbs .count {
@@ -204,7 +204,7 @@ const footnoteLine = footnoteParts.join(" · ");
       .filetitle {
         margin: 0;
         color: var(--fg);
-        font: 600 17px var(--mono);
+        font: 600 var(--text-h3) var(--mono);
         letter-spacing: -0.01em;
         overflow-wrap: anywhere;
       }
@@ -212,7 +212,7 @@ const footnoteLine = footnoteParts.join(" · ");
       .caption {
         margin: 0;
         color: var(--body);
-        font-size: 15px;
+        font-size: var(--text-body);
         line-height: 1.6;
         white-space: pre-wrap;
       }
@@ -221,7 +221,7 @@ const footnoteLine = footnoteParts.join(" · ");
       .footnote {
         margin: auto 0 0;
         color: var(--muted);
-        font: 11.5px/1.5 var(--mono);
+        font: var(--text-micro)/1.5 var(--sans);
       }
       .pager {
         display: flex;
@@ -229,7 +229,7 @@ const footnoteLine = footnoteParts.join(" · ");
         justify-content: space-between;
         gap: 12px;
         margin: 22px 0 0;
-        font: 13px var(--mono);
+        font: var(--text-meta) var(--sans);
       }
       .pager a,
       .pager span.disabled {

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -89,7 +89,8 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         min-height: 100dvh;
         background: var(--bg);
         color: var(--fg);
-        font: 14.5px/1.65 var(--mono);
+        font: var(--text-body) / var(--leading-body) var(--sans);
+        letter-spacing: var(--tracking-body);
         display: flex;
         flex-direction: column;
         padding: 0;
@@ -115,8 +116,8 @@ Source (and where to look if something breaks): https://github.com/buildinternet
 
       /* ---------- headline ---------- */
       h1 {
-        font: 600 clamp(24px, 5vw, 32px)/1.25 var(--sans);
-        letter-spacing: -0.015em;
+        font: var(--weight-semibold) var(--text-h1) / var(--leading-heading) var(--sans);
+        letter-spacing: var(--tracking-heading);
         margin: 6px 0 0;
         text-wrap: balance;
       }
@@ -124,17 +125,17 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         white-space: nowrap;
       }
       .byline {
-        font: 500 16px/1.4 var(--sans);
+        font: 500 var(--text-body)/1.4 var(--sans);
         color: var(--fg);
         margin: 0;
       }
       .lede {
-        font: 15px/1.65 var(--sans);
+        font: var(--text-body)/1.65 var(--sans);
         color: var(--body);
         margin: 0 0 8px;
       }
       .lede code {
-        font: 0.9em var(--mono);
+        font: var(--mono-optical) var(--mono);
         background: var(--panel);
         border: 1px solid var(--line);
         border-radius: 5px;
@@ -150,7 +151,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       }
       .screen {
         padding: 20px 20px 24px;
-        font-size: 13px;
+        font-size: var(--text-meta);
       }
       .line {
         white-space: pre-wrap;
@@ -180,7 +181,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
 
       /* ---------- connector ---------- */
       .flow-note {
-        font-size: 12px;
+        font-size: var(--text-micro);
         color: var(--muted);
         padding-left: 20px;
         margin: -6px 0;
@@ -190,7 +191,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       }
       /* Sits under the comment wireframe, indented to the bubble column. */
       .ghc-note {
-        font-size: 12px;
+        font-size: var(--text-micro);
         color: var(--muted);
         margin: -6px 0 0;
         padding-left: 52px; /* avatar 40 + gap 12 */
@@ -201,7 +202,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         display: grid;
         grid-template-columns: 40px 1fr;
         gap: 12px;
-        font: 13px/1.5 var(--sans);
+        font: var(--text-meta)/1.5 var(--sans);
       }
       .ghc .avatar {
         width: 40px;
@@ -247,10 +248,10 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       }
       .ghc .head .user {
         color: #e6edf3;
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
       }
       .ghc .head .bot-chip {
-        font: 10px var(--sans);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.02em;
         color: #8b949e;
         border: 1px solid #30363d;
@@ -263,7 +264,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       }
       .ghc .md-title {
         color: #e6edf3;
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
         margin: 0 0 10px;
       }
       .ghc .imgs {
@@ -286,7 +287,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         background: #1c2128;
       }
       .ghc figcaption {
-        font: 11px var(--mono);
+        font: var(--text-micro) var(--sans);
         color: #8b949e;
         margin-top: 6px;
         display: flex;
@@ -312,20 +313,28 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       }
 
       /* ---------- section headers ---------- */
+      /* These are real <h2>s. Set as 12px uppercase muted they were the
+         faintest, smallest text inside their own section — below the lede they
+         introduced. They now read at heading rank; the shell-comment `#` stays
+         and carries the terminal voice, tinted rather than shouted. */
       .sect-head {
-        color: var(--muted);
-        font-size: 11px;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
+        color: var(--fg);
+        font: var(--weight-semibold) var(--text-h2) / var(--leading-heading) var(--sans);
+        letter-spacing: var(--tracking-heading);
+        text-wrap: balance;
         margin: 0 0 10px 2px;
       }
+      .sect-head::first-letter {
+        color: var(--accent);
+      }
       .sect-lede {
-        font: 13px/1.6 var(--sans);
+        font: var(--text-body) / var(--leading-body) var(--sans);
         color: var(--body);
+        max-width: var(--measure);
         margin: 0 0 12px 2px;
       }
       .sect-lede code {
-        font: 11.5px var(--mono);
+        font: var(--text-micro) var(--mono);
         color: var(--fg);
         background: var(--panel);
         border: 1px solid var(--line);
@@ -350,17 +359,17 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         padding-top: 12px;
       }
       .feature h3 {
-        font: 600 13px/1.4 var(--mono);
+        font: var(--weight-semibold) var(--text-h4) / var(--leading-tight) var(--sans);
         color: var(--fg);
         margin: 0 0 4px;
       }
       .feature p {
-        font: 13px/1.6 var(--sans);
+        font: var(--text-meta)/1.6 var(--sans);
         color: var(--body);
         margin: 0;
       }
       .feature code {
-        font: 11.5px var(--mono);
+        font: var(--text-micro) var(--mono);
         color: var(--fg);
         background: var(--panel);
         border: 1px solid var(--line);
@@ -380,12 +389,12 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         border: 1px solid var(--line);
         border-radius: var(--radius-md);
         padding: 12px 14px;
-        font-size: 12.5px;
+        font-size: var(--text-meta);
       }
 
       /* ---------- install panel ---------- */
       .install {
-        font-size: 13px;
+        font-size: var(--text-meta);
         margin-top: 14px;
       }
       .install .rows {
@@ -412,7 +421,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       }
       .cmdrow .tag {
         color: var(--muted);
-        font-size: 10.5px;
+        font-size: var(--text-micro);
         letter-spacing: 0.1em;
         text-transform: uppercase;
       }
@@ -428,24 +437,24 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       }
       .cmdrow .agent-desc {
         color: var(--body);
-        font: 12.5px/1.65 var(--sans);
+        font: var(--text-meta)/1.65 var(--sans);
       }
       .cmdrow .agent-desc strong {
         color: var(--fg);
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
       }
       .agent-byline {
         display: flex;
         align-items: center;
         justify-content: center;
         gap: 10px;
-        font: 12.5px/1.5 var(--sans);
+        font: var(--text-meta)/1.5 var(--sans);
         color: var(--muted);
         margin: -6px 0 0;
       }
       .cmdrow button,
       .agent-byline button {
-        font: 11px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.06em;
         color: var(--accent);
         background: none;
@@ -467,7 +476,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         border-color: var(--green);
       }
       .prompt-note {
-        font: 12px/1.5 var(--sans);
+        font: var(--text-micro)/1.5 var(--sans);
         color: var(--muted);
         margin: -2px 0 0 2px;
       }
@@ -478,19 +487,19 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       /* The one loudest action on the page: the install row. Accent-washed
          panel, solid accent copy button. */
       .hero-install {
-        font-size: 14px;
+        font-size: var(--text-ui);
         margin-bottom: 2px;
         border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
         background: color-mix(in srgb, var(--accent) 7%, var(--panel));
       }
       .hero-install .cmdtext {
-        font-weight: 500;
+        font-weight: var(--weight-medium);
       }
       .hero-install button {
         color: var(--bg);
         background: var(--accent);
         border-color: var(--accent);
-        font-weight: 600;
+        font-weight: var(--weight-semibold);
       }
       .hero-install:hover {
         border-color: color-mix(in srgb, var(--accent) 70%, var(--line));
@@ -523,7 +532,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         display: inline-flex;
         align-items: center;
         gap: 8px;
-        font: 600 13.5px var(--mono);
+        font: var(--weight-medium) var(--text-ui) / 1 var(--sans);
         letter-spacing: 0.02em;
         color: var(--bg);
         background: var(--accent);
@@ -534,7 +543,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       }
       .cta-note {
         color: var(--muted);
-        font-size: 12.5px;
+        font-size: var(--text-meta);
       }
       /* Scope to main so header auth menu hover/active paint is not overridden
          (global `a` styles were bleeding into the avatar dropdown). */

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -24,7 +24,8 @@ import Footer from "../components/Footer.astro";
         padding: 28px;
         background: var(--bg);
         color: var(--fg);
-        font: 14.5px/1.65 var(--mono);
+        font: var(--text-body) / var(--leading-body) var(--sans);
+        letter-spacing: var(--tracking-body);
       }
       main {
         /* deliberately wider than --width-card (480px): this card carries setup instructions, not just a form */
@@ -41,8 +42,8 @@ import Footer from "../components/Footer.astro";
       }
       h1 {
         margin: 0 0 8px;
-        font-size: clamp(23px, 5vw, 30px);
-        font-weight: 600;
+        font-size: var(--text-h1);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.015em;
         line-height: 1.25;
       }
@@ -94,7 +95,7 @@ import Footer from "../components/Footer.astro";
         flex-shrink: 0;
       }
       button {
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.06em;
         border: 1px solid var(--line);
         border-radius: 6px;
@@ -113,7 +114,7 @@ import Footer from "../components/Footer.astro";
         margin-top: 26px;
         padding-top: 18px;
         border-top: 1px solid var(--line);
-        font-size: 13px;
+        font-size: var(--text-meta);
         color: var(--muted);
       }
       [hidden] {

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -31,7 +31,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         padding: 28px;
         background: var(--bg);
         color: var(--fg);
-        font: 14.5px/1.65 var(--mono);
+        font: var(--text-body) / var(--leading-body) var(--sans);
+        letter-spacing: var(--tracking-body);
       }
       main {
         width: min(var(--width-card, 480px), 100%);
@@ -47,8 +48,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       }
       h1 {
         margin: 0 0 8px;
-        font-size: clamp(21px, 5vw, 26px);
-        font-weight: 600;
+        font-size: var(--text-h2);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.015em;
         line-height: 1.25;
       }
@@ -66,8 +67,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         align-items: center;
         justify-content: center;
         gap: 10px;
-        font: 600 14px var(--mono);
-        letter-spacing: 0.02em;
+        font: var(--weight-medium) var(--text-ui) / 1 var(--sans);
+        letter-spacing: var(--tracking-ui);
         color: var(--bg);
         background: var(--accent);
         border: 1px solid var(--accent);
@@ -87,7 +88,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         gap: 12px;
         margin: 22px 0;
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.08em;
         text-transform: uppercase;
       }
@@ -106,7 +107,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         display: grid;
         gap: 6px;
         color: var(--muted);
-        font-size: 10.5px;
+        font-size: var(--text-micro);
         letter-spacing: 0.1em;
         text-transform: uppercase;
       }
@@ -116,14 +117,14 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         border-radius: var(--radius-md);
         color: var(--fg);
         padding: 10px 12px;
-        font: 14px var(--mono);
+        font: var(--text-ui) var(--sans);
       }
       input:focus-visible {
         border-color: var(--accent);
         outline: none;
       }
       button[type="submit"] {
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.04em;
         color: var(--accent);
         background: var(--bg);

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -29,7 +29,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         padding: 28px;
         background: var(--bg);
         color: var(--fg);
-        font: 14.5px/1.65 var(--mono);
+        font: var(--text-body) / var(--leading-body) var(--sans);
+        letter-spacing: var(--tracking-body);
       }
       main {
         width: min(var(--width-card, 480px), 100%);
@@ -45,8 +46,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       }
       h1 {
         margin: 0 0 8px;
-        font-size: clamp(21px, 5vw, 26px);
-        font-weight: 600;
+        font-size: var(--text-h2);
+        font-weight: var(--weight-semibold);
         letter-spacing: -0.015em;
         line-height: 1.25;
       }
@@ -59,7 +60,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       }
       .client-host {
         color: var(--muted);
-        font-size: 12.5px;
+        font-size: var(--text-meta);
         margin: -14px 0 20px;
         word-break: break-all;
       }
@@ -72,7 +73,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       .workspace-picker label {
         display: block;
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.08em;
         text-transform: uppercase;
         margin-bottom: 6px;
@@ -107,7 +108,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       .scopes :global(.id) {
         display: block;
         color: var(--muted);
-        font-size: 11px;
+        font-size: var(--text-micro);
         letter-spacing: 0.02em;
       }
       .actions {
@@ -118,7 +119,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         display: block;
         text-align: center;
         text-decoration: none;
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.04em;
         color: var(--accent);
         background: var(--bg);
@@ -134,7 +135,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       button.primary,
       button.secondary {
         flex: 1;
-        font: 12px var(--mono);
+        font: var(--text-micro) var(--sans);
         letter-spacing: 0.04em;
         color: var(--accent);
         background: var(--bg);
@@ -211,7 +212,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
             Create a workspace
           </a>
         </div>
-        <p class="muted" style="margin:14px 0 0;font-size:12.5px">
+        <p class="muted" style="margin:14px 0 0;font-size:var(--text-meta)">
           Have a workspace under another email? Link it from
           <a class="linklike" href="/account/profile">your profile</a> instead of creating a new one.
         </p>

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -24,15 +24,15 @@
   border-radius: 999px;
   background: var(--fg);
   color: var(--bg);
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--text-micro);
+  font-weight: var(--weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 .plan-card__name {
   margin: 0;
-  font-size: 15px;
-  font-weight: 600;
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
 }
 
 /* Compact "Pro" marker shown outside the billing tab (issue #365 follow-up)
@@ -45,20 +45,20 @@
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--line));
   color: var(--accent);
-  font-size: 10px;
-  font-weight: 600;
+  font-size: var(--text-micro);
+  font-weight: var(--weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   line-height: 1.4;
 }
 .plan-card__price {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-meta);
   color: var(--muted);
 }
 .plan-card__blurb {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 .plan-card__limits {
   margin: 4px 0 0;
@@ -66,7 +66,7 @@
   list-style: none;
   display: grid;
   gap: 4px;
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 .plan-card__cta {
   margin-top: auto;
@@ -76,7 +76,7 @@
    (same recipe as the invite-form submit) instead of native browser chrome. */
 .plan-card__cta,
 #ws-manage-billing-btn {
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   letter-spacing: 0.03em;
   color: var(--accent);
   border: 1px solid var(--line);
@@ -119,7 +119,7 @@ section.card.settings-page h2 {
 .settings-note {
   margin: 0 0 12px;
   max-width: 36rem;
-  font-size: 13px;
+  font-size: var(--text-meta);
   text-wrap: pretty;
 }
 .settings-section > .settings-note:last-child {
@@ -150,12 +150,12 @@ ul.dev-links li {
   border-right: 0;
   border-bottom: 0;
   border-radius: 0;
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 ul.dev-links a {
   color: var(--fg);
   text-decoration: none;
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 }
 ul.dev-links a:hover,
 ul.dev-links a:focus-visible {
@@ -164,7 +164,7 @@ ul.dev-links a:focus-visible {
 }
 ul.dev-links .slug {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 .settings-note a {
   text-underline-offset: 0.15em;
@@ -175,14 +175,14 @@ ul.dev-links .slug {
   grid-template-columns: max-content 1fr;
   gap: 6px 18px;
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 .settings-section .kv + .settings-note {
   margin-top: 12px;
 }
 .kv dt {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--text-micro);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   align-self: center;
@@ -207,7 +207,7 @@ ul.plain li {
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--bg);
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 /* Workspace blocks flatten: the surrounding .card is the only box. Each
    workspace is a borderless region, hairline-separated from the next. */
@@ -233,7 +233,7 @@ ul.plain .slug {
 }
 ul.plain .usage {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--text-micro);
   display: grid;
   gap: 6px;
   min-height: 1.2em;
@@ -243,7 +243,7 @@ ul.plain .usage .usage-meta {
   line-height: 1.35;
 }
 ul.plain .usage .usage-meta {
-  font-size: 11px;
+  font-size: var(--text-micro);
   opacity: 0.9;
 }
 ul.plain .ws-detail {
@@ -254,7 +254,7 @@ ul.plain .ws-detail {
   border-top: 1px solid var(--line);
 }
 ul.plain .ws-section-head {
-  font-size: 11px;
+  font-size: var(--text-micro);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
@@ -273,16 +273,16 @@ ul.plain .ws-items li {
   border: 0;
   border-radius: 0;
   background: none;
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 ul.plain .ws-empty {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--text-micro);
   margin: 0;
 }
 ul.plain .ws-note {
   color: var(--body);
-  font-size: 12px;
+  font-size: var(--text-micro);
   margin: 0;
 }
 /* Invite command: a light inset code row, not a raised bordered panel. The
@@ -307,11 +307,11 @@ ul.plain .command code {
   border: 0;
   background: none;
   padding: 0;
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 ul.plain .command button {
   flex-shrink: 0;
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--sans);
   letter-spacing: 0.05em;
   color: var(--accent);
   border: 1px solid var(--line);
@@ -327,7 +327,7 @@ ul.plain .command button:focus-visible {
 }
 ul.plain .cli-note {
   margin: 7px 0 0;
-  font-size: 11px;
+  font-size: var(--text-micro);
 }
 ul.plain .invite-form {
   display: flex;
@@ -349,7 +349,7 @@ ul.plain .invite-form input[type="email"] {
   border-radius: var(--radius-sm);
   color: var(--fg);
   padding: 8px 10px;
-  font: 13px var(--mono);
+  font: var(--text-meta) var(--sans);
 }
 ul.plain .invite-form input[type="email"]:focus-visible {
   border-color: var(--accent);
@@ -357,7 +357,7 @@ ul.plain .invite-form input[type="email"]:focus-visible {
 }
 ul.plain .invite-form button[type="submit"] {
   flex-shrink: 0;
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   letter-spacing: 0.03em;
   color: var(--accent);
   border: 1px solid var(--line);
@@ -386,7 +386,7 @@ section.card.is-pending {
 section.card .settings-note {
   margin: 6px 0 0;
   max-width: 36rem;
-  font-size: 13px;
+  font-size: var(--text-meta);
   text-wrap: pretty;
   color: var(--body);
 }
@@ -420,11 +420,11 @@ section.card .command code {
   border: 0;
   background: none;
   padding: 0;
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 section.card .command button {
   flex-shrink: 0;
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--sans);
   letter-spacing: 0.05em;
   color: var(--accent);
   border: 1px solid var(--line);
@@ -440,7 +440,7 @@ section.card .command button:focus-visible {
 }
 section.card .cli-note {
   margin: 12px 0 0;
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 
 /* Profile sign-in methods + sessions ──────────────────────────────────── */
@@ -456,11 +456,11 @@ section.card .cli-note {
 
 .detail-status {
   margin-top: 4px;
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 .detail-error {
   margin: 10px 0 0;
-  font-size: 12px;
+  font-size: var(--text-micro);
   color: var(--red);
 }
 /* Flat rows — no nested panel inside the settings card. */
@@ -479,7 +479,7 @@ ul.detail-list li {
   justify-content: space-between;
   gap: 12px;
   padding: 11px 0;
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 ul.detail-list li + li {
   border-top: 1px solid var(--line);
@@ -512,7 +512,7 @@ ul.detail-list .detail-title a:focus-visible {
 }
 a.text-btn,
 button.text-btn {
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   letter-spacing: 0.03em;
   color: var(--muted);
   background: none;
@@ -554,13 +554,13 @@ button.text-btn--boxed:focus-visible {
 }
 ul.detail-list .detail-meta {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--text-micro);
 }
 ul.detail-list .detail-action {
   flex-shrink: 0;
 }
 ul.detail-list .detail-current {
-  font-size: 11px;
+  font-size: var(--text-micro);
   color: var(--muted);
   letter-spacing: 0.04em;
 }
@@ -590,8 +590,8 @@ ul.detail-list .detail-current {
 }
 .ws-page-header h2 {
   margin: 0;
-  font-size: 1.05rem;
-  font-weight: 600;
+  font-size: var(--text-h3);
+  font-weight: var(--weight-semibold);
   text-wrap: balance;
 }
 .ws-page-header .ws-role {
@@ -600,7 +600,7 @@ ul.detail-list .detail-current {
 .ws-page-header .usage {
   width: 100%;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--text-micro);
   display: grid;
   gap: 10px;
   min-height: 1.2em;
@@ -611,7 +611,7 @@ ul.detail-list .detail-current {
   line-height: 1.35;
 }
 .ws-page-header .usage .usage-meta {
-  font-size: 11px;
+  font-size: var(--text-micro);
   opacity: 0.9;
 }
 /* Stacked regions inside the single card. */
@@ -627,7 +627,7 @@ ul.detail-list .detail-current {
 }
 .ws-page-card .ws-section-head,
 section.card .ws-section-head {
-  font-size: 11px;
+  font-size: var(--text-micro);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
@@ -648,14 +648,14 @@ section.card .ws-items {
 }
 .ws-page-card .ws-items li,
 section.card .ws-items li {
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 .ws-page-card .ws-empty,
 .ws-page-card .ws-note,
 section.card .ws-empty,
 section.card .ws-note {
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--text-meta);
   margin: 0;
 }
 .ws-page-card .ws-note,
@@ -673,12 +673,12 @@ section.card .ws-note {
 .ws-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: var(--text-meta);
   line-height: 1.4;
 }
 .ws-table th {
   text-align: left;
-  font: 500 11px var(--mono);
+  font: var(--weight-medium) var(--text-micro) / 1 var(--sans);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--muted);
@@ -707,7 +707,7 @@ section.card .ws-note {
 }
 .ws-table .ws-gallery-title {
   color: var(--fg);
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
   text-decoration: none;
 }
 .ws-table .ws-gallery-title:hover,
@@ -717,7 +717,7 @@ section.card .ws-note {
 }
 .ws-table .ws-gallery-desc {
   margin-top: 3px;
-  font-size: 12px;
+  font-size: var(--text-micro);
   max-width: 28rem;
 }
 .ws-gallery-links {
@@ -728,7 +728,7 @@ section.card .ws-note {
 }
 .ws-gallery-link {
   color: var(--fg);
-  font-size: 12px;
+  font-size: var(--text-micro);
   font-family: var(--mono);
   text-decoration: none;
   text-underline-offset: 0.15em;
@@ -743,11 +743,11 @@ section.card .ws-note {
   color: var(--muted);
 }
 .ws-gallery-link-more {
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 .ws-table .ws-gallery-updated {
   white-space: nowrap;
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 
 /* Galleries grid view ─────────────────────────────────────────────────────
@@ -807,8 +807,8 @@ section.card .ws-note {
 }
 .ws-gallery-card__title {
   color: var(--fg);
-  font-weight: 600;
-  font-size: 13.5px;
+  font-weight: var(--weight-semibold);
+  font-size: var(--text-meta);
   text-decoration: none;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -821,7 +821,7 @@ section.card .ws-note {
 }
 .ws-gallery-card__desc {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-micro);
   line-height: 1.45;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -835,7 +835,7 @@ section.card .ws-note {
   align-items: baseline;
   gap: 8px;
   margin-top: 2px;
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 .ws-gallery-card__count {
   color: var(--body);
@@ -869,7 +869,7 @@ section.card .ws-note {
 }
 .ws-status {
   margin-top: 12px;
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 .ws-form {
   margin-top: 12px;
@@ -911,7 +911,7 @@ section.card .ws-note {
   background: transparent;
   color: var(--fg);
   padding: 10px 12px;
-  font: 13px var(--mono);
+  font: var(--text-meta) var(--mono);
   outline: none;
 }
 .input-group__field input::placeholder {
@@ -928,7 +928,7 @@ section.card .ws-note {
   background: var(--panel);
   color: var(--accent);
   padding: 0 14px;
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   letter-spacing: 0.03em;
   cursor: pointer;
 }
@@ -950,7 +950,7 @@ section.card .ws-note {
 }
 .ws-hint {
   margin: 8px 0 0;
-  font-size: 11px;
+  font-size: var(--text-micro);
 }
 .ws-messages {
   display: grid;
@@ -999,7 +999,7 @@ section.card .ws-messages .command {
 .ws-search-error {
   margin: 0 0 10px;
   color: var(--red);
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
 }
 .ws-search-chips {
   display: flex;
@@ -1018,12 +1018,12 @@ section.card .ws-messages .command {
 }
 .ws-search-status {
   color: var(--muted);
-  font: 13px var(--mono);
+  font: var(--text-meta) var(--sans);
   margin: 8px 0;
 }
 .ws-search-truncated {
   color: var(--muted);
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   margin: 0 0 8px;
 }
 .ws-search-list {
@@ -1060,7 +1060,7 @@ section.card .ws-messages .command {
 }
 .ws-search-glyph {
   color: var(--muted);
-  font-size: 18px;
+  font-size: var(--text-h3);
 }
 .ws-search-body {
   flex: 1;
@@ -1070,7 +1070,7 @@ section.card .ws-messages .command {
   gap: 4px;
 }
 .ws-search-name {
-  font: 600 13px var(--mono);
+  font: var(--weight-semibold) var(--text-meta) / 1 var(--mono);
   overflow-wrap: anywhere;
 }
 .ws-search-meta {
@@ -1097,7 +1097,7 @@ section.card .ws-messages .command {
 }
 .wft-status {
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--text-meta);
   margin: 0;
 }
 /* Workspace-info "unavailable" state — error text + a retry affordance. */
@@ -1120,7 +1120,7 @@ section.card .ws-messages .command {
   position: relative;
 }
 .wft-filterbar .input-group__field input {
-  font-size: 12.5px;
+  font-size: var(--text-meta);
 }
 /* Loading-skeleton stand-in for the filter input/button (workspace-ui.ts's
    `renderFilesPlaceholderHtml`, mirrored in WorkspaceFileTable's own loading
@@ -1172,23 +1172,23 @@ section.card .ws-messages .command {
   background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 .wft-suggest__label {
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   color: var(--fg);
 }
 .wft-suggest__meta {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--text-micro);
   white-space: nowrap;
 }
 .wft-suggest__hint {
   padding: 6px 8px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--text-micro);
 }
 .wft-error {
   margin: 8px 0 0;
   color: var(--red);
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
 }
 
 .wft-sectionhead {
@@ -1208,14 +1208,14 @@ section.card .ws-messages .command {
 }
 .wft-sectionhead__label {
   color: var(--muted);
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   white-space: nowrap;
 }
 .wft-sectionhead__count {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 
 /* List / grid layout toggle — sits after the file count in the section head. */
@@ -1271,7 +1271,7 @@ section.card .ws-messages .command {
   border-radius: 2px;
   background: var(--panel);
   padding: 4px 5px 4px 9px;
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 .wft-chip__icon {
   width: 12px;
@@ -1287,7 +1287,7 @@ section.card .ws-messages .command {
   color: var(--fg);
 }
 .wft-chip__remove {
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   color: var(--muted);
   background: none;
   border: 0;
@@ -1302,7 +1302,7 @@ section.card .ws-messages .command {
 }
 .wft-clearall {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 .wft-clearall button {
   color: var(--muted);
@@ -1324,7 +1324,7 @@ section.card .ws-messages .command {
   align-items: center;
   gap: 2px;
   margin-top: 10px;
-  font-size: 12.5px;
+  font-size: var(--text-meta);
 }
 .wft-crumbs button {
   color: var(--muted);
@@ -1365,9 +1365,9 @@ section.card .ws-messages .command {
   flex: none;
 }
 .wft-banner__ref {
-  font-size: 12.5px;
+  font-size: var(--text-meta);
   color: var(--fg);
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
   text-decoration: none;
 }
 .wft-banner__ref:hover,
@@ -1380,7 +1380,7 @@ section.card .ws-messages .command {
 }
 .wft-banner__open {
   flex: none;
-  font-size: 11.5px;
+  font-size: var(--text-micro);
   color: var(--muted);
   text-decoration: none;
 }
@@ -1407,7 +1407,7 @@ section.card .ws-messages .command {
 .wft-head {
   padding: 7px 2px;
   color: var(--muted);
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -1417,7 +1417,7 @@ section.card .ws-messages .command {
 .wft-row {
   padding: 8px 2px;
   border-top: 1px solid var(--line);
-  font-size: 12.5px;
+  font-size: var(--text-meta);
 }
 button.wft-row {
   width: 100%;
@@ -1516,7 +1516,7 @@ button.wft-row {
   justify-self: end;
 }
 .wft-menu__trigger {
-  font: 600 13px var(--mono);
+  font: var(--weight-medium) var(--text-meta) / 1 var(--sans);
   color: var(--muted);
   background: none;
   border: 1px solid transparent;
@@ -1549,7 +1549,7 @@ button.wft-row {
   display: block;
   width: 100%;
   text-align: left;
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   color: var(--fg);
   background: none;
   border: 0;
@@ -1576,7 +1576,7 @@ button.wft-row {
 }
 .wft-confirm__text {
   margin: 0 0 8px;
-  font-size: 12px;
+  font-size: var(--text-micro);
   line-height: 1.5;
   color: var(--body);
   overflow-wrap: anywhere;
@@ -1591,7 +1591,7 @@ button.wft-row {
   border-top: 1px solid var(--line);
   padding: 9px 2px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 .wft-loadmore {
   margin-top: 10px;
@@ -1667,7 +1667,7 @@ button.wft-card:focus-visible {
   height: 22px;
 }
 .wft-card__ext {
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--mono);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--muted);
@@ -1690,7 +1690,7 @@ button.wft-card:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font: 12.5px var(--mono);
+  font: var(--text-meta) var(--mono);
   color: var(--fg);
   background: none;
   border: 0;
@@ -1716,7 +1716,7 @@ button.wft-card__name:focus-visible {
   align-items: center;
   gap: 8px;
   min-width: 0;
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--mono);
   color: var(--muted);
 }
 .wft-card__meta > span:first-child {
@@ -1732,7 +1732,7 @@ button.wft-card__name:focus-visible {
   flex: none;
 }
 .wft-card .wft-vis {
-  font-size: 11px;
+  font-size: var(--text-micro);
 }
 
 @media (max-width: 560px) {
@@ -1753,7 +1753,7 @@ button.wft-card__name:focus-visible {
   gap: 14px;
   padding: 9px 2px;
   border-top: 1px solid var(--line);
-  font-size: 12.5px;
+  font-size: var(--text-meta);
 }
 .member-row:first-child {
   border-top: 0;
@@ -1765,14 +1765,14 @@ button.wft-card__name:focus-visible {
   min-width: 0;
 }
 .member-row__name {
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .member-row__email {
   color: var(--muted);
-  font-size: 11.5px;
+  font-size: var(--text-micro);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1790,7 +1790,7 @@ button.wft-card__name:focus-visible {
    <span>, not a <select>, so the caret/background-image would be wrong. */
 .member-row__role {
   flex: none;
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   padding: 5px 9px;
   border: 1px solid transparent;
   border-radius: 6px;
@@ -1842,7 +1842,7 @@ button.wft-card__name:focus-visible {
   color: var(--accent);
 }
 .member-row--pending .member-row__name {
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   color: var(--muted);
 }
 
@@ -1856,14 +1856,14 @@ button.wft-card__name:focus-visible {
 .ws-empty-state__title {
   margin: 0;
   color: var(--fg);
-  font-size: 14px;
-  font-weight: 600;
+  font-size: var(--text-ui);
+  font-weight: var(--weight-semibold);
 }
 .ws-empty-state__body {
   margin: 0;
   max-width: 46ch;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 .ws-empty-state .command {
   width: 100%;
@@ -1894,7 +1894,7 @@ button.wft-card__name:focus-visible {
   cursor: pointer;
   list-style: none;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--text-micro);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   margin-bottom: 12px;
@@ -1929,13 +1929,13 @@ button.wft-card__name:focus-visible {
   width: 100%;
 }
 .wsp-project__label {
-  font-weight: 600;
-  font-size: 15px;
+  font-weight: var(--weight-semibold);
+  font-size: var(--text-body);
 }
 .wsp-project__viewall {
   margin-left: auto;
   color: var(--muted);
-  font-size: 11.5px;
+  font-size: var(--text-micro);
   white-space: nowrap;
   padding: 0;
 }
@@ -1962,18 +1962,18 @@ button.wft-card__name:focus-visible {
   cursor: pointer;
 }
 .wsp-group__path {
-  font-weight: 600;
-  font-size: 13px;
+  font-weight: var(--weight-semibold);
+  font-size: var(--text-meta);
 }
 .wsp-group__meta {
   color: var(--muted);
-  font-size: 11.5px;
+  font-size: var(--text-micro);
   white-space: nowrap;
 }
 .wsp-group__viewall {
   margin-left: auto;
   color: var(--muted);
-  font-size: 11.5px;
+  font-size: var(--text-micro);
   white-space: nowrap;
 }
 .wsp-group__head:hover .wsp-group__viewall,
@@ -1983,8 +1983,8 @@ button.wft-card__name:focus-visible {
 
 .wsp-drill__heading {
   margin: 10px 0 4px;
-  font-size: 15px;
-  font-weight: 600;
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
 }
 
 /* Horizontal strip of a group's recent thumbs (overview). Shared height,
@@ -2062,7 +2062,7 @@ button.wft-card__name:focus-visible {
   place-items: center;
   color: var(--muted);
   background: var(--panel);
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--sans);
   text-transform: lowercase;
 }
 .wsp-thumb--skel {
@@ -2083,7 +2083,7 @@ button.wft-card__name:focus-visible {
   background: var(--panel);
   border: 1px solid var(--line);
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--text-micro);
   line-height: 1.4;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -2124,7 +2124,7 @@ button.wft-card__name:focus-visible {
   min-width: 12rem;
   max-width: 100%;
   min-height: 36px;
-  font-size: 16px;
+  font-size: var(--text-body);
   box-sizing: border-box;
 }
 .wsp-filter .wsp-filter__qwrap {
@@ -2138,7 +2138,7 @@ button.wft-card__name:focus-visible {
   min-width: 0;
   min-height: 36px;
   padding: 6px 12px;
-  font-size: 16px;
+  font-size: var(--text-body);
   border-radius: 6px;
   box-sizing: border-box;
 }
@@ -2179,14 +2179,14 @@ button.wft-card__name:focus-visible {
   background: var(--bg);
 }
 .wsp-suggest__path {
-  font-size: 12.5px;
-  font-weight: 600;
+  font-size: var(--text-meta);
+  font-weight: var(--weight-semibold);
   overflow-wrap: anywhere;
 }
 .wsp-suggest__count {
   margin-left: auto;
   color: var(--muted);
-  font-size: 11.5px;
+  font-size: var(--text-micro);
   white-space: nowrap;
 }
 
@@ -2206,7 +2206,7 @@ button.wft-card__name:focus-visible {
   border: 0;
   color: var(--muted);
   font: inherit;
-  font-size: 12.5px;
+  font-size: var(--text-meta);
   cursor: pointer;
   white-space: nowrap;
 }
@@ -2245,7 +2245,7 @@ button.wft-card__name:focus-visible {
 @media (min-width: 640px) {
   .wsp-filter .wsp-filter__project,
   .wsp-filter .wsp-filter__q {
-    font-size: 12.5px;
+    font-size: var(--text-meta);
   }
 }
 
@@ -2280,14 +2280,14 @@ button.wft-card__name:focus-visible {
 }
 .wsp-preview__name {
   color: var(--fg);
-  font: 600 12px var(--mono);
+  font: var(--weight-semibold) var(--text-micro) / 1 var(--mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .wsp-preview__pr {
   color: var(--muted);
-  font: 11.5px var(--mono);
+  font: var(--text-micro) var(--mono);
 }
 /* Live PR/issue status pill (open/merged/closed) with a leading dot. */
 .wsp-preview__status {
@@ -2298,7 +2298,7 @@ button.wft-card__name:focus-visible {
   padding: 1px 6px;
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
-  font: 600 10px var(--mono);
+  font: var(--weight-medium) var(--text-micro) / 1 var(--sans);
   text-transform: uppercase;
   letter-spacing: 0.02em;
   vertical-align: 1px;
@@ -2321,7 +2321,7 @@ button.wft-card__name:focus-visible {
 }
 .wsp-preview__title {
   color: var(--fg);
-  font: 11.5px var(--body);
+  font: var(--text-micro) var(--body);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2329,7 +2329,7 @@ button.wft-card__name:focus-visible {
 }
 .wsp-preview__time {
   color: var(--muted);
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--mono);
 }
 @media (prefers-reduced-motion: no-preference) {
   .wsp-preview {

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -32,7 +32,7 @@
 .account-shell nav.side {
   --side-inset: 8px;
   gap: 2px;
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 .account-shell nav.side .side-link {
   display: block;
@@ -66,7 +66,7 @@
   margin: 20px 0 6px;
   padding: 0 var(--side-inset);
   color: var(--muted);
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
@@ -125,12 +125,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--fg);
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--text-meta);
+  font-weight: var(--weight-semibold);
 }
 .account-shell nav.side .ws-switcher__subtitle {
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--text-micro);
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
@@ -140,7 +140,7 @@
    label, so it stays on the name line rather than pushed to the subtitle. */
 .account-shell nav.side .ws-switcher .ws-switcher__trigger .pro-badge {
   flex: none;
-  font-size: 9px;
+  font-size: var(--text-micro);
   padding: 0 5px;
 }
 /* Visible switcher affordance — boxed chevron, not tiny label-tracking text. */
@@ -154,7 +154,7 @@
   border: 1px solid color-mix(in srgb, var(--line) 90%, var(--muted));
   border-radius: 3px;
   color: var(--fg);
-  font-size: 10px;
+  font-size: var(--text-micro);
   line-height: 1;
   letter-spacing: 0;
 }
@@ -196,7 +196,7 @@
   padding: 8px 10px;
   border-radius: 6px;
   color: var(--fg);
-  font-size: 13px;
+  font-size: var(--text-meta);
   letter-spacing: 0;
   text-transform: none;
   text-decoration: none;
@@ -218,7 +218,7 @@
 .account-shell nav.side .ws-switcher__item--new,
 .account-shell nav.side .ws-switcher__item--manage {
   color: color-mix(in srgb, var(--muted) 70%, var(--accent));
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 .account-shell nav.side .ws-switcher__sep {
   height: 1px;
@@ -248,7 +248,7 @@
   padding: 5px 8px;
   border-radius: 6px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--text-micro);
   text-decoration: none;
 }
 .account-shell nav.side .ws-settings-subnav__link:hover,
@@ -276,7 +276,7 @@
 .account-shell aside.rail {
   display: grid;
   gap: 22px;
-  font-size: 12.5px;
+  font-size: var(--text-meta);
   position: sticky;
   top: 28px;
   min-width: 0;
@@ -289,7 +289,7 @@
   display: contents;
 }
 .account-shell .ws-rail__section {
-  font-size: 12.5px;
+  font-size: var(--text-meta);
 }
 .account-shell .ws-rail__head {
   display: flex;
@@ -299,7 +299,7 @@
 }
 .account-shell .ws-rail__label {
   color: var(--muted);
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   white-space: nowrap;

--- a/apps/web/src/styles/admin-metrics.css
+++ b/apps/web/src/styles/admin-metrics.css
@@ -9,7 +9,7 @@
  * apps/web/src, so spacing here matches admin.css's raw-px convention (its
  * numbers are all literal px, not a token scale) and colors read the real
  * tokens — var(--line), var(--fg), var(--body), var(--muted), var(--accent),
- * var(--panel), var(--bg), var(--mono), var(--radius-sm), var(--radius-md).
+ * var(--panel), var(--bg), var(--sans), var(--radius-sm), var(--radius-md).
  */
 
 .metrics-tiles {
@@ -33,7 +33,7 @@
 .metrics-tile dt {
   margin: 0;
   color: var(--muted);
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--sans);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -41,8 +41,8 @@
 .metrics-tile dd {
   margin: 6px 0 0;
   color: var(--fg);
-  font-size: 20px;
-  font-weight: 600;
+  font-size: var(--text-h3);
+  font-weight: var(--weight-semibold);
   /* Tabular figures so the numbers don't jitter on refresh. */
   font-variant-numeric: tabular-nums;
 }
@@ -75,8 +75,8 @@
 
 .metrics-section h3 {
   margin: 0 0 14px;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--text-micro);
+  font-weight: var(--weight-semibold);
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--fg);
@@ -135,7 +135,7 @@
 
 .metrics-chart .metrics-axis-label {
   fill: var(--muted);
-  font: 9px var(--mono);
+  font: var(--text-micro) var(--mono);
 }
 
 .metrics-chart .metrics-bar-fill {
@@ -164,7 +164,7 @@
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   padding: 5px 8px;
-  font-size: 11px;
+  font-size: var(--text-micro);
   line-height: 1.4;
   white-space: nowrap;
   opacity: 0;
@@ -178,7 +178,7 @@
 
 .metrics-chart-tooltip .value {
   color: var(--fg);
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
   font-variant-numeric: tabular-nums;
 }
 
@@ -210,14 +210,14 @@
 .admin-hint {
   margin: 0 0 12px;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--text-meta);
   line-height: 1.5;
 }
 
 #breakdown-panel label {
   display: inline-block;
   margin: 0 8px 12px 0;
-  font-size: 13px;
+  font-size: var(--text-meta);
   color: var(--body);
 }
 

--- a/apps/web/src/styles/admin-oauth.css
+++ b/apps/web/src/styles/admin-oauth.css
@@ -9,7 +9,7 @@
 }
 .oauth-scopes legend {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--text-micro);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   padding: 0 4px;
@@ -22,7 +22,7 @@
   text-transform: none !important;
   letter-spacing: normal !important;
   color: var(--body) !important;
-  font-size: 12px !important;
+  font-size: var(--text-micro) !important;
 }
 .oauth-copy-row {
   display: flex;
@@ -39,7 +39,7 @@
   border-radius: var(--radius-sm);
   color: var(--fg);
   padding: 7px 9px;
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--mono);
 }
 .oauth-uri-list {
   list-style: none;
@@ -47,7 +47,7 @@
   padding: 0;
   display: grid;
   gap: 4px;
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--mono);
 }
 .oauth-detail-header {
   display: flex;
@@ -57,8 +57,8 @@
 }
 .oauth-detail-header h2 {
   margin: 0;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
 }
 .oauth-detail-badges {
   display: flex;

--- a/apps/web/src/styles/admin-workspaces.css
+++ b/apps/web/src/styles/admin-workspaces.css
@@ -4,7 +4,7 @@
 .workspace .plan-unapplied,
 .workspace .limit-usage {
   margin: 0 0 10px;
-  font-size: 12px;
+  font-size: var(--text-micro);
   color: var(--muted);
 }
 .workspace .plan-form {
@@ -19,7 +19,7 @@
   border-radius: var(--radius-sm);
   color: var(--fg);
   padding: 4px 6px;
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--mono);
 }
 /* .plan-select, .limit-unit, and .invite-role are styled by .ul-select
    .ul-select--sm (markup in admin/index.astro) instead of bespoke box CSS.
@@ -37,7 +37,7 @@
 .workspace .plan-status,
 .workspace .limit-status,
 .workspace .invite-status {
-  font-size: 12px;
+  font-size: var(--text-micro);
   width: 100%;
 }
 .workspace .plan-status[data-state="error"],
@@ -67,7 +67,7 @@
   grid-template-columns: 130px 1fr 70px auto;
 }
 .workspace .limit-row > label:first-child {
-  font-size: 13px;
+  font-size: var(--text-meta);
   color: var(--body);
 }
 /* .limit-unit's disabled treatment now comes from .ul-select:disabled. */
@@ -78,7 +78,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 12px;
+  font-size: var(--text-micro);
   white-space: nowrap;
   color: var(--muted);
 }
@@ -97,10 +97,10 @@
   display: flex;
   justify-content: space-between;
   gap: 8px;
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 .workspace .github-links-list .repo {
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--mono);
   color: var(--fg);
 }
 .workspace .invite-link-row {
@@ -117,7 +117,7 @@
   border-radius: var(--radius-sm);
   color: var(--fg);
   padding: 7px 9px;
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--mono);
 }
 
 @media (max-width: 560px) {

--- a/apps/web/src/styles/admin.css
+++ b/apps/web/src/styles/admin.css
@@ -21,14 +21,14 @@
 }
 .admin-page-header h2 {
   margin: 0;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
   color: var(--fg);
 }
 .admin-page-header p {
   margin: 0;
   color: var(--body);
-  font-size: 13px;
+  font-size: var(--text-meta);
   line-height: 1.55;
   text-wrap: pretty;
 }
@@ -39,7 +39,7 @@
 }
 .admin-subsection-label {
   margin: 0 0 10px;
-  font: 500 11px var(--mono);
+  font: var(--weight-medium) var(--text-micro) / 1 var(--sans);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--muted);
@@ -47,7 +47,7 @@
 
 /* ── Status / controls ─────────────────────────────────────────────────── */
 .admin-status {
-  font-size: 13px;
+  font-size: var(--text-meta);
   color: var(--muted);
 }
 .admin-status[data-state="error"] {
@@ -65,7 +65,7 @@
   max-width: 480px;
 }
 .admin-field label {
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--sans);
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -79,7 +79,7 @@
   border-radius: var(--radius-sm);
   color: var(--fg);
   padding: 7px 9px;
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
 }
 .admin-toolbar input:focus-visible,
 .admin-field input:focus-visible {
@@ -93,7 +93,7 @@
 .workspace .plan-form button,
 .workspace .limits-form button,
 .workspace .invite-link-row button {
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--sans);
   color: var(--accent);
   background: transparent;
   border: 1px solid var(--line);
@@ -138,7 +138,7 @@
   cursor: not-allowed;
 }
 .admin-back {
-  font-size: 12px;
+  font-size: var(--text-micro);
   color: var(--muted);
   text-decoration: none;
   width: fit-content;
@@ -164,12 +164,12 @@
 .admin-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: var(--text-meta);
   line-height: 1.4;
 }
 .admin-table th {
   text-align: left;
-  font: 500 11px var(--mono);
+  font: var(--weight-medium) var(--text-micro) / 1 var(--sans);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--muted);
@@ -209,16 +209,16 @@
 }
 .admin-table .primary {
   color: var(--fg);
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
 }
 .admin-table .email,
 .admin-table .mono {
   font-family: var(--mono);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 }
 .admin-table .muted {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 .admin-table a.admin-row-link {
   color: inherit;
@@ -241,7 +241,7 @@
 .admin-table .admin-expand {
   width: 18px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--text-micro);
   line-height: 1;
   transition: transform 0.15s ease;
   user-select: none;
@@ -269,8 +269,8 @@
 .workspace .limits-heading,
 .workspace .github-links-heading {
   margin: 0 0 8px;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--text-micro);
+  font-weight: var(--weight-semibold);
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--fg);
@@ -285,7 +285,7 @@
 .admin-detail-kv {
   display: grid;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--text-micro);
   color: var(--body);
 }
 .admin-detail-kv div {
@@ -298,7 +298,7 @@
   min-width: 7rem;
 }
 .admin-detail-kv code {
-  font: 11px var(--mono);
+  font: var(--text-micro) var(--mono);
   color: var(--fg);
   word-break: break-all;
 }
@@ -313,7 +313,7 @@
   display: flex;
   justify-content: space-between;
   gap: 8px;
-  font-size: 12px;
+  font-size: var(--text-micro);
   color: var(--body);
 }
 .admin-mini-list .role {
@@ -338,7 +338,7 @@
   display: grid;
   gap: 4px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--text-micro);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -360,7 +360,7 @@
   border-radius: var(--radius-sm);
   color: var(--fg);
   padding: 7px 9px;
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   text-transform: none;
   letter-spacing: normal;
 }
@@ -386,7 +386,7 @@
 }
 .users-self-note {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-micro);
   color: var(--muted);
 }
 .user-row.is-banned .email {
@@ -416,18 +416,18 @@
 }
 .admin-dl dt {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--text-micro);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 .admin-dl dd {
   margin: 4px 0 0;
   color: var(--body);
-  font-size: 13px;
+  font-size: var(--text-meta);
   overflow-wrap: anywhere;
 }
 .admin-dl code {
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--mono);
 }
 
 @media (max-width: 680px) {

--- a/apps/web/src/styles/signed-in-shell.css
+++ b/apps/web/src/styles/signed-in-shell.css
@@ -41,7 +41,8 @@ body {
   flex-direction: column;
   background: var(--bg);
   color: var(--fg);
-  font: 14px/1.6 var(--mono);
+  font: var(--text-ui) / var(--leading-ui) var(--sans);
+  letter-spacing: var(--tracking-ui);
   font-variant-ligatures: none;
   font-feature-settings:
     "calt" 0,
@@ -64,7 +65,8 @@ code {
   border: 1px solid var(--line);
   border-radius: 5px;
   padding: 1px 6px;
-  font-size: 0.9em;
+  font-family: var(--mono);
+  font-size: var(--mono-optical);
 }
 [hidden] {
   display: none !important;
@@ -123,7 +125,7 @@ code {
 a.button {
   display: inline-block;
   margin-top: 12px;
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   color: var(--accent);
   text-decoration: none;
   border: 1px solid var(--line);
@@ -156,7 +158,7 @@ nav.side a {
   border: 1px solid transparent;
   color: var(--muted);
   text-decoration: none;
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 nav.side a:hover {
   color: var(--fg);
@@ -175,7 +177,7 @@ nav.side .side-label {
   display: block;
   padding: 8px 12px 4px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--text-micro);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   user-select: none;
@@ -210,7 +212,7 @@ nav.side .side-nested-item {
   border: 1px solid transparent;
   color: var(--muted);
   text-decoration: none;
-  font-size: 12px;
+  font-size: var(--text-micro);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -225,7 +227,7 @@ nav.side .side-nested-item[aria-current="true"] {
   border-color: var(--line);
 }
 nav.side .side-nested-item.side-nested-subitem {
-  font-size: 11px;
+  font-size: var(--text-micro);
   padding: 5px 9px;
 }
 nav.side .side-nested-item.side-new {
@@ -244,11 +246,11 @@ nav.side .side-foot {
   gap: 4px;
 }
 nav.side .side-foot a {
-  font-size: 12px;
+  font-size: var(--text-micro);
 }
 nav.side button {
   text-align: left;
-  font: 12px var(--mono);
+  font: var(--text-micro) var(--sans);
   color: var(--muted);
   background: none;
   border: 1px solid transparent;
@@ -275,13 +277,13 @@ section.card {
 }
 section.card h2 {
   margin: 0 0 6px;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
 }
 section.card p {
   color: var(--body);
   margin: 8px 0 0;
-  font-size: 13px;
+  font-size: var(--text-meta);
 }
 p.muted,
 span.muted {
@@ -289,7 +291,7 @@ span.muted {
 }
 .pill {
   display: inline-block;
-  font-size: 11px;
+  font-size: var(--text-micro);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--accent);

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -53,6 +53,49 @@
     "Geist Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace; /* @kind font */
   --pixel: "Geist Pixel", "Geist Mono Variable", ui-monospace, monospace; /* @kind font */
   --pixel-shape: 1; /* @kind other */
+
+  /* ── Type scale ──────────────────────────────────────────────────────
+     Roles, not values. Sans is the interface voice; mono is reserved for
+     what it actually measures — commands, code, file keys, URLs, hashes,
+     and tabular figures. Reach for var(--mono) when the characters must
+     line up or be transcribed, never to make a label look technical. */
+  --text-display: clamp(34px, 6vw, 56px); /* landing hero only */
+  --text-h1: clamp(27px, 4.2vw, 36px); /* page title */
+  --text-h2: clamp(21px, 3vw, 26px); /* section heading */
+  --text-h3: 19px; /* subsection heading */
+  --text-h4: 16px; /* body-size heading — weight carries it, not size */
+  --text-body: 16px; /* prose and reading copy */
+  --text-ui: 14px; /* interface chrome: buttons, nav, labels, inputs */
+  --text-meta: 13px; /* metadata, captions, dense table cells */
+  --text-micro: 12px; /* badges and uppercase pills — the absolute floor */
+
+  /* Leading. Light-on-dark needs more air than the same face on white, so
+     body sits at 1.65 rather than the usual 1.5. */
+  --leading-display: 1.04;
+  --leading-heading: 1.22;
+  --leading-body: 1.65;
+  --leading-ui: 1.5;
+  --leading-tight: 1.3;
+
+  /* Tracking. Negative at display sizes to close optical gaps; a hair
+     positive at text sizes to counter dark-mode bloom. */
+  --tracking-display: -0.03em;
+  --tracking-heading: -0.015em;
+  --tracking-body: 0.004em;
+  --tracking-ui: 0.006em;
+  --tracking-caps: 0.08em; /* uppercase micro-labels only */
+
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
+  /* Reading measure — pair with `max-width: var(--measure)` on prose. */
+  --measure: 68ch;
+
+  /* Mono runs optically large next to Geist at the same px; scale inline
+     code and keys by this factor so the baseline rhythm survives. */
+  --mono-optical: 0.94em;
   --radius-sm: 7px;
   --radius-md: 8px;
   --radius-lg: 10px;
@@ -73,14 +116,17 @@
 /* ── Surface (theme root) ──────────────────────────────────────────────── */
 /*
  * Wrap product UI in <Surface> (class .ul-surface) so components sit on the
- * dark canvas with the tokens in scope. The body face is mono: uploads.sh is
- * CLI-first and the interface reads terminal-native by intent, not default.
- * Reach for var(--sans) deliberately (long prose), not as the base.
+ * dark canvas with the tokens in scope. The base face is sans — the terminal
+ * character comes from Geist Pixel, the chevron motif, and the density, not
+ * from setting every label in a typewriter. Reach for var(--mono) when the
+ * characters are a key, path, size, count, or timestamp: something the reader
+ * transcribes or compares column-to-column. Never to make a word look technical.
  */
 .ul-surface {
   background: var(--bg);
   color: var(--fg);
-  font: 14px/1.7 var(--mono);
+  font: var(--text-ui) / var(--leading-ui) var(--sans);
+  letter-spacing: var(--tracking-ui);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -139,8 +185,9 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  font-family: var(--mono);
-  letter-spacing: 0.03em;
+  font-family: var(--sans);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-ui);
   color: var(--fg);
   background: var(--bg);
   border: 1px solid var(--line);
@@ -165,16 +212,16 @@
 }
 /* sizes */
 .ul-btn--sm {
-  font-size: 12px;
+  font-size: var(--text-meta);
   padding: 9px 12px;
   border-radius: var(--radius-sm);
 }
 .ul-btn--md {
-  font-size: 14px;
+  font-size: var(--text-ui);
   padding: 11px 15px;
 }
 .ul-btn--lg {
-  font-size: 15px;
+  font-size: var(--text-h4);
   padding: 13px 20px;
 }
 /* variants */
@@ -200,7 +247,7 @@
   color: var(--bg);
   background: var(--accent);
   border-color: var(--accent);
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
 }
 .ul-btn--solid:hover,
 .ul-btn--solid:focus-visible {
@@ -234,16 +281,16 @@
   margin: 0 0 var(--space-2);
   color: var(--fg);
   font-family: var(--sans);
-  font-size: 17px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  line-height: 1.3;
+  font-size: var(--text-h3);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-heading);
+  line-height: var(--leading-tight);
 }
 .ul-panel__desc {
   margin: 0 0 var(--space-4);
   color: var(--body);
-  font-size: 13.5px;
-  line-height: 1.6;
+  font-size: var(--text-ui);
+  line-height: var(--leading-body);
 }
 .ul-panel__desc:last-child {
   margin-bottom: 0;
@@ -256,9 +303,10 @@
 }
 .ul-label {
   color: var(--muted);
-  font-family: var(--mono);
-  font-size: 10.5px;
-  letter-spacing: 0.1em;
+  font-family: var(--sans);
+  font-size: var(--text-micro);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-caps);
   text-transform: uppercase;
 }
 .ul-input {
@@ -267,7 +315,7 @@
   border-radius: var(--radius-md);
   color: var(--fg);
   padding: 10px 12px;
-  font: 14px var(--mono);
+  font: var(--text-ui) / var(--leading-ui) var(--sans);
   width: 100%;
 }
 .ul-input::placeholder {
@@ -306,7 +354,7 @@
   border-radius: var(--radius-md);
   color: var(--fg);
   padding: 10px 34px 10px 12px;
-  font: 14px var(--mono);
+  font: var(--text-ui) / var(--leading-ui) var(--sans);
   width: 100%;
 }
 .ul-select:focus-visible {
@@ -320,7 +368,7 @@
 /* Compact variant — matches .text-btn's box (account-content.css) so a
    member row's height converges on its own Remove button without a pin. */
 .ul-select--sm {
-  font: 12px var(--mono);
+  font: var(--text-meta) / var(--leading-ui) var(--sans);
   padding: 5px 22px 5px 9px;
   border-radius: 6px;
   background-position: right 8px center;
@@ -328,8 +376,15 @@
 }
 .ul-field__hint {
   color: var(--muted);
-  font: 11px var(--mono);
-  letter-spacing: 0.01em;
+  font: var(--text-meta) / var(--leading-ui) var(--sans);
+  letter-spacing: var(--tracking-ui);
+}
+/* Opt-in for fields whose value is a key, path, token, or URL — the places
+   where character-by-character transcription actually matters. */
+.ul-input--key,
+.ul-input--key::placeholder {
+  font-family: var(--mono);
+  letter-spacing: 0;
 }
 .ul-field--invalid .ul-input {
   border-color: var(--red);
@@ -351,7 +406,7 @@
   padding: 10px 14px 10px 36px;
   background: color-mix(in srgb, var(--callout-tone) 5%, transparent);
   color: var(--fg);
-  font: 13px/1.55 var(--mono);
+  font: var(--text-ui) / var(--leading-body) var(--sans);
   border: 1px solid color-mix(in srgb, var(--callout-tone) 26%, var(--line));
   border-radius: var(--radius-md);
 }
@@ -379,8 +434,9 @@
 .ul-callout__title {
   display: block;
   margin-bottom: 3px;
-  font-size: 10.5px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-micro);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-caps);
   text-transform: uppercase;
   color: var(--muted);
 }
@@ -390,8 +446,9 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font: 11px var(--mono);
-  letter-spacing: 0.02em;
+  font: var(--text-micro) / 1 var(--sans);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-ui);
   color: var(--body);
   background: var(--bg);
   border: 1px solid var(--line);
@@ -425,8 +482,9 @@
   align-items: center;
   gap: 12px;
   color: var(--muted);
-  font: 11px var(--mono);
-  letter-spacing: 0.08em;
+  font: var(--text-micro) / 1 var(--sans);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-caps);
   text-transform: uppercase;
 }
 .ul-divider::before,
@@ -473,17 +531,21 @@
   justify-content: space-between;
   align-items: baseline;
   gap: 12px;
-  font: 12px/1.35 var(--mono);
+  font: var(--text-meta) / var(--leading-tight) var(--sans);
   color: var(--muted);
 }
 .ul-progress__label {
   min-width: 0;
   color: var(--body);
 }
+/* The value is a measurement: mono keeps the digits from dancing as the
+   number ticks up, and tabular figures keep the column still. */
 .ul-progress__value {
   flex: none;
   text-align: right;
   white-space: nowrap;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
 }
 .ul-progress__track {
   height: 3px;
@@ -586,9 +648,9 @@
   gap: 6px;
 }
 .ul-tile__name {
-  font: 13px var(--mono);
+  font: var(--text-meta) / var(--leading-tight) var(--mono);
   color: var(--fg);
-  letter-spacing: 0.01em;
+  letter-spacing: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -597,7 +659,8 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font: 11px var(--mono);
+  font: var(--text-micro) / 1 var(--mono);
+  font-variant-numeric: tabular-nums;
   color: var(--muted);
 }
 .ul-tile__meta > * {
@@ -620,7 +683,7 @@
 }
 .ul-files__crumbs button,
 .ul-files__more {
-  font: 12px var(--mono);
+  font: var(--text-meta) / var(--leading-tight) var(--mono);
   color: var(--muted);
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
@@ -684,7 +747,7 @@
   align-items: center;
   gap: 9px;
   text-align: left;
-  font: 12.5px var(--mono);
+  font: var(--text-meta) / var(--leading-tight) var(--mono);
   color: var(--fg);
   border: 0;
   border-radius: var(--radius-sm);
@@ -745,7 +808,8 @@
 }
 .ul-files__name small {
   color: var(--muted);
-  font: 11px var(--mono);
+  font: var(--text-micro) / 1 var(--mono);
+  font-variant-numeric: tabular-nums;
 }
 /* Loading / empty / error states fill the reserved viewport so they neither
    grow the container nor leave it collapsed. */
@@ -757,7 +821,7 @@
   justify-content: center;
   gap: 7px;
   color: var(--muted);
-  font: 12px var(--mono);
+  font: var(--text-meta) / var(--leading-ui) var(--sans);
   padding: 12px;
 }
 .ul-files__spin {

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -65,6 +65,49 @@
   /* Geist Pixel element-shape axis (0 Regular · 1 Square · 20 Circle · 40 Grid · 60 Triangle · 80 Line) */
   --pixel-shape: 1;
 
+  /* ── Type scale ──────────────────────────────────────────────────────
+     Roles, not values. Sans is the interface voice; mono is reserved for
+     what it actually measures — commands, code, file keys, URLs, hashes,
+     and tabular figures. Reach for var(--mono) when the characters must
+     line up or be transcribed, never to make a label look technical. */
+  --text-display: clamp(34px, 6vw, 56px); /* landing hero only */
+  --text-h1: clamp(27px, 4.2vw, 36px); /* page title */
+  --text-h2: clamp(21px, 3vw, 26px); /* section heading */
+  --text-h3: 19px; /* subsection heading */
+  --text-h4: 16px; /* body-size heading — weight carries it, not size */
+  --text-body: 16px; /* prose and reading copy */
+  --text-ui: 14px; /* interface chrome: buttons, nav, labels, inputs */
+  --text-meta: 13px; /* metadata, captions, dense table cells */
+  --text-micro: 12px; /* badges and uppercase pills — the absolute floor */
+
+  /* Leading. Light-on-dark needs more air than the same face on white, so
+     body sits at 1.65 rather than the usual 1.5. */
+  --leading-display: 1.04;
+  --leading-heading: 1.22;
+  --leading-body: 1.65;
+  --leading-ui: 1.5;
+  --leading-tight: 1.3;
+
+  /* Tracking. Negative at display sizes to close optical gaps; a hair
+     positive at text sizes to counter dark-mode bloom. */
+  --tracking-display: -0.03em;
+  --tracking-heading: -0.015em;
+  --tracking-body: 0.004em;
+  --tracking-ui: 0.006em;
+  --tracking-caps: 0.08em; /* uppercase micro-labels only */
+
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
+  /* Reading measure — pair with `max-width: var(--measure)` on prose. */
+  --measure: 68ch;
+
+  /* Mono runs optically large next to Geist at the same px; scale inline
+     code and keys by this factor so the baseline rhythm survives. */
+  --mono-optical: 0.94em;
+
   /* Radii */
   --radius-sm: 7px;
   --radius-md: 8px;


### PR DESCRIPTION
Typography and navigation pass over the whole site, plus a refresh of `PRODUCT.md` against what actually shipped.

## Why

The design system defined three faces but **no sizes**. That left 236 hardcoded `font-size` declarations across 22 distinct values — including half-pixels (12.5, 11.5, 10.5, 9.5px) — with an effective UI floor around 11–13px on a dark background. Sizes 11 / 11.5 / 12 / 12.5 / 13 / 13.5 were all doing supposedly different jobs while reading identically.

Separately, `.ul-surface` set `font: 14px/1.7 var(--mono)`. That one line made mono the base face for all product UI, so buttons, labels, navigation, and metadata were all typewriter text.

## The type scale

Adds role-named tokens to `@uploads/ui` — `--text-display / h1–h4 / body / ui / meta / micro`, plus leading, tracking, weight, `--measure`, and `--mono-optical` — and migrates every raw value onto them.

| Role | Size | Used for |
| --- | --- | --- |
| `--text-body` | 16px | prose and reading copy |
| `--text-ui` | 14px | buttons, nav, labels, inputs |
| `--text-meta` | 13px | metadata, captions, dense table cells |
| `--text-micro` | 12px | badges and uppercase pills — the floor |

Nothing renders below 12px any more. Prose in docs and legal is capped at `--measure`, which pulled those lines back from roughly 85 characters to 68.

## The mono rule

Geist sans becomes the interface voice. **Mono is reserved for what it measures** — commands, code, file keys, URLs, hashes, and tabular figures. The test is whether a reader transcribes the characters or compares them column-to-column, never whether a word should look technical.

80 declarations flipped. Filenames, breadcrumbs, file keys, commands, and progress values kept mono (progress values also gained `tabular-nums`); buttons, labels, nav, status text, and callouts became sans. `.ul-input--key` lets a field holding a token or URL opt back in.

The terminal character now comes from Geist Pixel, the chevron motif, and the density — not from setting every label in a typewriter.

## Navigation

- `SiteHeader` marks its current section with `aria-current` and an accent hairline. It was the only nav on the site that never said where you were — the docs sidebar and account rail both already did this.
- Section matching, not exact matching, so `/docs/agents` lights up **Docs**.
- The header nav stays at Screenshots + Docs. Changelog is something you read occasionally, not somewhere you navigate mid-task, so it belongs in the footer.

## Footer

`Product` / `Project` read as near-homophones, and neither described its contents: Product held four documentation links plus a sign-in, Project mixed the repository with legal pages. Regrouped into **Resources** (Docs, Agent guide, GitHub App, Changelog), **Open source** (GitHub, Status), and **Legal** (Terms, Privacy).

Sign in is now header-only — `AuthIndicator` already renders a primary CTA there whenever the visitor is signed out, so the footer entry was a second, quieter path to the same page. The grid widens to four tracks, with the brand dropping to its own row at 900px before the existing 560px stack.

## Three bugs this surfaced

- **`.auth-indicator__muted` never matched its own rule.** It is injected by client JS, so Astro's scoped style never applied — every sibling injected class in that file already used `:global()`. It had been silently inheriting the page body size. Mono-everywhere hid this; sans exposed it at 16px in the header.
- **Landing section headings were smaller than their own lede.** Real `<h2>`s set at 12px uppercase muted, sitting above 16px body copy. They now read at heading rank, with the shell-comment `#` tinted via `::first-letter` so the voice survives.
- **`@font-face` can't resolve `var()`.** My own weight-tokenization pass put `var(--weight-regular)` into the Geist Pixel face descriptor; caught on inspection and reverted.

## Records updated

The direction contradicted two recorded commitments, so both were corrected rather than left to rot:

- `PRODUCT.md`'s "mono-first typography" is replaced with the explicit mono rule, dated.
- The two detector font waivers in `.impeccable/config.json` now say why each face is kept, instead of citing the retired framing.

The first commit on this branch is a separate `PRODUCT.md` refresh (agent-first users, staged-loop mechanism, live Free/Pro plans, BYO bucket, current surfaces, and an evidence inventory naming what must not be fabricated). It was ~2 years stale.

## Verification

- `pnpm --filter @uploads/web build` — passes
- `pnpm format:check` — clean
- `pnpm vitest run --root apps/web` — 814/814 pass
- Impeccable detector — clean except a pre-existing em-dash advisory on landing copy
- Inspected at 1440px and iPhone 13 across landing, docs, changelog, and login

`cli-help.test.ts` fails when run locally, but it fails identically on a clean tree — verified by stashing this work and re-running it — and it passes in CI, so it is a local ANSI-colour artifact, not something from this change.

No changeset: only the private `@uploads/ui` and `@uploads/web` changed, and per CONTRIBUTING only the published CLI belongs in one.

## Worth your eyes

I could not visually verify the signed-in console / account / admin surfaces — they need auth. `account-content.css` was the largest single file changed (79 sizes), so that's where I'd look first in the preview.
