### PR TITLE
fix(web): actionable copy + disabled retry for permanent OAuth consent errors

### DIFF
--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -6,6 +6,7 @@ import {
   getOAuthPublicClient,
   getSession,
   isBannedAuthError,
+  isOAuthQueryExpired,
   linkGitHub,
   listAccounts,
   listAdminUsers,
@@ -632,7 +633,62 @@ describe("submitOAuthConsent", () => {
     );
     await expect(
       submitOAuthConsent("https://auth.uploads.sh", { accept: false, oauthQuery: "sig=x" }),
-    ).resolves.toEqual({ ok: false, error: "expired request" });
+    ).resolves.toEqual({ ok: false, error: "expired request", permanent: false });
+  });
+
+  it("maps a bare invalid_signature envelope to actionable, permanent copy", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ error: "invalid_signature" }, { status: 400 })),
+    );
+    await expect(
+      submitOAuthConsent("https://auth.uploads.sh", { accept: false, oauthQuery: "sig=x" }),
+    ).resolves.toEqual({
+      ok: false,
+      error:
+        "This authorization request has expired. Return to the app you were connecting and start the connection again.",
+      permanent: true,
+    });
+  });
+
+  it("prefers error_description over the code map, but still flags as permanent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          { error: "invalid_signature", error_description: "signature mismatch" },
+          { status: 400 },
+        ),
+      ),
+    );
+    await expect(
+      submitOAuthConsent("https://auth.uploads.sh", { accept: false, oauthQuery: "sig=x" }),
+    ).resolves.toEqual({ ok: false, error: "signature mismatch", permanent: true });
+  });
+
+  it("falls back to the generic message for an unknown error code, not permanent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ error: "server_error" }, { status: 500 })),
+    );
+    await expect(
+      submitOAuthConsent("https://auth.uploads.sh", { accept: false, oauthQuery: "sig=x" }),
+    ).resolves.toEqual({ ok: false, error: "Something went wrong. Try again.", permanent: false });
+  });
+});
+
+describe("isOAuthQueryExpired", () => {
+  it("is true once exp (unix seconds) has elapsed", () => {
+    const now = 1_700_000_000_000;
+    expect(isOAuthQueryExpired("?client_id=c1&exp=1699999999", now)).toBe(true);
+    expect(isOAuthQueryExpired("client_id=c1&exp=1699999999", now)).toBe(true);
+  });
+
+  it("is false when exp is in the future or missing/malformed", () => {
+    const now = 1_700_000_000_000;
+    expect(isOAuthQueryExpired("?client_id=c1&exp=1700000001", now)).toBe(false);
+    expect(isOAuthQueryExpired("?client_id=c1", now)).toBe(false);
+    expect(isOAuthQueryExpired("?client_id=c1&exp=not-a-number", now)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1036,7 +1036,46 @@ export function repairOAuthQuery(search: string): string {
     );
 }
 
-export type OAuthConsentResult = { ok: true; redirectUri: string } | { ok: false; error: string };
+export type OAuthConsentResult =
+  | { ok: true; redirectUri: string }
+  | {
+      ok: false;
+      error: string;
+      /**
+       * True when retrying Allow/Deny on this page can never succeed — the
+       * consent page should stop inviting a doomed retry (disable the
+       * buttons) rather than leave them clickable.
+       */
+      permanent: boolean;
+    };
+
+/**
+ * Copy for `@better-auth/oauth-provider` wire codes that are permanent for
+ * this page: the signed authorize query in `location.search` no longer
+ * verifies. `verifyOAuthQueryParams` (apps/auth/node_modules/@better-auth/
+ * oauth-provider/dist/utils-*.mjs) folds a bad signature and an elapsed `exp`
+ * into the same boolean check, so both surface as `invalid_signature` — there
+ * is no separate expiry code. Neither cause is fixable by clicking Allow
+ * again; the client app holds the PKCE verifier needed to restart the flow,
+ * so recovery has to happen there.
+ */
+export const OAUTH_QUERY_EXPIRED_MESSAGE =
+  "This authorization request has expired. Return to the app you were connecting and start the connection again.";
+const OAUTH_CONSENT_PERMANENT_ERRORS: Record<string, string> = {
+  invalid_signature: OAUTH_QUERY_EXPIRED_MESSAGE,
+};
+
+/**
+ * True when the signed query's `exp` (unix seconds, set by
+ * @better-auth/oauth-provider's `signParams`) has already elapsed. Lets the
+ * consent page render the permanent expired state at load time instead of
+ * waiting on a POST /oauth2/consent that can only fail with
+ * `invalid_signature`.
+ */
+export function isOAuthQueryExpired(search: string, now: number = Date.now()): boolean {
+  const exp = Number(new URLSearchParams(search.replace(/^\?/, "")).get("exp"));
+  return Number.isFinite(exp) && exp > 0 && exp * 1000 <= now;
+}
 
 /**
  * POST /api/auth/oauth2/consent. `oauthQuery` is `location.search` with the
@@ -1044,8 +1083,10 @@ export type OAuthConsentResult = { ok: true; redirectUri: string } | { ok: false
  * required so the AS can resolve which pending authorize request this is.
  * `scope` is the space-delimited set of scopes the user is granting; omit on
  * deny. Response carries the redirect target (`url` on better-auth 1.6.23,
- * `redirect_uri` in older builds) on success, `error_description` /
- * `message` on rejection (expired/invalid signed query, unknown client, …).
+ * `redirect_uri` in older builds) on success. On rejection, Better Auth 1.7's
+ * oauth-provider envelopes are often a bare `{"error": "<code>"}` with no
+ * description — `error_description`/`message` win when present, otherwise a
+ * known `error` code maps to actionable copy, otherwise the generic fallback.
  */
 export async function submitOAuthConsent(
   origin: string,
@@ -1067,21 +1108,33 @@ export async function submitOAuthConsent(
       url?: string;
       error_description?: string;
       message?: string;
+      error?: string;
     } | null;
     if (!res.ok) {
+      const mapped = body?.error ? OAUTH_CONSENT_PERMANENT_ERRORS[body.error] : undefined;
       return {
         ok: false,
-        error: body?.error_description ?? body?.message ?? "Something went wrong. Try again.",
+        error:
+          body?.error_description ?? body?.message ?? mapped ?? "Something went wrong. Try again.",
+        permanent: mapped !== undefined,
       };
     }
     // better-auth 1.6.23 responds `{ redirect: true, url }` (prod-verified);
     // `redirect_uri` is the shape older plugin builds documented. Accept both.
     const redirectUri = body?.url ?? body?.redirect_uri;
     if (!redirectUri) {
-      return { ok: false, error: "The authorization server didn't return a redirect." };
+      return {
+        ok: false,
+        error: "The authorization server didn't return a redirect.",
+        permanent: false,
+      };
     }
     return { ok: true, redirectUri };
   } catch {
-    return { ok: false, error: "Couldn't reach the authorization server. Try again." };
+    return {
+      ok: false,
+      error: "Couldn't reach the authorization server. Try again.",
+      permanent: false,
+    };
   }
 }

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -190,6 +190,10 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         </div>
       </div>
 
+      <div id="expired-request" hidden>
+        <div class="ul-callout status" data-state="error" role="alert" id="expired-message"></div>
+      </div>
+
       <div id="signed-out" hidden>
         <p>
           Sign in to review this request. <a class="linklike" id="signin-link" href="/login"
@@ -250,7 +254,9 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         getOAuthPublicClient,
         getOAuthWorkspaceChoice,
         getSession,
+        isOAuthQueryExpired,
         listOrganizations,
+        OAUTH_QUERY_EXPIRED_MESSAGE,
         repairOAuthQuery,
         setOAuthWorkspaceChoice,
         submitOAuthConsent,
@@ -270,6 +276,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       const checking = requireElement<HTMLElement>("#checking");
       const authUnavailable = requireElement<HTMLElement>("#auth-unavailable");
       const noRequest = requireElement<HTMLElement>("#no-request");
+      const expiredRequest = requireElement<HTMLElement>("#expired-request");
+      const expiredMessage = requireElement<HTMLElement>("#expired-message");
       const signedOut = requireElement<HTMLElement>("#signed-out");
       const signinLink = requireElement<HTMLAnchorElement>("#signin-link");
       const noWorkspace = requireElement<HTMLElement>("#no-workspace");
@@ -317,6 +325,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
           checking,
           authUnavailable,
           noRequest,
+          expiredRequest,
           signedOut,
           noWorkspace,
           confirmBox,
@@ -388,6 +397,16 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       async function proceed() {
         hideAll();
         checking.hidden = false;
+
+        // Renders the permanent expired state up front instead of waiting on
+        // a POST /oauth2/consent that can only come back invalid_signature —
+        // verifyOAuthQueryParams checks `exp` the same way (see auth-client.ts).
+        if (isOAuthQueryExpired(location.search)) {
+          hideAll();
+          expiredMessage.textContent = OAUTH_QUERY_EXPIRED_MESSAGE;
+          expiredRequest.hidden = false;
+          return;
+        }
 
         if (!clientId) {
           hideAll();
@@ -476,8 +495,13 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
           oauthQuery,
         });
         if (!result.ok) {
-          allowBtn.disabled = false;
-          denyBtn.disabled = false;
+          // A permanent failure (e.g. the signed query no longer verifies)
+          // can't be fixed by clicking Allow/Deny again — leave the buttons
+          // disabled instead of inviting a doomed retry.
+          if (!result.permanent) {
+            allowBtn.disabled = false;
+            denyBtn.disabled = false;
+          }
           confirmError.textContent = result.error;
           confirmError.hidden = false;
           return;


### PR DESCRIPTION
Closes #765

## Problem

When `POST /api/auth/oauth2/consent` fails, the OAuth consent page (`apps/web/src/pages/oauth/consent.astro`) always showed a generic ">> Something went wrong. Try again." banner. Better Auth 1.7's `@better-auth/oauth-provider` often returns bare RFC 6749 envelopes with no `error_description` — e.g. `400 {"error":"invalid_signature"}` when the signed authorize query in the page URL no longer verifies (auth worker redeployed mid-flow, or the query's `exp` elapsed). Retrying Allow/Deny can never succeed in that case: only the client app, which holds the PKCE verifier, can restart the flow — so the generic copy left the user stuck with no way forward.

## What changed

**`apps/web/src/lib/auth-client.ts`**
- `submitOAuthConsent` now also reads the response's `error` code. Preference order stays `error_description` → `message` → mapped code copy → generic fallback.
- `OAuthConsentResult`'s error arm gains `permanent: boolean`, true only when the code is in a small local map of codes that can never be fixed by retrying on this page.
- `invalid_signature` is mapped to: "This authorization request has expired. Return to the app you were connecting and start the connection again." I grepped `apps/auth/node_modules/@better-auth/oauth-provider/dist/authorize-*.mjs` for the consent endpoint's error codes — `verifyOAuthQueryParams` folds a bad signature *and* an elapsed `exp` into the same boolean check, so both surface as this one code; there's no separate expiry code to map.
- New `isOAuthQueryExpired(search, now?)` reads the signed query's `exp` (unix seconds) and detects an already-expired request client-side.

**`apps/web/src/pages/oauth/consent.astro`**
- On a permanent failure, Allow/Deny stay disabled instead of being re-enabled for a doomed retry.
- New `#expired-request` panel: `proceed()` now checks `isOAuthQueryExpired(location.search)` up front and renders the expired state immediately, skipping the round trip that would only come back `invalid_signature` anyway.

## Why not `@uploads/errors`

`packages/errors`'s own doc comment frames it as a registry for codes *we* mint on *our* wire schema (consumed by `apps/api`/`apps/mcp`). The consent errors are Better Auth's OAuth wire codes from a dependency we don't control — so the mapping stays local to `apps/web/src/lib/auth-client.ts` rather than extending that registry.

## Tests

`apps/web/src/lib/auth-client.test.ts`:
- bare `{"error":"invalid_signature"}` → mapped copy + `permanent: true`
- `error_description` present alongside a known code → description still wins for text, `permanent` stays `true`
- unknown `error` code → generic fallback copy, `permanent: false`
- existing success/description-only cases updated for the new `permanent` field
- `isOAuthQueryExpired`: true once `exp` has elapsed, false when in the future, missing, or malformed

`pnpm --filter @uploads/web test` (819 tests), `apps/web` typecheck (0 errors), and `pnpm lint` (warnings only, none introduced) all pass.

## Skipped

Didn't map `invalid_request`/`invalid_client` (missing `oauth_query` server state, missing `client_id`, scope/claim-not-originally-requested) — those come from different, less clear-cut causes and aren't reachable from a normal Allow/Deny click on this page; scoping to `invalid_signature` keeps the map precise rather than guessing at "permanent" for ambiguous codes.
