### PR TITLE
feat(auth): adopt CIMD client registration alongside DCR (#556)

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@better-auth/cimd": "^1.7.1",
     "@better-auth/infra": "^0.4.1",
     "@better-auth/oauth-provider": "^1.7.1",
     "@better-auth/stripe": "^1.7.1",

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -5,6 +5,7 @@
  * after a redeploy, or a different D1 binding under `wrangler dev -c`) never
  * serves a stale instance.
  */
+import { cimd } from "@better-auth/cimd";
 import { dash } from "@better-auth/infra";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -20,6 +21,7 @@ import {
   magicLink,
   organization,
 } from "better-auth/plugins";
+import { fetchClientMetadataResource } from "./cimd-transport";
 import { deviceWorkspacePlugin } from "./device-workspace";
 import { sendAuthEmail } from "./email";
 import { localDemoEnabled, localDemoPlugin } from "./local-demo";
@@ -660,6 +662,23 @@ function buildAuth(
         // 403.
         customAccessTokenClaims: async ({ user, referenceId }) =>
           applyWorkspaceChoice(await resolveWorkspaceClaims(db, user?.id), referenceId),
+      }),
+      // Issue #556: Client ID Metadata Documents (CIMD). MCP spec 2026-07-28
+      // deprecates DCR in favour of an HTTPS-URL `client_id` that points at a
+      // metadata document; this plugin contributes that discovery to the
+      // oauthProvider() above (order is irrelevant — it registers via
+      // `extendOAuthProvider` at init) and advertises
+      // `client_id_metadata_document_supported: true` in the AS metadata.
+      // DCR stays enabled alongside for backward compatibility. Discovery-
+      // resolved clients are persisted as ordinary oauth_client rows tagged
+      // `client_discovery_id = 'cimd'` and are refreshed from their metadata
+      // URL on later resolutions, so the stale-client reaper may sweep them
+      // like any other anonymous row (see oauth-client-reaper.ts).
+      // The MCP profile pins the draft-00 requirements that spec revision
+      // mandates (client_name + redirect_uris required).
+      cimd({
+        fetchClientMetadataResource,
+        metadataProfile: "mcp-2026-07-28",
       }),
       // D5/Phase 4: bearer() lets the CLI present the device-flow session token
       // as `Authorization: Bearer <token>` so apps/api's session verification

--- a/apps/auth/src/cimd-transport.ts
+++ b/apps/auth/src/cimd-transport.ts
@@ -1,0 +1,56 @@
+/**
+ * Workers fetch transport for CIMD metadata documents (issue #556).
+ *
+ * `@better-auth/cimd` requires the application to supply the transport that
+ * fetches Client ID Metadata Documents, and states the contract in Node
+ * terms: resolve DNS once, reject RFC 6890 special-use addresses, pin the
+ * approved address for the connection, and never follow redirects. The
+ * package's own `@better-auth/cimd/node` transport implements that with
+ * `node:dns` + `node:https`, neither of which exists on Cloudflare Workers.
+ *
+ * This transport provides the equivalent guarantees at the Workers network
+ * boundary instead:
+ *
+ * - **Special-use hosts rejected up front** — literal-IP and special-use
+ *   FQDN targets (loopback, RFC 1918, link-local/IMDS, cloud-metadata
+ *   FQDNs, …) are rejected via the plugin's own `validateClientIdUrl`
+ *   (draft-02 §3), backed by the same RFC 6890 classifier the Node
+ *   transport runs against resolved addresses.
+ * - **No rebinding surface behind a public hostname** — Workers outbound
+ *   `fetch` egresses from Cloudflare's edge, where RFC 1918 / link-local
+ *   space is not routable to anything of ours: every uploads service is a
+ *   Worker/R2/D1 reached via bindings, not IP. A hostname that resolves to
+ *   a private address yields a connection error, not an internal service.
+ *   (Cloudflare additionally blocks subrequests into its own metadata
+ *   endpoints.) DNS resolution and connection reuse are the edge's; there
+ *   is no socket API with which to resolve-then-pin ourselves.
+ * - **Redirects returned, never followed** — `redirect: "manual"`.
+ * - **GET/HEAD only, HTTPS only** — same method/scheme gate as the Node
+ *   transport.
+ *
+ * The plugin has already run `validateClientIdUrl` on the `client_id` URL
+ * before fetching; the checks here also cover discovery-owned follow-up
+ * fetches such as a confidential client's `jwks_uri`.
+ */
+import { validateClientIdUrl } from "@better-auth/cimd";
+import type { ClientMetadataResourceFetch } from "@better-auth/oauth-provider";
+
+export const fetchClientMetadataResource: ClientMetadataResourceFetch = async (input, init) => {
+  const request = new Request(input, init);
+  const url = new URL(request.url);
+  if (url.protocol !== "https:") {
+    throw new TypeError("CIMD Workers transport requires an HTTPS URL");
+  }
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    throw new TypeError("CIMD Workers transport supports only GET and HEAD");
+  }
+  // draft-02 §3 URL validation (loopback/private/link-local/cloud-metadata
+  // hosts all rejected). The plugin runs this on the client_id URL before
+  // resolving; re-running it here also covers discovery-owned follow-up
+  // fetches such as a confidential client's `jwks_uri`.
+  const urlError = validateClientIdUrl(request.url);
+  if (urlError) {
+    throw new TypeError(`metadata URL rejected: ${urlError}`);
+  }
+  return fetch(new Request(request, { redirect: "manual" }));
+};

--- a/apps/auth/src/cimd.test.ts
+++ b/apps/auth/src/cimd.test.ts
@@ -1,0 +1,191 @@
+/**
+ * CIMD client registration (issue #556): URL-form `client_id` resolution via
+ * `@better-auth/cimd`, the Workers fetch transport, AS-metadata advertising,
+ * and the SEP-837 `application_type` DCR field. Driven against the real
+ * Better Auth handler (src/index.ts's `app`) and the fake-D1 harness, with
+ * the metadata-document fetch stubbed at the global `fetch` seam the Workers
+ * transport uses.
+ */
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AuthEnv } from "./auth";
+import { fetchClientMetadataResource } from "./cimd-transport";
+import { app } from "./index";
+import * as schema from "./schema";
+import { createFakeD1 } from "./test/fake-d1";
+
+function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
+  return {
+    DB: createFakeD1(),
+    WEB_ORIGIN: "https://uploads.sh",
+    BETTER_AUTH_URL: "https://uploads.sh",
+    ENVIRONMENT: "development",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
+    ...overrides,
+  };
+}
+
+const CLIENT_ID_URL = "https://client.example.com/oauth-client.json";
+const REDIRECT_URI = "https://client.example.com/callback";
+
+/** Minimal metadata document satisfying the mcp-2026-07-28 profile. */
+function metadataDocument(): Record<string, unknown> {
+  return {
+    client_id: CLIENT_ID_URL,
+    client_name: "Test CIMD MCP Client",
+    redirect_uris: [REDIRECT_URI],
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+  };
+}
+
+function stubMetadataFetch(body: unknown = metadataDocument()) {
+  const impl = vi.fn(async () =>
+    Response.json(body, { headers: { "cache-control": "max-age=300" } }),
+  );
+  vi.stubGlobal("fetch", impl);
+  return impl;
+}
+
+async function authorize(env: AuthEnv, params: Record<string, string> = {}) {
+  const query = new URLSearchParams({
+    client_id: CLIENT_ID_URL,
+    redirect_uri: REDIRECT_URI,
+    response_type: "code",
+    scope: "files:read",
+    state: "test-state",
+    code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    code_challenge_method: "S256",
+    ...params,
+  });
+  return app.request(`/api/auth/oauth2/authorize?${query}`, {}, env);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("AS metadata", () => {
+  it("advertises client_id_metadata_document_supported", async () => {
+    const res = await app.request("/.well-known/oauth-authorization-server", {}, dbEnv());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { client_id_metadata_document_supported?: boolean };
+    expect(body.client_id_metadata_document_supported).toBe(true);
+  });
+});
+
+describe("CIMD client resolution", () => {
+  it("resolves a URL client_id at /oauth2/authorize and persists a discovery-owned client", async () => {
+    const env = dbEnv();
+    const fetchImpl = stubMetadataFetch();
+
+    const res = await authorize(env);
+
+    // Unauthenticated user with a valid client → redirect to the login page,
+    // never an invalid_client error.
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/login");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+
+    const orm = drizzle(env.DB, { schema });
+    const [row] = await orm
+      .select({
+        clientId: schema.oauthClient.clientId,
+        discovery: schema.oauthClient.clientDiscoveryId,
+        userId: schema.oauthClient.userId,
+        skipConsent: schema.oauthClient.skipConsent,
+      })
+      .from(schema.oauthClient)
+      // The fake-D1 migration chain seeds the managed `uploads-cli` row —
+      // select only the discovery-created client.
+      .where(eq(schema.oauthClient.clientId, CLIENT_ID_URL));
+    expect(row?.clientId).toBe(CLIENT_ID_URL);
+    expect(row?.discovery).toBe("cimd");
+    // Anonymous + untrusted: stays within the stale-client reaper's candidate
+    // predicate, so unused CIMD rows are swept like abandoned DCR rows.
+    expect(row?.userId).toBeNull();
+    expect(row?.skipConsent).toBeFalsy();
+  });
+
+  it("rejects a metadata document missing the MCP profile's required fields", async () => {
+    const env = dbEnv();
+    const { client_name: _omitted, ...withoutName } = metadataDocument();
+    stubMetadataFetch(withoutName);
+
+    const res = await authorize(env);
+    // Resolution fails closed → the client does not exist for this AS.
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it("rejects a redirect_uri not listed in the metadata document", async () => {
+    const env = dbEnv();
+    stubMetadataFetch();
+
+    const res = await authorize(env, { redirect_uri: "https://evil.example.com/callback" });
+    // Exact-match failure sends the browser to the AS's own error page —
+    // never to the unlisted redirect target.
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("error=invalid_redirect");
+    expect(location).not.toContain("evil.example.com");
+  });
+});
+
+describe("Workers CIMD transport", () => {
+  it("refuses non-HTTPS URLs", async () => {
+    await expect(
+      fetchClientMetadataResource("http://client.example.com/meta.json"),
+    ).rejects.toThrow(/HTTPS/);
+  });
+
+  it("refuses non-GET/HEAD methods", async () => {
+    await expect(fetchClientMetadataResource(CLIENT_ID_URL, { method: "POST" })).rejects.toThrow(
+      /GET and HEAD/,
+    );
+  });
+
+  it("refuses loopback and private hosts", async () => {
+    for (const url of [
+      "https://localhost/meta.json",
+      "https://127.0.0.1/meta.json",
+      "https://192.168.1.10/meta.json",
+      "https://169.254.169.254/meta.json",
+    ]) {
+      await expect(fetchClientMetadataResource(url)).rejects.toThrow(/rejected/);
+    }
+  });
+
+  it("performs the fetch with manual redirect handling", async () => {
+    const impl = vi.fn(async (req: Request) => {
+      expect(req.redirect).toBe("manual");
+      return Response.json(metadataDocument());
+    });
+    vi.stubGlobal("fetch", impl);
+    const res = await fetchClientMetadataResource(CLIENT_ID_URL);
+    expect(res.status).toBe(200);
+    expect(impl).toHaveBeenCalledOnce();
+  });
+});
+
+describe("dynamic client registration (SEP-837)", () => {
+  it("tolerates the application_type field at /oauth2/register", async () => {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "Test MCP Client",
+          redirect_uris: ["https://client.example.com/callback"],
+          application_type: "web",
+        }),
+      },
+      dbEnv(),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { client_id?: string };
+    expect(typeof body.client_id).toBe("string");
+  });
+});

--- a/apps/auth/src/oauth-client-reaper.ts
+++ b/apps/auth/src/oauth-client-reaper.ts
@@ -7,6 +7,14 @@
  * (a probe, MCP Inspector, or an agent that registered but never completed
  * auth) accumulate as `oauth_client` rows. This sweep purges them.
  *
+ * CIMD (issue #556) does not retire this reaper: Better Auth persists
+ * discovery-resolved clients as ordinary anonymous `oauth_client` rows
+ * (`client_discovery_id = 'cimd'`), so URL-form client_ids accumulate the
+ * same way DCR rows do. They are deliberately NOT exempted below — a swept
+ * CIMD row is recreated on demand from its metadata URL at the next
+ * authorize, and the never-used guard already protects rows with live
+ * consents or tokens.
+ *
  * A client is REAPABLE only when ALL hold:
  *   - older than the retention window (default 30d,
  *     `OAUTH_CLIENT_REAPER_RETENTION_DAYS`),

--- a/apps/web/public/auth.md
+++ b/apps/web/public/auth.md
@@ -83,9 +83,13 @@ inferred from the `up_<workspace>_…` token form).
 
 `https://agents.uploads.sh/mcp` also accepts OAuth 2.1 bearer tokens issued by
 our authorization server at `https://uploads.sh` (issuer
-`https://uploads.sh/api/auth`). It supports PKCE and dynamic client
-registration (RFC 7591) — an MCP client can register itself, no manual setup.
-Discovery:
+`https://uploads.sh/api/auth`). It supports PKCE and self-service client
+registration, no manual setup — preferably via Client ID Metadata Documents
+(CIMD, per MCP spec 2026-07-28: use an HTTPS URL that serves your client
+metadata JSON as the `client_id`; the metadata must include `client_name` and
+`redirect_uris`, and `redirect_uri` must exactly match a listed entry).
+Dynamic client registration (RFC 7591) remains supported for older clients.
+Discovery (advertises `client_id_metadata_document_supported`):
 
 ```bash
 curl -s https://uploads.sh/.well-known/oauth-authorization-server

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -78,7 +78,7 @@ Default scopes on login: `files:read`, `files:write`, `files:delete`.
 Pass `--scopes` to mint a narrower token. Tokens default to 90 days.
 
 Hosted MCP also accepts OAuth 2.1 from https://uploads.sh (issuer
-https://uploads.sh/api/auth; PKCE + dynamic client registration). REST API
+https://uploads.sh/api/auth; PKCE + CIMD URL client_ids, or RFC 7591 DCR). REST API
 does **not** accept OAuth in v1 — workspace bearer only. Full detail:
 https://uploads.sh/auth.md
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
 
   apps/auth:
     dependencies:
+      '@better-auth/cimd':
+        specifier: ^1.7.1
+        version: 1.7.1(ea6bd093f1db96f9e15a920313b21b4b)
       '@better-auth/infra':
         specifier: ^0.4.1
         version: 0.4.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(better-auth@1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))))(zod@4.4.3)
@@ -723,6 +726,14 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@better-auth/cimd@1.7.1':
+    resolution: {integrity: sha512-x28HdfmDX94P0CL7EmChil5dHKEJI81AQ8e129gJIpmUW5lsVKUeEYCEG3O1t0izqfglX6jnsipWiqZ0OF4Hzg==}
+    peerDependencies:
+      '@better-auth/core': ^1.7.1
+      '@better-auth/oauth-provider': ^1.7.1
+      better-auth: ^1.7.1
+      better-call: 1.4.0
 
   '@better-auth/core@1.7.1':
     resolution: {integrity: sha512-eZ9lqcnVLMZ3QtUByRo4VZqkB1ESyRddd9NfWjBdDPgh+jcwLScoIUAqhtHLR8zaSUJZah8OLGlkzObyPdUH7A==}
@@ -6624,6 +6635,13 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@better-auth/cimd@1.7.1(ea6bd093f1db96f9e15a920313b21b4b)':
+    dependencies:
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/oauth-provider': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))
+      better-auth: 1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)))
+      better-call: 1.4.0(zod@4.4.3)
+
   '@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
@@ -7598,13 +7616,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -8062,7 +8073,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.1.4':


### PR DESCRIPTION
Towards #556. The blocker (Better Auth 1.7) landed in #744, so this enables the CIMD track itself.

## What changed

- **`@better-auth/cimd@1.7.1` registered on the auth worker** with the `mcp-2026-07-28` metadata profile (the MCP revision pins CIMD draft-00: `client_name` + `redirect_uris` required). An MCP client can now use an HTTPS URL as its `client_id`; the worker fetches, validates, and persists it as a discovery-owned `oauth_client` row (`client_discovery_id = 'cimd'`). AS metadata now advertises `client_id_metadata_document_supported: true`.
- **Workers fetch transport** (`apps/auth/src/cimd-transport.ts`) — the package's own transport needs `node:dns`/`node:https`. Ours enforces HTTPS, GET/HEAD only, draft-02 URL validation (loopback/private/link-local/cloud-metadata hosts rejected up front), and `redirect: "manual"`. The resolve-once-and-pin DNS guarantee is delegated to the Cloudflare edge network boundary, where private address space is not routable to any uploads service — the reasoning is spelled out in the module comment.
- **DCR stays on** for backward compatibility (the spec keeps it valid with a ≥12-month window). The existing register test plus a new one confirm the handler tolerates SEP-837's `application_type`.
- **Stale-client reaper stays** (issue expected it might retire): Better Auth's CIMD implementation *does* persist client rows, so anonymous URL-form clients accumulate exactly like DCR rows. They are deliberately not exempted — a swept CIMD row is recreated on demand from its metadata URL, and the never-used guard protects rows with live consents/tokens.
- **Docs**: `auth.md` and `llms-full.txt` now describe CIMD-first registration with DCR as the compatibility path.

## Issue checklist coverage

- [x] Enable CIMD client resolution alongside DCR
- [x] `redirect_uris` matching — covered in tests: exact-match failure 302s to the AS's own error page (`error=invalid_redirect`), never the unlisted target; real-client verification against `agents.uploads.sh` still owed post-deploy
- [x] DCR tolerates `application_type` (SEP-837)
- [x] Docs updated for CIMD-first registration
- [x] Reaper re-evaluated (kept, with rationale in its header)

## Verification

- 4757/4757 repo tests (9 new in `apps/auth/src/cimd.test.ts`, driven through the real handler + fake-D1, metadata fetch stubbed at the global `fetch` seam)
- Repo typecheck 0 errors (Node 24), lint clean
- `wrangler deploy --dry-run` bundles cleanly (the infra-0.4 lazy-import class of breakage that tsc/vitest miss)

## Owed after merge

Prod smoke with a real CIMD-speaking MCP client against `agents.uploads.sh` (the known `redirect_uris` ecosystem sharp edge), then a follow-up comment on #556.
