### PR TITLE
feat: minimal-binding profile — optional bindings degrade gracefully (#754 item 3)

### DIFF
--- a/apps/api/src/abuse-email.test.ts
+++ b/apps/api/src/abuse-email.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { notifyAbuseReport, withinAbuseNotifyBudget } from "./abuse-email";
+
+const ROW = {
+  id: "report-1",
+  reason: "spam",
+  message: null,
+  contact: null,
+  pageUrl: "https://uploads.sh/f/abc",
+  workspace: "acme",
+  objectKey: "acme/file.png",
+  surface: "file-page",
+  createdAt: "2026-08-22T00:00:00.000Z",
+};
+
+describe("notifyAbuseReport — EMAIL binding absent", () => {
+  it("logs instead of throwing when EMAIL is absent (issue #754 item 3)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(
+      notifyAbuseReport({ WEB_ORIGIN: "https://uploads.sh" }, ROW),
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls.at(-1)?.[0]).toContain("no EMAIL binding");
+    warn.mockRestore();
+  });
+
+  it("still applies the notify-rate budget check even without EMAIL", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let calls = 0;
+    const registry = {
+      get: async () => (calls > 0 ? "20" : null),
+      put: async () => {
+        calls++;
+      },
+    };
+    await notifyAbuseReport({ WEB_ORIGIN: "https://uploads.sh", REGISTRY: registry }, ROW);
+    warn.mockRestore();
+    // No throw either way — asserted implicitly by reaching this line.
+    expect(true).toBe(true);
+  });
+
+  it("sends when EMAIL is present", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    await notifyAbuseReport({ EMAIL: { send }, WEB_ORIGIN: "https://uploads.sh" }, ROW);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0].to).toBe("abuse@uploads.sh");
+  });
+});
+
+describe("withinAbuseNotifyBudget", () => {
+  it("fails open (allows) when REGISTRY is absent", async () => {
+    await expect(withinAbuseNotifyBudget(undefined, 20)).resolves.toBe(true);
+  });
+});

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -64,4 +64,23 @@ interface Env {
   MEDIA?: MediaBinding;
   FLAGS?: Flagship;
   POSTER_LIMITER?: RateLimit;
+  /**
+   * Browser Run (screenshot rendering, `POST /v1/render`). Like `MEDIA`, this
+   * has no local Miniflare simulation and self-hosters may skip the block
+   * entirely (uploads#754 item 3) — `browserRenderer()` in render.ts treats
+   * an absent binding as a distinct `renderer_unavailable` 503, never a
+   * crash.
+   */
+  BROWSER?: BrowserRun;
+  /**
+   * Per-workspace/IP rate limiters (uploads#754 item 3). All fail OPEN when
+   * absent (unlike POSTER_LIMITER above, which fails closed) — see
+   * guards.ts's `makeRateLimitGuard` and the five call sites of
+   * INVITE_LIMITER. A self-hoster may delete any of these `unsafe.bindings`
+   * blocks and simply run without that burst guard.
+   */
+  WRITE_LIMITER?: RateLimit;
+  RENDER_LIMITER?: RateLimit;
+  WS_CREATE_LIMITER?: RateLimit;
+  INVITE_LIMITER?: RateLimit;
 }

--- a/apps/api/src/github-app.test.ts
+++ b/apps/api/src/github-app.test.ts
@@ -396,3 +396,57 @@ describe("prHeadBranch", () => {
     expect(await prHeadBranch(envWith(kv), cfgWith(pem), 42, "o/r", 0, fetchImpl)).toBeNull();
   });
 });
+
+// GITHUB_CACHE is a core binding (uploads#754 item 3), but this module is
+// imported transitively into apps/mcp — which has no GITHUB_CACHE of its
+// own — and unit tests build minimal envs, so every exported function here
+// must still degrade to null (never throw) when the binding is absent,
+// matching the module's documented "every function degrades to null on
+// failure" contract.
+describe("GITHUB_CACHE binding absent", () => {
+  const noCacheEnv = {} as Env;
+
+  it("installationForRepo degrades to null instead of throwing", async () => {
+    const { pem } = await testKeyPair();
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ id: 4242 }), { status: 200 })) as typeof fetch;
+    await expect(
+      installationForRepo(noCacheEnv, cfgWith(pem), "o/r", fetchImpl),
+    ).resolves.toBeNull();
+  });
+
+  it("fetchPrActors degrades to null instead of throwing", async () => {
+    const { pem } = await testKeyPair();
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ user: { id: 1 } }), { status: 200 })) as typeof fetch;
+    await expect(
+      fetchPrActors(noCacheEnv, cfgWith(pem), 42, "o/r", "pull", 7, fetchImpl),
+    ).resolves.toBeNull();
+  });
+
+  it("installationToken degrades to null instead of throwing", async () => {
+    const { pem } = await testKeyPair();
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ token: "ghs_abc" }), { status: 201 })) as typeof fetch;
+    await expect(installationToken(noCacheEnv, cfgWith(pem), 4242, fetchImpl)).resolves.toBeNull();
+  });
+
+  it("repoIsPrivate degrades to null instead of throwing", async () => {
+    const { pem } = await testKeyPair();
+    const fetchImpl = (async (input: RequestInfo | URL) => {
+      // No cached installation token either, so this never even reaches the
+      // repo-privacy fetch — exercised for completeness.
+      if (String(input).endsWith("/access_tokens")) return new Response("", { status: 401 });
+      return new Response(JSON.stringify({ private: true }), { status: 200 });
+    }) as typeof fetch;
+    await expect(repoIsPrivate(noCacheEnv, cfgWith(pem), 42, "o/r", fetchImpl)).resolves.toBeNull();
+  });
+
+  it("prHeadBranch degrades to null instead of throwing", async () => {
+    const { pem } = await testKeyPair();
+    const fetchImpl = (async () => new Response("", { status: 401 })) as typeof fetch;
+    await expect(
+      prHeadBranch(noCacheEnv, cfgWith(pem), 42, "o/r", 7, fetchImpl),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/api/src/github-app.ts
+++ b/apps/api/src/github-app.ts
@@ -7,6 +7,24 @@
 
 import { b64urlDecode, b64urlEncode } from "./secrets";
 
+/**
+ * `env.GITHUB_CACHE.get`, tolerant of a missing binding. GITHUB_CACHE is a
+ * core KV binding (uploads#754 item 3) so every deployed worker provisions
+ * it, but this module is imported transitively into apps/mcp too (via
+ * `@uploads/api/uploader-identity`), and unit tests build minimal envs — a
+ * bare `env.GITHUB_CACHE.get(...)` would throw a raw TypeError on `undefined`
+ * before ever reaching this module's own try/catch blocks, contradicting its
+ * documented "every function degrades to null" contract. Treat a lookup
+ * failure the same as a cache miss: fall through to a fresh fetch.
+ */
+async function cacheGet(env: Env, key: string): Promise<string | null> {
+  try {
+    return (await env.GITHUB_CACHE?.get(key)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export interface GithubAppConfig {
   appId: string;
   privateKey: string;
@@ -138,7 +156,7 @@ export async function installationForRepo(
   fetchImpl: typeof fetch = fetch,
 ): Promise<number | null> {
   const key = `ghinst:${repo}`;
-  const cached = (await env.GITHUB_CACHE.get(key)) as string | null;
+  const cached = await cacheGet(env, key);
   if (cached !== null) return cached === "none" ? null : Number(cached);
   try {
     const res = await githubFetch(fetchImpl, `https://api.github.com/repos/${repo}/installation`, {
@@ -229,7 +247,7 @@ export async function fetchPrActors(
 ): Promise<number[] | null> {
   if (!REPO_RE.test(repo) || !Number.isSafeInteger(num) || num < 1) return null;
   const key = `pr-actors:${kind}:${repo}:${num}`;
-  const cached = (await env.GITHUB_CACHE.get(key)) as string | null;
+  const cached = await cacheGet(env, key);
   if (cached !== null) {
     try {
       const ids = JSON.parse(cached) as unknown;
@@ -285,7 +303,7 @@ export async function installationToken(
   fetchImpl: typeof fetch = fetch,
 ): Promise<string | null> {
   const key = `ghtok:${installationId}`;
-  const cached = (await env.GITHUB_CACHE.get(key)) as string | null;
+  const cached = await cacheGet(env, key);
   if (cached !== null) return cached;
   try {
     const res = await githubFetch(
@@ -324,7 +342,7 @@ export async function repoIsPrivate(
 ): Promise<boolean | null> {
   if (!REPO_RE.test(repo)) return null;
   const key = `ghpriv:${repo}`;
-  const cached = (await env.GITHUB_CACHE.get(key)) as string | null;
+  const cached = await cacheGet(env, key);
   if (cached !== null) return cached === "1";
   const token = await installationToken(env, cfg, installationId, fetchImpl);
   if (!token) return null;
@@ -374,7 +392,7 @@ export async function prHeadBranch(
 ): Promise<string | null> {
   if (!REPO_RE.test(repo) || !Number.isSafeInteger(num) || num < 1) return null;
   const key = `prhead:${repo}#${num}`;
-  const cached = (await env.GITHUB_CACHE.get(key)) as string | null;
+  const cached = await cacheGet(env, key);
   if (cached !== null) return cached;
   const token = await installationToken(env, cfg, installationId, fetchImpl);
   if (!token) return null;

--- a/apps/api/src/github-webhook-queue.test.ts
+++ b/apps/api/src/github-webhook-queue.test.ts
@@ -305,6 +305,19 @@ describe("handleWebhook producer path", () => {
     await handleWebhook(envWith(kv, queue), "issues", issuesPayload);
     expect(kv.store.has("ghref:o/r#1")).toBe(false);
   });
+
+  it("processes inline when GITHUB_WEBHOOK_QUEUE is absent entirely (issue #754 item 3: self-hosters may skip the queue)", async () => {
+    const kv = new FakeKv();
+    kv.store.set("ghref:o/r#1", { value: "{}" });
+    // No queue at all — envWith(kv, undefined) leaves GITHUB_WEBHOOK_QUEUE unset.
+    await expect(
+      handleWebhook({ GITHUB_CACHE: kv } as unknown as Env, "issues", issuesPayload),
+    ).resolves.toBeUndefined();
+    // Same signal as the "send fails" case above: the inline path ran and
+    // consumed the reconcile-cache entry (the consumer-owned delete never
+    // gets a chance to run without a queue).
+    expect(kv.store.has("ghref:o/r#1")).toBe(false);
+  });
 });
 
 describe("handleGithubWebhookBatch", () => {

--- a/apps/api/src/render.ts
+++ b/apps/api/src/render.ts
@@ -498,10 +498,27 @@ function decodePngDimensions(bytes: Uint8Array): { width: number; height: number
   return { width, height };
 }
 
-/** Wraps the Browser Run `BROWSER` binding behind the `Renderer` seam. */
-export function browserRenderer(browser: BrowserRun): Renderer {
+/**
+ * Wraps the Browser Run `BROWSER` binding behind the `Renderer` seam.
+ * `BROWSER` is an optional binding (uploads#754 item 3 — self-hosters can
+ * skip it): an absent binding degrades this single endpoint to a 503 with a
+ * distinct `renderer_unavailable` code, never a worker crash. This used to be
+ * only *incidentally* fail-soft — `browser.quickAction` throwing a `TypeError`
+ * on `undefined` happened to land in the catch below as a generic
+ * `render_failed` 502 — so the explicit check here is for a clearer signal to
+ * callers, not a behavior fix.
+ */
+export function browserRenderer(browser: BrowserRun | undefined): Renderer {
   return {
     async screenshot(input) {
+      if (!browser) {
+        throw new AppError({
+          type: "unavailable",
+          code: "renderer_unavailable",
+          message: "screenshot rendering is not configured on this deployment",
+          status: 503,
+        });
+      }
       const options = toBrowserRunOptions(input);
       let response: Response;
       try {

--- a/apps/api/src/routes/admin-enrollments-email.test.ts
+++ b/apps/api/src/routes/admin-enrollments-email.test.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /admin/enrollments with an `email` recipient (issue #754 item 3):
+ * EMAIL is an optional binding, and the invite-email send is wrapped in its
+ * own try/catch (see admin.ts) so a missing/failing binding degrades to
+ * `emailed: false` on an otherwise-successful 201, never a 500 — the
+ * enrollment record itself is always created regardless of mail delivery.
+ */
+import { Hono } from "hono";
+import { beforeAll, describe, expect, it } from "vitest";
+import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
+import { respondError } from "../error-response";
+import { admin } from "./admin";
+
+const ADMIN_TOKEN = "test-admin-token";
+const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
+  "migrations/20260711120000_invite_pages.sql",
+  "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
+];
+
+const RECORD = {
+  provider: "r2",
+  bucket: "shared",
+  binding: "UPLOADS_DEFAULT",
+  prefix: "acme/",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+beforeAll(() => {
+  if (typeof crypto.subtle.timingSafeEqual !== "function") {
+    (
+      crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+    ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+      a.length === b.length && a.every((byte, i) => byte === b[i]);
+  }
+});
+
+function appWith(email?: { send: (message: unknown) => Promise<unknown> }) {
+  const app = new Hono<{ Bindings: Env }>()
+    .route("/admin", admin)
+    .onError((err, c) => respondError(c, err));
+  const store = new Map<string, unknown>(Object.entries({ "ws:acme": RECORD }));
+  const env = {
+    ADMIN_TOKEN,
+    REGISTRY: {
+      get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+    },
+    DB: database(new SqliteD1(MIGRATIONS)),
+    EMAIL: email,
+  } as unknown as Env;
+  return { app, env };
+}
+
+function post(app: Hono<{ Bindings: Env }>, env: Env, body: unknown) {
+  return app.request(
+    "/admin/enrollments",
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${ADMIN_TOKEN}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+describe("POST /admin/enrollments — EMAIL binding absent", () => {
+  it("creates the enrollment and reports emailed: false without throwing", async () => {
+    const { app, env } = appWith(undefined);
+    const res = await post(app, env, {
+      workspace: "acme",
+      label: "ci",
+      scopes: ["files:read"],
+      email: "person@example.com",
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { emailed?: boolean; code?: string };
+    expect(body.emailed).toBe(false);
+    expect(typeof body.code).toBe("string");
+  });
+
+  it("reports emailed: true when EMAIL is present", async () => {
+    const send = async () => ({});
+    const { app, env } = appWith({ send });
+    const res = await post(app, env, {
+      workspace: "acme",
+      label: "ci",
+      scopes: ["files:read"],
+      email: "person@example.com",
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { emailed?: boolean };
+    expect(body.emailed).toBe(true);
+  });
+
+  it("omits emailed entirely (undefined) when no recipient was requested", async () => {
+    const { app, env } = appWith(undefined);
+    const res = await post(app, env, { workspace: "acme", label: "ci", scopes: ["files:read"] });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { emailed?: boolean };
+    expect(body.emailed).toBeUndefined();
+  });
+});

--- a/apps/api/test/rate-limiters-fail-open.test.ts
+++ b/apps/api/test/rate-limiters-fail-open.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The five apps/api rate limiters (WRITE_LIMITER, RENDER_LIMITER,
+ * WS_CREATE_LIMITER, INVITE_LIMITER — POSTER_LIMITER is covered separately in
+ * poster-gate.test.ts, since it fails *closed* by design) are optional
+ * bindings (issue #754 item 3): every guard already fails open when its
+ * binding is absent, but until now nothing pinned that behavior with a
+ * dedicated absent-binding test. These do.
+ */
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "../src/error-response";
+import { allowRender, allowWorkspaceCreate, allowWrite } from "../src/guards";
+import { auth } from "../src/routes/auth";
+
+const authApp = new Hono<{ Bindings: Env }>()
+  .route("/", auth)
+  .onError((err, c) => respondError(c, err));
+
+describe("guards.ts rate limiters — binding absent fails open", () => {
+  it("allowWrite (WRITE_LIMITER) allows when the binding is absent", async () => {
+    await expect(allowWrite({}, "acme")).resolves.toBe(true);
+  });
+
+  it("allowWrite (WRITE_LIMITER) still enforces the limit when the binding is present", async () => {
+    const env = { WRITE_LIMITER: { limit: async () => ({ success: false }) } };
+    await expect(allowWrite(env, "acme")).resolves.toBe(false);
+  });
+
+  it("allowRender (RENDER_LIMITER) allows when the binding is absent", async () => {
+    await expect(allowRender({}, "acme")).resolves.toBe(true);
+  });
+
+  it("allowWorkspaceCreate (WS_CREATE_LIMITER) allows when the binding is absent", async () => {
+    await expect(allowWorkspaceCreate({}, "user-1")).resolves.toBe(true);
+  });
+
+  it("allowWorkspaceCreate (WS_CREATE_LIMITER) still enforces the limit when present", async () => {
+    const env = { WS_CREATE_LIMITER: { limit: async () => ({ success: false }) } };
+    await expect(allowWorkspaceCreate(env, "user-1")).resolves.toBe(false);
+  });
+});
+
+describe("INVITE_LIMITER absent — /enrollments/:pageId never 429s", () => {
+  function envWithout(): Env {
+    return { INVITE_LIMITER: undefined, DB: {} } as unknown as Env;
+  }
+
+  it("falls through to the handler's own response instead of rate-limiting", async () => {
+    const res = await authApp.request(
+      "/enrollments/not-a-real-page-id",
+      { headers: { "CF-Connecting-IP": "203.0.113.1" } },
+      envWithout(),
+    );
+    // findEnrollmentPage rejects the malformed pageId before ever touching
+    // DB, so the meaningful assertion here is that the guard let the request
+    // through at all (never a 429) rather than the exact 4xx code.
+    expect(res.status).not.toBe(429);
+  });
+
+  it("429s when INVITE_LIMITER is present and denies", async () => {
+    const env = {
+      INVITE_LIMITER: { limit: async () => ({ success: false }) },
+      DB: {},
+    } as unknown as Env;
+    const res = await authApp.request(
+      "/enrollments/not-a-real-page-id",
+      { headers: { "CF-Connecting-IP": "203.0.113.1" } },
+      env,
+    );
+    expect(res.status).toBe(429);
+  });
+});

--- a/apps/api/test/routes-render.test.ts
+++ b/apps/api/test/routes-render.test.ts
@@ -89,6 +89,10 @@ async function makeEnv(
   opts: {
     overrides?: Partial<WorkspaceRecord>;
     browser?: FakeBrowser;
+    // Explicit tri-state: omit `browser` for the default FakeBrowser, or pass
+    // `noBrowser: true` to build an env with BROWSER absent entirely (issue
+    // #754 item 3 — BROWSER is an optional binding self-hosters may skip).
+    noBrowser?: boolean;
     rateLimitOk?: boolean;
     scopedToken?: { rawToken: string; scopes: string[] };
   } = {},
@@ -110,11 +114,17 @@ async function makeEnv(
         }
       : undefined,
   );
-  const browser = opts.browser ?? FakeBrowser.pngResponse(PNG);
+  // Typed as always-defined for the many existing callers that destructure
+  // `browser` and use it unconditionally; `noBrowser: true` (used only by the
+  // BROWSER-absent test below, which never touches this field) sets the
+  // env's actual BROWSER binding to `undefined` regardless of this type.
+  const browser: FakeBrowser = opts.noBrowser
+    ? (undefined as unknown as FakeBrowser)
+    : (opts.browser ?? FakeBrowser.pngResponse(PNG));
   const env = {
     REGISTRY: { get: async () => record, put: async () => undefined },
     DB: db,
-    BROWSER: browser,
+    BROWSER: opts.noBrowser ? undefined : browser,
     RENDER_LIMITER: { limit: async () => ({ success: opts.rateLimitOk ?? true }) },
   };
   return { env, db, browser };
@@ -446,6 +456,18 @@ describe("POST /v1/render Browser Run error passthrough", () => {
     expect(res.status).toBe(502);
     const json = (await res.json()) as { error: { code: string } };
     expect(json.error.code).toBe("render_failed");
+  });
+
+  it("503s with renderer_unavailable when BROWSER is absent (self-host, no crash)", async () => {
+    const { env, db } = await makeEnv({ noBrowser: true });
+    const res = await renderReq(env, { url: "https://example.com" });
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { error: { code: string; type: string } };
+    expect(json.error.code).toBe("renderer_unavailable");
+    expect(json.error.type).toBe("unavailable");
+    // The upload reservation made before the Browser Run call must be
+    // released, same as any other failed render.
+    expect(db.usage.get("default")?.uploads_in_period ?? 0).toBe(0);
   });
 });
 

--- a/apps/mcp/src/env.d.ts
+++ b/apps/mcp/src/env.d.ts
@@ -17,4 +17,11 @@ interface Env {
   // OPENAI_APPS_CHALLENGE --config apps/mcp/wrangler.jsonc` when submitting
   // the plugin; unset or blank → 404.
   OPENAI_APPS_CHALLENGE?: string;
+  /**
+   * Per-workspace write rate limit (uploads#754 item 3), shared with apps/api
+   * via `@uploads/api/guards`'s `allowWrite` — fails open when absent. This
+   * worker binds it unconditionally in wrangler.jsonc, but a self-hoster may
+   * delete that `unsafe.bindings` block and run without the burst guard.
+   */
+  WRITE_LIMITER?: RateLimit;
 }

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -1,2 +1,19 @@
 /// <reference types="astro/client" />
 /// <reference path="../worker-configuration.d.ts" />
+
+// uploads#754 item 3 (minimal-binding profile): AUTH, API, and FLAGS are all
+// optional here even though wrangler.jsonc declares them unconditionally.
+// This mirrors the apps/api / apps/auth env.d.ts "optional-shadow" pattern —
+// required-ness in wrangler.jsonc is a deploy-time guarantee, not a runtime
+// one. The actual fail-soft logic already lives in each call site's own
+// narrow local type (`AuthProxyEnv` in lib/auth-proxy.ts, `ApiProxyEnv` in
+// lib/api-proxy.ts, `FlagshipLike`'s env shape in lib/console-mode.ts); this
+// augmentation only centralizes the documentation on the shared `Env` so an
+// audit doesn't have to hunt through three files to see which bindings a
+// self-hoster may skip. ASSETS is NOT listed here — it is a core binding
+// (the site cannot serve without it); see docs/ops.md.
+interface Env {
+  AUTH?: Fetcher;
+  API?: Fetcher;
+  FLAGS?: Flagship;
+}

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -550,6 +550,57 @@ eight secrets and needed no changes here. A manual `wrangler preview`
 inherits the same worker-level secrets too, unless a branch explicitly
 overrides one with `wrangler preview secret put`.
 
+## Minimal-binding profile (self-hosting, uploads#754 item 3)
+
+The four workers' `wrangler.jsonc` files declare ~15+ bindings between them,
+but not all of them are load-bearing. This section is the self-host contract:
+which bindings a deployment must have to run at all, and which ones are
+optional and degrade gracefully when skipped. **No dedicated self-hosting doc
+exists yet in this repo** — this table lives here (the closest existing home
+for operator-facing config) until one does; if that changes, move this
+section wholesale rather than duplicating it.
+
+Every optional binding below fails soft on its own: a self-hoster can delete
+the corresponding block from `wrangler.jsonc` (or a preview/branch config)
+without touching application code. This repo's own production config keeps
+every binding — this table is about what tolerates absence, not what we
+recommend removing.
+
+### Core (required — absence is a hard crash or an unusable deploy)
+
+| Binding                      | Worker(s)      | Type            |
+| ---------------------------- | -------------- | --------------- |
+| `DB`                         | api, auth, mcp | D1              |
+| `REGISTRY`, `GITHUB_CACHE`   | api, mcp       | KV              |
+| `UPLOADS`, `UPLOADS_DEFAULT` | api, mcp       | R2              |
+| `AUTH`                       | api, web       | Service binding |
+| `API`                        | auth, web      | Service binding |
+| `ASSETS`                     | web            | Workers Assets  |
+
+### Optional (fail-soft when absent)
+
+| Binding                                                                        | Worker    | What's lost without it                                                                                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ANALYTICS`                                                                    | api       | The `/admin/metrics` breakdown panel's wide-dimension data (surface, content type, client, plan, repo). D1-backed metrics still work.                                                                                                                                                                                                            |
+| `ANALYTICS_API_TOKEN`                                                          | api       | Same as above — without it the breakdown panel reports `not_configured` even if `ANALYTICS` itself is bound.                                                                                                                                                                                                                                     |
+| `BROWSER`                                                                      | api       | `POST /v1/render` (CLI screenshot capture) answers 503 `renderer_unavailable`. Nothing else is affected.                                                                                                                                                                                                                                         |
+| `MEDIA`                                                                        | api       | Video poster-frame generation is skipped; uploads still succeed, just without a generated poster image.                                                                                                                                                                                                                                          |
+| `FLAGS`                                                                        | api       | Poster generation's runtime kill switch always evaluates to disabled (fails closed) — same effect as never enabling the feature.                                                                                                                                                                                                                 |
+| `FLAGS`                                                                        | web       | `/console` visibility falls back to the static `CONSOLE_MODE` var instead of a live-toggleable flag.                                                                                                                                                                                                                                             |
+| `GITHUB_WEBHOOK_QUEUE`                                                         | api       | GitHub webhook deliveries process inline (`waitUntil`) instead of through a durable queue — functionally the same, just without queue-level retry/DLQ semantics.                                                                                                                                                                                 |
+| `WRITE_LIMITER`                                                                | api, mcp  | No per-workspace burst limit on uploads/deletes.                                                                                                                                                                                                                                                                                                 |
+| `RENDER_LIMITER`                                                               | api       | No burst limit on `POST /v1/render` independent of the monthly upload budget.                                                                                                                                                                                                                                                                    |
+| `WS_CREATE_LIMITER`                                                            | api       | No burst limit on self-serve workspace creation (the 3-per-user cap itself still applies).                                                                                                                                                                                                                                                       |
+| `INVITE_LIMITER`                                                               | api       | No per-recipient/IP rate limit on invite emails, invite lookup/exchange, or CLI report/abuse endpoints.                                                                                                                                                                                                                                          |
+| `POSTER_LIMITER`                                                               | api       | **Fails closed, not open** — unlike every other limiter above, an absent `POSTER_LIMITER` disables poster generation entirely rather than removing its burst cap, since posters are a metered, billable operation.                                                                                                                               |
+| `EMAIL`                                                                        | api       | Welcome emails, abuse-report notifications, and invite-code emails are skipped (logged instead); the underlying record/report/enrollment is still created.                                                                                                                                                                                       |
+| `EMAIL`                                                                        | auth      | Magic-link, invitation, member-joined, and welcome emails are skipped (logged instead, with the link itself logged for invitations). GitHub OAuth sign-in is unaffected — it has no dependency on `EMAIL`. A deployment with neither `EMAIL` nor GitHub OAuth configured has no working sign-in method; that's a configuration gap, not a crash. |
+| `ADMIN_TOKEN`                                                                  | api       | The static break-glass admin token is disabled; scoped operator tokens (minted through the normal admin flow) still work.                                                                                                                                                                                                                        |
+| `BILLING_INTERNAL_KEY`                                                         | api, auth | Fails closed by design: `/internal/billing/plan` always 401s and the auth→api plan-sync bridge no-ops (queues a retry) instead of sending an unauthenticated request.                                                                                                                                                                            |
+| `GITHUB_APP_WEBHOOK_SECRET`                                                    | api       | The GitHub webhook endpoint 503s.                                                                                                                                                                                                                                                                                                                |
+| `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY` / `GITHUB_APP_HOME_INSTALLATION_ID` | api, mcp  | GitHub App integration (PR/issue title resolution, managed comments, private-repo detection, auto-promotion) is disabled entirely — an all-or-nothing trio.                                                                                                                                                                                      |
+| `OPENAI_APPS_CHALLENGE`                                                        | mcp       | `/.well-known/openai-apps-challenge` 404s (only needed when submitting the OpenAI plugin directory listing).                                                                                                                                                                                                                                     |
+
 ## Presign
 
 `POST /v1/:ws/files/sign` — workspace needs HTTP S3 credentials (not binding-only).


### PR DESCRIPTION
Implements #754 item 3: a documented core/optional split of every Worker binding, with each optional binding verified or made fail-soft so a self-hoster can run the platform with only core resources.

## Classification (full table in `docs/ops.md` § Minimal-binding profile)

- **Core**: `DB`, `REGISTRY`, `GITHUB_CACHE`, `UPLOADS`/`UPLOADS_DEFAULT`, the `AUTH`/`API` service bindings, `ASSETS`.
- **Optional (fail-soft)**: `ANALYTICS`(+token), `BROWSER`, `MEDIA`, `FLAGS`, `GITHUB_WEBHOOK_QUEUE`, all five rate limiters, `EMAIL` (both workers — every send site guards it; GitHub sign-in is independent and magic-link degrades to a logged link), `ADMIN_TOKEN`, `BILLING_INTERNAL_KEY`, `GITHUB_APP_WEBHOOK_SECRET`, the GitHub App trio, `OPENAI_APPS_CHALLENGE`.

## Real gaps fixed (most sites were already fail-soft — verified with new tests rather than assumed)

- `apps/api/src/render.ts`: `browserRenderer()` takes `BrowserRun | undefined` and returns an explicit `renderer_unavailable` 503 instead of relying on an incidental catch.
- `apps/api/src/github-app.ts`: five unguarded `env.GITHUB_CACHE.get()` reads now degrade to `null` per the module's documented contract.

## Tests & types

- New absence-path tests: GITHUB_CACHE (×5), BROWSER, queue-absent, EMAIL paths, rate-limiter fail-open. Full suite: 318 files / 4770 green.
- Optional shadows added per the apps/auth `env.d.ts` precedent (api: `BROWSER?` + limiters; mcp: `WRITE_LIMITER?`; web: `AUTH?`/`API?`/`FLAGS?`); `ANALYTICS`/queue left on their existing local-cast pattern per the in-code comment.
- No wrangler.jsonc restructuring — prod keeps every binding; the profile is about tolerating absence.

## Flagged, not changed

- `apps/auth`'s `AUTH_RATE_LIMITER` is declared but never read — dead binding or missing call site, worth a look.
- `apps/mcp`'s `AUTH` service binding is declared but unreferenced (mcp auths via D1 bearer tokens) — likely vestigial.
- No dedicated self-hosting doc exists yet; the profile landed in `docs/ops.md` and should migrate to `docs/self-hosting.md` when #753's Foundation lands.

Part of #754.