### PR TITLE
fix(web): send JSON content-type on sign-out so Better Auth 1.7 accepts it

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -309,11 +309,17 @@ export async function sendMagicLink(
   return res.ok;
 }
 
-/** POST /api/auth/sign-out. */
+/**
+ * POST /api/auth/sign-out. The JSON header/body are load-bearing: better-call
+ * runs its Content-Type gate on every POST under the Workers runtime and 415s
+ * a bare POST (see `devSession` above), leaving the session cookie intact.
+ */
 export async function signOut(origin: string): Promise<void> {
   await fetch(`${authOrigin(origin)}/api/auth/sign-out`, {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
   }).catch(() => undefined);
 }
 


### PR DESCRIPTION
Sign-out has been silently broken since the Better Auth 1.7.1 upgrade (#744): 1.7's router (better-call) enforces its Content-Type gate on every POST under the Workers runtime, and `signOut()` in `apps/web/src/lib/auth-client.ts` was the only auth-client caller sending a bare POST. The endpoint answers `415 UNSUPPORTED_MEDIA_TYPE`, the client swallows the error and redirects to `/login`, and the session cookie survives — so the user appears signed in again on the next page load.

## Fix

Add `Content-Type: application/json` and a `{}` body to the sign-out fetch, matching every other POST in the file (the `dev-session` helper documents this exact footgun). Comment added so it doesn't get "simplified" away.

## Verification

- Prod probe: `POST /api/auth/sign-out` bare → 415 `UNSUPPORTED_MEDIA_TYPE`; with JSON header + `{}` → 200.
- `pnpm --filter @uploads/web test` — 814 tests green; `changeset:lint` clean.
- Post-merge: sign out on uploads.sh, confirm the homepage no longer renders the signed-in shell (note the 5-minute `cookieCache` window is not a factor here — sign-out clears both cookies once the request actually executes).