### PR TITLE
feat(auth): dual-read plain secrets ahead of Secrets Store removal (#754 item 2)

### DIFF
--- a/apps/auth/.dev.vars.example
+++ b/apps/auth/.dev.vars.example
@@ -1,11 +1,10 @@
 # Copy to .dev.vars for local dev.
 
-# Dev-only signing secret fallback. The Secrets Store binding
-# (UPL_BETTER_AUTH_SECRET) exists locally too under `wrangler dev`, but an
-# unpopulated store entry does NOT get overridden by a same-named .dev.vars
-# value (see src/secrets.ts) — that's why this is a distinctly-named var.
-# Without it, /api/auth/* answers 503 locally. Any string >= 32 chars works.
-BETTER_AUTH_SECRET_DEV=
+# Better Auth signing secret. Plain secret, preferred over the transitional
+# UPL_BETTER_AUTH_SECRET Secrets Store binding (see src/secrets.ts and
+# uploads#754 item 2). Without it, /api/auth/* answers 503 locally. Any
+# string >= 32 chars works.
+BETTER_AUTH_SECRET=
 
 # #731 phase C: this worker's own origin is pinned in wrangler.jsonc (dev
 # port 8788), but BETTER_AUTH_URL is set to the WEB app's origin, not this
@@ -44,11 +43,10 @@ ENVIRONMENT=development
 # it locally (see src/auth.ts).
 AUTH_RATE_LIMIT_DISABLED=true
 
-# Optional: infra dashboard API key (plain fallback for UPL_BETTER_AUTH_API_KEY).
+# Optional: infra dashboard API key (mounts dash() when set).
 # BETTER_AUTH_API_KEY=
 
-# Optional: dev-only GitHub OAuth plain fallbacks (same store-vs-dev-var
-# footgun as the signing secret above). Leave unset to keep GitHub gated off
+# Optional: GitHub OAuth credentials. Leave unset to keep GitHub gated off
 # locally — magic link alone is enough for most dev flows.
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=

--- a/apps/auth/README.md
+++ b/apps/auth/README.md
@@ -14,8 +14,10 @@ target and direct machine origin — used for CLI device/bearer flows and
 internal service-binding calls, not for browser traffic.
 
 The Better Auth Infrastructure dashboard (`@better-auth/infra` `dash()`) mounts
-when `UPL_BETTER_AUTH_API_KEY` or local `BETTER_AUTH_API_KEY` resolves. Point the
-project's Base URL at `https://uploads.sh` with Base Path `/api/auth`.
+when `BETTER_AUTH_API_KEY` resolves (plain secret; a transitional
+`UPL_BETTER_AUTH_API_KEY` Secrets Store fallback still exists — see
+src/secrets.ts and uploads#754 item 2). Point the project's Base URL at
+`https://uploads.sh` with Base Path `/api/auth`.
 
 ## First admin
 

--- a/apps/auth/src/account-linking.test.ts
+++ b/apps/auth/src/account-linking.test.ts
@@ -23,7 +23,7 @@ function dbEnv(db: FakeD1Database, overrides: Partial<AuthEnv> = {}): AuthEnv {
     WEB_ORIGIN: "https://uploads.sh",
     BETTER_AUTH_URL: "https://auth.uploads.sh",
     ENVIRONMENT: "development",
-    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
     GITHUB_CLIENT_ID: "test-github-client-id",
     GITHUB_CLIENT_SECRET: "test-github-client-secret",
     ...overrides,

--- a/apps/auth/src/admin-last-guard.test.ts
+++ b/apps/auth/src/admin-last-guard.test.ts
@@ -32,7 +32,7 @@ function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
     DB: createFakeD1(),
     WEB_ORIGIN: "https://uploads.sh",
     ENVIRONMENT: "development",
-    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
     ...overrides,
   };
 }

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -287,7 +287,8 @@ export type AuthEnv = GitHubCredentialsEnv &
     DB: D1Database;
     EMAIL?: import("./email").EmailBinding;
     BETTER_AUTH_URL?: string;
-    BETTER_AUTH_SECRET_DEV?: string;
+    BETTER_AUTH_SECRET?: string;
+    /** Transitional Secrets Store fallback — see src/secrets.ts and uploads#754 item 2. */
     UPL_BETTER_AUTH_SECRET?: import("./secrets").SecretLike;
     WEB_ORIGIN?: string;
     /** The auth worker's own direct origin (e.g. https://auth.uploads.sh),

--- a/apps/auth/src/billing-bridge.test.ts
+++ b/apps/auth/src/billing-bridge.test.ts
@@ -16,7 +16,7 @@ function dbEnv(overrides: Partial<TestEnv> = {}): TestEnv {
     WEB_ORIGIN: "https://uploads.sh",
     BETTER_AUTH_URL: "https://auth.uploads.sh",
     ENVIRONMENT: "development",
-    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
     ...overrides,
   };
 }

--- a/apps/auth/src/billing-outbox.test.ts
+++ b/apps/auth/src/billing-outbox.test.ts
@@ -27,7 +27,7 @@ function dbEnv(overrides: Partial<TestEnv> = {}): TestEnv {
     WEB_ORIGIN: "https://uploads.sh",
     BETTER_AUTH_URL: "https://auth.uploads.sh",
     ENVIRONMENT: "development",
-    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
     BILLING_INTERNAL_KEY: "shh-its-secret",
     ...overrides,
   };

--- a/apps/auth/src/device-workspace.test.ts
+++ b/apps/auth/src/device-workspace.test.ts
@@ -20,7 +20,7 @@ function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
     WEB_ORIGIN: "https://uploads.sh",
     BETTER_AUTH_URL: "https://auth.uploads.sh",
     ENVIRONMENT: "development",
-    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
     ...overrides,
   };
 }

--- a/apps/auth/src/device.test.ts
+++ b/apps/auth/src/device.test.ts
@@ -21,7 +21,7 @@ function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
     DB: createFakeD1(),
     WEB_ORIGIN: "https://uploads.sh",
     ENVIRONMENT: "development",
-    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
     ...overrides,
   };
 }

--- a/apps/auth/src/env.d.ts
+++ b/apps/auth/src/env.d.ts
@@ -3,14 +3,18 @@
 // here, mirroring apps/api/src/env.d.ts.
 interface Env {
   /**
-   * Dev-only fallback for the Better Auth signing secret. Preferred only when
-   * UPL_BETTER_AUTH_SECRET (Secrets Store) is unresolvable — see
-   * src/secrets.ts and the D7 footgun note there.
+   * The Better Auth signing secret (`wrangler secret put BETTER_AUTH_SECRET`).
+   * Preferred over the transitional `UPL_BETTER_AUTH_SECRET` Secrets Store
+   * binding declared in wrangler.jsonc — see src/secrets.ts and uploads#754
+   * item 2.
    */
-  BETTER_AUTH_SECRET_DEV?: string;
-  /** Dev plain fallback for UPL_BETTER_AUTH_API_KEY (mounts `dash()` when set). */
+  BETTER_AUTH_SECRET?: string;
+  /** Infra dashboard API key (mounts `dash()` when set). Preferred over the
+   * transitional `UPL_BETTER_AUTH_API_KEY` store binding. */
   BETTER_AUTH_API_KEY?: string;
-  /** Dev-only plain fallbacks for GitHub OAuth, gated the same way as the store pair. */
+  /** GitHub OAuth credentials, gated the same way as the store pair.
+   * Preferred over the transitional `UPL_GITHUB_CLIENT_ID`/`_SECRET` store
+   * bindings. */
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;
   /** Comma-separated extra trusted origins (see src/trusted-origins.ts). */

--- a/apps/auth/src/index.test.ts
+++ b/apps/auth/src/index.test.ts
@@ -10,7 +10,7 @@ function envWithoutSecret(): AuthEnv {
     DB: {} as unknown as D1Database,
     WEB_ORIGIN: "https://uploads.sh",
     ENVIRONMENT: "development",
-    // No UPL_BETTER_AUTH_SECRET, no BETTER_AUTH_SECRET_DEV: unresolvable.
+    // No UPL_BETTER_AUTH_SECRET, no BETTER_AUTH_SECRET: unresolvable.
   };
 }
 
@@ -21,7 +21,7 @@ function envWithoutSecret(): AuthEnv {
 function localEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
   return {
     DB: createFakeD1(),
-    BETTER_AUTH_SECRET_DEV: "x".repeat(32),
+    BETTER_AUTH_SECRET: "x".repeat(32),
     LOCAL_STACK: "true",
     ENVIRONMENT: "development",
     BETTER_AUTH_URL: LOCAL_STACK_WEB_ORIGIN,
@@ -67,8 +67,8 @@ describe("503 guard", () => {
     expect(body.error.code).toBe("auth_unavailable");
   });
 
-  it("boots once BETTER_AUTH_SECRET_DEV is set", async () => {
-    const env: AuthEnv = { ...envWithoutSecret(), BETTER_AUTH_SECRET_DEV: "x".repeat(32) };
+  it("boots once BETTER_AUTH_SECRET is set", async () => {
+    const env: AuthEnv = { ...envWithoutSecret(), BETTER_AUTH_SECRET: "x".repeat(32) };
     const response = await app.request(
       "/api/auth/get-session",
       { headers: { Origin: "https://uploads.sh" } },
@@ -85,7 +85,7 @@ describe("CORS on /api/auth/*", () => {
     DB: {} as unknown as D1Database,
     WEB_ORIGIN: "https://uploads.sh",
     ENVIRONMENT: "production",
-    BETTER_AUTH_SECRET_DEV: "x".repeat(32),
+    BETTER_AUTH_SECRET: "x".repeat(32),
   };
 
   function preflight(origin: string) {

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -191,9 +191,10 @@ export const app = new Hono<{ Bindings: AuthEnv }>()
   .on(["POST", "GET"], "/api/auth/*", async (c) => {
     const auth = await createAuth(c.env);
     if (!auth) {
-      // Signing secret unresolved (Secrets Store entry not populated yet, or
-      // no BETTER_AUTH_SECRET_DEV in dev) — never boot Better Auth on an
-      // ephemeral secret (D7). Fail closed instead of 500ing.
+      // Signing secret unresolved (BETTER_AUTH_SECRET not set, and the
+      // transitional Secrets Store fallback is also empty/unpopulated) —
+      // never boot Better Auth on an ephemeral secret (D7). Fail closed
+      // instead of 500ing.
       return c.json(
         { error: { code: "auth_unavailable", message: "Auth is not configured yet." } },
         503,

--- a/apps/auth/src/internal-metrics.test.ts
+++ b/apps/auth/src/internal-metrics.test.ts
@@ -24,7 +24,7 @@ describe("GET /internal/metrics", () => {
       DB: db,
       WEB_ORIGIN: "https://uploads.sh",
       ENVIRONMENT: "development",
-      BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+      BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
     } as AuthEnv;
   }
 

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -111,7 +111,7 @@ describe("DB-backed behavior", () => {
       DB: db,
       WEB_ORIGIN: "https://uploads.sh",
       ENVIRONMENT: "development",
-      BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+      BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
       ...overrides,
     };
   }

--- a/apps/auth/src/member-cap.test.ts
+++ b/apps/auth/src/member-cap.test.ts
@@ -251,7 +251,7 @@ describe("POST /internal/invite at cap", () => {
       DB: db,
       WEB_ORIGIN: "https://uploads.sh",
       ENVIRONMENT: "development",
-      BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+      BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
       BILLING_INTERNAL_KEY: INTERNAL_KEY,
       API: capBinding({
         workspace: "acme",

--- a/apps/auth/src/oauth.test.ts
+++ b/apps/auth/src/oauth.test.ts
@@ -19,7 +19,7 @@ function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
     WEB_ORIGIN: "https://uploads.sh",
     BETTER_AUTH_URL: "https://uploads.sh",
     ENVIRONMENT: "development",
-    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
     ...overrides,
   };
 }

--- a/apps/auth/src/secrets.test.ts
+++ b/apps/auth/src/secrets.test.ts
@@ -42,31 +42,38 @@ describe("resolveSecret", () => {
 });
 
 describe("resolveSigningSecret", () => {
-  it("prefers the Secrets Store binding", async () => {
+  it("prefers the plain BETTER_AUTH_SECRET over the store fallback", async () => {
+    expect(
+      await resolveSigningSecret({
+        BETTER_AUTH_SECRET: "plain-secret",
+        UPL_BETTER_AUTH_SECRET: store("store-secret"),
+      }),
+    ).toBe("plain-secret");
+  });
+
+  it("falls back to the store when the plain secret is unset", async () => {
     expect(
       await resolveSigningSecret({
         UPL_BETTER_AUTH_SECRET: store("store-secret"),
-        BETTER_AUTH_SECRET_DEV: "dev-secret",
       }),
     ).toBe("store-secret");
   });
 
-  it("falls back to BETTER_AUTH_SECRET_DEV when the store is empty", async () => {
+  it("falls back to the store when the plain secret is empty", async () => {
     expect(
       await resolveSigningSecret({
-        UPL_BETTER_AUTH_SECRET: store(""),
-        BETTER_AUTH_SECRET_DEV: "dev-secret",
+        BETTER_AUTH_SECRET: "",
+        UPL_BETTER_AUTH_SECRET: store("store-secret"),
       }),
-    ).toBe("dev-secret");
+    ).toBe("store-secret");
   });
 
-  it("falls back to BETTER_AUTH_SECRET_DEV when the store fails", async () => {
+  it("returns null when the store fails and no plain secret is set", async () => {
     expect(
       await resolveSigningSecret({
         UPL_BETTER_AUTH_SECRET: failingStore(),
-        BETTER_AUTH_SECRET_DEV: "dev-secret",
       }),
-    ).toBe("dev-secret");
+    ).toBeNull();
   });
 
   it("returns null when nothing resolves", async () => {
@@ -75,13 +82,23 @@ describe("resolveSigningSecret", () => {
 });
 
 describe("resolveGitHubCredentials", () => {
-  it("returns credentials when both id and secret resolve", async () => {
+  it("returns credentials when both id and secret resolve from the store", async () => {
     expect(
       await resolveGitHubCredentials({
         UPL_GITHUB_CLIENT_ID: store("id"),
         UPL_GITHUB_CLIENT_SECRET: store("secret"),
       }),
     ).toEqual({ clientId: "id", clientSecret: "secret" });
+  });
+
+  it("prefers plain vars over the store, per half", async () => {
+    expect(
+      await resolveGitHubCredentials({
+        GITHUB_CLIENT_ID: "plain-id",
+        UPL_GITHUB_CLIENT_ID: store("store-id"),
+        UPL_GITHUB_CLIENT_SECRET: store("store-secret"),
+      }),
+    ).toEqual({ clientId: "plain-id", clientSecret: "store-secret" });
   });
 
   it("gates on both halves — id only is not enough", async () => {
@@ -100,34 +117,38 @@ describe("resolveGitHubCredentials", () => {
     ).toBeNull();
   });
 
-  it("falls back to dev plain vars when the store is unpopulated", async () => {
+  it("resolves entirely from plain vars when the store is unset", async () => {
     expect(
       await resolveGitHubCredentials({
-        GITHUB_CLIENT_ID: "dev-id",
-        GITHUB_CLIENT_SECRET: "dev-secret",
+        GITHUB_CLIENT_ID: "plain-id",
+        GITHUB_CLIENT_SECRET: "plain-secret",
       }),
-    ).toEqual({ clientId: "dev-id", clientSecret: "dev-secret" });
+    ).toEqual({ clientId: "plain-id", clientSecret: "plain-secret" });
   });
 
-  it("returns null with neither store nor dev vars set", async () => {
+  it("returns null with neither plain vars nor store set", async () => {
     expect(await resolveGitHubCredentials({})).toBeNull();
   });
 });
 
 describe("resolveDashApiKey", () => {
-  it("prefers the store, falls back to BETTER_AUTH_API_KEY, else null", async () => {
+  it("prefers the plain BETTER_AUTH_API_KEY, falls back to the store, else null", async () => {
+    expect(
+      await resolveDashApiKey({
+        BETTER_AUTH_API_KEY: "plain-key",
+        UPL_BETTER_AUTH_API_KEY: store("store-key"),
+      }),
+    ).toBe("plain-key");
     expect(
       await resolveDashApiKey({
         UPL_BETTER_AUTH_API_KEY: store("store-key"),
-        BETTER_AUTH_API_KEY: "dev-key",
       }),
     ).toBe("store-key");
     expect(
       await resolveDashApiKey({
         UPL_BETTER_AUTH_API_KEY: failingStore(),
-        BETTER_AUTH_API_KEY: "dev-key",
       }),
-    ).toBe("dev-key");
+    ).toBeNull();
     expect(await resolveDashApiKey({})).toBeNull();
   });
 });

--- a/apps/auth/src/secrets.ts
+++ b/apps/auth/src/secrets.ts
@@ -1,20 +1,30 @@
 /**
- * Secret resolution for the auth worker (see plan D7).
+ * Secret resolution for the auth worker (see plan D7, and uploads#754 item 2
+ * for the Secrets Store → plain secret transition).
  *
- * Pattern copied from `~/Code/releases/workers/api/src/auth/index.ts`
- * (`resolveSecret`/`resolveSigningSecret`): a Secrets Store binding's
- * `.get()` is preferred, with a same-named plain-string env var as the dev
- * fallback, and store-resolution failures are swallowed rather than thrown —
- * a missing/misconfigured secret degrades the *feature* it gates (GitHub
+ * All four auth secrets (signing secret, infra dashboard API key, GitHub
+ * OAuth client id/secret) have exactly one consumer — this worker — so the
+ * Secrets Store's cross-worker propagation never paid for itself, and its
+ * `store_id` pointed at an account-level store shared across buildinternet
+ * repos (non-portable for a self-hoster). The target shape is a plain
+ * per-worker secret (`wrangler secret put BETTER_AUTH_SECRET`, etc.), read
+ * synchronously off `env` like every other secret in this repo.
+ *
+ * Transition (dual-read): each resolver below prefers the plain env var when
+ * it's a non-empty string, and falls back to the (still-declared, still
+ * async) Secrets Store binding otherwise. This makes it safe to merge the
+ * code change before an operator has run `wrangler secret put` for all
+ * four — the worker keeps answering out of the store exactly as it does
+ * today until the plain secrets are set, at which point they take over with
+ * no further deploy required. Once an operator confirms the plain secrets
+ * are live in prod (and preview, if used), a follow-up change removes the
+ * `secrets_store_secrets` blocks from wrangler.jsonc and the `UPL_*`
+ * fallback branches here.
+ *
+ * Store-resolution failures are still swallowed rather than thrown — a
+ * missing/misconfigured secret degrades the *feature* it gates (GitHub
  * omitted from socialProviders, signing secret unresolved → 503) instead of
  * 500ing every request.
- *
- * ⚠ footgun (D7): under `wrangler dev`, a same-named `.dev.vars` string does
- * NOT override an unpopulated Secrets Store binding — the binding still
- * "exists" and its `.get()` just rejects/returns empty. That's why the dev
- * fallback vars below are distinctly named (`BETTER_AUTH_SECRET_DEV`,
- * `BETTER_AUTH_API_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`) rather
- * than shadowing the `UPL_`-prefixed binding names.
  */
 
 /** Minimal shape of a Cloudflare Secrets Store binding. */
@@ -35,58 +45,71 @@ export async function resolveSecret(value: SecretLike): Promise<string | null> {
   }
 }
 
+/**
+ * Resolve a value that's either a plain string (preferred) or a Secrets
+ * Store binding (fallback, during the transition — see module doc).
+ */
+async function resolvePreferPlain(
+  plain: string | undefined,
+  store: SecretLike,
+): Promise<string | null> {
+  if (plain) return plain;
+  return resolveSecret(store);
+}
+
 export type SigningSecretEnv = {
+  BETTER_AUTH_SECRET?: string;
+  /** Transitional Secrets Store fallback — see module doc. Removed once the
+   * plain secret is confirmed live in every environment. */
   UPL_BETTER_AUTH_SECRET?: SecretLike;
-  BETTER_AUTH_SECRET_DEV?: string;
 };
 
 /**
- * The Better Auth signing secret. Store binding wins; `BETTER_AUTH_SECRET_DEV`
- * is used only when the store value is unresolved (empty/missing/store
- * failure) — never as a silent override of a populated store entry.
+ * The Better Auth signing secret. `BETTER_AUTH_SECRET` (plain) wins; the
+ * `UPL_BETTER_AUTH_SECRET` store binding is used only when the plain value is
+ * unset — never as a silent override of a populated plain secret.
  *
  * Returns null when neither resolves. Callers MUST treat null as "answer 503
  * from /api/auth/*" rather than booting Better Auth with an ephemeral secret
  * (see {@link authGuardStatus} and src/index.ts).
  */
 export async function resolveSigningSecret(env: SigningSecretEnv): Promise<string | null> {
-  const fromStore = await resolveSecret(env.UPL_BETTER_AUTH_SECRET);
-  return fromStore || env.BETTER_AUTH_SECRET_DEV || null;
+  return resolvePreferPlain(env.BETTER_AUTH_SECRET, env.UPL_BETTER_AUTH_SECRET);
 }
 
 export type GitHubCredentialsEnv = {
-  UPL_GITHUB_CLIENT_ID?: SecretLike;
-  UPL_GITHUB_CLIENT_SECRET?: SecretLike;
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;
+  /** Transitional Secrets Store fallback — see module doc. */
+  UPL_GITHUB_CLIENT_ID?: SecretLike;
+  UPL_GITHUB_CLIENT_SECRET?: SecretLike;
 };
 
 export type GitHubCredentials = { clientId: string; clientSecret: string };
 
 /**
  * GitHub OAuth credentials, gated: returns null unless BOTH id and secret
- * resolve non-empty (D3 — "socialProviders built by a gate function"). Same
- * dev-fallback shape as {@link resolveSigningSecret}.
+ * resolve non-empty (D3 — "socialProviders built by a gate function"). Each
+ * half independently prefers its plain env var over its store fallback.
  */
 export async function resolveGitHubCredentials(
   env: GitHubCredentialsEnv,
 ): Promise<GitHubCredentials | null> {
   const [clientId, clientSecret] = await Promise.all([
-    resolveSecret(env.UPL_GITHUB_CLIENT_ID).then((v) => v || env.GITHUB_CLIENT_ID || null),
-    resolveSecret(env.UPL_GITHUB_CLIENT_SECRET).then((v) => v || env.GITHUB_CLIENT_SECRET || null),
+    resolvePreferPlain(env.GITHUB_CLIENT_ID, env.UPL_GITHUB_CLIENT_ID),
+    resolvePreferPlain(env.GITHUB_CLIENT_SECRET, env.UPL_GITHUB_CLIENT_SECRET),
   ]);
   if (!clientId || !clientSecret) return null;
   return { clientId, clientSecret };
 }
 
 export type DashApiKeyEnv = {
-  UPL_BETTER_AUTH_API_KEY?: SecretLike;
-  /** Dev plain fallback (same store-vs-dev-var footgun as the signing secret). */
   BETTER_AUTH_API_KEY?: string;
+  /** Transitional Secrets Store fallback — see module doc. */
+  UPL_BETTER_AUTH_API_KEY?: SecretLike;
 };
 
-/** Infra dashboard API key; null → omit `dash()`. Store wins over plain fallback. */
+/** Infra dashboard API key; null → omit `dash()`. Plain wins over store fallback. */
 export async function resolveDashApiKey(env: DashApiKeyEnv): Promise<string | null> {
-  const fromStore = await resolveSecret(env.UPL_BETTER_AUTH_API_KEY);
-  return fromStore || env.BETTER_AUTH_API_KEY || null;
+  return resolvePreferPlain(env.BETTER_AUTH_API_KEY, env.UPL_BETTER_AUTH_API_KEY);
 }

--- a/apps/auth/src/stripe-plugin.test.ts
+++ b/apps/auth/src/stripe-plugin.test.ts
@@ -23,7 +23,7 @@ function dbEnv(overrides: Partial<TestEnv> = {}): TestEnv {
     WEB_ORIGIN: "https://uploads.sh",
     BETTER_AUTH_URL: "https://auth.uploads.sh",
     ENVIRONMENT: "development",
-    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
     ...overrides,
   };
 }

--- a/apps/auth/src/workspace-choice.test.ts
+++ b/apps/auth/src/workspace-choice.test.ts
@@ -20,7 +20,7 @@ function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
     WEB_ORIGIN: "https://uploads.sh",
     BETTER_AUTH_URL: "https://auth.uploads.sh",
     ENVIRONMENT: "development",
-    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
     ...overrides,
   };
 }

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -81,16 +81,22 @@
       "migrations_dir": "migrations",
     },
   ],
-  // Cloudflare Secrets Store, prefixed UPL_ (mirrors room-configurator's RS_
-  // convention — see D7). store_id below is the "releases" store, the only
-  // Secrets Store that already exists on the Build Internet account
-  // (confirmed via `wrangler secrets-store store list --remote`); it's
-  // shared across buildinternet-org repos the same way KV/D1 IDs are noted
-  // inline elsewhere in this repo. Wrangler FAILS a deploy when a declared
-  // secrets_store_secrets entry doesn't exist in the store yet. Until
-  // populated: GitHub stays omitted from socialProviders (D3), dash() stays
-  // omitted (no infra API key), and /api/auth/* answers 503 without a signing
-  // secret (see src/secrets.ts) rather than booting on an ephemeral secret.
+  // TRANSITIONAL (uploads#754 item 2) — these four are being moved off the
+  // account-level Secrets Store (store_id below is the "releases" store,
+  // shared across buildinternet-org repos — non-portable for a self-hoster,
+  // and each of these four secrets has exactly one consumer: this worker, so
+  // the store's cross-worker propagation never applied) onto plain per-worker
+  // secrets: BETTER_AUTH_SECRET, BETTER_AUTH_API_KEY, GITHUB_CLIENT_ID,
+  // GITHUB_CLIENT_SECRET (matching this repo's plain-secret naming
+  // elsewhere). src/secrets.ts now prefers the plain env var and falls back
+  // to the matching binding below only when the plain var is unset — kept
+  // here so a deploy stays safe before an operator has run `wrangler secret
+  // put` for all four. Once prod (and preview, if used) confirm the plain
+  // secrets are live, remove this block (and the matching one under
+  // `previews` below) and the UPL_* fallback branches in src/secrets.ts.
+  // Wrangler FAILS a deploy when a declared secrets_store_secrets entry
+  // doesn't exist in the store, which is why these stay populated rather
+  // than being deleted piecemeal.
   "secrets_store_secrets": [
     {
       "binding": "UPL_BETTER_AUTH_SECRET",

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -125,7 +125,7 @@ Prefer the manual steps over `bootstrap`?
 ```bash
 pnpm install
 cp apps/api/.dev.vars.example apps/api/.dev.vars   # set ADMIN_TOKEN to any non-empty string
-cp apps/auth/.dev.vars.example apps/auth/.dev.vars # set a 32+ character BETTER_AUTH_SECRET_DEV
+cp apps/auth/.dev.vars.example apps/auth/.dev.vars # set a 32+ character BETTER_AUTH_SECRET
 cp .env.example .env                               # point UPLOADS_API_URL at http://127.0.0.1:8787
 pnpm types
 pnpm --filter @uploads/api run migrate:d1:local

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -480,6 +480,50 @@ pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY
 
 Do **not** delete PREVIOUS before re-encrypt completes.
 
+### Auth worker: Secrets Store → plain secret cutover (uploads#754 item 2)
+
+`apps/auth`'s four secrets are moving off the account-level Cloudflare
+Secrets Store onto plain per-worker secrets. `src/secrets.ts` prefers the
+plain secret and only falls back to the (still-declared) store binding when
+the plain one is unset, so **the code change is safe to merge before this
+cutover runs** — the worker keeps answering out of the store until these are
+set.
+
+| Plain secret           | Replaces store binding     |
+| ---------------------- | -------------------------- |
+| `BETTER_AUTH_SECRET`   | `UPL_BETTER_AUTH_SECRET`   |
+| `BETTER_AUTH_API_KEY`  | `UPL_BETTER_AUTH_API_KEY`  |
+| `GITHUB_CLIENT_ID`     | `UPL_GITHUB_CLIENT_ID`     |
+| `GITHUB_CLIENT_SECRET` | `UPL_GITHUB_CLIENT_SECRET` |
+
+Set all four on the production worker (from `apps/auth`), pasting the same
+values already live in the Secrets Store:
+
+```bash
+pnpm exec wrangler secret put BETTER_AUTH_SECRET
+pnpm exec wrangler secret put BETTER_AUTH_API_KEY
+pnpm exec wrangler secret put GITHUB_CLIENT_ID
+pnpm exec wrangler secret put GITHUB_CLIENT_SECRET
+```
+
+Each takes effect on the next request after `wrangler secret put` completes —
+no redeploy needed. Verify `/api/auth/*` still answers (magic link + GitHub
+login) and the infra dashboard (if used) still mounts.
+
+Workers Previews (`apps/auth`'s `previews` block, see
+[previews.md](previews.md)) are rarely used for auth and have no shared
+plain-secret mechanism of their own — a preview would need its own
+`wrangler preview secret put NAME --name <preview>` per branch. Leave them on
+the store fallback for now; nothing forces the previews cutover to happen in
+the same pass as prod.
+
+**Follow-up removal PR** (only after confirming the plain secrets are live
+everywhere they're used): delete the `secrets_store_secrets` blocks from
+`apps/auth/wrangler.jsonc` (both the top-level and `previews` blocks) and the
+`UPL_*` fallback branches in `apps/auth/src/secrets.ts`. There's no rush —
+the store entries stay valid and harmless in the meantime — but the account-
+level store dependency should not outlive this transition.
+
 ## Presign
 
 `POST /v1/:ws/files/sign` — workspace needs HTTP S3 credentials (not binding-only).


### PR DESCRIPTION
Part of #754 item 2: move the auth worker off the account-level Secrets Store onto plain per-worker secrets. This PR is the **safe-to-merge transition** — code prefers a plain env secret and falls back to the existing `UPL_*` store binding when the plain value is unset, so nothing breaks before the operator sets the plain secrets. Store bindings in `wrangler.jsonc` are deliberately kept until the follow-up removal PR.

## Changes

- `apps/auth/src/secrets.ts` — `resolveSigningSecret`, `resolveGitHubCredentials`, `resolveDashApiKey` now prefer `BETTER_AUTH_SECRET`, `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET`, `BETTER_AUTH_API_KEY` (plain), falling back to the `UPL_*` store bindings.
- `BETTER_AUTH_SECRET_DEV` renamed to `BETTER_AUTH_SECRET` across env types, `.dev.vars.example`, docs, and 15 test fixtures — the other three plain names already existed as dev-only fallbacks and simply became the primary path.
- `secrets.test.ts` rewritten to assert the priority order (plain wins, store is fallback, per-field independence) plus the original store-failure/empty coverage; the 503-without-signing-secret behavior is unchanged and still covered.
- `docs/ops.md` gains the cutover runbook; `wrangler.jsonc` secrets comment rewritten (blocks untouched — also keeps this PR conflict-free with #755's D1 work).

## Operator cutover (after merge, no redeploy needed)

```
# from apps/auth, prod
pnpm exec wrangler secret put BETTER_AUTH_SECRET
pnpm exec wrangler secret put BETTER_AUTH_API_KEY
pnpm exec wrangler secret put GITHUB_CLIENT_ID
pnpm exec wrangler secret put GITHUB_CLIENT_SECRET
```

Then verify `/api/auth/*` (magic link + GitHub sign-in). Follow-up PR afterwards: delete both `secrets_store_secrets` blocks and the `UPL_*` fallback paths/types.

## Verification

- Full `pnpm test`: 314 files / 4748 tests green; `@uploads/auth` typecheck exit 0
- `format:check`, `changeset:lint` pass (no changeset — private package)
- Pre-existing `pnpm run lint` failures in web/api/mcp exist on main too (missing generated worker types) and are untouched here

Part of #754.