### PR TITLE
fix(auth): let self-registered OAuth clients request files:delete

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -607,6 +607,17 @@ function buildAuth(
         consentPage: `${webOrigin}/oauth/consent`,
         scopes: [...OAUTH_SCOPES],
         clientRegistrationDefaultScopes: [...OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES],
+        // Better Auth 1.7 persists every self-registered client (DCR and
+        // CIMD alike) with scope = defaultScopes ∪ allowedScopes, DISCARDING
+        // any `scope` the registration or metadata document declares — so
+        // without this line the defaults above are a hard cap and no
+        // self-registered client can ever request files:delete (authorize
+        // 400s with invalid_scope; found by the #556 MCP Inspector run,
+        // which requests every scope the resource advertises). Listing
+        // files:delete here lets self-registered clients REQUEST it; every
+        // grant still goes through the user's consent screen, and device-flow
+        // workspace tokens already get files:delete by default.
+        clientRegistrationAllowedScopes: ["files:delete"],
         // Better Auth 1.7: `validAudiences` → the persisted `resources` model.
         // String form (plugin-level defaults) preserves the 1.6 accepted-audience
         // behavior; `resourceSeedMode` defaults to the safe "insertOnly".

--- a/apps/auth/src/cimd.test.ts
+++ b/apps/auth/src/cimd.test.ts
@@ -109,6 +109,19 @@ describe("CIMD client resolution", () => {
     expect(row?.skipConsent).toBeFalsy();
   });
 
+  it("lets a self-registered client request files:delete (clientRegistrationAllowedScopes)", async () => {
+    // Better Auth 1.7 persists self-registered clients with
+    // defaultScopes ∪ allowedScopes and discards any document-declared
+    // `scope` — without files:delete in clientRegistrationAllowedScopes this
+    // request 400s with invalid_scope (found by the #556 Inspector run).
+    const env = dbEnv();
+    stubMetadataFetch();
+
+    const res = await authorize(env, { scope: "files:read files:write files:delete" });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/login");
+  });
+
   it("rejects a metadata document missing the MCP profile's required fields", async () => {
     const env = dbEnv();
     const { client_name: _omitted, ...withoutName } = metadataDocument();


### PR DESCRIPTION
Found by the #556 real-client verification run (MCP Inspector requests every scope the protected resource advertises).

**Bug:** Better Auth 1.7 persists every self-registered client — DCR and CIMD alike — with `scope = clientRegistrationDefaultScopes ∪ clientRegistrationAllowedScopes`, discarding any `scope` the registration request or CIMD metadata document declares. We only set the defaults (`files:read files:write`), which 1.7 turns into a hard cap: authorize returns `invalid_scope: cannot request scope files:delete` to every self-registered client, even one whose metadata document declares all three scopes. Our config comment described the option as a *default* for clients that request none — the cap behavior is new in 1.7.

**Fix:** declare `files:delete` in `clientRegistrationAllowedScopes`. Self-registered clients can now request it; every grant still passes the user's consent screen, and device-flow workspace tokens already include `files:delete` by default, so this restores parity rather than widening anything unattended.

**Tests:** new regression in cimd.test.ts (CIMD authorize requesting all three scopes reaches the login redirect instead of 400). Full auth suite green.

After deploy I'll finish the Inspector end-to-end run (authorize → consent → token → `tools/list`) and report on #556.