### PR TITLE
fix(auth): disable per-client resource enforcement (MCP OAuth invalid_target)

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -608,13 +608,18 @@ function buildAuth(
         // suppressed are gone; root /.well-known aliases are still served by
         // src/index.ts.)
         resources: OAUTH_RESOURCES,
-        // 1.7 gates which resources a DCR client may request at registration:
-        // with neither `clientRegistration{Default,Allowed}Resources` set, a
-        // register request that carries `resources` is rejected `invalid_target`.
-        // Mark our resources as *allowed* (client selects) rather than *default*
-        // (force-attached to every client), matching the 1.6 behavior where any
-        // client could target these audiences.
-        clientRegistrationAllowedResources: OAUTH_RESOURCES,
+        // `enforcePerClientResources` defaults to `true` in 1.7 (RFC 8707 §3):
+        // /oauth2/authorize + /oauth2/token then require the client to be linked
+        // to every requested resource via `oauth_client_resource`, else they
+        // return `invalid_target`. Standard MCP clients request `resource` at
+        // authorize/token time (not as a DCR field), so they never get linked
+        // and would be rejected. We have no mechanism to link third-party
+        // clients, and in 1.6 (`validAudiences`) any client could target these
+        // audiences. `false` restores that — all *enabled* resources are
+        // requestable by any client — while tokens stay aud-bound to the
+        // requested resource. (Per-client enforcement would need an admin flow
+        // to link clients to resources, which we don't have.)
+        enforcePerClientResources: false,
         allowDynamicClientRegistration: true,
         allowUnauthenticatedClientRegistration: true,
         // Explicit abuse ceiling on the public /oauth2/register endpoint —


### PR DESCRIPTION
Closes #747.

## Problem
Better Auth 1.7's oauth-provider defaults `enforcePerClientResources: true` (RFC 8707 §3): `/oauth2/authorize` and `/oauth2/token` then require a client to be linked to every requested `resource` via `oauth_client_resource`, else `invalid_target`. Standard MCP clients request `resource` at authorize/token time, not as a DCR field, so they're never linked → rejected. This is a behavior change from 1.6's `validAudiences` (introduced by the 1.7 migration in #744).

## Fix
Set `enforcePerClientResources: false` — Better Auth's documented knob that "keeps all enabled resources requestable by any client." Tokens stay aud-bound to the requested resource. We have no admin flow to link third-party clients, so per-client enforcement isn't usable here anyway. This replaces the earlier `clientRegistrationAllowedResources` setting, which only linked clients that declare `resources` at registration (which normal MCP clients don't).

## Verification
End-to-end prod OAuth smoke (authorize→token→MCP verify) plus a preview A/B on real infra:

| | unlinked client + `resource` at `/oauth2/authorize` |
|---|---|
| prod (enforce=true, default) | `302 → …?error=invalid_target` |
| preview (enforce=false) | `302 → /login` (proceeds normally) |

Also: 307 auth tests pass, typecheck clean.

## Note
A separate, pre-existing issue blocks the *advertised* token endpoint (`uploads.sh/api/auth/oauth2/token`) — Astro `checkOrigin` on the same-origin `/api` proxy 403s form POSTs. Tracked separately; this PR is necessary but not sufficient for full external-client OAuth until that's resolved.