### PR TITLE
fix(api): allow BYO storage detach after byoBucketEnabled is revoked (#619)

### DIFF
--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -524,7 +524,9 @@ export async function storageDeleteHandler(c: Context<SettingsVars>) {
   const userId = c.get("settingsUserId");
   const record = await loadWorkspaceRecord(c.env, name);
   if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-  if (!byoBucketAllowed(record)) {
+  // Detach must stay available after the flag is revoked, otherwise the
+  // workspace is stranded on the customer bucket (#619).
+  if (!byoBucketAllowed(record) && !record.storageConfiguredAt) {
     throw new ForbiddenError("BYO storage is not enabled for this workspace", {
       code: "byo_bucket_disabled",
     });

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -567,6 +567,40 @@ describe("storage vertical (self-serve BYO bucket)", () => {
         "settings_requires_session",
       );
     });
+
+    it("still detaches an already-BYO-configured workspace after byoBucketEnabled is revoked (#619)", async () => {
+      const { env, registry } = makeEnv({
+        role: "owner",
+        record: { ...BYO_RECORD, byoBucketEnabled: false },
+        usage: { objects: 0 },
+      });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { method: "DELETE", headers: sessionHeaders },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ mode: "shared" });
+      const saved = registry.record<{ accessKeyId?: unknown }>("acme");
+      expect(saved?.accessKeyId).toBeUndefined();
+    });
+
+    it("still 403s (byo_bucket_disabled) a shared-mode workspace with the flag off — the gate isn't just deleted", async () => {
+      const { env } = makeEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: false },
+        usage: { objects: 0 },
+      });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { method: "DELETE", headers: sessionHeaders },
+        env,
+      );
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+        "byo_bucket_disabled",
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

`storageDeleteHandler` (the `DELETE /:workspace/storage` route) gates on
`byoBucketAllowed(record)` — the same flag check used to gate *attaching* a
BYO bucket in the first place. If `byoBucketEnabled` is revoked on a
workspace that is already BYO-configured, the workspace can no longer detach:
the 403 fires before the handler ever looks at whether the workspace is
actually sitting on a customer bucket. The workspace is stranded on that
bucket with no way back to shared storage short of a manual KV edit.

## Fix

`storageDeleteHandler` now also allows the request through when the record
is already BYO-configured (`record.storageConfiguredAt` is set), regardless
of the current flag value:

```ts
// Detach must stay available after the flag is revoked, otherwise the
// workspace is stranded on the customer bucket (#619).
if (!byoBucketAllowed(record) && !record.storageConfiguredAt) {
  throw new ForbiddenError("BYO storage is not enabled for this workspace", {
    code: "byo_bucket_disabled",
  });
}
```

A workspace that was never BYO-configured (shared-mode) and has the flag off
still gets the 403 `byo_bucket_disabled` as before — this only widens the
gate for the "already on a customer bucket" case, it doesn't remove it.

## Test coverage

Added two cases to the existing storage-route suite in
`apps/api/test/routes-workspace-settings.test.ts`:

- A BYO-configured workspace with `byoBucketEnabled: false` can still
  `DELETE /:workspace/storage` and gets restored to shared-mode (200,
  `mode: "shared"`).
- A shared-mode workspace with `byoBucketEnabled: false` still gets 403
  `byo_bucket_disabled` on the same route, confirming the gate isn't just
  deleted.

Full `@uploads/api` test suite and `tsc --noEmit` both pass.

Closes #619.
