### PR TITLE
feat(auth): finish the Secrets Store removal, add secrets.required (#754 item 2)

### DIFF
--- a/apps/auth/README.md
+++ b/apps/auth/README.md
@@ -14,10 +14,9 @@ target and direct machine origin — used for CLI device/bearer flows and
 internal service-binding calls, not for browser traffic.
 
 The Better Auth Infrastructure dashboard (`@better-auth/infra` `dash()`) mounts
-when `BETTER_AUTH_API_KEY` resolves (plain secret; a transitional
-`UPL_BETTER_AUTH_API_KEY` Secrets Store fallback still exists — see
-src/secrets.ts and uploads#754 item 2). Point the project's Base URL at
-`https://uploads.sh` with Base Path `/api/auth`.
+when `BETTER_AUTH_API_KEY` resolves (plain secret — see src/secrets.ts).
+Point the project's Base URL at `https://uploads.sh` with Base Path
+`/api/auth`.
 
 ## First admin
 

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -288,8 +288,6 @@ export type AuthEnv = GitHubCredentialsEnv &
     EMAIL?: import("./email").EmailBinding;
     BETTER_AUTH_URL?: string;
     BETTER_AUTH_SECRET?: string;
-    /** Transitional Secrets Store fallback — see src/secrets.ts and uploads#754 item 2. */
-    UPL_BETTER_AUTH_SECRET?: import("./secrets").SecretLike;
     WEB_ORIGIN?: string;
     /** The auth worker's own direct origin (e.g. https://auth.uploads.sh),
      * used to advertise the OAuth form-POST endpoints off the same-origin

--- a/apps/auth/src/env.d.ts
+++ b/apps/auth/src/env.d.ts
@@ -1,20 +1,28 @@
-// Runtime Worker secrets/dev fallbacks (see .dev.vars.example), not declared
-// in wrangler.jsonc, so `wrangler types` does not generate them. Augment Env
-// here, mirroring apps/api/src/env.d.ts.
+// Runtime Worker ambient declarations, mirroring apps/api/src/env.d.ts.
+//
+// The eight secrets below (BETTER_AUTH_SECRET, BETTER_AUTH_API_KEY,
+// GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, STRIPE_SECRET_KEY,
+// STRIPE_WEBHOOK_SECRET, STRIPE_PRO_PRICE_ID, BILLING_INTERNAL_KEY) and
+// STRIPE_CHECKOUT_TOS_CONSENT are now ALSO declared in wrangler.jsonc — the
+// first eight in `secrets.required` (uploads#754 item 2), the last as a
+// `vars` entry — which makes `wrangler types` generate them as required (not
+// optional) on the ambient `Env`. That required-ness is a deploy-time
+// guarantee (`wrangler deploy`/`versions upload` refuses to ship without
+// them), not a runtime one: every call site here still treats a missing
+// value as an expected, fail-soft case (GitHub/Stripe/dash() features stay
+// unmounted, /api/auth/* answers 503) rather than a programming error. The
+// declarations below intentionally keep them optional, overriding the
+// generated required version — see src/secrets.ts for the fail-soft
+// resolvers and docs/ops.md for the cutover.
 interface Env {
   /**
    * The Better Auth signing secret (`wrangler secret put BETTER_AUTH_SECRET`).
-   * Preferred over the transitional `UPL_BETTER_AUTH_SECRET` Secrets Store
-   * binding declared in wrangler.jsonc — see src/secrets.ts and uploads#754
-   * item 2.
+   * See src/secrets.ts.
    */
   BETTER_AUTH_SECRET?: string;
-  /** Infra dashboard API key (mounts `dash()` when set). Preferred over the
-   * transitional `UPL_BETTER_AUTH_API_KEY` store binding. */
+  /** Infra dashboard API key (mounts `dash()` when set). */
   BETTER_AUTH_API_KEY?: string;
-  /** GitHub OAuth credentials, gated the same way as the store pair.
-   * Preferred over the transitional `UPL_GITHUB_CLIENT_ID`/`_SECRET` store
-   * bindings. */
+  /** GitHub OAuth credentials, gated as a pair (src/secrets.ts). */
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;
   /** Comma-separated extra trusted origins (see src/trusted-origins.ts). */

--- a/apps/auth/src/index.test.ts
+++ b/apps/auth/src/index.test.ts
@@ -10,7 +10,7 @@ function envWithoutSecret(): AuthEnv {
     DB: {} as unknown as D1Database,
     WEB_ORIGIN: "https://uploads.sh",
     ENVIRONMENT: "development",
-    // No UPL_BETTER_AUTH_SECRET, no BETTER_AUTH_SECRET: unresolvable.
+    // No BETTER_AUTH_SECRET: unresolvable.
   };
 }
 

--- a/apps/auth/src/secrets.test.ts
+++ b/apps/auth/src/secrets.test.ts
@@ -1,123 +1,22 @@
 import { describe, expect, it } from "vitest";
-import {
-  resolveDashApiKey,
-  resolveGitHubCredentials,
-  resolveSecret,
-  resolveSigningSecret,
-  type SecretsStoreSecret,
-} from "./secrets";
-
-function store(value: string): SecretsStoreSecret {
-  return { get: async () => value };
-}
-
-function failingStore(): SecretsStoreSecret {
-  return {
-    get: async () => {
-      throw new Error("store unreachable");
-    },
-  };
-}
-
-describe("resolveSecret", () => {
-  it("returns a plain string as-is", async () => {
-    expect(await resolveSecret("plain")).toBe("plain");
-  });
-
-  it("returns null for undefined", async () => {
-    expect(await resolveSecret(undefined)).toBeNull();
-  });
-
-  it("resolves a Secrets Store binding", async () => {
-    expect(await resolveSecret(store("from-store"))).toBe("from-store");
-  });
-
-  it("treats an empty store value as unresolved", async () => {
-    expect(await resolveSecret(store(""))).toBeNull();
-  });
-
-  it("swallows store failures rather than throwing", async () => {
-    await expect(resolveSecret(failingStore())).resolves.toBeNull();
-  });
-});
+import { resolveDashApiKey, resolveGitHubCredentials, resolveSigningSecret } from "./secrets";
 
 describe("resolveSigningSecret", () => {
-  it("prefers the plain BETTER_AUTH_SECRET over the store fallback", async () => {
-    expect(
-      await resolveSigningSecret({
-        BETTER_AUTH_SECRET: "plain-secret",
-        UPL_BETTER_AUTH_SECRET: store("store-secret"),
-      }),
-    ).toBe("plain-secret");
+  it("returns the plain BETTER_AUTH_SECRET when set", async () => {
+    expect(await resolveSigningSecret({ BETTER_AUTH_SECRET: "plain-secret" })).toBe("plain-secret");
   });
 
-  it("falls back to the store when the plain secret is unset", async () => {
-    expect(
-      await resolveSigningSecret({
-        UPL_BETTER_AUTH_SECRET: store("store-secret"),
-      }),
-    ).toBe("store-secret");
-  });
-
-  it("falls back to the store when the plain secret is empty", async () => {
-    expect(
-      await resolveSigningSecret({
-        BETTER_AUTH_SECRET: "",
-        UPL_BETTER_AUTH_SECRET: store("store-secret"),
-      }),
-    ).toBe("store-secret");
-  });
-
-  it("returns null when the store fails and no plain secret is set", async () => {
-    expect(
-      await resolveSigningSecret({
-        UPL_BETTER_AUTH_SECRET: failingStore(),
-      }),
-    ).toBeNull();
-  });
-
-  it("returns null when nothing resolves", async () => {
+  it("returns null when unset", async () => {
     expect(await resolveSigningSecret({})).toBeNull();
+  });
+
+  it("returns null for an empty string", async () => {
+    expect(await resolveSigningSecret({ BETTER_AUTH_SECRET: "" })).toBeNull();
   });
 });
 
 describe("resolveGitHubCredentials", () => {
-  it("returns credentials when both id and secret resolve from the store", async () => {
-    expect(
-      await resolveGitHubCredentials({
-        UPL_GITHUB_CLIENT_ID: store("id"),
-        UPL_GITHUB_CLIENT_SECRET: store("secret"),
-      }),
-    ).toEqual({ clientId: "id", clientSecret: "secret" });
-  });
-
-  it("prefers plain vars over the store, per half", async () => {
-    expect(
-      await resolveGitHubCredentials({
-        GITHUB_CLIENT_ID: "plain-id",
-        UPL_GITHUB_CLIENT_ID: store("store-id"),
-        UPL_GITHUB_CLIENT_SECRET: store("store-secret"),
-      }),
-    ).toEqual({ clientId: "plain-id", clientSecret: "store-secret" });
-  });
-
-  it("gates on both halves — id only is not enough", async () => {
-    expect(
-      await resolveGitHubCredentials({
-        UPL_GITHUB_CLIENT_ID: store("id"),
-      }),
-    ).toBeNull();
-  });
-
-  it("gates on both halves — secret only is not enough", async () => {
-    expect(
-      await resolveGitHubCredentials({
-        UPL_GITHUB_CLIENT_SECRET: store("secret"),
-      }),
-    ).toBeNull();
-  });
-
-  it("resolves entirely from plain vars when the store is unset", async () => {
+  it("returns credentials when both id and secret are set", async () => {
     expect(
       await resolveGitHubCredentials({
         GITHUB_CLIENT_ID: "plain-id",
@@ -126,29 +25,25 @@ describe("resolveGitHubCredentials", () => {
     ).toEqual({ clientId: "plain-id", clientSecret: "plain-secret" });
   });
 
-  it("returns null with neither plain vars nor store set", async () => {
+  it("gates on both halves — id only is not enough", async () => {
+    expect(await resolveGitHubCredentials({ GITHUB_CLIENT_ID: "id" })).toBeNull();
+  });
+
+  it("gates on both halves — secret only is not enough", async () => {
+    expect(await resolveGitHubCredentials({ GITHUB_CLIENT_SECRET: "secret" })).toBeNull();
+  });
+
+  it("returns null with neither set", async () => {
     expect(await resolveGitHubCredentials({})).toBeNull();
   });
 });
 
 describe("resolveDashApiKey", () => {
-  it("prefers the plain BETTER_AUTH_API_KEY, falls back to the store, else null", async () => {
-    expect(
-      await resolveDashApiKey({
-        BETTER_AUTH_API_KEY: "plain-key",
-        UPL_BETTER_AUTH_API_KEY: store("store-key"),
-      }),
-    ).toBe("plain-key");
-    expect(
-      await resolveDashApiKey({
-        UPL_BETTER_AUTH_API_KEY: store("store-key"),
-      }),
-    ).toBe("store-key");
-    expect(
-      await resolveDashApiKey({
-        UPL_BETTER_AUTH_API_KEY: failingStore(),
-      }),
-    ).toBeNull();
+  it("returns the plain BETTER_AUTH_API_KEY when set", async () => {
+    expect(await resolveDashApiKey({ BETTER_AUTH_API_KEY: "plain-key" })).toBe("plain-key");
+  });
+
+  it("returns null when unset", async () => {
     expect(await resolveDashApiKey({})).toBeNull();
   });
 });

--- a/apps/auth/src/secrets.ts
+++ b/apps/auth/src/secrets.ts
@@ -1,115 +1,61 @@
 /**
  * Secret resolution for the auth worker (see plan D7, and uploads#754 item 2
- * for the Secrets Store → plain secret transition).
+ * for the completed Secrets Store → plain secret migration).
  *
  * All four auth secrets (signing secret, infra dashboard API key, GitHub
  * OAuth client id/secret) have exactly one consumer — this worker — so the
- * Secrets Store's cross-worker propagation never paid for itself, and its
- * `store_id` pointed at an account-level store shared across buildinternet
- * repos (non-portable for a self-hoster). The target shape is a plain
- * per-worker secret (`wrangler secret put BETTER_AUTH_SECRET`, etc.), read
+ * Cloudflare Secrets Store's cross-worker propagation never paid for itself,
+ * and its `store_id` pointed at an account-level store shared across
+ * buildinternet repos (non-portable for a self-hoster). They're now plain
+ * per-worker secrets (`wrangler secret put BETTER_AUTH_SECRET`, etc.), read
  * synchronously off `env` like every other secret in this repo.
  *
- * Transition (dual-read): each resolver below prefers the plain env var when
- * it's a non-empty string, and falls back to the (still-declared, still
- * async) Secrets Store binding otherwise. This makes it safe to merge the
- * code change before an operator has run `wrangler secret put` for all
- * four — the worker keeps answering out of the store exactly as it does
- * today until the plain secrets are set, at which point they take over with
- * no further deploy required. Once an operator confirms the plain secrets
- * are live in prod (and preview, if used), a follow-up change removes the
- * `secrets_store_secrets` blocks from wrangler.jsonc and the `UPL_*`
- * fallback branches here.
- *
- * Store-resolution failures are still swallowed rather than thrown — a
- * missing/misconfigured secret degrades the *feature* it gates (GitHub
- * omitted from socialProviders, signing secret unresolved → 503) instead of
- * 500ing every request.
+ * These resolvers stay `async` even though resolution is now synchronous —
+ * every call site already `await`s them, and keeping the shape stable avoids
+ * churn at each caller. A missing secret still degrades the *feature* it
+ * gates (GitHub omitted from socialProviders, signing secret unresolved →
+ * 503) instead of 500ing every request.
  */
-
-/** Minimal shape of a Cloudflare Secrets Store binding. */
-export type SecretsStoreSecret = { get: () => Promise<string> };
-
-export type SecretLike = string | SecretsStoreSecret | undefined;
-
-/** Resolve one Secrets Store binding (or plain string) to a value or null. */
-export async function resolveSecret(value: SecretLike): Promise<string | null> {
-  if (value == null) return null;
-  if (typeof value === "string") return value || null;
-  try {
-    const resolved = await value.get();
-    return resolved || null;
-  } catch {
-    // Store unreachable, entry not populated yet, etc. — degrade, don't throw.
-    return null;
-  }
-}
-
-/**
- * Resolve a value that's either a plain string (preferred) or a Secrets
- * Store binding (fallback, during the transition — see module doc).
- */
-async function resolvePreferPlain(
-  plain: string | undefined,
-  store: SecretLike,
-): Promise<string | null> {
-  if (plain) return plain;
-  return resolveSecret(store);
-}
 
 export type SigningSecretEnv = {
   BETTER_AUTH_SECRET?: string;
-  /** Transitional Secrets Store fallback — see module doc. Removed once the
-   * plain secret is confirmed live in every environment. */
-  UPL_BETTER_AUTH_SECRET?: SecretLike;
 };
 
 /**
- * The Better Auth signing secret. `BETTER_AUTH_SECRET` (plain) wins; the
- * `UPL_BETTER_AUTH_SECRET` store binding is used only when the plain value is
- * unset — never as a silent override of a populated plain secret.
- *
- * Returns null when neither resolves. Callers MUST treat null as "answer 503
- * from /api/auth/*" rather than booting Better Auth with an ephemeral secret
- * (see {@link authGuardStatus} and src/index.ts).
+ * The Better Auth signing secret. Returns null when unset — callers MUST
+ * treat null as "answer 503 from /api/auth/*" rather than booting Better
+ * Auth with an ephemeral secret (see {@link authGuardStatus} and
+ * src/index.ts).
  */
 export async function resolveSigningSecret(env: SigningSecretEnv): Promise<string | null> {
-  return resolvePreferPlain(env.BETTER_AUTH_SECRET, env.UPL_BETTER_AUTH_SECRET);
+  return env.BETTER_AUTH_SECRET || null;
 }
 
 export type GitHubCredentialsEnv = {
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;
-  /** Transitional Secrets Store fallback — see module doc. */
-  UPL_GITHUB_CLIENT_ID?: SecretLike;
-  UPL_GITHUB_CLIENT_SECRET?: SecretLike;
 };
 
 export type GitHubCredentials = { clientId: string; clientSecret: string };
 
 /**
  * GitHub OAuth credentials, gated: returns null unless BOTH id and secret
- * resolve non-empty (D3 — "socialProviders built by a gate function"). Each
- * half independently prefers its plain env var over its store fallback.
+ * are set (D3 — "socialProviders built by a gate function").
  */
 export async function resolveGitHubCredentials(
   env: GitHubCredentialsEnv,
 ): Promise<GitHubCredentials | null> {
-  const [clientId, clientSecret] = await Promise.all([
-    resolvePreferPlain(env.GITHUB_CLIENT_ID, env.UPL_GITHUB_CLIENT_ID),
-    resolvePreferPlain(env.GITHUB_CLIENT_SECRET, env.UPL_GITHUB_CLIENT_SECRET),
-  ]);
+  const clientId = env.GITHUB_CLIENT_ID || null;
+  const clientSecret = env.GITHUB_CLIENT_SECRET || null;
   if (!clientId || !clientSecret) return null;
   return { clientId, clientSecret };
 }
 
 export type DashApiKeyEnv = {
   BETTER_AUTH_API_KEY?: string;
-  /** Transitional Secrets Store fallback — see module doc. */
-  UPL_BETTER_AUTH_API_KEY?: SecretLike;
 };
 
-/** Infra dashboard API key; null → omit `dash()`. Plain wins over store fallback. */
+/** Infra dashboard API key; null → omit `dash()`. */
 export async function resolveDashApiKey(env: DashApiKeyEnv): Promise<string | null> {
-  return resolvePreferPlain(env.BETTER_AUTH_API_KEY, env.UPL_BETTER_AUTH_API_KEY);
+  return env.BETTER_AUTH_API_KEY || null;
 }

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -45,6 +45,15 @@
     // Dashboard field is ever cleared, remove this var in the same change.
     // See packages/billing/src/stripe-checkout.ts.
     "STRIPE_CHECKOUT_TOS_CONSENT": "true",
+    // Declared (empty/falsy) so a local `.dev.vars` override keeps working
+    // now that `secrets` (below) is defined: once a Worker declares
+    // `secrets.required`, wrangler only loads `.dev.vars`/`.env` keys that
+    // are either already a declared `vars` key or a required secret — an
+    // ambient-only key like this one would otherwise silently stop loading
+    // locally. Only takes effect when ENVIRONMENT is "production" (see
+    // isProduction in src/auth.ts); local/preview ENVIRONMENT values already
+    // skip rate limiting regardless of this var.
+    "AUTH_RATE_LIMIT_DISABLED": "",
   },
   "routes": [
     {
@@ -81,44 +90,38 @@
       "migrations_dir": "migrations",
     },
   ],
-  // TRANSITIONAL (uploads#754 item 2) — these four are being moved off the
-  // account-level Secrets Store (store_id below is the "releases" store,
-  // shared across buildinternet-org repos — non-portable for a self-hoster,
-  // and each of these four secrets has exactly one consumer: this worker, so
-  // the store's cross-worker propagation never applied) onto plain per-worker
-  // secrets: BETTER_AUTH_SECRET, BETTER_AUTH_API_KEY, GITHUB_CLIENT_ID,
-  // GITHUB_CLIENT_SECRET (matching this repo's plain-secret naming
-  // elsewhere). src/secrets.ts now prefers the plain env var and falls back
-  // to the matching binding below only when the plain var is unset — kept
-  // here so a deploy stays safe before an operator has run `wrangler secret
-  // put` for all four. Once prod (and preview, if used) confirm the plain
-  // secrets are live, remove this block (and the matching one under
-  // `previews` below) and the UPL_* fallback branches in src/secrets.ts.
-  // Wrangler FAILS a deploy when a declared secrets_store_secrets entry
-  // doesn't exist in the store, which is why these stay populated rather
-  // than being deleted piecemeal.
-  "secrets_store_secrets": [
-    {
-      "binding": "UPL_BETTER_AUTH_SECRET",
-      "store_id": "a887a71cab084105b79706df23380723",
-      "secret_name": "UPL_BETTER_AUTH_SECRET",
-    },
-    {
-      "binding": "UPL_BETTER_AUTH_API_KEY",
-      "store_id": "a887a71cab084105b79706df23380723",
-      "secret_name": "UPL_BETTER_AUTH_API_KEY",
-    },
-    {
-      "binding": "UPL_GITHUB_CLIENT_ID",
-      "store_id": "a887a71cab084105b79706df23380723",
-      "secret_name": "UPL_GITHUB_CLIENT_ID",
-    },
-    {
-      "binding": "UPL_GITHUB_CLIENT_SECRET",
-      "store_id": "a887a71cab084105b79706df23380723",
-      "secret_name": "UPL_GITHUB_CLIENT_SECRET",
-    },
-  ],
+  // Plain per-worker secrets (uploads#754 item 2 — moved off the
+  // account-level Cloudflare Secrets Store: each of these had exactly one
+  // consumer, this worker, so the store's cross-worker propagation never
+  // applied, and its store_id pointed at a store shared across
+  // buildinternet-org repos, non-portable for a self-hoster). Declaring them
+  // here makes `wrangler deploy`/`wrangler versions upload` fail with a clear
+  // error instead of a silent 503 if any go missing, and is the source of
+  // truth for `wrangler types` (see the `secrets` configuration property:
+  // https://developers.cloudflare.com/workers/wrangler/configuration/#secrets-configuration-property).
+  // Cutover commands and the Stripe/billing pair's own history are in
+  // docs/ops.md ("Auth worker: Secrets Store → plain secret cutover").
+  //
+  // This validates the SAME underlying Worker script's secrets that prod
+  // uses — not a `previews`-scoped set. Per docs/previews.md, the
+  // automatic per-branch "Branch Preview URL" that Workers Builds deploys
+  // for every PR runs against production bindings (it is NOT the
+  // `npx wrangler preview` / `previews` block flow below), so it sees these
+  // same secrets and is unaffected by this list. A manual `wrangler preview`
+  // inherits the same worker-level secrets unless a branch explicitly
+  // overrides one with `wrangler preview secret put`.
+  "secrets": {
+    "required": [
+      "BETTER_AUTH_SECRET",
+      "BETTER_AUTH_API_KEY",
+      "GITHUB_CLIENT_ID",
+      "GITHUB_CLIENT_SECRET",
+      "STRIPE_SECRET_KEY",
+      "STRIPE_WEBHOOK_SECRET",
+      "STRIPE_PRO_PRICE_ID",
+      "BILLING_INTERNAL_KEY",
+    ],
+  },
   // Magic-link delivery. uploads.sh is onboarded for Cloudflare Email Sending;
   // all auth mail comes from noreply@uploads.sh (D7).
   "send_email": [{ "name": "EMAIL", "allowed_sender_addresses": ["noreply@uploads.sh"] }],
@@ -160,11 +163,14 @@
   // callback URLs, so social login cannot work on a preview; magic-link and
   // session flows can once BETTER_AUTH_URL is set. Auth state must never be
   // shared, so previews get their own D1. Bindings do NOT inherit from the
-  // production config — a preview gets only what this block lists — so the
-  // Secrets Store references, EMAIL, the API service binding (always calls
-  // production uploads-api), and the rate limiter are repeated verbatim.
-  // Note a preview CAN send real mail from noreply@uploads.sh, but only
-  // explicit flows (magic links) do.
+  // production config — a preview gets only what this block lists — so
+  // EMAIL, the API service binding (always calls production uploads-api),
+  // and the rate limiter are repeated verbatim. The eight plain secrets
+  // above are NOT bindings declared per-config-block — they live on the
+  // Worker script itself, so previews see the same ones prod does unless a
+  // branch overrides one with `wrangler preview secret put`. Note a preview
+  // CAN send real mail from noreply@uploads.sh, but only explicit flows
+  // (magic links) do.
   //
   // One-time setup (migrations go through wrangler.preview.jsonc — the
   // `d1 migrations` command cannot see databases declared inside `previews`):
@@ -186,28 +192,6 @@
         "database_name": "uploads-auth-preview",
         "database_id": "8f581b6a-6238-4153-a846-a94b83cac86c",
         "migrations_dir": "migrations",
-      },
-    ],
-    "secrets_store_secrets": [
-      {
-        "binding": "UPL_BETTER_AUTH_SECRET",
-        "store_id": "a887a71cab084105b79706df23380723",
-        "secret_name": "UPL_BETTER_AUTH_SECRET",
-      },
-      {
-        "binding": "UPL_BETTER_AUTH_API_KEY",
-        "store_id": "a887a71cab084105b79706df23380723",
-        "secret_name": "UPL_BETTER_AUTH_API_KEY",
-      },
-      {
-        "binding": "UPL_GITHUB_CLIENT_ID",
-        "store_id": "a887a71cab084105b79706df23380723",
-        "secret_name": "UPL_GITHUB_CLIENT_ID",
-      },
-      {
-        "binding": "UPL_GITHUB_CLIENT_SECRET",
-        "store_id": "a887a71cab084105b79706df23380723",
-        "secret_name": "UPL_GITHUB_CLIENT_SECRET",
       },
     ],
     "send_email": [{ "name": "EMAIL", "allowed_sender_addresses": ["noreply@uploads.sh"] }],

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -482,47 +482,57 @@ Do **not** delete PREVIOUS before re-encrypt completes.
 
 ### Auth worker: Secrets Store → plain secret cutover (uploads#754 item 2)
 
-`apps/auth`'s four secrets are moving off the account-level Cloudflare
-Secrets Store onto plain per-worker secrets. `src/secrets.ts` prefers the
-plain secret and only falls back to the (still-declared) store binding when
-the plain one is unset, so **the code change is safe to merge before this
-cutover runs** — the worker keeps answering out of the store until these are
-set.
+**Done.** `apps/auth`'s four auth secrets moved off the account-level
+Cloudflare Secrets Store onto plain per-worker secrets in two steps: #756
+added a dual-read accessor (plain preferred, store fallback) so the code
+change was safe to merge before an operator ran `wrangler secret put`; once
+the operator set all four plain values on the prod worker and confirmed
+GitHub sign-in and sessions stayed healthy, a follow-up change removed the
+`secrets_store_secrets` blocks from `apps/auth/wrangler.jsonc` (both the
+top-level and `previews` blocks) and the store-fallback branches in
+`apps/auth/src/secrets.ts`. `src/secrets.ts` now reads all four straight off
+`env` like every other secret in this repo — no store, no fallback branch.
 
-| Plain secret           | Replaces store binding     |
-| ---------------------- | -------------------------- |
-| `BETTER_AUTH_SECRET`   | `UPL_BETTER_AUTH_SECRET`   |
-| `BETTER_AUTH_API_KEY`  | `UPL_BETTER_AUTH_API_KEY`  |
-| `GITHUB_CLIENT_ID`     | `UPL_GITHUB_CLIENT_ID`     |
-| `GITHUB_CLIENT_SECRET` | `UPL_GITHUB_CLIENT_SECRET` |
+`apps/auth/wrangler.jsonc` also declares a `secrets` configuration property
+now, covering all eight of the worker's secrets (the four above plus the
+pre-existing plain Stripe/billing pair):
 
-Set all four on the production worker (from `apps/auth`), pasting the same
-values already live in the Secrets Store:
-
-```bash
-pnpm exec wrangler secret put BETTER_AUTH_SECRET
-pnpm exec wrangler secret put BETTER_AUTH_API_KEY
-pnpm exec wrangler secret put GITHUB_CLIENT_ID
-pnpm exec wrangler secret put GITHUB_CLIENT_SECRET
+```jsonc
+"secrets": {
+  "required": [
+    "BETTER_AUTH_SECRET",
+    "BETTER_AUTH_API_KEY",
+    "GITHUB_CLIENT_ID",
+    "GITHUB_CLIENT_SECRET",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "STRIPE_PRO_PRICE_ID",
+    "BILLING_INTERNAL_KEY",
+  ],
+}
 ```
 
-Each takes effect on the next request after `wrangler secret put` completes —
-no redeploy needed. Verify `/api/auth/*` still answers (magic link + GitHub
-login) and the infra dashboard (if used) still mounts.
+This makes `wrangler deploy`/`wrangler versions upload` fail with a clear
+error instead of shipping a 503-on-everything build if any of the eight are
+missing from the target worker, and is now the source of truth `wrangler
+types` reads for these names (see apps/auth's `src/env.d.ts`, which
+deliberately keeps its own optional overrides for each — the app code treats
+every one of them as fail-soft at runtime; `secrets.required` is a
+deploy-time guarantee, not a type-level one).
 
-Workers Previews (`apps/auth`'s `previews` block, see
-[previews.md](previews.md)) are rarely used for auth and have no shared
-plain-secret mechanism of their own — a preview would need its own
-`wrangler preview secret put NAME --name <preview>` per branch. Leave them on
-the store fallback for now; nothing forces the previews cutover to happen in
-the same pass as prod.
+**Rotating any of the eight going forward** is a plain `wrangler secret put
+<NAME>` from `apps/auth` — no store, no binding, takes effect on the next
+request.
 
-**Follow-up removal PR** (only after confirming the plain secrets are live
-everywhere they're used): delete the `secrets_store_secrets` blocks from
-`apps/auth/wrangler.jsonc` (both the top-level and `previews` blocks) and the
-`UPL_*` fallback branches in `apps/auth/src/secrets.ts`. There's no rush —
-the store entries stay valid and harmless in the meantime — but the account-
-level store dependency should not outlive this transition.
+**Previews.** This validates the same underlying `uploads-auth` Worker
+script's secrets that production uses, not a separate `previews`-scoped set.
+The automatic per-branch "Branch Preview URL" that Workers Builds deploys for
+every PR runs against production bindings (see
+[previews.md](previews.md#the-two-layers) — it is not the
+`npx wrangler preview` / `previews` block flow), so it already sees the same
+eight secrets and needed no changes here. A manual `wrangler preview`
+inherits the same worker-level secrets too, unless a branch explicitly
+overrides one with `wrangler preview secret put`.
 
 ## Presign
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -520,9 +520,25 @@ deliberately keeps its own optional overrides for each — the app code treats
 every one of them as fail-soft at runtime; `secrets.required` is a
 deploy-time guarantee, not a type-level one).
 
-**Rotating any of the eight going forward** is a plain `wrangler secret put
-<NAME>` from `apps/auth` — no store, no binding, takes effect on the next
-request.
+**Rotating an independent secret** (`BETTER_AUTH_SECRET`, `BETTER_AUTH_API_KEY`,
+`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRO_PRICE_ID`,
+`BILLING_INTERNAL_KEY`) is a plain `wrangler secret put <NAME>` from
+`apps/auth` — no store, no binding, takes effect on the next request.
+
+**Rotating `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` together** must NOT use
+two separate `wrangler secret put` calls: each one deploys immediately, so a
+sequential pair leaves a window where the new id is live against the old
+secret (or vice versa) and GitHub OAuth briefly breaks. Update both in one
+request instead:
+
+```bash
+printf 'GITHUB_CLIENT_ID=%s\nGITHUB_CLIENT_SECRET=%s\n' "$NEW_ID" "$NEW_SECRET" \
+  | pnpm exec wrangler secret bulk
+```
+
+(from `apps/auth`; `wrangler secret bulk` also accepts a JSON file of
+`{"key": "value"}` pairs). This lands both values in a single deploy, so
+they're never mismatched.
 
 **Previews.** This validates the same underlying `uploads-auth` Worker
 script's secrets that production uses, not a separate `previews`-scoped set.


### PR DESCRIPTION
Completes #754 item 2, now that the four plain secrets are set and verified working on the prod auth worker (dual-read from #756 has been serving the plain values).

## Changes

- **Store removal**: both `secrets_store_secrets` blocks deleted from `apps/auth/wrangler.jsonc`; `secrets.ts` fallback machinery (`SecretsStoreSecret`/`resolveSecret`/dual-read) stripped to plain env reads; transitional `UPL_*` types removed. No `UPL_*` references remain outside a historical plan doc.
- **Deploy-time guardrail**: `secrets.required` added with all eight worker secrets (`BETTER_AUTH_SECRET`, `BETTER_AUTH_API_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRO_PRICE_ID`, `BILLING_INTERNAL_KEY`) — verified against actual `env.*` reads in src. A missing secret now fails the deploy instead of 503ing at runtime.
- **`wrangler types` side effects handled** (verified by before/after diff, not just reasoned): `AUTH_RATE_LIMIT_DISABLED` added to `vars` so `.dev.vars` keeps loading it under `wrangler dev`; `env.d.ts` keeps optional shadows for the eight secrets because consuming call sites (`billing-bridge`, `billing-outbox`, `member-cap`, `stripe-plugin`) deliberately treat them as fail-soft — same precedent as the existing `STRIPE_CHECKOUT_TOS_CONSENT` shadow.
- Docs: `docs/ops.md` cutover section marked done, previews analysis recorded; README/`.dev.vars.example` cleaned up.

## Previews analysis

The `previews` wrangler.jsonc block only serves manual `npx wrangler preview`; the per-PR **Branch Preview URL** from Workers Builds runs against production bindings (per `docs/previews.md`), and secrets live on the Worker script itself — so top-level `secrets.required` covers both paths and no per-env scoping is needed. **This PR's own Workers Build is the live confirmation**: if the `uploads-auth` build passes, the validation holds.

## Verification

- `pnpm test` — 314 files / 4740 green (8 store-fallback test cases removed with the fallback; the 503-without-secret guard remains covered)
- `pnpm --filter @uploads/auth typecheck` exit 0 from fresh baseline and post-change; `format:check` and `changeset:lint` clean
- Zero diff touching `d1_databases`, `fake-d1.ts`, or `auth-client.ts` (no overlap with #755/#757)

Closes out the secrets portion of #754.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated authentication deployment and operations guidance to reflect the completed move to per-worker secrets.
  - Clarified required secrets, deployment behavior, preview configuration, and secret rotation steps.

- **Configuration**
  - Added a local rate-limit override.
  - Updated authentication, GitHub, Stripe, and billing secret configuration.

- **Bug Fixes**
  - Simplified secret resolution and ensured missing credentials fail gracefully instead of causing server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->