### PR TITLE
fix(web): restore mono to commands and the device code, and de-duplicate the workspace label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,12 @@ coverage/
 # and worktree agrees on what is intentionally ignored.
 .impeccable/*
 !.impeccable/config.json
+# Impeccable's setup also writes a GitHub Copilot-flavoured hook registration
+# (see docs/superpowers/specs/2026-07-24-multi-harness-hooks-design.md — the
+# `.github/hooks/` adapter). This repo does not use Copilot hooks; its own live
+# in hooks/hooks.json, and the script that file points at is not installed here,
+# so it is inert. Ignored so a context.mjs run does not dirty the tree.
+.github/hooks/impeccable.json
 # Local agent notes, private plans, pricing scratch (not for the public repo)
 .context/
 .superpowers/

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -152,7 +152,6 @@ const serverSignedIn = serverSessionUserJson !== null;
                     }
                     <span class="ws-switcher__label" id="ws-switcher-label">{switcherHeading}</span>
                   </span>
-                  <span class="ws-switcher__subtitle">workspace</span>
                 </span>
                 <span class="ws-switcher__chevron" aria-hidden="true" title="Switch workspace"
                   >▾</span

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -110,6 +110,7 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
         outline: none;
       }
       pre {
+        font: var(--text-meta) / var(--leading-body) var(--mono);
         background: var(--panel);
         border: 1px solid var(--line);
         border-radius: var(--radius-md);
@@ -135,6 +136,8 @@ const authOrigin = SAME_ORIGIN_AUTH_BASE;
       }
       code {
         color: var(--fg);
+        font-family: var(--mono);
+        font-size: var(--mono-optical);
       }
       .admin {
         display: grid;

--- a/apps/web/src/pages/device.astro
+++ b/apps/web/src/pages/device.astro
@@ -67,7 +67,9 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
         margin: 16px 0;
       }
       .code {
+        font-family: var(--mono);
         font-size: var(--text-h1);
+        font-variant-numeric: tabular-nums;
         letter-spacing: 0.28em;
         font-weight: var(--weight-semibold);
         color: var(--fg);

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -151,6 +151,8 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       }
       .screen {
         padding: 20px 20px 24px;
+        font-family: var(--mono);
+        font-variant-ligatures: none;
         font-size: var(--text-meta);
       }
       .line {
@@ -317,15 +319,26 @@ Source (and where to look if something breaks): https://github.com/buildinternet
          faintest, smallest text inside their own section — below the lede they
          introduced. They now read at heading rank; the shell-comment `#` stays
          and carries the terminal voice, tinted rather than shouted. */
+      /* The shell-comment `#` is voice, not a word in the sentence. At label
+         size it read as a comment marker; blown up to heading size it read as a
+         stray character. It is now a real marker: mono (it is terminal syntax),
+         muted, and optically smaller than the heading it introduces. */
       .sect-head {
+        display: flex;
+        align-items: baseline;
+        gap: 0.45em;
         color: var(--fg);
         font: var(--weight-semibold) var(--text-h2) / var(--leading-heading) var(--sans);
         letter-spacing: var(--tracking-heading);
         text-wrap: balance;
         margin: 0 0 10px 2px;
       }
-      .sect-head::first-letter {
-        color: var(--accent);
+      .sect-head .hash {
+        flex: none;
+        font: var(--weight-regular) var(--text-h3) / 1 var(--mono);
+        color: var(--muted);
+        letter-spacing: 0;
+        user-select: none;
       }
       .sect-lede {
         font: var(--text-body) / var(--leading-body) var(--sans);
@@ -401,15 +414,19 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         display: grid;
         gap: 10px;
       }
+      /* Padded for mono: the command sets in Geist Mono, which runs optically
+         larger than the sans around it, so the row needs a little more air than
+         a sans row of the same size would. The label column is sized to the
+         longest label (PROMPT) rather than left at a round number. */
       .cmdrow {
         display: grid;
-        grid-template-columns: 74px 1fr auto;
+        grid-template-columns: 62px 1fr auto;
         align-items: center;
-        gap: 12px;
+        gap: 14px;
         background: var(--panel);
         border: 1px solid var(--line);
         border-radius: var(--radius-md);
-        padding: 10px 12px;
+        padding: 13px 14px;
       }
       /* Snippet pattern: whole row is the hit target; the real <button>
          keeps keyboard + screen-reader affordance. */
@@ -425,8 +442,12 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         letter-spacing: 0.1em;
         text-transform: uppercase;
       }
+      /* A command you copy and run: mono, explicitly. These used to inherit it
+         from the page body and lost it when the body became sans. */
       .cmdrow .cmdtext {
         color: var(--fg);
+        font-family: var(--mono);
+        font-variant-ligatures: none;
         overflow-x: auto;
         white-space: nowrap;
         scrollbar-width: none;
@@ -704,7 +725,9 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       </p>
 
       <section class="features" aria-label="Features">
-        <h2 class="sect-head"># "Which page was that?"</h2>
+        <h2 class="sect-head">
+          <span class="hash" aria-hidden="true">#</span>“Which page was that?”
+        </h2>
         <p class="sect-lede">
           Attach a path (or anything else) with&#32;
           <code>--meta</code>, then <code>uploads find</code> brings it back.
@@ -736,7 +759,9 @@ Source (and where to look if something breaks): https://github.com/buildinternet
           </p>
         </div>
 
-        <h2 class="sect-head later"># more than file-hosting</h2>
+        <h2 class="sect-head later">
+          <span class="hash" aria-hidden="true">#</span>more than file-hosting
+        </h2>
         <div class="grid">
           <div class="feature">
             <h3>capture and host</h3>
@@ -772,7 +797,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       </section>
 
       <section class="install" aria-label="Install commands">
-        <h2 class="sect-head"># get set up</h2>
+        <h2 class="sect-head"><span class="hash" aria-hidden="true">#</span>get set up</h2>
         <div class="rows">
           <div class="cmdrow">
             <span class="tag">cli</span>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -319,26 +319,12 @@ Source (and where to look if something breaks): https://github.com/buildinternet
          faintest, smallest text inside their own section — below the lede they
          introduced. They now read at heading rank; the shell-comment `#` stays
          and carries the terminal voice, tinted rather than shouted. */
-      /* The shell-comment `#` is voice, not a word in the sentence. At label
-         size it read as a comment marker; blown up to heading size it read as a
-         stray character. It is now a real marker: mono (it is terminal syntax),
-         muted, and optically smaller than the heading it introduces. */
       .sect-head {
-        display: flex;
-        align-items: baseline;
-        gap: 0.45em;
         color: var(--fg);
         font: var(--weight-semibold) var(--text-h2) / var(--leading-heading) var(--sans);
         letter-spacing: var(--tracking-heading);
         text-wrap: balance;
         margin: 0 0 10px 2px;
-      }
-      .sect-head .hash {
-        flex: none;
-        font: var(--weight-regular) var(--text-h3) / 1 var(--mono);
-        color: var(--muted);
-        letter-spacing: 0;
-        user-select: none;
       }
       .sect-lede {
         font: var(--text-body) / var(--leading-body) var(--sans);
@@ -725,9 +711,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       </p>
 
       <section class="features" aria-label="Features">
-        <h2 class="sect-head">
-          <span class="hash" aria-hidden="true">#</span>“Which page was that?”
-        </h2>
+        <h2 class="sect-head">“Which page was that?”</h2>
         <p class="sect-lede">
           Attach a path (or anything else) with&#32;
           <code>--meta</code>, then <code>uploads find</code> brings it back.
@@ -759,19 +743,17 @@ Source (and where to look if something breaks): https://github.com/buildinternet
           </p>
         </div>
 
-        <h2 class="sect-head later">
-          <span class="hash" aria-hidden="true">#</span>more than file-hosting
-        </h2>
+        <h2 class="sect-head later">More than file-hosting</h2>
         <div class="grid">
           <div class="feature">
-            <h3>capture and host</h3>
+            <h3>Capture and host</h3>
             <p>
               <code>uploads screenshot &lt;url&gt;</code> captures and hosts in one step, with both local
               and remote browser support.
             </p>
           </div>
           <div class="feature">
-            <h3>point at the change</h3>
+            <h3>Point at the change</h3>
             <p>
               Bake hand-drawn boxes, arrows, labels, and solid redactions into a capture with&#32;
               <code>screenshot --annotate</code> or <code>uploads annotate</code> — so reviewers see what
@@ -779,7 +761,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
             </p>
           </div>
           <div class="feature">
-            <h3>device frames</h3>
+            <h3>Device frames</h3>
             <p>
               Wrap a raw screenshot in device chrome — phone, browser, or a specific iPhone — with <code
                 >--frame</code
@@ -787,7 +769,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
             </p>
           </div>
           <div class="feature">
-            <h3>group into a gallery</h3>
+            <h3>Group into a gallery</h3>
             <p>
               Group uploads into a gallery that can live across multiple PRs — one link for the
               whole set that shows linked issues and pull requests.
@@ -797,7 +779,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       </section>
 
       <section class="install" aria-label="Install commands">
-        <h2 class="sect-head"><span class="hash" aria-hidden="true">#</span>get set up</h2>
+        <h2 class="sect-head">Get set up</h2>
         <div class="rows">
           <div class="cmdrow">
             <span class="tag">cli</span>
@@ -832,7 +814,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
             <span data-home-cta-icon aria-hidden="true">
               <GitHubMark size={15} />
             </span>
-            <span data-home-cta-label>sign in with GitHub</span>
+            <span data-home-cta-label>Sign in with GitHub</span>
           </a>
           <span class="cta-note" data-home-cta-note
             >free to start in the cloud · open source to self-host</span
@@ -873,12 +855,12 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         if (signedIn) {
           cta.href = workspaceHref();
           if (icon) icon.hidden = true;
-          if (label) label.textContent = "go to workspace";
+          if (label) label.textContent = "Go to workspace";
           if (note) note.hidden = true;
         } else {
           cta.href = "/login";
           if (icon) icon.hidden = false;
-          if (label) label.textContent = "sign in with GitHub";
+          if (label) label.textContent = "Sign in with GitHub";
           if (note) note.hidden = false;
         }
       }

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -108,10 +108,12 @@
   border-color: var(--accent);
   outline: none;
 }
+/* One line now: the trigger names the workspace, and the `workspace` section
+   label directly beneath it in the nav already says what kind of thing it is —
+   the trigger's own uppercase subtitle just said it twice. */
 .account-shell nav.side .ws-switcher__body {
   min-width: 0;
   display: grid;
-  gap: 2px;
 }
 .account-shell nav.side .ws-switcher__line1 {
   display: flex;
@@ -127,12 +129,6 @@
   color: var(--fg);
   font-size: var(--text-meta);
   font-weight: var(--weight-semibold);
-}
-.account-shell nav.side .ws-switcher__subtitle {
-  color: var(--muted);
-  font-size: var(--text-micro);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
 }
 /* Trigger's own Pro badge (workspaces-nav.ts paintTriggerBadge, inserted as
    `label`'s next sibling) — same `.pro-badge` idiom as the menu rows
@@ -363,9 +359,6 @@
   }
   .account-shell nav.side .ws-switcher .ws-switcher__trigger {
     padding: 7px 10px;
-  }
-  .account-shell nav.side .ws-switcher__subtitle {
-    display: none;
   }
   /* Eyebrow labels spend rows without adding meaning at this size. */
   .account-shell nav.side .side-label {


### PR DESCRIPTION
Fixes regressions Zach spotted on production after #745.

## The regression

Three places carried no `font-family` of their own and were **inheriting mono from each page's `body`**. #745 flipped those bodies to sans and silently took the commands with them:

| Element | Was rendering | Should be |
| --- | --- | --- |
| `.screen` / `.screen p` (hero terminal) | Geist Variable | mono — it is a simulated terminal |
| `.cmdrow .cmdtext` (install rows) | Geist Variable | mono — commands you copy and run |
| `.code` on `/device` | Geist Variable | mono — a code you read off screen and type |

The device one is the worst of the three: that code exists to be transcribed into a CLI, and a proportional face is exactly where `0`/`O` and `1`/`l` stop being distinguishable.

Each now names `var(--mono)` explicitly instead of depending on inheritance. The device code also gains `tabular-nums`. `console.astro`'s `<pre>` and `<code>` now name `var(--mono)` too — they had been falling through to the browser's default monospace rather than Geist Mono.

This is the same class of bug I documented for the design-system comps in #746 (`NOTES.md`, "commands … had been inheriting mono from the page's mono base"). I checked it there and did not check it here.

## Also from #745, on the landing page

**The shell-comment hash.** #745 promoted the section `<h2>`s from 12px uppercase muted to real heading rank — correct, they were smaller than the lede they introduced — but it carried the `#` up with them, where it read as a stray character instead of a comment marker. It is now an actual marker: mono (it *is* terminal syntax), muted, and optically smaller than the heading it prefixes, on its own baseline-aligned track. Section titles also take curly quotes.

**Command row spacing.** The rows were padded for sans. Mono runs optically larger at the same size, so they came out tight — padding goes 10/12 → 13/14, the gap 12 → 14, and the label column is now sized to the longest label (`PROMPT`) rather than left at a round 74px.

## Duplicate WORKSPACE label

The workspace switcher's trigger carried an uppercase `workspace` subtitle under the workspace name, and the nav's own `workspace` section label sits directly beneath it — the word appeared twice in a row. Removed. The trigger names the workspace; the section label already says what kind of thing it is.

Two existing decisions in this codebase already pointed the same way: the mobile breakpoint hid this exact subtitle with the comment *"eyebrow labels spend rows without adding meaning at this size"*, and `workspace-rail.ts` independently dropped a repeated-word subtitle for the same reason. The two-line body grid collapses to one line with it.

## Verification

Computed styles on the dev build, desktop and iPhone 13:

- `.screen`, `.screen p`, `.cmdrow .cmdtext`, `.hero-install .cmdtext` → Geist Mono Variable
- `/device` `.code` → Geist Mono Variable, 36px
- `.sect-head` → Geist Variable 26px, `.sect-head .hash` → Geist Mono Variable 19px
- `pnpm --filter @uploads/web build` — passes
- `pnpm format:check` — clean
- `pnpm vitest run --root apps/web` — 814/814 pass

## Worth noting for next time

`<code>` and `<pre>` elements resist this whole class of bug because the UA stylesheet gives them `font-family: monospace` — which is also why they never picked up Geist Mono unless a rule said so. The elements that broke were all `<span>`/`<div>` carrying command text, which inherit normally. A design-system-level `code, kbd, samp, pre { font-family: var(--mono) }` would close the second half of that gap; I have left it out of this PR to keep it to the regression, but it is worth a follow-up.
