### PR TITLE
fix(auth): pin CIMD transport redirect mode before Request construction

### DIFF
--- a/apps/auth/src/cimd-transport.ts
+++ b/apps/auth/src/cimd-transport.ts
@@ -36,7 +36,13 @@ import { validateClientIdUrl } from "@better-auth/cimd";
 import type { ClientMetadataResourceFetch } from "@better-auth/oauth-provider";
 
 export const fetchClientMetadataResource: ClientMetadataResourceFetch = async (input, init) => {
-  const request = new Request(input, init);
+  // The plugin calls this with `redirect: "error"`, which workerd's Request
+  // constructor REJECTS outright ("won't be implemented... use manual and
+  // check the response status"). Pin "manual" at construction time — the
+  // plugin already treats any non-200 (including 3xx) as a failed fetch, so
+  // returned redirects are refused either way. Caught in prod smoke, not by
+  // vitest: Node's undici accepts `redirect: "error"`.
+  const request = new Request(input, { ...init, redirect: "manual" });
   const url = new URL(request.url);
   if (url.protocol !== "https:") {
     throw new TypeError("CIMD Workers transport requires an HTTPS URL");
@@ -52,5 +58,5 @@ export const fetchClientMetadataResource: ClientMetadataResourceFetch = async (i
   if (urlError) {
     throw new TypeError(`metadata URL rejected: ${urlError}`);
   }
-  return fetch(new Request(request, { redirect: "manual" }));
+  return fetch(request);
 };

--- a/apps/auth/src/cimd.test.ts
+++ b/apps/auth/src/cimd.test.ts
@@ -157,13 +157,17 @@ describe("Workers CIMD transport", () => {
     }
   });
 
-  it("performs the fetch with manual redirect handling", async () => {
+  it("pins manual redirect handling even when called with redirect: 'error'", async () => {
+    // The plugin passes `redirect: "error"`, which workerd's Request
+    // constructor rejects — the transport must replace it with "manual"
+    // BEFORE constructing the Request (caught by prod smoke; Node's undici
+    // accepts "error" so this test can only pin the replacement behavior).
     const impl = vi.fn(async (req: Request) => {
       expect(req.redirect).toBe("manual");
       return Response.json(metadataDocument());
     });
     vi.stubGlobal("fetch", impl);
-    const res = await fetchClientMetadataResource(CLIENT_ID_URL);
+    const res = await fetchClientMetadataResource(CLIENT_ID_URL, { redirect: "error" });
     expect(res.status).toBe(200);
     expect(impl).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
Follow-up to #760, found by the #556 prod smoke.

**Bug:** workerd's `Request` constructor rejects `redirect: "error"` outright, and `@better-auth/cimd` calls the transport with exactly that init — so every prod metadata-document fetch threw before any network I/O, and `/oauth2/authorize` with a URL `client_id` returned `invalid_client` ("Failed to fetch metadata document"). Node's undici accepts `"error"`, so the vitest suite couldn't catch it.

**Fix:** construct the Request with `redirect: "manual"` from the start. Redirect refusal is unchanged — the plugin already treats any non-200 (including a returned 3xx) as a failed fetch.

**Verified:** reproduced the failure and re-verified the fix under `wrangler dev` (real workerd) using the plugin's exact call shape against a live hosted metadata document — 200, JSON parsed. The updated test pins the replacement behavior (transport called with `redirect: "error"` must hand `fetch` a `redirect: "manual"` request). I'll re-run the prod authorize smoke once this deploys and then report on #556.