### PR TITLE
fix(auth): advertise OAuth form-POST endpoints on the direct auth origin (#749)

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -290,6 +290,11 @@ export type AuthEnv = GitHubCredentialsEnv &
     BETTER_AUTH_SECRET_DEV?: string;
     UPL_BETTER_AUTH_SECRET?: import("./secrets").SecretLike;
     WEB_ORIGIN?: string;
+    /** The auth worker's own direct origin (e.g. https://auth.uploads.sh),
+     * used to advertise the OAuth form-POST endpoints off the same-origin
+     * `/api` proxy so Astro's checkOrigin can't 403 them (see #749, and the
+     * discovery-metadata rewrite in src/index.ts). Unset in dev/preview. */
+    AUTH_DIRECT_ORIGIN?: string;
     ENVIRONMENT?: string;
     BETTER_AUTH_TRUSTED_ORIGINS?: string;
     AUTH_RATE_LIMIT_DISABLED?: string;

--- a/apps/auth/src/index.test.ts
+++ b/apps/auth/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { app } from "./index";
+import { app, rewriteDiscoveryEndpoints } from "./index";
 import { ROBOTS_TXT } from "./robots";
 import type { AuthEnv } from "./auth";
 import { LOCAL_STACK_WEB_ORIGIN } from "./local-demo";
@@ -208,5 +208,79 @@ describe("local demo session", () => {
         .prepare("SELECT role FROM member WHERE organization_id = 'local-dev-demo-org'")
         .all(),
     ).toEqual([{ role: "member" }]);
+  });
+});
+
+const DISCOVERY_META_URL = "https://uploads.sh/api/auth/.well-known/oauth-authorization-server";
+const discoveryMetadata = () => ({
+  issuer: "https://uploads.sh/api/auth",
+  authorization_endpoint: "https://uploads.sh/api/auth/oauth2/authorize",
+  token_endpoint: "https://uploads.sh/api/auth/oauth2/token",
+  registration_endpoint: "https://uploads.sh/api/auth/oauth2/register",
+  introspection_endpoint: "https://uploads.sh/api/auth/oauth2/introspect",
+  revocation_endpoint: "https://uploads.sh/api/auth/oauth2/revoke",
+  jwks_uri: "https://uploads.sh/api/auth/jwks",
+});
+const discoveryEnv = (overrides: Partial<AuthEnv> = {}): AuthEnv => ({
+  DB: {} as unknown as D1Database,
+  BETTER_AUTH_URL: "https://uploads.sh",
+  WEB_ORIGIN: "https://uploads.sh",
+  AUTH_DIRECT_ORIGIN: "https://auth.uploads.sh",
+  ENVIRONMENT: "production",
+  ...overrides,
+});
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), { headers: { "content-type": "application/json" } });
+
+describe("rewriteDiscoveryEndpoints (#749)", () => {
+  const META_URL = DISCOVERY_META_URL;
+  const metadata = discoveryMetadata;
+  const metaEnv = discoveryEnv;
+  const jsonRes = jsonResponse;
+
+  it("moves only the form-POST endpoints to the direct auth origin", async () => {
+    const out = await rewriteDiscoveryEndpoints(META_URL, jsonRes(metadata()), metaEnv());
+    const j = (await out.json()) as Record<string, string>;
+    // Form-POST endpoints move to auth.uploads.sh …
+    expect(j.token_endpoint).toBe("https://auth.uploads.sh/api/auth/oauth2/token");
+    expect(j.introspection_endpoint).toBe("https://auth.uploads.sh/api/auth/oauth2/introspect");
+    expect(j.revocation_endpoint).toBe("https://auth.uploads.sh/api/auth/oauth2/revoke");
+    // … while issuer and the browser/JSON/GET endpoints stay same-origin.
+    expect(j.issuer).toBe("https://uploads.sh/api/auth");
+    expect(j.authorization_endpoint).toBe("https://uploads.sh/api/auth/oauth2/authorize");
+    expect(j.registration_endpoint).toBe("https://uploads.sh/api/auth/oauth2/register");
+    expect(j.jwks_uri).toBe("https://uploads.sh/api/auth/jwks");
+  });
+
+  it("is a no-op when AUTH_DIRECT_ORIGIN is unset (dev/preview)", async () => {
+    const out = await rewriteDiscoveryEndpoints(
+      META_URL,
+      jsonRes(metadata()),
+      metaEnv({ AUTH_DIRECT_ORIGIN: undefined }),
+    );
+    expect(((await out.json()) as Record<string, string>).token_endpoint).toBe(
+      "https://uploads.sh/api/auth/oauth2/token",
+    );
+  });
+
+  it("is a no-op for non-discovery paths (never reads the body)", async () => {
+    const res = jsonRes({ access_token: "x" });
+    const out = await rewriteDiscoveryEndpoints(
+      "https://uploads.sh/api/auth/oauth2/token",
+      res,
+      metaEnv(),
+    );
+    expect(out).toBe(res); // same Response instance, untouched
+  });
+
+  it("is a no-op when the direct origin equals the issuer origin", async () => {
+    const out = await rewriteDiscoveryEndpoints(
+      META_URL,
+      jsonRes(metadata()),
+      metaEnv({ AUTH_DIRECT_ORIGIN: "https://uploads.sh" }),
+    );
+    expect(((await out.json()) as Record<string, string>).token_endpoint).toBe(
+      "https://uploads.sh/api/auth/oauth2/token",
+    );
   });
 });

--- a/apps/auth/src/index.test.ts
+++ b/apps/auth/src/index.test.ts
@@ -273,6 +273,21 @@ describe("rewriteDiscoveryEndpoints (#749)", () => {
     expect(out).toBe(res); // same Response instance, untouched
   });
 
+  it("does not rewrite a lookalike host that only shares the issuer prefix", async () => {
+    const out = await rewriteDiscoveryEndpoints(
+      DISCOVERY_META_URL,
+      jsonResponse({
+        ...discoveryMetadata(),
+        token_endpoint: "https://uploads.sh.evil/api/auth/oauth2/token",
+      }),
+      discoveryEnv(),
+    );
+    const j = (await out.json()) as Record<string, string>;
+    // The lookalike is left untouched; the genuine endpoints still move.
+    expect(j.token_endpoint).toBe("https://uploads.sh.evil/api/auth/oauth2/token");
+    expect(j.revocation_endpoint).toBe("https://auth.uploads.sh/api/auth/oauth2/revoke");
+  });
+
   it("is a no-op when the direct origin equals the issuer origin", async () => {
     const out = await rewriteDiscoveryEndpoints(
       META_URL,

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -43,10 +43,86 @@ async function discoveryAlias(
   }
   const url = new URL(c.req.raw.url);
   url.pathname = pathname;
-  const res = await auth.handler(new Request(url.toString(), c.req.raw));
+  const aliasReq = new Request(url.toString(), c.req.raw);
+  const res = await rewriteDiscoveryEndpoints(url.toString(), await auth.handler(aliasReq), c.env);
   const headers = new Headers(res.headers);
   headers.set("Access-Control-Allow-Origin", "*");
   return new Response(res.body, { status: res.status, headers });
+}
+
+/**
+ * OAuth discovery metadata paths whose form-POST endpoints need the direct
+ * auth origin (see `rewriteDiscoveryEndpoints`).
+ */
+function isDiscoveryMetadataPath(pathname: string): boolean {
+  return (
+    pathname.endsWith("/.well-known/oauth-authorization-server") ||
+    pathname.endsWith("/.well-known/openid-configuration")
+  );
+}
+
+/**
+ * The OAuth 2.1 token, introspection, and revocation endpoints are
+ * machine-to-machine, non-cookie form POSTs (RFC 6749 §3.2 / 7662 / 7009). When
+ * this worker is reached through the web origin's same-origin `/api` proxy
+ * (#731), Astro's `checkOrigin` CSRF guard 403s those cross-site form POSTs
+ * ("Cross-site POST form submissions are forbidden"). So we advertise them on
+ * the worker's DIRECT origin (`AUTH_DIRECT_ORIGIN`, e.g. https://auth.uploads.sh),
+ * which bypasses the proxy entirely. Browser-facing (`authorization_endpoint`)
+ * and JSON/GET endpoints (`registration_endpoint`, `jwks_uri`, `issuer`) stay on
+ * the same-origin issuer so session cookies and discovery are unaffected. See
+ * issue #749.
+ *
+ * No-op unless `AUTH_DIRECT_ORIGIN` is set and differs from the issuer origin —
+ * dev/preview reach the worker directly, so they skip this. Only rewrites the
+ * two discovery documents; every other `/api/auth/*` response passes straight
+ * through (the path check short-circuits before the body is ever read).
+ */
+const FORM_POST_ENDPOINT_KEYS = [
+  "token_endpoint",
+  "introspection_endpoint",
+  "revocation_endpoint",
+] as const;
+
+export async function rewriteDiscoveryEndpoints(
+  requestUrl: string,
+  res: Response,
+  env: AuthEnv,
+): Promise<Response> {
+  const authOrigin = env.AUTH_DIRECT_ORIGIN;
+  if (!authOrigin || !res.ok) return res;
+  if (!isDiscoveryMetadataPath(new URL(requestUrl).pathname)) return res;
+
+  let issuerOrigin: string;
+  let directOrigin: string;
+  try {
+    issuerOrigin = new URL(env.BETTER_AUTH_URL || "https://auth.uploads.sh").origin;
+    directOrigin = new URL(authOrigin).origin;
+  } catch {
+    return res;
+  }
+  if (issuerOrigin === directOrigin) return res;
+
+  let json: Record<string, unknown>;
+  try {
+    json = (await res.clone().json()) as Record<string, unknown>;
+  } catch {
+    return res;
+  }
+
+  let changed = false;
+  for (const key of FORM_POST_ENDPOINT_KEYS) {
+    const value = json[key];
+    if (typeof value === "string" && value.startsWith(issuerOrigin)) {
+      json[key] = directOrigin + value.slice(issuerOrigin.length);
+      changed = true;
+    }
+  }
+  if (!changed) return res;
+
+  const headers = new Headers(res.headers);
+  headers.delete("content-length");
+  return new Response(JSON.stringify(json), { status: res.status, headers });
 }
 
 // Public, non-credentialed CORS for /billing/prices — the web app fetches
@@ -122,7 +198,12 @@ export const app = new Hono<{ Bindings: AuthEnv }>()
     // awaits its own DB writes before returning a response, so there is
     // nothing here that needs `c.executionCtx.waitUntil`; revisit if a future
     // better-auth version adds one.
-    return auth.handler(c.req.raw);
+    //
+    // The discovery-metadata rewrite (#749) advertises the OAuth form-POST
+    // endpoints on AUTH_DIRECT_ORIGIN; it no-ops for every non-metadata path
+    // (the path check short-circuits before the body is read), so it doesn't
+    // touch the actual /oauth2/token request itself.
+    return rewriteDiscoveryEndpoints(c.req.raw.url, await auth.handler(c.req.raw), c.env);
   })
   .notFound((c) => c.json({ error: { code: "not_found", message: "Not found" } }, 404));
 

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -113,8 +113,17 @@ export async function rewriteDiscoveryEndpoints(
   let changed = false;
   for (const key of FORM_POST_ENDPOINT_KEYS) {
     const value = json[key];
-    if (typeof value === "string" && value.startsWith(issuerOrigin)) {
-      json[key] = directOrigin + value.slice(issuerOrigin.length);
+    if (typeof value !== "string") continue;
+    let endpoint: URL;
+    try {
+      endpoint = new URL(value);
+    } catch {
+      continue; // preserve malformed / non-URL values unchanged
+    }
+    // Exact origin match — a `startsWith` prefix check would also rewrite a
+    // lookalike host like `https://uploads.sh.evil/…` (CodeRabbit, #750).
+    if (endpoint.origin === issuerOrigin) {
+      json[key] = `${directOrigin}${endpoint.pathname}${endpoint.search}${endpoint.hash}`;
       changed = true;
     }
   }

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -31,6 +31,12 @@
     // Web app origin; credentialed CORS on /api/auth/* and the magic-link
     // email template both derive from this.
     "WEB_ORIGIN": "https://uploads.sh",
+    // This worker's own direct custom-domain origin (see the `routes` block).
+    // Discovery advertises the OAuth token/introspection/revocation endpoints
+    // here so machine form-POSTs bypass the web origin's same-origin `/api`
+    // proxy and its Astro `checkOrigin` CSRF guard (issue #749). Unset in the
+    // previews block / dev — those reach the worker directly.
+    "AUTH_DIRECT_ORIGIN": "https://auth.uploads.sh",
     "ENVIRONMENT": "production",
     // Makes Stripe Checkout require a Terms of Service checkbox before it
     // takes payment. Safe only because the Stripe Dashboard's Terms of


### PR DESCRIPTION
Closes #749.

## Problem
OAuth `token`/`introspection`/`revocation` are machine-to-machine, non-cookie **form** POSTs (RFC 6749 §3.2 / 7662 / 7009). Discovery advertises them on the web origin's same-origin `/api` proxy (`uploads.sh/api/auth/oauth2/token`, per #731), where Astro's `checkOrigin` CSRF guard 403s cross-site form POSTs (`Cross-site POST form submissions are forbidden`). So a spec-compliant external client following discovery can't complete the token exchange — it only works at `auth.uploads.sh` directly, which discovery didn't advertise.

## Fix (option A from the issue)
Rewrite just those three endpoints in the AS + OpenID discovery documents to a new `AUTH_DIRECT_ORIGIN` (`https://auth.uploads.sh`), so machine clients POST straight to the worker and bypass the proxy. Everything else stays same-origin:

| Endpoint | Host | Why |
|---|---|---|
| `token` / `introspection` / `revocation` | **auth.uploads.sh** | form POST — must dodge Astro checkOrigin |
| `authorization_endpoint` | uploads.sh | browser redirect; benefits from same-origin session |
| `registration_endpoint` | uploads.sh | JSON POST — checkOrigin doesn't block JSON |
| `jwks_uri`, `issuer` | uploads.sh | GET / identity; issuer must stay stable (#731, MCP verifies `iss`) |

The rewrite (`rewriteDiscoveryEndpoints` in `apps/auth/src/index.ts`):
- **no-ops** unless `AUTH_DIRECT_ORIGIN` is set and differs from the issuer origin — dev/preview reach the worker directly, so they skip it (var is prod-only);
- **short-circuits on the path** before reading any body, so it never touches the real `/oauth2/token` request — only the two discovery documents.

## Verification
- New unit tests for the rewrite (moves only the 3 form endpoints; no-op when the var is unset, for non-discovery paths, and when direct==issuer). 311 auth tests pass; typecheck + lint clean.
- The direct endpoint itself is already proven: the prod OAuth smoke completed the token exchange at `auth.uploads.sh` (form POST → JWT `aud=agents.uploads.sh/mcp` → MCP verified 200).
- Post-deploy, discovery will advertise `token_endpoint=https://auth.uploads.sh/...`; a form POST there works, closing the gap end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth discovery metadata now advertises direct endpoints for token, introspection, and revocation requests when configured.
  * Browser-based and issuer endpoints remain unchanged.
  * Responses are safely preserved when rewriting is unavailable or metadata is invalid.

* **Configuration**
  * Added support for configuring the direct authentication origin in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->