### PR TITLE
chore(release): cover every private package in the changesets ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,10 +9,15 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@uploads/api",
-    "@uploads/mcp",
-    "@uploads/web",
-    "@uploads/storage",
     "@uploads/auth",
-    "@uploads/billing"
+    "@uploads/billing",
+    "@uploads/comment-config",
+    "@uploads/comment-render",
+    "@uploads/email",
+    "@uploads/errors",
+    "@uploads/mcp",
+    "@uploads/storage",
+    "@uploads/ui",
+    "@uploads/web"
   ]
 }


### PR DESCRIPTION
## Summary

Audit of changesets usage found the `ignore` list only covered 6 of the 11 private workspace packages. The five missing ones (`@uploads/ui`, `@uploads/errors`, `@uploads/email`, `@uploads/comment-config`, `@uploads/comment-render`) could be named in a changeset that passed `changeset:lint`, producing meaningless version bumps and CHANGELOGs for packages nobody installs — `@uploads/ui` is at 0.1.2 from exactly this.

This adds all private packages to `ignore`, so `@buildinternet/uploads` (the only publishable package) is the only valid changeset target and `scripts/changeset-lint.mjs` now rejects changesets naming any private package.

## Verification

- `pnpm run changeset:lint` — 0 changesets, OK
- `pnpm exec changeset status` — clean, no packages to bump