### PR TITLE
feat(api): storage-lane primitive (no behavior change)

### DIFF
--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -70,6 +70,16 @@ export const UPLOAD_CACHE_CONTROL = "public, max-age=60";
 /** Server-only first-upload stamp (Files SDK object metadata). Not client provenance. */
 export const UPLOADED_AT_META_KEY = "uploaded-at";
 
+/**
+ * Server-only provenance key naming which storage lane this object was
+ * written to (two-lane storage). "lane_origin" marks an upload made before
+ * `WorkspaceRecord.storageLaneId` existed. Zero read-path dependency today —
+ * resolution stays fallback-based (`resolveObjectLane`) — this is a cheap
+ * forward hook for future per-file routing/migration tooling (#630/#594).
+ */
+export const STORAGE_LANE_META_KEY = "storage-lane";
+const STORAGE_LANE_ORIGIN = "lane_origin";
+
 const KEY_RE = /^[\w!*'()./-]+$/;
 
 /**
@@ -489,6 +499,7 @@ export async function putObject(
     // matching the historical shape of objects uploaded before this existed.
     ...(storedVisibility ? { [VISIBILITY_META_KEY]: storedVisibility } : {}),
     [UPLOADED_AT_META_KEY]: uploadedAt,
+    [STORAGE_LANE_META_KEY]: ws.storageLaneId ?? STORAGE_LANE_ORIGIN,
   };
 
   try {

--- a/apps/api/src/reencrypt-registry.ts
+++ b/apps/api/src/reencrypt-registry.ts
@@ -8,6 +8,60 @@ import { resealCredentialFields, secretsKeyRingFromEnv, type SecretsKeyRing } fr
 import type { WorkspaceRecord } from "./workspace";
 import { mutateWorkspaceRecord } from "./workspace-mutate";
 
+/** True when any credential lives at the top level or inside a saved lane. */
+function hasAnyCredentials(record: WorkspaceRecord): boolean {
+  if (record.accessKeyId || record.secretAccessKey) return true;
+  return (record.storageLanes ?? []).some((lane) => lane.accessKeyId || lane.secretAccessKey);
+}
+
+/**
+ * Reseal the active-lane pair and every `storageLanes` entry's credentials
+ * under the current KEK (issue: two-lane storage — a lane's sealed
+ * `accessKeyId`/`secretAccessKey` must never be missed by the rotation
+ * sweep). Fields with no credentials round-trip as `undefined`, same as
+ * `resealCredentialFields` alone.
+ */
+async function resealWorkspaceCredentials(
+  ring: SecretsKeyRing,
+  record: WorkspaceRecord,
+): Promise<{ record: WorkspaceRecord; changed: boolean }> {
+  let changed = false;
+
+  const top = await resealCredentialFields(ring, {
+    accessKeyId: record.accessKeyId,
+    secretAccessKey: record.secretAccessKey,
+  });
+  if (top.changed) changed = true;
+
+  let storageLanes = record.storageLanes;
+  if (storageLanes && storageLanes.length > 0) {
+    storageLanes = await Promise.all(
+      storageLanes.map(async (lane) => {
+        const resealed = await resealCredentialFields(ring, {
+          accessKeyId: lane.accessKeyId,
+          secretAccessKey: lane.secretAccessKey,
+        });
+        if (resealed.changed) changed = true;
+        return {
+          ...lane,
+          accessKeyId: resealed.accessKeyId,
+          secretAccessKey: resealed.secretAccessKey,
+        };
+      }),
+    );
+  }
+
+  return {
+    record: {
+      ...record,
+      accessKeyId: top.accessKeyId,
+      secretAccessKey: top.secretAccessKey,
+      storageLanes,
+    },
+    changed,
+  };
+}
+
 export interface ReencryptResult {
   dryRun: boolean;
   scanned: number;
@@ -60,7 +114,7 @@ export async function reencryptRegistryCredentials(
         workspaces.push({ workspace: name, action: "skipped", reason: "missing" });
         continue;
       }
-      if (!record.accessKeyId && !record.secretAccessKey) {
+      if (!hasAnyCredentials(record)) {
         skipped += 1;
         workspaces.push({ workspace: name, action: "skipped", reason: "no_credentials" });
         continue;
@@ -68,10 +122,7 @@ export async function reencryptRegistryCredentials(
 
       try {
         if (dryRun) {
-          const resealed = await resealCredentialFields(ring, {
-            accessKeyId: record.accessKeyId,
-            secretAccessKey: record.secretAccessKey,
-          });
+          const resealed = await resealWorkspaceCredentials(ring, record);
           if (!resealed.changed) {
             skipped += 1;
             workspaces.push({ workspace: name, action: "skipped", reason: "already_current" });
@@ -89,17 +140,10 @@ export async function reencryptRegistryCredentials(
         // pay for the crypto twice on every workspace the sweep rewrites.
         let changed = false;
         await mutateWorkspaceRecord(env, name, async (current) => {
-          const resealed = await resealCredentialFields(ring, {
-            accessKeyId: current.accessKeyId,
-            secretAccessKey: current.secretAccessKey,
-          });
+          const resealed = await resealWorkspaceCredentials(ring, current);
           changed = resealed.changed;
           if (!changed) return null;
-          return {
-            ...current,
-            accessKeyId: resealed.accessKeyId,
-            secretAccessKey: resealed.secretAccessKey,
-          };
+          return resealed.record;
         });
         if (!changed) {
           skipped += 1;

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -4,6 +4,8 @@ import {
   publicAndEmbedUrls,
   publicUrl,
   type EmbedUrlOptions,
+  type Files,
+  type R2Jurisdiction,
   type StorageConfig,
 } from "@uploads/storage";
 import { openCredentialFields, secretsKeyRingFromEnv } from "./secrets";
@@ -24,19 +26,38 @@ export function objectPublicUrls(
   return publicAndEmbedUrls(cfg, key, embedUrlOptionsFromEnv(env));
 }
 
-export async function storageConfig(env: Env, ws: WorkspaceRecord): Promise<StorageConfig> {
+/** The storage-field bag shared by a `WorkspaceRecord`'s top-level (active) fields and a `StorageLane`. */
+interface StorageFieldsLike {
+  bucket: string;
+  binding?: string;
+  prefix?: string;
+  publicBaseUrl?: string;
+  accountId?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  jurisdiction?: R2Jurisdiction;
+}
+
+/**
+ * Shared binding lookup + credential opening for both the active lane
+ * (`storageConfig`) and fallback lanes (`storageConfigs`). Only "r2" is ever
+ * a valid `StorageConfig.provider`, so the caller is responsible for
+ * validating a lane's `provider` string before calling this — see
+ * `storageConfigs`.
+ */
+async function resolveStorageConfig(env: Env, fields: StorageFieldsLike): Promise<StorageConfig> {
   let binding: R2Bucket | undefined;
-  if (ws.binding) {
-    const candidate: unknown = Reflect.get(env, ws.binding);
+  if (fields.binding) {
+    const candidate: unknown = Reflect.get(env, fields.binding);
     if (!candidate || typeof (candidate as R2Bucket).get !== "function") {
       // A config/deploy mismatch (wrangler.jsonc binding renamed or removed
       // while the workspace record still names it) — an operator fix, not a
       // caller mistake, so 503 rather than a 4xx. Never a 500: the route
       // layer's onError translates AppError subclasses via respondError.
-      throw new ServiceUnavailableError(`workspace references unknown R2 binding "${ws.binding}"`, {
-        code: "storage_misconfigured",
-        details: { binding: ws.binding },
-      });
+      throw new ServiceUnavailableError(
+        `workspace references unknown R2 binding "${fields.binding}"`,
+        { code: "storage_misconfigured", details: { binding: fields.binding } },
+      );
     }
     binding = candidate as R2Bucket;
   }
@@ -44,8 +65,8 @@ export async function storageConfig(env: Env, ws: WorkspaceRecord): Promise<Stor
   let opened: Awaited<ReturnType<typeof openCredentialFields>>;
   try {
     opened = await openCredentialFields(ring, {
-      accessKeyId: ws.accessKeyId,
-      secretAccessKey: ws.secretAccessKey,
+      accessKeyId: fields.accessKeyId,
+      secretAccessKey: fields.secretAccessKey,
     });
   } catch (err) {
     // Missing/rotated WORKSPACE_SECRETS_KEY, or corrupt ciphertext — surface
@@ -66,20 +87,104 @@ export async function storageConfig(env: Env, ws: WorkspaceRecord): Promise<Stor
     );
   }
   return {
-    provider: ws.provider,
-    bucket: ws.bucket,
-    prefix: ws.prefix,
-    publicBaseUrl: ws.publicBaseUrl,
+    provider: "r2",
+    bucket: fields.bucket,
+    prefix: fields.prefix,
+    publicBaseUrl: fields.publicBaseUrl,
     r2Binding: binding,
-    accountId: ws.accountId,
+    accountId: fields.accountId,
     accessKeyId: opened.accessKeyId,
     secretAccessKey: opened.secretAccessKey,
-    jurisdiction: ws.jurisdiction,
+    jurisdiction: fields.jurisdiction,
   };
+}
+
+export async function storageConfig(env: Env, ws: WorkspaceRecord): Promise<StorageConfig> {
+  return resolveStorageConfig(env, ws);
 }
 
 export async function storage(env: Env, ws: WorkspaceRecord) {
   return createStorage(await storageConfig(env, ws));
+}
+
+/** One resolvable storage configuration, tagged with the lane it came from. */
+export interface LaneConfig {
+  /** `null` = the pre-lanes implicit active lane (no `storageLaneId` stamped yet). */
+  laneId: string | null;
+  role: "active" | "fallback";
+  config: StorageConfig;
+}
+
+/**
+ * Active lane first, then fallback lanes (`lastActiveAt` set) in array
+ * order. Standby lanes (no `lastActiveAt`) are pure saved configuration and
+ * are excluded — they never participate in read resolution. A fallback lane
+ * that fails to resolve (bad binding name, undecryptable creds, unsupported
+ * provider) is logged and skipped, never throws — a stale fallback must
+ * never take down the active lane. Active-lane failures still throw exactly
+ * as `storageConfig` does today.
+ */
+export async function storageConfigs(env: Env, ws: WorkspaceRecord): Promise<LaneConfig[]> {
+  const configs: LaneConfig[] = [
+    { laneId: ws.storageLaneId ?? null, role: "active", config: await storageConfig(env, ws) },
+  ];
+
+  for (const lane of ws.storageLanes ?? []) {
+    if (!lane.lastActiveAt) continue; // standby: saved, never active — not a read source.
+    if (lane.provider !== "r2") {
+      console.error(
+        JSON.stringify({
+          message: "storage_lane_skipped",
+          laneId: lane.id,
+          reason: "unsupported_provider",
+          provider: lane.provider,
+        }),
+      );
+      continue;
+    }
+    try {
+      const config = await resolveStorageConfig(env, lane);
+      configs.push({ laneId: lane.id, role: "fallback", config });
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          message: "storage_lane_skipped",
+          laneId: lane.id,
+          reason: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
+  }
+
+  return configs;
+}
+
+/** A storage lane resolved to a live `Files` instance, for object-level operations. */
+export interface ResolvedLane {
+  store: Files;
+  config: StorageConfig;
+  laneId: string | null;
+  role: "active" | "fallback";
+}
+
+/**
+ * Walk lanes in order (active, then fallbacks) — first `store.exists(key)`
+ * hit wins. Returns `null` when the key exists in no lane. Single-lane
+ * records short-circuit to the current behavior: exactly one `exists` call.
+ */
+export async function resolveObjectLane(
+  env: Env,
+  ws: WorkspaceRecord,
+  key: string,
+): Promise<ResolvedLane | null> {
+  const configs = await storageConfigs(env, ws);
+  for (const lane of configs) {
+    const store = createStorage(lane.config);
+    if (await store.exists(key)) {
+      return { store, config: lane.config, laneId: lane.laneId, role: lane.role };
+    }
+  }
+  return null;
 }
 
 export { publicUrl };

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -5,11 +5,10 @@ import {
   publicUrl,
   type EmbedUrlOptions,
   type Files,
-  type R2Jurisdiction,
   type StorageConfig,
 } from "@uploads/storage";
 import { openCredentialFields, secretsKeyRingFromEnv } from "./secrets";
-import type { WorkspaceRecord } from "./workspace";
+import type { StorageLane, StorageLaneFields, WorkspaceRecord } from "./workspace";
 
 /** Worker env override for the embed CDN base (self-host / disable). */
 function embedUrlOptionsFromEnv(env: Env): EmbedUrlOptions {
@@ -26,26 +25,20 @@ export function objectPublicUrls(
   return publicAndEmbedUrls(cfg, key, embedUrlOptionsFromEnv(env));
 }
 
-/** The storage-field bag shared by a `WorkspaceRecord`'s top-level (active) fields and a `StorageLane`. */
-interface StorageFieldsLike {
-  bucket: string;
-  binding?: string;
-  prefix?: string;
-  publicBaseUrl?: string;
-  accountId?: string;
-  accessKeyId?: string;
-  secretAccessKey?: string;
-  jurisdiction?: R2Jurisdiction;
-}
-
 /**
  * Shared binding lookup + credential opening for both the active lane
- * (`storageConfig`) and fallback lanes (`storageConfigs`). Only "r2" is ever
- * a valid `StorageConfig.provider`, so the caller is responsible for
- * validating a lane's `provider` string before calling this — see
- * `storageConfigs`.
+ * (`storageConfig`) and fallback lanes (`storageConfigs`/`resolveObjectLane`).
+ * Single enforcement point for `provider`: only `"r2"` is ever a valid
+ * `StorageConfig.provider`, so every caller — active or fallback — goes
+ * through this check rather than validating it themselves.
  */
-async function resolveStorageConfig(env: Env, fields: StorageFieldsLike): Promise<StorageConfig> {
+async function resolveStorageConfig(env: Env, fields: StorageLaneFields): Promise<StorageConfig> {
+  if (fields.provider !== "r2") {
+    throw new ServiceUnavailableError(`unsupported storage provider "${fields.provider}"`, {
+      code: "storage_misconfigured",
+      details: { provider: fields.provider },
+    });
+  }
   let binding: R2Bucket | undefined;
   if (fields.binding) {
     const candidate: unknown = Reflect.get(env, fields.binding);
@@ -116,13 +109,36 @@ export interface LaneConfig {
 }
 
 /**
+ * Resolve one fallback lane's config, or `null` if it's a standby lane (no
+ * `lastActiveAt` — pure saved configuration, never a read source) or if it
+ * fails to resolve (bad binding name, undecryptable creds, unsupported
+ * provider — logged, never thrown, so a stale fallback can never take down
+ * the active lane).
+ */
+async function resolveFallbackLane(env: Env, lane: StorageLane): Promise<StorageConfig | null> {
+  if (!lane.lastActiveAt) return null;
+  try {
+    return await resolveStorageConfig(env, lane);
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "storage_lane_skipped",
+        laneId: lane.id,
+        reason: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return null;
+  }
+}
+
+/**
  * Active lane first, then fallback lanes (`lastActiveAt` set) in array
- * order. Standby lanes (no `lastActiveAt`) are pure saved configuration and
- * are excluded — they never participate in read resolution. A fallback lane
- * that fails to resolve (bad binding name, undecryptable creds, unsupported
- * provider) is logged and skipped, never throws — a stale fallback must
- * never take down the active lane. Active-lane failures still throw exactly
- * as `storageConfig` does today.
+ * order. Standby lanes are excluded. Active-lane failures still throw
+ * exactly as `storageConfig` does today; a fallback lane that fails to
+ * resolve is skipped (see `resolveFallbackLane`). Resolves every lane's
+ * config up front — the right choice for a listing/status caller that needs
+ * them all; `resolveObjectLane` below resolves lazily instead, since it
+ * usually needs at most one.
  */
 export async function storageConfigs(env: Env, ws: WorkspaceRecord): Promise<LaneConfig[]> {
   const configs: LaneConfig[] = [
@@ -130,46 +146,24 @@ export async function storageConfigs(env: Env, ws: WorkspaceRecord): Promise<Lan
   ];
 
   for (const lane of ws.storageLanes ?? []) {
-    if (!lane.lastActiveAt) continue; // standby: saved, never active — not a read source.
-    if (lane.provider !== "r2") {
-      console.error(
-        JSON.stringify({
-          message: "storage_lane_skipped",
-          laneId: lane.id,
-          reason: "unsupported_provider",
-          provider: lane.provider,
-        }),
-      );
-      continue;
-    }
-    try {
-      const config = await resolveStorageConfig(env, lane);
-      configs.push({ laneId: lane.id, role: "fallback", config });
-    } catch (err) {
-      console.error(
-        JSON.stringify({
-          message: "storage_lane_skipped",
-          laneId: lane.id,
-          reason: err instanceof Error ? err.message : String(err),
-        }),
-      );
-    }
+    const config = await resolveFallbackLane(env, lane);
+    if (config) configs.push({ laneId: lane.id, role: "fallback", config });
   }
 
   return configs;
 }
 
 /** A storage lane resolved to a live `Files` instance, for object-level operations. */
-export interface ResolvedLane {
+export interface ResolvedLane extends LaneConfig {
   store: Files;
-  config: StorageConfig;
-  laneId: string | null;
-  role: "active" | "fallback";
 }
 
 /**
  * Walk lanes in order (active, then fallbacks) — first `store.exists(key)`
- * hit wins. Returns `null` when the key exists in no lane. Single-lane
+ * hit wins. Returns `null` when the key exists in no lane. Resolves lazily:
+ * a fallback lane's config (and its credential decrypt) is only resolved
+ * once every earlier lane has missed, so the common case — the active lane
+ * has the key — never touches fallback credentials at all. Single-lane
  * records short-circuit to the current behavior: exactly one `exists` call.
  */
 export async function resolveObjectLane(
@@ -177,13 +171,26 @@ export async function resolveObjectLane(
   ws: WorkspaceRecord,
   key: string,
 ): Promise<ResolvedLane | null> {
-  const configs = await storageConfigs(env, ws);
-  for (const lane of configs) {
-    const store = createStorage(lane.config);
+  const activeConfig = await storageConfig(env, ws);
+  const activeStore = createStorage(activeConfig);
+  if (await activeStore.exists(key)) {
+    return {
+      store: activeStore,
+      config: activeConfig,
+      laneId: ws.storageLaneId ?? null,
+      role: "active",
+    };
+  }
+
+  for (const lane of ws.storageLanes ?? []) {
+    const config = await resolveFallbackLane(env, lane);
+    if (!config) continue;
+    const store = createStorage(config);
     if (await store.exists(key)) {
-      return { store, config: lane.config, laneId: lane.laneId, role: lane.role };
+      return { store, config, laneId: lane.id, role: "fallback" };
     }
   }
+
   return null;
 }
 

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -202,23 +202,16 @@ export interface WorkspaceRecord {
 }
 
 /**
- * A saved-or-formerly-active storage configuration, addressed by `id`.
- * Lane state is derived, not stored as an enum: **standby** = configured and
- * verified, `lastActiveAt` absent — a saved config that has never received
- * writes; **fallback** = `lastActiveAt` set — a former active lane that may
- * hold objects and participates in read resolution. See the spec's
- * "N-lane readiness": `provider` is a widened string (validated to `"r2"` at
- * every boundary today) so future files-sdk-supported providers need no
- * record-shape migration.
+ * The storage-connection fields shared by `WorkspaceRecord`'s top-level
+ * (active-lane) fields and a `StorageLane` — bucket/binding/credentials, not
+ * lane bookkeeping (id, verifiedAt, lastActiveAt) or the display-only
+ * mirrors. `packages/storage`'s `resolveStorageConfig` accepts this shape so
+ * one function resolves either the active fields or a saved lane.
+ * `provider` is a widened string (validated to `"r2"` at that boundary, not
+ * here) so future files-sdk-supported providers need no record-shape
+ * migration — see the spec's "N-lane readiness".
  */
-export interface StorageLane {
-  /** Short opaque id, e.g. "lane_<8hex>"; stamped into new-upload provenance. */
-  id: string;
-  /** Last successful verify run against this lane's config. */
-  verifiedAt?: string;
-  /** Set when the lane is demoted from active; absence = never held writes (standby). */
-  lastActiveAt?: string;
-  /** "r2" is the only value accepted today; widened now so future providers need no migration. */
+export interface StorageLaneFields {
   provider: string;
   bucket: string;
   /** Shared lane uses the binding; BYO lanes are HTTP-credential mode. */
@@ -226,11 +219,27 @@ export interface StorageLane {
   prefix?: string;
   publicBaseUrl?: string;
   accountId?: string;
-  /** Sealed (`enc:v1:`), same KEK ring as active-lane credentials. */
+  /** Sealed (`enc:v1:`) on a `StorageLane`; same shape as the active-lane pair. */
   accessKeyId?: string;
-  /** Sealed (`enc:v1:`). */
+  /** Sealed (`enc:v1:`) on a `StorageLane`. */
   secretAccessKey?: string;
   jurisdiction?: R2Jurisdiction;
+}
+
+/**
+ * A saved-or-formerly-active storage configuration, addressed by `id`.
+ * Lane state is derived, not stored as an enum: **standby** = configured and
+ * verified, `lastActiveAt` absent — a saved config that has never received
+ * writes; **fallback** = `lastActiveAt` set — a former active lane that may
+ * hold objects and participates in read resolution.
+ */
+export interface StorageLane extends StorageLaneFields {
+  /** Short opaque id, e.g. "lane_<8hex>"; stamped into new-upload provenance. */
+  id: string;
+  /** Last successful verify run against this lane's config. */
+  verifiedAt?: string;
+  /** Set when the lane is demoted from active; absence = never held writes (standby). */
+  lastActiveAt?: string;
   /** Display/provenance mirrors of the top-level fields of the same name. */
   storageAccessKeyIdLast4?: string;
   storageConfiguredAt?: string;

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -186,6 +186,62 @@ export interface WorkspaceRecord {
    * save, so its trailing characters are ciphertext.
    */
   storageAccessKeyIdLast4?: string;
+  /**
+   * All configured inactive lanes: saved-but-never-used configs and demoted
+   * former actives (spec: docs/superpowers/specs/2026-08-22-two-lane-storage-design.md,
+   * "Record shape"). Absent/empty on every record until a later PR starts
+   * writing to it — nothing in PR B populates this field.
+   */
+  storageLanes?: StorageLane[];
+  /**
+   * Id of the currently-active lane (the top-level storage fields above).
+   * Absent means a record that predates this design — the implicit original
+   * lane. Stamped into new-upload provenance (see `files-core.ts`).
+   */
+  storageLaneId?: string;
+}
+
+/**
+ * A saved-or-formerly-active storage configuration, addressed by `id`.
+ * Lane state is derived, not stored as an enum: **standby** = configured and
+ * verified, `lastActiveAt` absent — a saved config that has never received
+ * writes; **fallback** = `lastActiveAt` set — a former active lane that may
+ * hold objects and participates in read resolution. See the spec's
+ * "N-lane readiness": `provider` is a widened string (validated to `"r2"` at
+ * every boundary today) so future files-sdk-supported providers need no
+ * record-shape migration.
+ */
+export interface StorageLane {
+  /** Short opaque id, e.g. "lane_<8hex>"; stamped into new-upload provenance. */
+  id: string;
+  /** Last successful verify run against this lane's config. */
+  verifiedAt?: string;
+  /** Set when the lane is demoted from active; absence = never held writes (standby). */
+  lastActiveAt?: string;
+  /** "r2" is the only value accepted today; widened now so future providers need no migration. */
+  provider: string;
+  bucket: string;
+  /** Shared lane uses the binding; BYO lanes are HTTP-credential mode. */
+  binding?: string;
+  prefix?: string;
+  publicBaseUrl?: string;
+  accountId?: string;
+  /** Sealed (`enc:v1:`), same KEK ring as active-lane credentials. */
+  accessKeyId?: string;
+  /** Sealed (`enc:v1:`). */
+  secretAccessKey?: string;
+  jurisdiction?: R2Jurisdiction;
+  /** Display/provenance mirrors of the top-level fields of the same name. */
+  storageAccessKeyIdLast4?: string;
+  storageConfiguredAt?: string;
+  storageConfiguredBy?: string;
+}
+
+/** New lane id: "lane_" + 8 lowercase hex chars from crypto.getRandomValues. */
+export function newLaneId(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(4));
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `lane_${hex}`;
 }
 
 /**

--- a/apps/api/test/files-core-storage-lane.test.ts
+++ b/apps/api/test/files-core-storage-lane.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Task B3 (two-lane storage primitive): new uploads stamp `ws.storageLaneId`
+ * into the R2 provenance bag as a cheap forward hook for future per-file
+ * routing/migration tooling. See
+ * docs/superpowers/specs/2026-08-22-two-lane-storage-design.md, "Provenance
+ * stamping".
+ */
+import { describe, expect, it } from "vitest";
+import { makePosterEnv, PNG, WORKSPACE } from "./poster-fixtures";
+import { putObject, STORAGE_LANE_META_KEY } from "../src/files-core";
+
+describe("putObject storage-lane provenance stamp", () => {
+  it("stamps the active lane id when the record has one", async () => {
+    const { env, bucket, ws } = makePosterEnv();
+    const wsWithLane = { ...ws, storageLaneId: "lane_ab12cd34" };
+    const result = await putObject(env, wsWithLane, "images/pic.png", PNG, WORKSPACE);
+    // makePosterEnv's ws.prefix ("default/") is applied by the storage
+    // wrapper, not reflected in the returned key — see poster-upload.test.ts.
+    const stored = bucket.store.get(`default/${result.key}`);
+    expect(stored?.customMetadata?.[STORAGE_LANE_META_KEY]).toBe("lane_ab12cd34");
+  });
+
+  it("stamps lane_origin when the record predates lane ids", async () => {
+    const { env, bucket, ws } = makePosterEnv();
+    const result = await putObject(env, ws, "images/pic2.png", PNG, WORKSPACE);
+    const stored = bucket.store.get(`default/${result.key}`);
+    expect(stored?.customMetadata?.[STORAGE_LANE_META_KEY]).toBe("lane_origin");
+  });
+});

--- a/apps/api/test/reencrypt-registry.test.ts
+++ b/apps/api/test/reencrypt-registry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { fakeRegistry } from "./fake-kv";
 import { encryptSecret } from "../src/secrets";
 import { reencryptRegistryCredentials } from "../src/reencrypt-registry";
-import type { WorkspaceRecord } from "../src/workspace";
+import type { StorageLane, WorkspaceRecord } from "../src/workspace";
 
 const CURRENT = "current-master-secret!!";
 const PREVIOUS = "previous-master-secret!";
@@ -47,6 +47,56 @@ describe("reencryptRegistryCredentials", () => {
     const opened = await openCredentialFields(CURRENT, next);
     expect(opened.accessKeyId).toBe("AKIA");
     expect(opened.secretAccessKey).toBe("secret");
+    expect(opened.usedPrevious).toBe(false);
+  });
+
+  it("reseals a fallback lane's credentials alongside the active pair", async () => {
+    const laneSealedAk = await encryptSecret(PREVIOUS, "LANE_AKIA");
+    const laneSealedSk = await encryptSecret(PREVIOUS, "lane-secret");
+    const lane: StorageLane = {
+      id: "lane_deadbeef",
+      provider: "r2",
+      bucket: "customer-bucket",
+      lastActiveAt: "2026-08-01T00:00:00.000Z",
+      accessKeyId: laneSealedAk,
+      secretAccessKey: laneSealedSk,
+    };
+    const registry = fakeRegistry({
+      "two-lane": {
+        provider: "r2",
+        bucket: "uploads-default",
+        prefix: "two-lane/",
+        storageLanes: [lane],
+      } satisfies WorkspaceRecord,
+    });
+    const store = registry.store;
+
+    const env = {
+      WORKSPACE_SECRETS_KEY: CURRENT,
+      WORKSPACE_SECRETS_KEY_PREVIOUS: PREVIOUS,
+      REGISTRY: registry,
+    } as unknown as Env;
+
+    // No top-level credentials on this record — only the lane's. The sweep
+    // must not skip it as "no_credentials".
+    const dry = await reencryptRegistryCredentials(env, { dryRun: true });
+    expect(dry.workspaces.find((w) => w.workspace === "two-lane")?.action).toBe("would_update");
+
+    const live = await reencryptRegistryCredentials(env, { dryRun: false });
+    expect(live.workspaces.find((w) => w.workspace === "two-lane")?.action).toBe("updated");
+
+    const next = JSON.parse(store.get("ws:two-lane")!) as WorkspaceRecord;
+    const nextLane = next.storageLanes?.[0];
+    expect(nextLane?.id).toBe("lane_deadbeef");
+    expect(nextLane?.accessKeyId).not.toBe(laneSealedAk);
+
+    const { openCredentialFields } = await import("../src/secrets");
+    const opened = await openCredentialFields(CURRENT, {
+      accessKeyId: nextLane?.accessKeyId,
+      secretAccessKey: nextLane?.secretAccessKey,
+    });
+    expect(opened.accessKeyId).toBe("LANE_AKIA");
+    expect(opened.secretAccessKey).toBe("lane-secret");
     expect(opened.usedPrevious).toBe(false);
   });
 });

--- a/apps/api/test/storage-lanes.test.ts
+++ b/apps/api/test/storage-lanes.test.ts
@@ -5,7 +5,7 @@
  * walks them in order and returns the first lane whose store has the key.
  * See docs/superpowers/specs/2026-08-22-two-lane-storage-design.md.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
 import { resolveObjectLane, storageConfigs } from "../src/storage";
 import type { StorageLane, WorkspaceRecord } from "../src/workspace";
@@ -140,5 +140,25 @@ describe("resolveObjectLane", () => {
     };
     await resolveObjectLane(env, ACTIVE_WS, "default/whatever.png");
     expect(existsCalls).toBe(1);
+  });
+
+  it("never resolves a fallback lane's config when the active lane already has the key (lazy walk)", async () => {
+    // The fallback lane names a binding that doesn't exist on env — resolving
+    // it would log a "storage_lane_skipped" error. A lazy walk never attempts
+    // it once the active lane hits, so console.error must stay silent.
+    const active = new FakeR2Bucket();
+    await active.put("default/only-active.png", new Uint8Array([1]));
+    const env = makeEnv({ UPLOADS_DEFAULT: active });
+    const badLane: StorageLane = { ...FALLBACK_LANE, binding: "NO_SUCH_BINDING" };
+    const ws: WorkspaceRecord = { ...ACTIVE_WS, storageLanes: [badLane] };
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const resolved = await resolveObjectLane(env, ws, "default/only-active.png");
+      expect(resolved?.role).toBe("active");
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/apps/api/test/storage-lanes.test.ts
+++ b/apps/api/test/storage-lanes.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Task B2 (two-lane storage primitive, no behavior change yet — nothing
+ * writes `storageLanes` before PR D): `storageConfigs` walks the active lane
+ * plus every fallback lane (standby lanes excluded); `resolveObjectLane`
+ * walks them in order and returns the first lane whose store has the key.
+ * See docs/superpowers/specs/2026-08-22-two-lane-storage-design.md.
+ */
+import { describe, expect, it } from "vitest";
+import { FakeR2Bucket } from "./fake-r2";
+import { resolveObjectLane, storageConfigs } from "../src/storage";
+import type { StorageLane, WorkspaceRecord } from "../src/workspace";
+
+function makeEnv(bindings: Record<string, FakeR2Bucket>) {
+  return { WORKSPACE_SECRETS_KEY: "test-master-secret-key!!", ...bindings } as unknown as Env;
+}
+
+// No `prefix` here so raw keys written into the fake buckets line up exactly
+// with the keys `exists()` is asked about — a prefix mismatch between the
+// active and fallback fixtures would silently point lookups at different
+// underlying keys.
+const ACTIVE_WS: WorkspaceRecord = {
+  provider: "r2",
+  bucket: "uploads-default",
+  binding: "UPLOADS_DEFAULT",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+const FALLBACK_LANE: StorageLane = {
+  id: "lane_fallback1",
+  provider: "r2",
+  bucket: "customer-bucket",
+  binding: "UPLOADS_FALLBACK",
+  lastActiveAt: "2026-08-01T00:00:00.000Z",
+  publicBaseUrl: "https://customer.example.com",
+};
+
+describe("storageConfigs", () => {
+  it("returns a single active entry for a record with no lanes", async () => {
+    const env = makeEnv({ UPLOADS_DEFAULT: new FakeR2Bucket() });
+    const configs = await storageConfigs(env, ACTIVE_WS);
+    expect(configs).toHaveLength(1);
+    expect(configs[0]).toMatchObject({ laneId: null, role: "active" });
+  });
+
+  it("includes a fallback lane after the active lane, in order", async () => {
+    const env = makeEnv({
+      UPLOADS_DEFAULT: new FakeR2Bucket(),
+      UPLOADS_FALLBACK: new FakeR2Bucket(),
+    });
+    const ws: WorkspaceRecord = {
+      ...ACTIVE_WS,
+      storageLaneId: "lane_active1",
+      storageLanes: [FALLBACK_LANE],
+    };
+    const configs = await storageConfigs(env, ws);
+    expect(configs).toHaveLength(2);
+    expect(configs[0]).toMatchObject({ laneId: "lane_active1", role: "active" });
+    expect(configs[1]).toMatchObject({ laneId: "lane_fallback1", role: "fallback" });
+  });
+
+  it("excludes a standby lane (no lastActiveAt)", async () => {
+    const env = makeEnv({
+      UPLOADS_DEFAULT: new FakeR2Bucket(),
+      UPLOADS_FALLBACK: new FakeR2Bucket(),
+    });
+    const standby: StorageLane = { ...FALLBACK_LANE, lastActiveAt: undefined };
+    const ws: WorkspaceRecord = { ...ACTIVE_WS, storageLanes: [standby] };
+    const configs = await storageConfigs(env, ws);
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.role).toBe("active");
+  });
+
+  it("skips a fallback lane naming a nonexistent binding without throwing, keeping the active lane", async () => {
+    const env = makeEnv({ UPLOADS_DEFAULT: new FakeR2Bucket() });
+    const badLane: StorageLane = { ...FALLBACK_LANE, binding: "NO_SUCH_BINDING" };
+    const ws: WorkspaceRecord = { ...ACTIVE_WS, storageLanes: [badLane] };
+    const configs = await storageConfigs(env, ws);
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.role).toBe("active");
+  });
+
+  it("skips a fallback lane whose provider is not r2", async () => {
+    const env = makeEnv({
+      UPLOADS_DEFAULT: new FakeR2Bucket(),
+      UPLOADS_FALLBACK: new FakeR2Bucket(),
+    });
+    const badLane: StorageLane = { ...FALLBACK_LANE, provider: "s3" };
+    const ws: WorkspaceRecord = { ...ACTIVE_WS, storageLanes: [badLane] };
+    const configs = await storageConfigs(env, ws);
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.role).toBe("active");
+  });
+});
+
+describe("resolveObjectLane", () => {
+  it("finds a key present only in the fallback store", async () => {
+    const active = new FakeR2Bucket();
+    const fallback = new FakeR2Bucket();
+    await fallback.put("default/only-in-fallback.png", new Uint8Array([1]));
+    const env = makeEnv({ UPLOADS_DEFAULT: active, UPLOADS_FALLBACK: fallback });
+    const ws: WorkspaceRecord = { ...ACTIVE_WS, storageLanes: [FALLBACK_LANE] };
+
+    const resolved = await resolveObjectLane(env, ws, "default/only-in-fallback.png");
+    expect(resolved?.laneId).toBe("lane_fallback1");
+    expect(resolved?.role).toBe("fallback");
+  });
+
+  it("prefers the active lane when the key is present in both", async () => {
+    const active = new FakeR2Bucket();
+    const fallback = new FakeR2Bucket();
+    await active.put("default/both.png", new Uint8Array([1]));
+    await fallback.put("default/both.png", new Uint8Array([2]));
+    const env = makeEnv({ UPLOADS_DEFAULT: active, UPLOADS_FALLBACK: fallback });
+    const ws: WorkspaceRecord = { ...ACTIVE_WS, storageLanes: [FALLBACK_LANE] };
+
+    const resolved = await resolveObjectLane(env, ws, "default/both.png");
+    expect(resolved?.laneId).toBeNull();
+    expect(resolved?.role).toBe("active");
+  });
+
+  it("returns null when the key is in neither lane", async () => {
+    const env = makeEnv({
+      UPLOADS_DEFAULT: new FakeR2Bucket(),
+      UPLOADS_FALLBACK: new FakeR2Bucket(),
+    });
+    const ws: WorkspaceRecord = { ...ACTIVE_WS, storageLanes: [FALLBACK_LANE] };
+
+    const resolved = await resolveObjectLane(env, ws, "default/nowhere.png");
+    expect(resolved).toBeNull();
+  });
+
+  it("short-circuits to a single exists() call for a single-lane record", async () => {
+    const active = new FakeR2Bucket();
+    const env = makeEnv({ UPLOADS_DEFAULT: active });
+    let existsCalls = 0;
+    const originalHead = active.head.bind(active);
+    active.head = async (key: string) => {
+      existsCalls++;
+      return originalHead(key);
+    };
+    await resolveObjectLane(env, ACTIVE_WS, "default/whatever.png");
+    expect(existsCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Zero-behavior-change contract

This PR introduces the storage-lane primitive with **no behavior change** for
any workspace record without `storageLanes` — which is every record today,
since nothing in this PR writes the field yet. Every existing test passes
unmodified; the changes are additive types, a new resolver module, and one
new provenance metadata key on upload.

See the design doc for the full picture:
`docs/superpowers/specs/2026-08-22-two-lane-storage-design.md`.

## Commits

1. **`feat(api): StorageLane record shape with sealed-credential reseal coverage`**
   Adds the `StorageLane` interface, `newLaneId()`, and `storageLanes` /
   `storageLaneId` fields on `WorkspaceRecord`. Extends the credential
   rotation sweep (`reencryptRegistryCredentials`) to reseal a lane's
   `accessKeyId`/`secretAccessKey` alongside the active-lane pair — a record
   whose only credentials live in a lane is no longer skipped as
   `no_credentials`. Audited every credential-touching call site
   (`storageStatusResponse`, the admin `/workspaces/:name` projection) —
   both use explicit field allowlists that don't reference `storageLanes`,
   so there's no leak surface to close here; that surface gets added
   deliberately in a later PR when lanes actually get exposed to those
   responses.

2. **`feat(api): lane-aware storage resolution (storageConfigs, resolveObjectLane)`**
   Extracts `storageConfig`'s binding-lookup + credential-opening body into a
   shared helper so it can resolve either the top-level active fields or a
   `StorageLane`. Adds `storageConfigs(env, ws)` (active lane first, then
   fallback lanes — lanes with `lastActiveAt` set — in order; standby lanes
   are excluded; a fallback lane with a bad binding, undecryptable creds, or
   a non-`"r2"` provider is logged and skipped rather than throwing) and
   `resolveObjectLane(env, ws, key)` (first `exists()` hit wins; a
   single-lane record short-circuits to exactly one `exists` call, matching
   today's behavior byte-for-byte). All storage IO still goes through
   `packages/storage`'s `createStorage` — no direct S3/R2 clients.

3. **`feat(api): stamp storage lane id into upload provenance`**
   New uploads write `ws.storageLaneId ?? "lane_origin"` into the existing R2
   provenance bag at put time. Zero D1 schema, no read-path dependency —
   this is purely the forward hook the design calls out for future per-file
   routing/migration tooling.

## Verification

- `pnpm --filter @uploads/api test` — 151 files / 2055 tests, all green
  (2053 pre-existing + 2 new for the provenance stamp; the lane-resolution
  and reseal-sweep coverage landed as new test files/cases in commits 1–2).
- `pnpm --filter @uploads/api exec tsc --noEmit` — clean.
- Root `pnpm test` — 320 files / 4788 tests, all green.

## Context

Groundwork for #594 (does not close it) — this PR ships the record-shape and
resolver primitive; read-path lane-awareness and the save/activate/remove UI
land in follow-up PRs per the plan in
`docs/superpowers/plans/2026-08-22-two-lane-storage.md`.
