### PR TITLE
fix(web): show a pending state while sign-out completes

### DIFF
--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -198,6 +198,12 @@ const MENU_ITEMS = [
       signOutBtn?.addEventListener(
         "click",
         () => {
+          // The sign-out POST must complete before navigating (its response
+          // clears the session cookie), so show a pending state for the
+          // round-trip instead of a dead button.
+          if (signOutBtn.disabled) return;
+          signOutBtn.disabled = true;
+          signOutBtn.textContent = "Signing out…";
           clearCachedSessionUser();
           paintHeaderFiles(false);
           void signOut(origin).then(() => {
@@ -393,5 +399,11 @@ const MENU_ITEMS = [
   .auth-indicator :global(.auth-menu__signout:focus-visible) {
     color: var(--red, #d98a9c);
     background: color-mix(in srgb, var(--red, #d98a9c) 10%, transparent);
+  }
+  .auth-indicator :global(.auth-menu__signout:disabled) {
+    color: var(--muted, #8a8a83);
+    background: none;
+    opacity: 0.6;
+    cursor: wait;
   }
 </style>


### PR DESCRIPTION
Follow-up to #757. Sign-out now works, but the POST's round-trip (web proxy → auth worker → D1 session revoke) happens with zero feedback — the click reads as a hang until the redirect lands. This disables the button and swaps its label to "Signing out…" for the duration (plus a `:disabled` style: muted, `cursor: wait`), and guards against double-clicks.

Kept the await-then-navigate order deliberately: the response's `Set-Cookie` clears the session, so navigating optimistically could land on /login with a still-valid cookie.

Verification: `pnpm --filter @uploads/web test` green. UI-only change in the client script of `AuthIndicator.astro`.