### PR TITLE
feat: fold the auth D1 schema into the main migration chain (#754 phase 1)

### DIFF
--- a/apps/api/migrations/20260822120000_auth_tables.sql
+++ b/apps/api/migrations/20260822120000_auth_tables.sql
@@ -1,0 +1,385 @@
+-- Issue #754 item 1: fold apps/auth's dedicated D1 database into this one.
+--
+-- This is a squash of every file in apps/auth/migrations/ (16 files, listed
+-- below) into the schema shape they produce when applied in order against an
+-- empty database. It does not replay each historical step (some add a column
+-- then another migration backfills/dedupes/re-indexes it) — it just creates
+-- the tables and indexes in their final form. apps/auth/migrations/ is the
+-- historical record and keeps driving the OLD dedicated auth D1
+-- (uploads-auth) until the data move happens; this file is additive only and
+-- does not touch it.
+--
+-- Source files (apps/auth/migrations/):
+--   20260712200000_better_auth_core.sql       user, session, account,
+--                                              verification, rate_limit
+--   20260712210000_admin_plugin.sql           session.impersonated_by
+--   20260712220000_organization.sql           organization, member,
+--                                              invitation, session.active_
+--                                              organization_id
+--   20260712230000_device_code.sql            device_code
+--   20260714120000_cli_onboarded_at.sql       user.cli_onboarded_at (+ backfill,
+--                                              not replayed — no rows exist yet)
+--   20260717000000_oauth_provider.sql         jwks, oauth_client,
+--                                              oauth_access_token,
+--                                              oauth_refresh_token, oauth_consent
+--   20260718000000_oauth_workspace_choice.sql oauth_workspace_choice
+--   20260719000000_seed_cli_oauth_client.sql  seed row in oauth_client (replayed
+--                                              below, still INSERT OR IGNORE)
+--   20260721160000_invitation_org_status_idx.sql
+--   20260722180000_retention_expires_at_idx.sql
+--   20260722190000_stripe_subscription.sql    subscription,
+--                                              user/organization.stripe_customer_id
+--   20260723120000_session_cli_version.sql    session.cli_version
+--   20260723150000_billing_plan_outbox.sql    billing_plan_outbox
+--   20260728120000_created_at_indexes.sql
+--   20260731120000_github_identity.sql        github_identity
+--   20260821120000_better_auth_1_7.sql        account.issuer + unique index,
+--                                              device_code unique indexes,
+--                                              oauth_client/access_token/
+--                                              refresh_token/jwks/consent 1.7
+--                                              columns, oauth_resource,
+--                                              oauth_client_resource,
+--                                              oauth_client_assertion
+--
+-- Schema-collision check (done by hand against apps/api/migrations/*.sql, see
+-- .context/754-auth-d1-merge-plan.md): no table or index name below collides
+-- with an existing apps/api table/index. Every statement is guarded with
+-- IF NOT EXISTS so this is safe to run twice and safe to run against a
+-- database that already has these tables (e.g. a local D1 that previously
+-- ran apps/auth's own migrations against the same file, or a re-run after a
+-- partial apply).
+
+CREATE TABLE IF NOT EXISTS user (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE,
+  email_verified INTEGER NOT NULL DEFAULT 0,
+  image TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  role TEXT,
+  banned INTEGER,
+  ban_reason TEXT,
+  ban_expires INTEGER,
+  cli_onboarded_at INTEGER,
+  stripe_customer_id TEXT
+);
+CREATE INDEX IF NOT EXISTS user_created_at_idx ON user (created_at);
+
+CREATE TABLE IF NOT EXISTS session (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES user (id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  expires_at INTEGER NOT NULL,
+  ip_address TEXT,
+  user_agent TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  impersonated_by TEXT,
+  active_organization_id TEXT,
+  cli_version TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_session_user_id ON session (user_id);
+
+CREATE TABLE IF NOT EXISTS account (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES user (id) ON DELETE CASCADE,
+  account_id TEXT NOT NULL,
+  provider_id TEXT NOT NULL,
+  access_token TEXT,
+  refresh_token TEXT,
+  access_token_expires_at INTEGER,
+  refresh_token_expires_at INTEGER,
+  scope TEXT,
+  id_token TEXT,
+  password TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  issuer TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_account_user_id ON account (user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_account_issuer_account_id ON account (issuer, account_id);
+
+CREATE TABLE IF NOT EXISTS verification (
+  id TEXT PRIMARY KEY,
+  identifier TEXT NOT NULL,
+  value TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_verification_identifier ON verification (identifier);
+CREATE INDEX IF NOT EXISTS idx_verification_expires_at ON verification (expires_at);
+
+CREATE TABLE IF NOT EXISTS rate_limit (
+  id TEXT PRIMARY KEY,
+  "key" TEXT NOT NULL UNIQUE,
+  count INTEGER NOT NULL,
+  last_request INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS organization (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  logo TEXT,
+  created_at INTEGER NOT NULL,
+  metadata TEXT,
+  stripe_customer_id TEXT
+);
+CREATE INDEX IF NOT EXISTS organization_created_at_idx ON organization (created_at);
+
+CREATE TABLE IF NOT EXISTS member (
+  id TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organization (id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL REFERENCES user (id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'member',
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_member_organization_id ON member (organization_id);
+CREATE INDEX IF NOT EXISTS idx_member_user_id ON member (user_id);
+
+CREATE TABLE IF NOT EXISTS invitation (
+  id TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organization (id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  role TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  expires_at INTEGER NOT NULL,
+  inviter_id TEXT NOT NULL REFERENCES user (id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_invitation_organization_id ON invitation (organization_id);
+CREATE INDEX IF NOT EXISTS idx_invitation_organization_status ON invitation (organization_id, status);
+
+CREATE TABLE IF NOT EXISTS device_code (
+  id TEXT PRIMARY KEY NOT NULL,
+  device_code TEXT NOT NULL,
+  user_code TEXT NOT NULL,
+  user_id TEXT,
+  expires_at INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  last_polled_at INTEGER,
+  polling_interval INTEGER,
+  client_id TEXT,
+  scope TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_device_code_device_code ON device_code (device_code);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_device_code_user_code ON device_code (user_code);
+CREATE INDEX IF NOT EXISTS idx_device_code_expires_at ON device_code (expires_at);
+
+CREATE TABLE IF NOT EXISTS jwks (
+  id TEXT PRIMARY KEY,
+  public_key TEXT NOT NULL,
+  private_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER,
+  alg TEXT,
+  crv TEXT
+);
+
+CREATE TABLE IF NOT EXISTS oauth_client (
+  id TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL UNIQUE,
+  client_secret TEXT,
+  name TEXT,
+  icon TEXT,
+  uri TEXT,
+  redirect_uris TEXT NOT NULL,
+  post_logout_redirect_uris TEXT,
+  scopes TEXT NOT NULL,
+  grant_types TEXT,
+  response_types TEXT,
+  contacts TEXT,
+  token_endpoint_auth_method TEXT,
+  type TEXT,
+  public INTEGER,
+  require_pkce INTEGER,
+  disabled INTEGER,
+  skip_consent INTEGER,
+  enable_end_session INTEGER,
+  subject_type TEXT,
+  tos TEXT,
+  policy TEXT,
+  software_id TEXT,
+  software_version TEXT,
+  software_statement TEXT,
+  user_id TEXT,
+  reference_id TEXT,
+  metadata TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  client_discovery_id TEXT,
+  client_credentials_scopes TEXT DEFAULT '[]',
+  backchannel_logout_uri TEXT,
+  backchannel_logout_session_required INTEGER,
+  application_type TEXT,
+  jwks TEXT,
+  jwks_uri TEXT,
+  dpop_bound_access_tokens INTEGER DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_oauth_client_client_id ON oauth_client (client_id);
+
+CREATE TABLE IF NOT EXISTS oauth_access_token (
+  id TEXT PRIMARY KEY,
+  token TEXT NOT NULL UNIQUE,
+  client_id TEXT NOT NULL REFERENCES oauth_client (client_id),
+  session_id TEXT REFERENCES session (id) ON DELETE SET NULL,
+  refresh_id TEXT,
+  user_id TEXT,
+  reference_id TEXT,
+  scopes TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  authorization_code_id TEXT,
+  resources TEXT,
+  requested_user_info_claims TEXT,
+  confirmation TEXT,
+  revoked INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_oauth_access_token_token ON oauth_access_token (token);
+CREATE INDEX IF NOT EXISTS idx_oauth_access_client_id ON oauth_access_token (client_id);
+CREATE INDEX IF NOT EXISTS idx_oauth_access_session_id ON oauth_access_token (session_id);
+CREATE INDEX IF NOT EXISTS idx_oauth_access_authorization_code_id ON oauth_access_token (authorization_code_id);
+
+CREATE TABLE IF NOT EXISTS oauth_refresh_token (
+  id TEXT PRIMARY KEY,
+  token TEXT NOT NULL UNIQUE,
+  client_id TEXT NOT NULL REFERENCES oauth_client (client_id),
+  session_id TEXT REFERENCES session (id) ON DELETE SET NULL,
+  user_id TEXT NOT NULL,
+  reference_id TEXT,
+  scopes TEXT NOT NULL,
+  revoked INTEGER,
+  auth_time INTEGER,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  authorization_code_id TEXT,
+  resources TEXT,
+  requested_user_info_claims TEXT,
+  rotated_at INTEGER,
+  rotation_replay_response TEXT,
+  rotation_replay_expires_at INTEGER,
+  confirmation TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_oauth_refresh_token_token ON oauth_refresh_token (token);
+CREATE INDEX IF NOT EXISTS idx_oauth_refresh_client_id ON oauth_refresh_token (client_id);
+CREATE INDEX IF NOT EXISTS idx_oauth_refresh_session_id ON oauth_refresh_token (session_id);
+CREATE INDEX IF NOT EXISTS idx_oauth_refresh_authorization_code_id ON oauth_refresh_token (authorization_code_id);
+
+CREATE TABLE IF NOT EXISTS oauth_consent (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  client_id TEXT NOT NULL,
+  reference_id TEXT,
+  scopes TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  resources TEXT,
+  requested_user_info_claims TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_oauth_consent_user_client ON oauth_consent (user_id, client_id);
+
+CREATE TABLE IF NOT EXISTS oauth_resource (
+  id TEXT PRIMARY KEY,
+  identifier TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  access_token_ttl INTEGER,
+  refresh_token_ttl INTEGER,
+  signing_algorithm TEXT,
+  signing_key_id TEXT,
+  allowed_scopes TEXT,
+  custom_claims TEXT,
+  dpop_bound_access_tokens_required INTEGER DEFAULT 0,
+  disabled INTEGER DEFAULT 0,
+  policy_version INTEGER DEFAULT 1,
+  metadata TEXT,
+  created_at INTEGER,
+  updated_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS oauth_client_resource (
+  id TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL REFERENCES oauth_client (client_id),
+  resource_id TEXT NOT NULL REFERENCES oauth_resource (identifier),
+  metadata TEXT,
+  created_at INTEGER
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_oauth_client_resource_client_resource
+  ON oauth_client_resource (client_id, resource_id);
+
+CREATE TABLE IF NOT EXISTS oauth_client_assertion (
+  id TEXT PRIMARY KEY,
+  expires_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS oauth_workspace_choice (
+  user_id TEXT PRIMARY KEY,
+  workspace TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS subscription (
+  id TEXT PRIMARY KEY,
+  plan TEXT NOT NULL,
+  reference_id TEXT NOT NULL,
+  stripe_customer_id TEXT,
+  stripe_subscription_id TEXT,
+  status TEXT DEFAULT 'incomplete',
+  period_start INTEGER,
+  period_end INTEGER,
+  trial_start INTEGER,
+  trial_end INTEGER,
+  cancel_at_period_end INTEGER DEFAULT FALSE,
+  cancel_at INTEGER,
+  canceled_at INTEGER,
+  ended_at INTEGER,
+  seats INTEGER,
+  billing_interval TEXT,
+  stripe_schedule_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS billing_plan_outbox (
+  reference_id TEXT PRIMARY KEY,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  next_attempt_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS billing_plan_outbox_next_attempt_at_idx ON billing_plan_outbox (next_attempt_at);
+
+CREATE TABLE IF NOT EXISTS github_identity (
+  account_id TEXT PRIMARY KEY NOT NULL,
+  login TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- Seed row from apps/auth/migrations/20260719000000_seed_cli_oauth_client.sql
+-- (issue #251) — the CLI device-flow client as a managed oauth_client
+-- registration. INSERT OR IGNORE keys off the client_id UNIQUE constraint, so
+-- this is a no-op if the row already exists (e.g. it was carried over by the
+-- prod data-move rather than created fresh here).
+INSERT OR IGNORE INTO oauth_client (
+  id, client_id, client_secret, name, redirect_uris, scopes,
+  grant_types, response_types, token_endpoint_auth_method, type,
+  public, require_pkce, disabled, skip_consent, user_id, metadata,
+  created_at, updated_at
+) VALUES (
+  'oc_uploads_cli_seed',
+  'uploads-cli',
+  NULL,
+  'Uploads CLI',
+  '[]',
+  '["files:read","files:write","files:delete"]',
+  '["urn:ietf:params:oauth:grant-type:device_code"]',
+  '[]',
+  'none',
+  'web',
+  1, 1, 0, 1,
+  NULL,
+  '{"official":true}',
+  CAST(strftime('%s','now') AS INTEGER) * 1000,
+  CAST(strftime('%s','now') AS INTEGER) * 1000
+);

--- a/apps/auth/src/test/fake-d1.ts
+++ b/apps/auth/src/test/fake-d1.ts
@@ -6,9 +6,19 @@
  * `.raw()` (used when a query has field selectors — see `SQLiteD1Session`'s
  * `values()` path), and `client.batch(...)`.
  *
- * Schema is loaded by applying the real `apps/auth/migrations/*.sql` files
- * in order, so drift between `src/schema.ts` and the migrations is caught by
- * tests instead of only at `wrangler d1 migrations apply` time.
+ * Schema is loaded by applying the real `apps/api/migrations/*.sql` files in
+ * order (issue #754: apps/auth's dedicated D1 folds into the main one, so
+ * that is now the single source of truth for this worker's tables too) —
+ * drift between `src/schema.ts` and the migrations is caught by tests
+ * instead of only at `wrangler d1 migrations apply` time. Those files also
+ * create apps/api's own tables, which is harmless here — no table/index name
+ * collides (see .context/754-auth-d1-merge-plan.md) and this worker's tests
+ * never touch them.
+ *
+ * `apps/auth/migrations/*.sql` still exists and still drives the OLD
+ * dedicated auth D1 in production until the item-1 cutover lands; it is
+ * intentionally no longer the source this harness reads from, since new auth
+ * schema changes should land in apps/api/migrations going forward.
  *
  * Deliberately NOT a full D1 emulator: no `.dump()`, no `sessions`/bookmark
  * API, and `meta` fields are minimal stubs. Good enough for drizzle+Better
@@ -25,7 +35,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const MIGRATIONS_DIR = join(__dirname, "..", "..", "migrations");
+const MIGRATIONS_DIR = join(__dirname, "..", "..", "..", "api", "migrations");
 
 function applyMigrations(db: DatabaseSync): void {
   const files = readdirSync(MIGRATIONS_DIR)

--- a/apps/auth/src/test/fake-d1.ts
+++ b/apps/auth/src/test/fake-d1.ts
@@ -16,9 +16,15 @@
  * never touch them.
  *
  * `apps/auth/migrations/*.sql` still exists and still drives the OLD
- * dedicated auth D1 in production until the item-1 cutover lands; it is
- * intentionally no longer the source this harness reads from, since new auth
- * schema changes should land in apps/api/migrations going forward.
+ * dedicated auth D1 that production actually runs against, until the item-1
+ * cutover lands; it is intentionally no longer the source this harness reads
+ * from. Transitional policy until cutover: a schema change affecting this
+ * worker MUST land in BOTH chains — `apps/api/migrations` (so the future
+ * merged layout and this test harness stay correct) AND
+ * `apps/auth/migrations` (so the live `uploads-auth` database production
+ * actually reads from gets the change too). Landing it in only one chain
+ * either leaves prod's real database out of date or leaves the future
+ * merged schema/tests silently behind.
  *
  * Deliberately NOT a full D1 emulator: no `.dump()`, no `sessions`/bookmark
  * API, and `meta` fields are minimal stubs. Good enough for drizzle+Better

--- a/scripts/auth-d1-data-move.mjs
+++ b/scripts/auth-d1-data-move.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Issue #754 item 1 — one-time data move from the dedicated auth D1
+ * (uploads-auth) into the main D1 (uploads-production), once the merged
+ * schema (apps/api/migrations/20260822120000_auth_tables.sql) is live on the
+ * destination.
+ *
+ * This is a Phase 1 deliverable: it is written and tested against LOCAL D1
+ * (both `--local` simulators are just files under .wrangler/state — no
+ * network calls), and is NOT wired into any CI workflow. Running it against
+ * `--remote` is the actual prod cutover step described in
+ * .context/754-auth-d1-merge-plan.md — do that as a deliberate, supervised
+ * action (maintenance window, fresh `wrangler d1 export` backup of both
+ * databases first, apps/auth's wrangler.jsonc D1 binding flipped to the main
+ * DB in the same change so nothing writes to the old DB after the copy)
+ * rather than by running this script on a whim.
+ *
+ * What it does, per table (in FK-safe order):
+ *   1. `wrangler d1 execute <source> --json --command "SELECT * FROM <table>"`
+ *   2. Turn each row into an `INSERT OR IGNORE` statement (OR IGNORE so a
+ *      re-run, or a table that already got the migration's seed row, does
+ *      not fail on a duplicate primary key).
+ *   3. `wrangler d1 execute <dest> --file=<tmp>.sql` to apply them.
+ *   4. Compare `SELECT COUNT(*)` on source vs. destination and report a
+ *      mismatch (destination >= source is expected and fine — see the OR
+ *      IGNORE note above; destination < source is the failure case).
+ *
+ * Usage:
+ *   node scripts/auth-d1-data-move.mjs --local              # default, safe
+ *   node scripts/auth-d1-data-move.mjs --remote              # prod cutover only
+ *   node scripts/auth-d1-data-move.mjs --local --dry-run      # export + count, no import
+ *   node scripts/auth-d1-data-move.mjs --local --tables=user,session
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const AUTH_DIR = resolve(REPO_ROOT, "apps/auth");
+const API_DIR = resolve(REPO_ROOT, "apps/api");
+
+// FK-safe insert order: referenced tables before their referencers.
+const AUTH_TABLES = [
+  "user",
+  "organization",
+  "session",
+  "account",
+  "verification",
+  "rate_limit",
+  "member",
+  "invitation",
+  "device_code",
+  "jwks",
+  "oauth_client",
+  "oauth_resource",
+  "oauth_client_resource",
+  "oauth_client_assertion",
+  "oauth_access_token",
+  "oauth_refresh_token",
+  "oauth_consent",
+  "oauth_workspace_choice",
+  "subscription",
+  "billing_plan_outbox",
+  "github_identity",
+];
+
+function parseArgs(argv) {
+  const args = { mode: "--local", dryRun: false, tables: null };
+  for (const arg of argv) {
+    if (arg === "--local" || arg === "--remote") args.mode = arg;
+    else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg.startsWith("--tables=")) args.tables = arg.slice("--tables=".length).split(",");
+    else if (arg === "--help" || arg === "-h") args.help = true;
+    else throw new Error(`Unknown argument: ${arg}. See --help.`);
+  }
+  return args;
+}
+
+function usage() {
+  console.log(`Usage: node scripts/auth-d1-data-move.mjs [--local|--remote] [--dry-run] [--tables=a,b,c]
+
+  --local      Target both databases' local D1 simulators (default; no network calls).
+  --remote     Target the real Cloudflare D1 databases. This IS the prod cutover step —
+               only run it as part of the documented cutover in
+               .context/754-auth-d1-merge-plan.md, after a fresh backup of both databases.
+  --dry-run    Export and report row counts from the source only; skip the import.
+  --tables=... Comma-separated table subset (default: all ${AUTH_TABLES.length} auth tables).
+`);
+}
+
+/** Run a wrangler d1 command from a given cwd and return parsed stdout. */
+function wranglerJson(cwd, args) {
+  const result = spawnSync(
+    process.execPath,
+    [resolve(cwd, "node_modules/wrangler/bin/wrangler.js"), "d1", ...args, "--json"],
+    { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `wrangler d1 ${args.join(" ")} (cwd=${cwd}) failed:\n${result.stderr || result.stdout}`,
+    );
+  }
+  // `--json` prints one JSON array of per-statement results; wrangler also
+  // sometimes prefixes informational lines before the JSON on stdout, so
+  // parse from the first `[`.
+  const jsonStart = result.stdout.indexOf("[");
+  if (jsonStart === -1) {
+    throw new Error(`wrangler d1 ${args.join(" ")}: no JSON found in output:\n${result.stdout}`);
+  }
+  return JSON.parse(result.stdout.slice(jsonStart));
+}
+
+function selectAll(dir, database, table, mode) {
+  const out = wranglerJson(dir, ["execute", database, mode, "--command", `SELECT * FROM ${table}`]);
+  return out[0]?.results ?? [];
+}
+
+function countRows(dir, database, table, mode) {
+  const out = wranglerJson(dir, [
+    "execute",
+    database,
+    mode,
+    "--command",
+    `SELECT COUNT(*) AS n FROM ${table}`,
+  ]);
+  return Number(out[0]?.results?.[0]?.n ?? 0);
+}
+
+/** SQLite string literal: wrap in single quotes, double embedded quotes. */
+function sqlString(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function sqlLiteral(value) {
+  if (value === null || value === undefined) return "NULL";
+  if (typeof value === "number") return Number.isFinite(value) ? String(value) : "NULL";
+  if (typeof value === "boolean") return value ? "1" : "0";
+  return sqlString(value);
+}
+
+function rowsToInserts(table, rows) {
+  if (rows.length === 0) return "";
+  const columns = Object.keys(rows[0]);
+  const statements = rows.map((row) => {
+    const values = columns.map((col) => sqlLiteral(row[col]));
+    return `INSERT OR IGNORE INTO ${table} (${columns.map((c) => `"${c}"`).join(", ")}) VALUES (${values.join(", ")});`;
+  });
+  return statements.join("\n") + "\n";
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) return usage();
+
+  const mode = args.mode; // "--local" | "--remote"
+  const tables = args.tables ?? AUTH_TABLES;
+  const unknown = tables.filter((t) => !AUTH_TABLES.includes(t));
+  if (unknown.length > 0) {
+    throw new Error(`Unknown table(s): ${unknown.join(", ")}. Known: ${AUTH_TABLES.join(", ")}`);
+  }
+
+  if (mode === "--remote") {
+    console.log(
+      "⚠  --remote targets the real Cloudflare D1 databases. This is the prod cutover step —\n" +
+        "   make sure you have followed .context/754-auth-d1-merge-plan.md (backups taken,\n" +
+        "   apps/auth's wrangler.jsonc D1 binding ready to flip in the same change) before continuing.\n",
+    );
+  }
+
+  const tmpDir = mkdtempSync(join(tmpdir(), "auth-d1-move-"));
+  const summary = [];
+  try {
+    for (const table of tables) {
+      process.stdout.write(`\n== ${table} ==\n`);
+      const sourceCount = countRows(AUTH_DIR, "DB", table, mode);
+      process.stdout.write(`  source (uploads-auth) rows: ${sourceCount}\n`);
+
+      if (args.dryRun) {
+        summary.push({ table, sourceCount, destCountBefore: null, destCountAfter: null });
+        continue;
+      }
+
+      const rows = selectAll(AUTH_DIR, "DB", table, mode);
+      const destCountBefore = countRows(API_DIR, "DB", table, mode);
+
+      if (rows.length > 0) {
+        const sql = rowsToInserts(table, rows);
+        const file = join(tmpDir, `${table}.sql`);
+        writeFileSync(file, sql, "utf8");
+        wranglerJson(API_DIR, ["execute", "DB", mode, "--file", file]);
+      }
+
+      const destCountAfter = countRows(API_DIR, "DB", table, mode);
+      process.stdout.write(
+        `  destination (uploads-api) rows: ${destCountBefore} -> ${destCountAfter}\n`,
+      );
+      summary.push({ table, sourceCount, destCountBefore, destCountAfter });
+    }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  console.log("\n== Row-count verification ==");
+  let failed = false;
+  for (const row of summary) {
+    if (args.dryRun) {
+      console.log(`${row.table}: source=${row.sourceCount} (dry run, no import)`);
+      continue;
+    }
+    // Destination can be >= source (OR IGNORE against a pre-existing seed
+    // row, or a re-run) but never less — that means rows failed to copy.
+    const ok = row.destCountAfter >= row.sourceCount;
+    if (!ok) failed = true;
+    console.log(
+      `${row.table}: source=${row.sourceCount} dest_after=${row.destCountAfter} ${ok ? "OK" : "MISMATCH"}`,
+    );
+  }
+
+  if (failed) {
+    console.error(
+      "\nRow-count verification FAILED for at least one table. Do not proceed with cutover.",
+    );
+    process.exitCode = 1;
+  } else if (!args.dryRun) {
+    console.log("\nAll tables verified.");
+  }
+}
+
+main();

--- a/scripts/auth-d1-data-move.mjs
+++ b/scripts/auth-d1-data-move.mjs
@@ -17,13 +17,27 @@
  *
  * What it does, per table (in FK-safe order):
  *   1. `wrangler d1 execute <source> --json --command "SELECT * FROM <table>"`
- *   2. Turn each row into an `INSERT OR IGNORE` statement (OR IGNORE so a
- *      re-run, or a table that already got the migration's seed row, does
- *      not fail on a duplicate primary key).
+ *   2. Turn each row into a plain `INSERT` statement. A conflict here (e.g.
+ *      an unexpected pre-existing row with the same primary key at the
+ *      destination) is NOT silently swallowed — wrangler fails the `d1
+ *      execute --file` call and this script throws. The one documented
+ *      exception is `oauth_client`'s CLI seed row (see
+ *      `OAUTH_CLIENT_SEED_ID` below): the merged migration
+ *      (apps/api/migrations/20260822120000_auth_tables.sql) already seeds
+ *      that exact row with `INSERT OR IGNORE`, which always collides with
+ *      the source's real historical row of the same id. This script deletes
+ *      the migration's seed row from the destination immediately before
+ *      copying `oauth_client`, so the source's authoritative row (real
+ *      `created_at`, any admin edits made in prod) lands via the same plain
+ *      `INSERT` as every other row, instead of being dropped by an
+ *      ignore-on-conflict insert.
  *   3. `wrangler d1 execute <dest> --file=<tmp>.sql` to apply them.
- *   4. Compare `SELECT COUNT(*)` on source vs. destination and report a
- *      mismatch (destination >= source is expected and fine — see the OR
- *      IGNORE note above; destination < source is the failure case).
+ *   4. Verify by primary-key set, not aggregate count: for each table, every
+ *      primary key present in the source must also be present in the
+ *      destination afterward. A plain row count can read "OK" even when
+ *      rows silently failed to copy (e.g. old `INSERT OR IGNORE` dropping a
+ *      row on an `email` unique conflict while an unrelated row happened to
+ *      make up the count) — set membership catches that.
  *
  * Usage:
  *   node scripts/auth-d1-data-move.mjs --local              # default, safe
@@ -65,6 +79,37 @@ const AUTH_TABLES = [
   "billing_plan_outbox",
   "github_identity",
 ];
+
+/** Primary-key column per table, used for post-copy set verification. */
+const PRIMARY_KEYS = {
+  user: "id",
+  organization: "id",
+  session: "id",
+  account: "id",
+  verification: "id",
+  rate_limit: "id",
+  member: "id",
+  invitation: "id",
+  device_code: "id",
+  jwks: "id",
+  oauth_client: "id",
+  oauth_resource: "id",
+  oauth_client_resource: "id",
+  oauth_client_assertion: "id",
+  oauth_access_token: "id",
+  oauth_refresh_token: "id",
+  oauth_consent: "id",
+  oauth_workspace_choice: "user_id",
+  subscription: "id",
+  billing_plan_outbox: "reference_id",
+  github_identity: "account_id",
+};
+
+// Seeded by apps/api/migrations/20260822120000_auth_tables.sql via
+// INSERT OR IGNORE so a fresh merged database has a working CLI OAuth
+// client before any data move runs. Deleted from the destination right
+// before the real `oauth_client` copy — see the header comment.
+const OAUTH_CLIENT_SEED_ID = "oc_uploads_cli_seed";
 
 function parseArgs(argv) {
   const args = { mode: "--local", dryRun: false, tables: null };
@@ -145,9 +190,39 @@ function rowsToInserts(table, rows) {
   const columns = Object.keys(rows[0]);
   const statements = rows.map((row) => {
     const values = columns.map((col) => sqlLiteral(row[col]));
-    return `INSERT OR IGNORE INTO ${table} (${columns.map((c) => `"${c}"`).join(", ")}) VALUES (${values.join(", ")});`;
+    return `INSERT INTO ${table} (${columns.map((c) => `"${c}"`).join(", ")}) VALUES (${values.join(", ")});`;
   });
   return statements.join("\n") + "\n";
+}
+
+/** All primary-key values for a table, as strings (for set comparison). */
+function selectPks(dir, table, mode) {
+  const pk = PRIMARY_KEYS[table];
+  const out = wranglerJson(dir, [
+    "execute",
+    "DB",
+    mode,
+    "--command",
+    `SELECT "${pk}" AS pk FROM ${table}`,
+  ]);
+  return new Set((out[0]?.results ?? []).map((row) => String(row.pk)));
+}
+
+/**
+ * Deletes the merged migration's `oauth_client` seed row from the
+ * destination, so the source's real row of the same id can land via a plain
+ * (conflict-failing) INSERT instead of colliding with it. No-op for every
+ * other table.
+ */
+function cleanUpSeedException(table, mode) {
+  if (table !== "oauth_client") return;
+  wranglerJson(API_DIR, [
+    "execute",
+    "DB",
+    mode,
+    "--command",
+    `DELETE FROM oauth_client WHERE id = '${OAUTH_CLIENT_SEED_ID}'`,
+  ]);
 }
 
 function main() {
@@ -155,11 +230,15 @@ function main() {
   if (args.help) return usage();
 
   const mode = args.mode; // "--local" | "--remote"
-  const tables = args.tables ?? AUTH_TABLES;
-  const unknown = tables.filter((t) => !AUTH_TABLES.includes(t));
+  // Filter the canonical FK-safe list down to the requested subset, rather
+  // than using the caller's `--tables=` order directly — `--tables=session,user`
+  // must still insert `user` before `session`, since `session.user_id`
+  // references it.
+  const unknown = args.tables?.filter((t) => !AUTH_TABLES.includes(t)) ?? [];
   if (unknown.length > 0) {
     throw new Error(`Unknown table(s): ${unknown.join(", ")}. Known: ${AUTH_TABLES.join(", ")}`);
   }
+  const tables = args.tables ? AUTH_TABLES.filter((t) => args.tables.includes(t)) : AUTH_TABLES;
 
   if (mode === "--remote") {
     console.log(
@@ -185,6 +264,8 @@ function main() {
       const rows = selectAll(AUTH_DIR, "DB", table, mode);
       const destCountBefore = countRows(API_DIR, "DB", table, mode);
 
+      cleanUpSeedException(table, mode);
+
       if (rows.length > 0) {
         const sql = rowsToInserts(table, rows);
         const file = join(tmpDir, `${table}.sql`);
@@ -193,34 +274,43 @@ function main() {
       }
 
       const destCountAfter = countRows(API_DIR, "DB", table, mode);
+      const sourcePks = selectPks(AUTH_DIR, table, mode);
+      const destPks = selectPks(API_DIR, table, mode);
+      const missing = [...sourcePks].filter((pk) => !destPks.has(pk));
       process.stdout.write(
         `  destination (uploads-api) rows: ${destCountBefore} -> ${destCountAfter}\n`,
       );
-      summary.push({ table, sourceCount, destCountBefore, destCountAfter });
+      summary.push({ table, sourceCount, destCountBefore, destCountAfter, missing });
     }
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });
   }
 
-  console.log("\n== Row-count verification ==");
+  console.log("\n== Primary-key verification ==");
   let failed = false;
   for (const row of summary) {
     if (args.dryRun) {
       console.log(`${row.table}: source=${row.sourceCount} (dry run, no import)`);
       continue;
     }
-    // Destination can be >= source (OR IGNORE against a pre-existing seed
-    // row, or a re-run) but never less — that means rows failed to copy.
-    const ok = row.destCountAfter >= row.sourceCount;
+    // Authoritative check: every primary key present in the source must be
+    // present in the destination. A count comparison alone can't catch a
+    // row that silently failed to copy while an unrelated row made up the
+    // number.
+    const ok = row.missing.length === 0;
     if (!ok) failed = true;
     console.log(
-      `${row.table}: source=${row.sourceCount} dest_after=${row.destCountAfter} ${ok ? "OK" : "MISMATCH"}`,
+      `${row.table}: source=${row.sourceCount} dest_after=${row.destCountAfter} ${
+        ok
+          ? "OK"
+          : `MISMATCH (missing ${row.missing.length}: ${row.missing.slice(0, 5).join(", ")}${row.missing.length > 5 ? ", …" : ""})`
+      }`,
     );
   }
 
   if (failed) {
     console.error(
-      "\nRow-count verification FAILED for at least one table. Do not proceed with cutover.",
+      "\nPrimary-key verification FAILED for at least one table. Do not proceed with cutover.",
     );
     process.exitCode = 1;
   } else if (!args.dryRun) {


### PR DESCRIPTION
First phase of #754 item 1 (merging the auth worker's dedicated D1 into the main database). Prod behavior on merge: the new migration auto-applies to the main D1 and creates the Better Auth tables there, empty and unused — the auth worker keeps pointing at its dedicated database until the phase 3 cutover.

## What's here

- `apps/api/migrations/20260822120000_auth_tables.sql` — all 21 Better Auth tables + 26 indexes appended to the main chain, `IF NOT EXISTS`-guarded. Schema-collision analysis found zero overlap with the API's tables; no renames needed.
- `apps/auth/src/test/fake-d1.ts` — auth's test harness now builds its schema from the merged `apps/api/migrations/` chain, so tests run against the future layout.
- `scripts/auth-d1-data-move.mjs` — the cutover data-move (export auth DB → import into main, row-count verification, `--dry-run` support). Runnable but not wired into CI; its `--local` path is tested end-to-end, `--remote` is untested by construction.

## What deliberately does NOT change

- `apps/auth/wrangler.jsonc` D1 binding (prod and previews) — still the dedicated `uploads-auth` DB.
- `apps/auth/migrations/` — keeps driving the live auth DB until cutover.
- `d1-migrations-auth.yml` — consolidation happens at cutover.

## Transitional cost

Until cutover, a new auth schema change must land in `apps/api/migrations/` (future chain + tests) and, if it must reach prod's live auth DB, also in `apps/auth/migrations/`. Keep the window short.

## Cutover (phase 3, separate PR + operator step)

Maintenance window → `wrangler d1 export` backups → `scripts/auth-d1-data-move.mjs --remote` with row-count verification → flip the auth worker's D1 binding + delete `apps/auth/migrations/` in one change → deploy, smoke-test → decommission `uploads-auth` after a confidence window → fold `d1-migrations-auth.yml` into `d1-migrations.yml`.

## Verification

- `pnpm test`: 314 files / 4746 tests green
- `pnpm --filter @uploads/auth typecheck` clean; `changeset:lint` passes (no changeset — private packages)
- `migrate:d1:local` applies all 22 migrations to a fresh local D1; auth + API tables both present
- Data-move script verified against local D1 including the `oauth_client` seed-row `OR IGNORE` dedup path

Part of #754.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consolidated authentication database schema supporting accounts, sessions, organizations, memberships, OAuth, subscriptions, billing, and GitHub identities.
  * Added a data migration utility to transfer authentication records between databases, with local, remote, dry-run, and table-selection options.
  * Added row-count verification to confirm migrated data is complete.
* **Chores**
  * Updated authentication testing to use the shared API database schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->