### PR TITLE
feat(api): lane-aware read paths

### DIFF
--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -32,6 +32,7 @@ import {
 import { recordPrActivityFromMetadata } from "./github-pr-activity";
 import { DEFAULT_MAX_UPLOAD_BYTES, inspectUpload, resolveUploadPolicy } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
+import { decodeLaneCursor, encodeLaneCursor, mergeBounded } from "./lane-list";
 import {
   makePoster,
   mediabunnyProbe,
@@ -808,6 +809,78 @@ export function filePageUrl(env: Env, workspace: string, key: string): string {
   return `${webOrigin(env)}/f/${encodeURIComponent(workspace)}/${encodedKey}`;
 }
 
+/** A provider-list item shape, before projection to the API's `ListedObject`. */
+interface RawListedItem {
+  key: string;
+  size?: number;
+  type?: string;
+  lastModified?: number;
+  metadata?: Record<string, string>;
+}
+
+/** Shared HEAD/list projection, parameterized on which lane's config to derive URLs from — the single-lane and multi-lane `listObjects` paths both funnel through this. */
+function projectListedObject(
+  env: Env,
+  ws: WorkspaceRecord,
+  cfg: Awaited<ReturnType<typeof storageConfig>>,
+  item: RawListedItem,
+): ListedObject {
+  const visibility = objectVisibility(item.metadata ?? undefined);
+  const urls = objectPublicUrls(env, cfg, item.key);
+  return {
+    key: item.key,
+    url: urls.url,
+    embedUrl: urls.embedUrl,
+    ...storedMetaJson(item),
+    ...(visibility ? { visibility } : {}),
+    ...(urls.url && ws.name ? { pageUrl: filePageUrl(env, ws.name, item.key) } : {}),
+  };
+}
+
+/**
+ * Packs a lane's next-fetch state into one opaque string: how many items to
+ * skip past a batch already fetched from `cursor` (a lane whose merged page
+ * didn't consume its whole fetched batch must resume mid-batch — providers
+ * only support resuming at a *batch* boundary, so the leftover is re-fetched
+ * and re-skipped rather than lost), plus the underlying provider cursor to
+ * fetch that batch from (`undefined` = start of listing). Internal to
+ * `listObjects`'s multi-lane fan-out — `LaneCursorMap`'s value type is just
+ * `string`, so this format is a private implementation detail of this file.
+ */
+function encodeLaneResumeState(skip: number, cursor: string | undefined): string {
+  return `${skip}:${cursor ?? ""}`;
+}
+
+function decodeLaneResumeState(raw: string | undefined): {
+  skip: number;
+  cursor: string | undefined;
+} {
+  const sep = raw?.indexOf(":") ?? -1;
+  if (raw === undefined || sep < 0) return { skip: 0, cursor: undefined };
+  const skip = Number(raw.slice(0, sep));
+  const cursor = raw.slice(sep + 1);
+  return {
+    skip: Number.isFinite(skip) && skip >= 0 ? skip : 0,
+    cursor: cursor.length > 0 ? cursor : undefined,
+  };
+}
+
+/** One lane's fetched-and-filtered batch, tagged with enough state to resume it next page. */
+interface LaneFetch {
+  laneKeyStr: string;
+  cfg: Awaited<ReturnType<typeof storageConfig>>;
+  /** This batch's items after dropping the portion already emitted on an earlier page. */
+  remaining: RawListedItem[];
+  /** How many of this batch's items were already skipped before this fetch (for the next page's bookkeeping). */
+  skipBase: number;
+  /** The provider cursor this fetch itself used (re-used verbatim if `remaining` isn't fully consumed this page). */
+  providerCursorUsed: string | undefined;
+  /** The provider's own next-cursor for this batch, if it was truncated. */
+  providerNextCursor: string | undefined;
+}
+
+const ACTIVE_LANE_CURSOR_KEY = "active";
+
 export async function listObjects(
   env: Env,
   ws: WorkspaceRecord,
@@ -819,39 +892,99 @@ export async function listObjects(
   } = {},
 ): Promise<{ items: ListedObject[]; cursor: string | null; prefixes?: string[] }> {
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 1000);
-  const store = await storage(env, ws);
-  const result = await store.list({
-    prefix: opts.prefix,
-    delimiter: opts.delimiter,
-    limit,
-    cursor: opts.cursor,
+  const configs = await storageConfigs(env, ws);
+
+  if (configs.length === 1) {
+    // Single-lane record (the entire fleet until a second lane exists):
+    // exactly today's path — one provider call, today's raw opaque cursor,
+    // no composite envelope. Backward compatible with an in-flight cursor.
+    const cfg = configs[0].config;
+    const store = createStorage(cfg);
+    const result = await store.list({
+      prefix: opts.prefix,
+      delimiter: opts.delimiter,
+      limit,
+      cursor: opts.cursor,
+    });
+    return {
+      // Server-owned derived artifacts (issue #299 posters, CLI report
+      // uploads) are not user objects and must never appear as rows. Caveat:
+      // `limit` applies to the underlying page *before* this filter, so a
+      // page can come back shorter than `limit` while `cursor` is still
+      // non-null — callers that paginate must follow the cursor, not stop on
+      // a short page.
+      items: result.items
+        .filter((item) => !item.key.startsWith(INTERNAL_KEY_PREFIX))
+        .map((item) => projectListedObject(env, ws, cfg, item)),
+      cursor: result.cursor ?? null,
+      ...(result.prefixes ? { prefixes: result.prefixes } : {}),
+    };
+  }
+
+  // Multi-lane fan-out + merge (spec: "Listing: merged fan-out"). Garbage or
+  // a plain (pre-lanes) cursor decodes to `null` — treated as a fresh start
+  // rather than an error.
+  const cursorMap = decodeLaneCursor(opts.cursor) ?? { v: 1, lanes: {} };
+  const laneCursorKey = (laneId: string | null) => laneId ?? ACTIVE_LANE_CURSOR_KEY;
+
+  const prefixesSeen: string[] = [];
+  const fetches: LaneFetch[] = await Promise.all(
+    configs.map(async (lc): Promise<LaneFetch> => {
+      const laneKeyStr = laneCursorKey(lc.laneId);
+      const { skip, cursor: providerCursor } = decodeLaneResumeState(cursorMap.lanes[laneKeyStr]);
+      const store = createStorage(lc.config);
+      const result = await store.list({
+        prefix: opts.prefix,
+        delimiter: opts.delimiter,
+        limit,
+        cursor: providerCursor,
+      });
+      for (const p of result.prefixes ?? []) if (!prefixesSeen.includes(p)) prefixesSeen.push(p);
+      const filtered = result.items.filter((item) => !item.key.startsWith(INTERNAL_KEY_PREFIX));
+      return {
+        laneKeyStr,
+        cfg: lc.config,
+        remaining: filtered.slice(skip),
+        skipBase: skip,
+        providerCursorUsed: providerCursor,
+        providerNextCursor: result.cursor,
+      };
+    }),
+  );
+
+  // Tag each raw item with the config it came from (by object identity) so
+  // the merge result can still be projected to a `ListedObject` per its
+  // owning lane, without threading lane info through `mergeBounded`'s
+  // generic `{ key }` constraint.
+  const taggedPages = fetches.map((fetch, laneOrder) => ({
+    laneOrder,
+    items: fetch.remaining.map((raw) => ({ ...raw, __cfg: fetch.cfg })),
+  }));
+  const merged = mergeBounded(taggedPages, limit);
+
+  const nextLanes: Record<string, string> = {};
+  fetches.forEach((fetch, i) => {
+    const consumedCount = merged.consumed[i] ?? 0;
+    if (consumedCount >= fetch.remaining.length) {
+      // This batch is fully spent. More to come only if the provider itself
+      // wasn't exhausted — advance to its next batch, skip reset to 0.
+      if (fetch.providerNextCursor) {
+        nextLanes[fetch.laneKeyStr] = encodeLaneResumeState(0, fetch.providerNextCursor);
+      }
+    } else {
+      // Trimmed mid-batch: re-fetch the same provider cursor next page and
+      // skip further ahead — providers only resume at a batch boundary.
+      nextLanes[fetch.laneKeyStr] = encodeLaneResumeState(
+        fetch.skipBase + consumedCount,
+        fetch.providerCursorUsed,
+      );
+    }
   });
-  const cfg = await storageConfig(env, ws);
-  // files-sdk returns rich StoredFile items (size, type, lastModified); project
-  // each to the shared HEAD/list subset (`storedMetaJson`) rather than spreading
-  // the StoredFile, which carries reader methods and a raw epoch timestamp.
+
   return {
-    // Server-owned derived artifacts (issue #299 posters, CLI report uploads)
-    // are not user objects and must never appear as rows. Caveat: `limit`
-    // applies to the underlying page *before* this filter, so a page can come
-    // back shorter than `limit` while `cursor` is still non-null — callers
-    // that paginate must follow the cursor, not stop on a short page.
-    items: result.items
-      .filter((item) => !item.key.startsWith(INTERNAL_KEY_PREFIX))
-      .map((item) => {
-        const visibility = objectVisibility(item.metadata ?? undefined);
-        const urls = objectPublicUrls(env, cfg, item.key);
-        return {
-          key: item.key,
-          url: urls.url,
-          embedUrl: urls.embedUrl,
-          ...storedMetaJson(item),
-          ...(visibility ? { visibility } : {}),
-          ...(urls.url && ws.name ? { pageUrl: filePageUrl(env, ws.name, item.key) } : {}),
-        };
-      }),
-    cursor: result.cursor ?? null,
-    ...(result.prefixes ? { prefixes: result.prefixes } : {}),
+    items: merged.items.map((raw) => projectListedObject(env, ws, raw.__cfg, raw)),
+    cursor: Object.keys(nextLanes).length > 0 ? encodeLaneCursor({ v: 1, lanes: nextLanes }) : null,
+    ...(prefixesSeen.length > 0 ? { prefixes: prefixesSeen } : {}),
   };
 }
 

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -6,7 +6,7 @@
  * `message` in the tool error.
  */
 import { ConflictError, NotFoundError, ValidationError } from "@uploads/errors";
-import type { Files } from "@uploads/storage";
+import { createStorage, type Files } from "@uploads/storage";
 import { recordAdoptionSafe, type UploadSurface } from "./adoption";
 import {
   budgetDenialError,
@@ -45,7 +45,7 @@ import {
   sanitizeProvenance,
   type ProvenanceMap,
 } from "./provenance";
-import { objectPublicUrls, storage, storageConfig } from "./storage";
+import { objectPublicUrls, storage, storageConfig, storageConfigs } from "./storage";
 import {
   claimDeleteUsageSafe,
   clearDeleteUsageClaimSafe,
@@ -855,6 +855,31 @@ export async function listObjects(
   };
 }
 
+/**
+ * Delete `key` from every lane's store that actually holds it and return the
+ * size reported by the first lane hit (active-first order) — `null` if no
+ * lane had it. Two-lane storage: a key can exist in more than one lane after
+ * a detach/re-attach cycle, and every copy must go so the file actually
+ * disappears (spec: "Read path" — deletion). Single-lane records take the
+ * exact path this always has: one lane, one `existingSize` + `delete` call.
+ */
+async function deleteFromEveryLane(
+  env: Env,
+  ws: WorkspaceRecord,
+  key: string,
+): Promise<number | null> {
+  const configs = await storageConfigs(env, ws);
+  let prev: number | null = null;
+  for (const lc of configs) {
+    const store = createStorage(lc.config);
+    const size = await existingSize(store, key);
+    if (size === null) continue;
+    if (prev === null) prev = size;
+    await store.delete(key);
+  }
+  return prev;
+}
+
 /** Delete an object (and its D1 custom metadata) and decrement the workspace ledger when size was known. */
 export async function deleteObject(
   env: Env,
@@ -864,10 +889,7 @@ export async function deleteObject(
 ): Promise<{ key: string; deleted: true }> {
   if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
 
-  const store = await storage(env, ws);
-  const prev = await existingSize(store, key);
-
-  await store.delete(key);
+  const prev = await deleteFromEveryLane(env, ws, key);
   await deleteFileMetadata(env.DB, workspaceName, key);
 
   if (prev !== null) {
@@ -895,15 +917,15 @@ export async function deleteObject(
 
   // Derived poster (issue #299), best-effort: a missing one is the norm for
   // every non-video object. Guarded so a transient poster-cleanup failure
-  // never fails a delete whose primary work already succeeded.
+  // never fails a delete whose primary work already succeeded. Same
+  // every-lane-that-has-it treatment as the primary object above.
   const posterKey = posterKeyFor(key);
   try {
-    const posterSize = await existingSize(store, posterKey);
-    if (posterSize !== null) {
-      await store.delete(posterKey);
+    const posterPrev = await deleteFromEveryLane(env, ws, posterKey);
+    if (posterPrev !== null) {
       if (await claimDeleteUsageSafe(env.DB, workspaceName, posterKey)) {
         await recordUsageSafe(env.DB, workspaceName, {
-          bytes: -posterSize,
+          bytes: -posterPrev,
           objects: -1,
           uploads: 0,
         });

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -32,7 +32,14 @@ import {
 import { recordPrActivityFromMetadata } from "./github-pr-activity";
 import { DEFAULT_MAX_UPLOAD_BYTES, inspectUpload, resolveUploadPolicy } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
-import { decodeLaneCursor, encodeLaneCursor, mergeBounded } from "./lane-list";
+import {
+  decodeLaneCursor,
+  decodeLaneResumeState,
+  encodeLaneCursor,
+  encodeLaneResumeState,
+  LANE_DONE,
+  mergeBounded,
+} from "./lane-list";
 import {
   makePoster,
   mediabunnyProbe,
@@ -46,7 +53,13 @@ import {
   sanitizeProvenance,
   type ProvenanceMap,
 } from "./provenance";
-import { objectPublicUrls, storage, storageConfig, storageConfigs } from "./storage";
+import {
+  objectPublicUrls,
+  storage,
+  storageConfig,
+  storageConfigs,
+  type LaneConfig,
+} from "./storage";
 import {
   claimDeleteUsageSafe,
   clearDeleteUsageClaimSafe,
@@ -837,46 +850,18 @@ function projectListedObject(
   };
 }
 
-/**
- * Packs a lane's next-fetch state into one opaque string: how many items to
- * skip past a batch already fetched from `cursor` (a lane whose merged page
- * didn't consume its whole fetched batch must resume mid-batch — providers
- * only support resuming at a *batch* boundary, so the leftover is re-fetched
- * and re-skipped rather than lost), plus the underlying provider cursor to
- * fetch that batch from (`undefined` = start of listing). Internal to
- * `listObjects`'s multi-lane fan-out — `LaneCursorMap`'s value type is just
- * `string`, so this format is a private implementation detail of this file.
- */
-function encodeLaneResumeState(skip: number, cursor: string | undefined): string {
-  return `${skip}:${cursor ?? ""}`;
-}
-
-function decodeLaneResumeState(raw: string | undefined): {
-  skip: number;
-  cursor: string | undefined;
-} {
-  const sep = raw?.indexOf(":") ?? -1;
-  if (raw === undefined || sep < 0) return { skip: 0, cursor: undefined };
-  const skip = Number(raw.slice(0, sep));
-  const cursor = raw.slice(sep + 1);
-  return {
-    skip: Number.isFinite(skip) && skip >= 0 ? skip : 0,
-    cursor: cursor.length > 0 ? cursor : undefined,
-  };
-}
-
 /** One lane's fetched-and-filtered batch, tagged with enough state to resume it next page. */
 interface LaneFetch {
   laneKeyStr: string;
   cfg: Awaited<ReturnType<typeof storageConfig>>;
-  /** This batch's items after dropping the portion already emitted on an earlier page. */
+  /** This batch's items, already dropped for anything at or before the composite cursor's high-water key. Empty (without ever fetching) when the lane was already `LANE_DONE`. */
   remaining: RawListedItem[];
-  /** How many of this batch's items were already skipped before this fetch (for the next page's bookkeeping). */
-  skipBase: number;
-  /** The provider cursor this fetch itself used (re-used verbatim if `remaining` isn't fully consumed this page). */
+  /** The provider cursor this fetch itself used (re-used verbatim next page if `remaining` isn't fully consumed this page) — `undefined` if the lane was already done (never fetched). */
   providerCursorUsed: string | undefined;
   /** The provider's own next-cursor for this batch, if it was truncated. */
   providerNextCursor: string | undefined;
+  /** True when this lane was already `LANE_DONE` coming in — skipped entirely, no fetch made. */
+  wasDone: boolean;
 }
 
 const ACTIVE_LANE_CURSOR_KEY = "active";
@@ -925,13 +910,27 @@ export async function listObjects(
   // a plain (pre-lanes) cursor decodes to `null` — treated as a fresh start
   // rather than an error.
   const cursorMap = decodeLaneCursor(opts.cursor) ?? { v: 1, lanes: {} };
+  // The global high-water key: nothing at or before it is ever re-emitted,
+  // even if a lane's own resume state were somehow lost — defense in depth
+  // alongside the explicit `LANE_DONE` sentinel below.
+  const highWater = cursorMap.after;
   const laneCursorKey = (laneId: string | null) => laneId ?? ACTIVE_LANE_CURSOR_KEY;
 
   const prefixesSeen: string[] = [];
   const fetches: LaneFetch[] = await Promise.all(
     configs.map(async (lc): Promise<LaneFetch> => {
       const laneKeyStr = laneCursorKey(lc.laneId);
-      const { skip, cursor: providerCursor } = decodeLaneResumeState(cursorMap.lanes[laneKeyStr]);
+      const { cursor: providerCursor, done } = decodeLaneResumeState(cursorMap.lanes[laneKeyStr]);
+      if (done) {
+        return {
+          laneKeyStr,
+          cfg: lc.config,
+          remaining: [],
+          providerCursorUsed: undefined,
+          providerNextCursor: undefined,
+          wasDone: true,
+        };
+      }
       const store = createStorage(lc.config);
       const result = await store.list({
         prefix: opts.prefix,
@@ -940,14 +939,16 @@ export async function listObjects(
         cursor: providerCursor,
       });
       for (const p of result.prefixes ?? []) if (!prefixesSeen.includes(p)) prefixesSeen.push(p);
-      const filtered = result.items.filter((item) => !item.key.startsWith(INTERNAL_KEY_PREFIX));
+      const remaining = result.items
+        .filter((item) => !item.key.startsWith(INTERNAL_KEY_PREFIX))
+        .filter((item) => highWater === undefined || item.key > highWater);
       return {
         laneKeyStr,
         cfg: lc.config,
-        remaining: filtered.slice(skip),
-        skipBase: skip,
+        remaining,
         providerCursorUsed: providerCursor,
         providerNextCursor: result.cursor,
+        wasDone: false,
       };
     }),
   );
@@ -955,61 +956,75 @@ export async function listObjects(
   // Tag each raw item with the config it came from (by object identity) so
   // the merge result can still be projected to a `ListedObject` per its
   // owning lane, without threading lane info through `mergeBounded`'s
-  // generic `{ key }` constraint.
-  const taggedPages = fetches.map((fetch, laneOrder) => ({
-    laneOrder,
+  // generic `{ key }` constraint. `fetches` is already active-first order
+  // (matches `storageConfigs`), which is exactly the merge priority order
+  // `mergeBounded` wants.
+  const taggedPages = fetches.map((fetch) => ({
     items: fetch.remaining.map((raw) => ({ ...raw, __cfg: fetch.cfg })),
   }));
   const merged = mergeBounded(taggedPages, limit);
 
   const nextLanes: Record<string, string> = {};
   fetches.forEach((fetch, i) => {
+    if (fetch.wasDone) {
+      nextLanes[fetch.laneKeyStr] = LANE_DONE;
+      return;
+    }
     const consumedCount = merged.consumed[i] ?? 0;
-    if (consumedCount >= fetch.remaining.length) {
-      // This batch is fully spent. More to come only if the provider itself
-      // wasn't exhausted — advance to its next batch, skip reset to 0.
-      if (fetch.providerNextCursor) {
-        nextLanes[fetch.laneKeyStr] = encodeLaneResumeState(0, fetch.providerNextCursor);
-      }
+    const fullyConsumed = consumedCount >= fetch.remaining.length;
+    if (fullyConsumed && !fetch.providerNextCursor) {
+      // Nothing left in this lane, ever — mark it explicitly done so the
+      // next page skips fetching it entirely, rather than reinterpreting
+      // "no entry" as "hasn't started yet" (the bug this cursor format
+      // guards against — see decodeLaneResumeState).
+      nextLanes[fetch.laneKeyStr] = LANE_DONE;
+    } else if (fullyConsumed) {
+      // Batch fully spent, but the provider says there's more — advance.
+      nextLanes[fetch.laneKeyStr] = encodeLaneResumeState(fetch.providerNextCursor);
     } else {
-      // Trimmed mid-batch: re-fetch the same provider cursor next page and
-      // skip further ahead — providers only resume at a batch boundary.
-      nextLanes[fetch.laneKeyStr] = encodeLaneResumeState(
-        fetch.skipBase + consumedCount,
-        fetch.providerCursorUsed,
-      );
+      // Trimmed mid-batch: re-fetch the same provider cursor next page.
+      // `highWater` (updated below) filters out what's already been
+      // emitted, so this never re-emits a duplicate.
+      nextLanes[fetch.laneKeyStr] = encodeLaneResumeState(fetch.providerCursorUsed);
     }
   });
 
+  const lastEmittedKey = merged.items.at(-1)?.key;
+  const nextHighWater = lastEmittedKey ?? highWater;
+  const allDone = Object.values(nextLanes).every((v) => v === LANE_DONE);
+
   return {
     items: merged.items.map((raw) => projectListedObject(env, ws, raw.__cfg, raw)),
-    cursor: Object.keys(nextLanes).length > 0 ? encodeLaneCursor({ v: 1, lanes: nextLanes }) : null,
+    cursor: allDone
+      ? null
+      : encodeLaneCursor({
+          v: 1,
+          lanes: nextLanes,
+          ...(nextHighWater !== undefined ? { after: nextHighWater } : {}),
+        }),
     ...(prefixesSeen.length > 0 ? { prefixes: prefixesSeen } : {}),
   };
 }
 
 /**
- * Delete `key` from every lane's store that actually holds it and return the
- * size reported by the first lane hit (active-first order) — `null` if no
- * lane had it. Two-lane storage: a key can exist in more than one lane after
- * a detach/re-attach cycle, and every copy must go so the file actually
+ * Delete `key` from every one of `configs`'s stores that actually holds it
+ * and return the size reported by the first lane hit (active-first order,
+ * matching `storageConfigs`'s own order) — `null` if no lane had it. Probes
+ * every lane concurrently, then deletes concurrently from whichever lanes
+ * hit. Two-lane storage: a key can exist in more than one lane after a
+ * detach/re-attach cycle, and every copy must go so the file actually
  * disappears (spec: "Read path" — deletion). Single-lane records take the
  * exact path this always has: one lane, one `existingSize` + `delete` call.
+ * Callers resolve `storageConfigs` once and pass it in — `deleteObject`
+ * reuses the same resolution for both the primary key and its poster.
  */
-async function deleteFromEveryLane(
-  env: Env,
-  ws: WorkspaceRecord,
-  key: string,
-): Promise<number | null> {
-  const configs = await storageConfigs(env, ws);
-  let prev: number | null = null;
-  for (const lc of configs) {
-    const store = createStorage(lc.config);
-    const size = await existingSize(store, key);
-    if (size === null) continue;
-    if (prev === null) prev = size;
-    await store.delete(key);
-  }
+async function deleteFromEveryLane(configs: LaneConfig[], key: string): Promise<number | null> {
+  const stores = configs.map((lc) => createStorage(lc.config));
+  const sizes = await Promise.all(stores.map((store) => existingSize(store, key)));
+  // `.find` over the Promise.all result preserves `configs`' order (active
+  // first) regardless of which probe actually settled first.
+  const prev = sizes.find((size) => size !== null) ?? null;
+  await Promise.all(stores.filter((_, i) => sizes[i] !== null).map((store) => store.delete(key)));
   return prev;
 }
 
@@ -1022,7 +1037,8 @@ export async function deleteObject(
 ): Promise<{ key: string; deleted: true }> {
   if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
 
-  const prev = await deleteFromEveryLane(env, ws, key);
+  const configs = await storageConfigs(env, ws);
+  const prev = await deleteFromEveryLane(configs, key);
   await deleteFileMetadata(env.DB, workspaceName, key);
 
   if (prev !== null) {
@@ -1054,7 +1070,7 @@ export async function deleteObject(
   // every-lane-that-has-it treatment as the primary object above.
   const posterKey = posterKeyFor(key);
   try {
-    const posterPrev = await deleteFromEveryLane(env, ws, posterKey);
+    const posterPrev = await deleteFromEveryLane(configs, posterKey);
     if (posterPrev !== null) {
       if (await claimDeleteUsageSafe(env.DB, workspaceName, posterKey)) {
         await recordUsageSafe(env.DB, workspaceName, {

--- a/apps/api/src/gallery-service.ts
+++ b/apps/api/src/gallery-service.ts
@@ -22,7 +22,7 @@ import {
   projectPublicGallery,
 } from "./galleries";
 import { resolveTitles, withPublicTitleBudget, type TitleInfo } from "./github-titles";
-import { objectPublicUrls, resolveObjectLane, storageConfig } from "./storage";
+import { createLaneResolver, objectPublicUrls, type LaneResolver } from "./storage";
 import type { StorageConfig } from "@uploads/storage";
 import { objectVisibility } from "./visibility";
 import { webOrigin } from "./web-url";
@@ -281,14 +281,17 @@ export async function hydrateGalleryItems(
   items: GalleryItemRecord[],
   opts: { audience: "owner" | "public" } = { audience: "owner" },
 ): Promise<Omit<GalleryItemDto, "pageUrl">[]> {
-  // Two-lane storage (PR C audit): each item resolves its OWN lane —
-  // `resolveObjectLane` rather than a single shared store/config — since a
-  // gallery can reference objects uploaded before a storage switch. Confirm
-  // the active lane itself resolves up front so a misconfigured workspace
-  // still fails fast with the same error as before, rather than failing
-  // per-item deep inside `mapBounded`.
+  // Two-lane storage (PR C audit): each item resolves its OWN lane via a
+  // shared `LaneResolver` — a gallery can reference objects uploaded before
+  // a storage switch, and the resolver caches each lane's store/config
+  // across all of this gallery's items instead of re-resolving (and
+  // re-decrypting a fallback lane's credentials) per item. Confirm the
+  // active lane itself resolves up front so a misconfigured workspace still
+  // fails fast with the same error as before, rather than failing per-item
+  // deep inside `mapBounded`.
+  const resolver = createLaneResolver(env, workspace);
   try {
-    await storageConfig(env, workspace);
+    await resolver.activeConfig();
   } catch (cause) {
     throw new ServiceUnavailableError("Gallery storage unavailable.", {
       code: "gallery_storage_unavailable",
@@ -303,7 +306,7 @@ export async function hydrateGalleryItems(
       let meta: GalleryObjectHead | null;
       let itemConfig: StorageConfig | null = null;
       try {
-        const lane = await resolveObjectLane(env, workspace, item.object_key);
+        const lane = await resolver.resolve(item.object_key);
         if (lane) {
           itemConfig = lane.config;
           laneConfigByKey.set(item.object_key, lane.config);
@@ -415,27 +418,32 @@ function isPreviewImageKey(key: string): boolean {
 }
 
 /**
- * Storage config for building preview URLs, or `null` when it can't be
- * resolved. The list endpoint historically needed no storage at all, so a
- * misconfigured/undecryptable workspace must degrade to no thumbnails rather
- * than 503 the whole list (unlike `hydrateGalleryItems`, which does hard-fail).
+ * Cover URL for one gallery, or `null` unless it's a still image the caller
+ * can actually resolve to a lane. Two-lane storage (PR C audit): this now
+ * resolves the cover key's owning lane via `resolver` — a cover uploaded
+ * before a storage switch previously derived the wrong (active-lane) host.
+ * `resolver` caches lane store/config across every gallery in one
+ * `galleryListSummaries` call, so this costs one `exists` probe per
+ * *distinct* cover key, not a re-decrypt per gallery. The list endpoint
+ * historically needed no storage existence check at all — a
+ * misconfigured/undecryptable workspace, or a lane resolve failure, must
+ * still degrade to no thumbnail rather than 503 the whole list (unlike
+ * `hydrateGalleryItems`, which hard-fails).
  */
-async function galleryPreviewConfig(env: Env, ws: WorkspaceRecord): Promise<StorageConfig | null> {
+async function previewUrlForKey(
+  env: Env,
+  resolver: LaneResolver,
+  key: string | null,
+): Promise<string | null> {
+  if (!key || !isPreviewImageKey(key)) return null;
+  let lane: Awaited<ReturnType<LaneResolver["resolve"]>>;
   try {
-    return await storageConfig(env, ws);
+    lane = await resolver.resolve(key);
   } catch {
     return null;
   }
-}
-
-/** Cover URL for one gallery: pure key→URL, no head. `null` unless it's a still image on a public workspace. */
-function previewUrlForKey(
-  env: Env,
-  config: StorageConfig | null,
-  key: string | null,
-): string | null {
-  if (!config || !key || !isPreviewImageKey(key)) return null;
-  const { url, embedUrl } = objectPublicUrls(env, config, key);
+  if (!lane) return null;
+  const { url, embedUrl } = objectPublicUrls(env, lane.config, key);
   return embedUrl ?? url;
 }
 
@@ -456,25 +464,27 @@ export async function galleryListSummaries(
   const coverIds = records
     .map((record) => record.cover_item_id)
     .filter((id): id is string => id !== null);
-  const [itemCounts, refsByGallery, firstKeys, coverKeys, config] = await Promise.all([
+  const [itemCounts, refsByGallery, firstKeys, coverKeys] = await Promise.all([
     countItemsForGalleries(env.DB, name, ids),
     listExternalReferencesForGalleries(env.DB, name, ids),
     firstItemKeyForGalleries(env.DB, name, ids),
     itemKeysByIds(env.DB, name, coverIds),
-    galleryPreviewConfig(env, workspace),
   ]);
-  return records.map((record) => {
-    const coverKey =
-      (record.cover_item_id ? coverKeys.get(record.cover_item_id) : undefined) ??
-      firstKeys.get(record.id) ??
-      null;
-    return {
-      ...gallerySummary(env, record),
-      itemCount: itemCounts.get(record.id) ?? 0,
-      references: (refsByGallery.get(record.id) ?? []).map(referenceDto),
-      previewUrl: previewUrlForKey(env, config, coverKey),
-    };
-  });
+  const resolver = createLaneResolver(env, workspace);
+  return Promise.all(
+    records.map(async (record) => {
+      const coverKey =
+        (record.cover_item_id ? coverKeys.get(record.cover_item_id) : undefined) ??
+        firstKeys.get(record.id) ??
+        null;
+      return {
+        ...gallerySummary(env, record),
+        itemCount: itemCounts.get(record.id) ?? 0,
+        references: (refsByGallery.get(record.id) ?? []).map(referenceDto),
+        previewUrl: await previewUrlForKey(env, resolver, coverKey),
+      };
+    }),
+  );
 }
 
 export async function hydrateOwnerGallery(

--- a/apps/api/src/gallery-service.ts
+++ b/apps/api/src/gallery-service.ts
@@ -22,7 +22,7 @@ import {
   projectPublicGallery,
 } from "./galleries";
 import { resolveTitles, withPublicTitleBudget, type TitleInfo } from "./github-titles";
-import { objectPublicUrls, storage, storageConfig } from "./storage";
+import { objectPublicUrls, resolveObjectLane, storageConfig } from "./storage";
 import type { StorageConfig } from "@uploads/storage";
 import { objectVisibility } from "./visibility";
 import { webOrigin } from "./web-url";
@@ -281,25 +281,36 @@ export async function hydrateGalleryItems(
   items: GalleryItemRecord[],
   opts: { audience: "owner" | "public" } = { audience: "owner" },
 ): Promise<Omit<GalleryItemDto, "pageUrl">[]> {
-  let store: Awaited<ReturnType<typeof storage>>;
-  let config: Awaited<ReturnType<typeof storageConfig>>;
+  // Two-lane storage (PR C audit): each item resolves its OWN lane —
+  // `resolveObjectLane` rather than a single shared store/config — since a
+  // gallery can reference objects uploaded before a storage switch. Confirm
+  // the active lane itself resolves up front so a misconfigured workspace
+  // still fails fast with the same error as before, rather than failing
+  // per-item deep inside `mapBounded`.
   try {
-    [store, config] = await Promise.all([storage(env, workspace), storageConfig(env, workspace)]);
+    await storageConfig(env, workspace);
   } catch (cause) {
     throw new ServiceUnavailableError("Gallery storage unavailable.", {
       code: "gallery_storage_unavailable",
       cause,
     });
   }
+  const laneConfigByKey = new Map<string, StorageConfig>();
   const hydrated = await mapBounded(
     items,
     8,
     async (item): Promise<Omit<GalleryItemDto, "pageUrl">> => {
       let meta: GalleryObjectHead | null;
+      let itemConfig: StorageConfig | null = null;
       try {
-        meta = (await store.exists(item.object_key))
-          ? ((await store.head(item.object_key)) as GalleryObjectHead)
-          : null;
+        const lane = await resolveObjectLane(env, workspace, item.object_key);
+        if (lane) {
+          itemConfig = lane.config;
+          laneConfigByKey.set(item.object_key, lane.config);
+          meta = (await lane.store.head(item.object_key)) as GalleryObjectHead;
+        } else {
+          meta = null;
+        }
       } catch (cause) {
         throw new ServiceUnavailableError("Gallery storage unavailable.", {
           code: "gallery_storage_unavailable",
@@ -309,8 +320,8 @@ export async function hydrateGalleryItems(
       const isPrivate = meta ? objectVisibility(meta.metadata) === "private" : false;
       const withheld = opts.audience === "public" && isPrivate;
       const urls =
-        meta && !withheld
-          ? objectPublicUrls(env, config, item.object_key)
+        meta && !withheld && itemConfig
+          ? objectPublicUrls(env, itemConfig, item.object_key)
           : { url: null, embedUrl: null };
       if (meta && !withheld && urls.url === null)
         throw new ServiceUnavailableError("Gallery object is not publicly served.", {
@@ -349,10 +360,14 @@ export async function hydrateGalleryItems(
       });
       for (const item of hydrated) {
         const metadata = metadataByKey.get(item.objectKey);
-        if (!metadata) continue;
+        // Same lane the primary object resolved from above — posters are
+        // written alongside their video at upload time, so they live in the
+        // same lane by construction.
+        const itemConfig = laneConfigByKey.get(item.objectKey);
+        if (!metadata || !itemConfig) continue;
         const { posterUrl, videoDimensions } = videoPresentation(
           env,
-          config,
+          itemConfig,
           item.objectKey,
           metadata,
         );

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -329,6 +329,14 @@ describe("gatherCommentBody poster hydration (issue #299)", () => {
     const { env, ws, workspaceName, bucket } = makeTestEnv();
     const key = "gh/acme/web/pull/12/clip.mp4";
     await bucket.put(`acme/${key}`, PNG, { httpMetadata: { contentType: "video/mp4" } });
+    // The real write path (`generateAndStorePoster`, files-core.ts) always
+    // writes the poster object alongside the `video.poster` flag — the
+    // poster URL now resolves the poster's own lane (PR C simplify
+    // follow-up), so the fixture must reflect that real invariant rather
+    // than the flag alone.
+    await bucket.put(`acme/${posterKeyFor(key)}`, PNG, {
+      httpMetadata: { contentType: "image/jpeg" },
+    });
     // The real write path (`setServerFileMetadata`) is what generateAndStorePoster
     // (Task 8) uses — this is the only legitimate way `video.poster` gets set.
     await setServerFileMetadata(env.DB, workspaceName, key, { "video.poster": "1" });
@@ -378,6 +386,11 @@ describe("gatherCommentBody poster hydration (issue #299)", () => {
     const { env, ws, workspaceName, bucket } = makeTestEnv();
     const key = "gh/acme/web/pull/12/clip.mp4";
     await bucket.put(`acme/${key}`, PNG, { httpMetadata: { contentType: "video/mp4" } });
+    // See the poster-hydration test above: the poster resolves its own
+    // lane now, so it must actually exist for its URL to render.
+    await bucket.put(`acme/${posterKeyFor(key)}`, PNG, {
+      httpMetadata: { contentType: "image/jpeg" },
+    });
     await setServerFileMetadata(env.DB, workspaceName, key, {
       "video.poster": "1",
       "video.duration": "14",
@@ -395,6 +408,42 @@ describe("gatherCommentBody poster hydration (issue #299)", () => {
     // display width selection rather than appearing verbatim, so duration is
     // the one directly observable proof that videoMeta parsed as numbers.
     expect(result.body).toContain("0:14");
+  });
+
+  // Two-lane storage (simplify follow-up on PR #771): the poster resolves
+  // its OWN lane, independent of where the primary video lives.
+  it("resolves a poster living in a different (fallback) lane than the video", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    const key = "gh/acme/web/pull/12/clip.mp4";
+    await bucket.put(`acme/${key}`, PNG, { httpMetadata: { contentType: "video/mp4" } });
+
+    const fallbackBucket = new FakeR2Bucket();
+    await fallbackBucket.put(posterKeyFor(key), PNG, {
+      httpMetadata: { contentType: "image/jpeg" },
+    });
+    (env as unknown as Record<string, FakeR2Bucket>).UPLOADS_FALLBACK = fallbackBucket;
+    const wsWithFallback: WorkspaceRecord = {
+      ...ws,
+      storageLaneId: "lane_active1",
+      storageLanes: [
+        {
+          id: "lane_fallback1",
+          provider: "r2",
+          bucket: "customer-bucket",
+          binding: "UPLOADS_FALLBACK",
+          lastActiveAt: "2026-08-01T00:00:00.000Z",
+          publicBaseUrl: "https://storage.customer.example.com",
+        },
+      ],
+    };
+    await setServerFileMetadata(env.DB, workspaceName, key, { "video.poster": "1" });
+
+    const result = await gatherCommentBody(env, wsWithFallback, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+    expect(result.body).toContain(`https://storage.customer.example.com/${posterKeyFor(key)}`);
   });
 });
 

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -12,7 +12,7 @@ import { getMetadataForKeys } from "./file-metadata";
 import { findGalleriesByReference, listGalleryItems, type GalleryCursor } from "./galleries";
 import { galleryUrl, hydrateOwnerGallery } from "./gallery-service";
 import { parseExternalReference } from "./external-references";
-import { objectPublicUrls, storageConfig } from "./storage";
+import { createLaneResolver, objectPublicUrls } from "./storage";
 import { posterKeyFor } from "./poster";
 import { listActivePrefixIds } from "./github-private-prefixes";
 import type { WorkspaceRecord } from "./workspace";
@@ -176,7 +176,13 @@ async function gatherAttachments(
     items.map((item) => item.key),
     { metaKeys: COMMENT_META_KEYS },
   );
-  const cfg = await storageConfig(env, ws);
+  // Two-lane storage (PR C simplify follow-up): the poster resolves its OWN
+  // lane rather than the active one — `item.url`/`embedUrl` above already
+  // came from whichever lane `listObjects` found the primary key in, but a
+  // poster is a distinct key that needs its own lookup (they're written
+  // together at upload time, but a workspace can switch lanes afterward).
+  // `resolver` caches lane store/config across every item in this batch.
+  const resolver = createLaneResolver(env, ws);
   for (const item of items) {
     const meta = metaByKey.get(item.key);
     if (!meta) continue;
@@ -185,10 +191,15 @@ async function gatherAttachments(
       item.meta = { ...(path ? { path } : {}), ...(state ? { state } : {}) };
     }
     // `video.poster` is a presence flag only. The URL is always recomputed
-    // from the object key, so a client-settable row can never decide what
-    // image renders in a public comment.
+    // from the object key (never trusted from a stored row), and only
+    // rendered when the poster actually resolves to a lane — a
+    // client-settable metadata row can never conjure a URL for bytes that
+    // don't exist.
     if (meta["video.poster"] === "1") {
-      const posterUrls = objectPublicUrls(env, cfg, posterKeyFor(item.key));
+      const posterLane = await resolver.resolve(posterKeyFor(item.key));
+      const posterUrls = posterLane
+        ? objectPublicUrls(env, posterLane.config, posterKeyFor(item.key))
+        : { url: null, embedUrl: null };
       item.posterUrl = posterUrls.embedUrl ?? posterUrls.url;
       const duration = Number(meta["video.duration"]);
       const width = Number(meta["video.width"]);

--- a/apps/api/src/lane-list.ts
+++ b/apps/api/src/lane-list.ts
@@ -1,68 +1,86 @@
 /**
  * Pure helpers for the two-lane merged listing (PR C, Task C4): the
- * composite cursor codec and the k-way merge across lane pages. See
+ * composite cursor codec, the per-lane resume-state codec, and the k-way
+ * merge across lane pages. See
  * docs/superpowers/specs/2026-08-22-two-lane-storage-design.md, "Listing:
  * merged fan-out". Single-lane records never touch this module —
  * `listObjects` (files-core.ts) short-circuits straight to today's raw
  * provider-cursor path, so an in-flight single-lane cursor never gets
  * reinterpreted as a composite one.
  */
+import { b64urlDecode, b64urlEncode } from "./secrets";
 
-/** Per-lane pagination state: lane id (`"active"` for the active/null lane) → an opaque per-lane cursor string (format owned by the caller — see `listObjects`'s skip-and-resume packing). */
+/**
+ * Per-lane pagination state, keyed by lane id (`"active"` for the
+ * active/null lane): each value is either `LANE_DONE` (this lane will never
+ * produce another item) or the per-lane resume state from
+ * `encodeLaneResumeState`. `after` is the global high-water key — the
+ * largest key emitted across every lane so far. Every fresh fetch drops any
+ * item at or before it, so an exhausted lane that (for any reason) resolves
+ * back to "start of listing" can never re-emit something already returned;
+ * `LANE_DONE` is the primary mechanism, `after` is the defense in depth.
+ */
 export interface LaneCursorMap {
   v: 1;
   lanes: Record<string, string>;
-}
-
-function toBase64Url(json: string): string {
-  const bytes = new TextEncoder().encode(json);
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function fromBase64Url(raw: string): string {
-  const base64 = raw.replace(/-/g, "+").replace(/_/g, "/");
-  const padLength = (4 - (base64.length % 4)) % 4;
-  const binary = atob(base64 + "=".repeat(padLength));
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return new TextDecoder().decode(bytes);
+  after?: string;
 }
 
 /** base64url(JSON) of a `LaneCursorMap` — the composite cursor a multi-lane listing hands back. */
 export function encodeLaneCursor(map: LaneCursorMap): string {
-  return toBase64Url(JSON.stringify(map));
+  return b64urlEncode(new TextEncoder().encode(JSON.stringify(map)));
+}
+
+function isLaneCursorMap(value: unknown): value is LaneCursorMap {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  if ((value as { v?: unknown }).v !== 1) return false;
+  const lanes = (value as { lanes?: unknown }).lanes;
+  if (lanes === null || typeof lanes !== "object" || Array.isArray(lanes)) return false;
+  if (Object.values(lanes as Record<string, unknown>).some((v) => typeof v !== "string")) {
+    return false;
+  }
+  const after = (value as { after?: unknown }).after;
+  return after === undefined || typeof after === "string";
 }
 
 /**
  * Decodes a composite cursor. Returns `null` on anything that isn't a
- * well-formed `{ v: 1, lanes: {...} }` — garbage, or a plain single-lane
- * provider cursor handed to a record that has since grown a second lane
- * (rare; degrades to "start over" rather than throwing).
+ * well-formed `{ v: 1, lanes: { [id]: string }, after?: string }` — garbage,
+ * a plain single-lane provider cursor handed to a record that has since
+ * grown a second lane, or a crafted cursor with a non-string `lanes` value
+ * (rejected rather than reaching `decodeLaneResumeState` with the wrong
+ * type). Degrades to "start over" rather than throwing either way.
  */
 export function decodeLaneCursor(raw: string | undefined): LaneCursorMap | null {
   if (!raw) return null;
   try {
-    const parsed: unknown = JSON.parse(fromBase64Url(raw));
-    if (
-      parsed !== null &&
-      typeof parsed === "object" &&
-      (parsed as { v?: unknown }).v === 1 &&
-      typeof (parsed as { lanes?: unknown }).lanes === "object" &&
-      (parsed as { lanes?: unknown }).lanes !== null
-    ) {
-      return parsed as LaneCursorMap;
-    }
-    return null;
+    const json = new TextDecoder().decode(b64urlDecode(raw));
+    const parsed: unknown = JSON.parse(json);
+    return isLaneCursorMap(parsed) ? parsed : null;
   } catch {
     return null;
   }
 }
 
-/** One lane's page of already ascending-key-sorted items, tagged with merge priority (lower `laneOrder` wins ties — the active lane is always 0). */
+/** Sentinel `LaneCursorMap` lane value: this lane will never produce another item — never re-fetched, and never mistaken for "hasn't started yet" (which is what an *absent* entry meant in an earlier, buggier version of this cursor — see the regression test in list-page-url.test.ts). */
+export const LANE_DONE = "done";
+
+/** Packs a lane's next-fetch provider cursor into its `LaneCursorMap` value. `undefined` (start of listing) encodes as `""`. */
+export function encodeLaneResumeState(cursor: string | undefined): string {
+  return cursor ?? "";
+}
+
+/** Unpacks a lane's `LaneCursorMap` value. Anything that isn't `LANE_DONE` is a provider cursor (empty string decodes to `undefined` — start of listing). */
+export function decodeLaneResumeState(raw: string | undefined): {
+  cursor: string | undefined;
+  done: boolean;
+} {
+  if (raw === LANE_DONE) return { cursor: undefined, done: true };
+  return { cursor: raw ? raw : undefined, done: false };
+}
+
+/** One lane's page of already ascending-key-sorted items. Pages must be pre-ordered by merge priority — index 0 wins a duplicate key over index 1, etc. (the active lane goes first, matching write-lane reality). */
 export interface LanePage<T extends { key: string }> {
-  laneOrder: number;
   items: T[];
 }
 
@@ -73,28 +91,26 @@ export interface MergeResult<T> {
 }
 
 /**
- * k-way merge by ascending key across `pages`. On a duplicate key, keeps the
- * entry from the lowest `laneOrder` (the active lane wins over fallbacks,
- * matching write-lane reality — spec: "Listing: merged fan-out") and
- * discards the rest. Stable within a lane. Stops once `limit` items have
- * been emitted (or every page is exhausted), which is what lets a caller
- * trim a fan-out page to a fixed size while still knowing exactly how far to
+ * k-way merge by ascending key across `pages`, indexed by priority (index 0
+ * wins a duplicate key — spec: "Listing: merged fan-out", active lane wins
+ * over fallbacks). Stable within a page. Stops once `limit` items have been
+ * emitted (or every page is exhausted), which is what lets a caller trim a
+ * fan-out page to a fixed size while still knowing exactly how far to
  * advance each lane's cursor for the next page.
  */
 export function mergeBounded<T extends { key: string }>(
   pages: Array<LanePage<T>>,
   limit: number,
 ): MergeResult<T> {
-  const byLaneOrder = [...pages].sort((a, b) => a.laneOrder - b.laneOrder);
-  const pointers = byLaneOrder.map(() => 0);
-  const consumedSorted = byLaneOrder.map(() => 0);
+  const pointers = pages.map(() => 0);
+  const consumed = pages.map(() => 0);
   const items: T[] = [];
 
   while (items.length < limit) {
     let winner = -1;
     let winnerKey: string | undefined;
-    for (let i = 0; i < byLaneOrder.length; i++) {
-      const page = byLaneOrder[i];
+    for (let i = 0; i < pages.length; i++) {
+      const page = pages[i];
       if (pointers[i] >= page.items.length) continue;
       const key = page.items[pointers[i]].key;
       if (winnerKey === undefined || key < winnerKey) {
@@ -103,33 +119,18 @@ export function mergeBounded<T extends { key: string }>(
       }
     }
     if (winner === -1) break;
-    items.push(byLaneOrder[winner].items[pointers[winner]]);
+    items.push(pages[winner].items[pointers[winner]]);
     // Advance every page currently pointing at the winning key — the winner
     // itself, and any lower-priority duplicates, which are discarded here
     // rather than ever being emitted.
-    for (let i = 0; i < byLaneOrder.length; i++) {
-      const page = byLaneOrder[i];
+    for (let i = 0; i < pages.length; i++) {
+      const page = pages[i];
       if (pointers[i] < page.items.length && page.items[pointers[i]].key === winnerKey) {
         pointers[i]++;
-        consumedSorted[i]++;
+        consumed[i]++;
       }
     }
   }
 
-  const consumed = pages.map(() => 0);
-  byLaneOrder.forEach((page, sortedIndex) => {
-    const originalIndex = pages.indexOf(page);
-    consumed[originalIndex] = consumedSorted[sortedIndex];
-  });
   return { items, consumed };
-}
-
-/**
- * Merge multiple lane pages into one ascending-key sequence with the same
- * duplicate-resolution rule as `listObjects`'s fan-out (`mergeBounded`), with
- * no trim. The pure, easy-to-unit-test form; `listObjects` itself uses
- * `mergeBounded` directly so it can also track per-lane cursor advancement.
- */
-export function mergeLaneListings<T extends { key: string }>(pages: Array<LanePage<T>>): T[] {
-  return mergeBounded(pages, Number.POSITIVE_INFINITY).items;
 }

--- a/apps/api/src/lane-list.ts
+++ b/apps/api/src/lane-list.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure helpers for the two-lane merged listing (PR C, Task C4): the
+ * composite cursor codec and the k-way merge across lane pages. See
+ * docs/superpowers/specs/2026-08-22-two-lane-storage-design.md, "Listing:
+ * merged fan-out". Single-lane records never touch this module —
+ * `listObjects` (files-core.ts) short-circuits straight to today's raw
+ * provider-cursor path, so an in-flight single-lane cursor never gets
+ * reinterpreted as a composite one.
+ */
+
+/** Per-lane pagination state: lane id (`"active"` for the active/null lane) → an opaque per-lane cursor string (format owned by the caller — see `listObjects`'s skip-and-resume packing). */
+export interface LaneCursorMap {
+  v: 1;
+  lanes: Record<string, string>;
+}
+
+function toBase64Url(json: string): string {
+  const bytes = new TextEncoder().encode(json);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(raw: string): string {
+  const base64 = raw.replace(/-/g, "+").replace(/_/g, "/");
+  const padLength = (4 - (base64.length % 4)) % 4;
+  const binary = atob(base64 + "=".repeat(padLength));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+/** base64url(JSON) of a `LaneCursorMap` — the composite cursor a multi-lane listing hands back. */
+export function encodeLaneCursor(map: LaneCursorMap): string {
+  return toBase64Url(JSON.stringify(map));
+}
+
+/**
+ * Decodes a composite cursor. Returns `null` on anything that isn't a
+ * well-formed `{ v: 1, lanes: {...} }` — garbage, or a plain single-lane
+ * provider cursor handed to a record that has since grown a second lane
+ * (rare; degrades to "start over" rather than throwing).
+ */
+export function decodeLaneCursor(raw: string | undefined): LaneCursorMap | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(fromBase64Url(raw));
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      (parsed as { v?: unknown }).v === 1 &&
+      typeof (parsed as { lanes?: unknown }).lanes === "object" &&
+      (parsed as { lanes?: unknown }).lanes !== null
+    ) {
+      return parsed as LaneCursorMap;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** One lane's page of already ascending-key-sorted items, tagged with merge priority (lower `laneOrder` wins ties — the active lane is always 0). */
+export interface LanePage<T extends { key: string }> {
+  laneOrder: number;
+  items: T[];
+}
+
+/** Result of a bounded k-way merge: the merged page, plus how many raw entries were scanned (emitted, or discarded as a lower-priority duplicate) from each input page — parallel to the `pages` argument, so a caller can advance each lane's own pagination state by exactly that many items. */
+export interface MergeResult<T> {
+  items: T[];
+  consumed: number[];
+}
+
+/**
+ * k-way merge by ascending key across `pages`. On a duplicate key, keeps the
+ * entry from the lowest `laneOrder` (the active lane wins over fallbacks,
+ * matching write-lane reality — spec: "Listing: merged fan-out") and
+ * discards the rest. Stable within a lane. Stops once `limit` items have
+ * been emitted (or every page is exhausted), which is what lets a caller
+ * trim a fan-out page to a fixed size while still knowing exactly how far to
+ * advance each lane's cursor for the next page.
+ */
+export function mergeBounded<T extends { key: string }>(
+  pages: Array<LanePage<T>>,
+  limit: number,
+): MergeResult<T> {
+  const byLaneOrder = [...pages].sort((a, b) => a.laneOrder - b.laneOrder);
+  const pointers = byLaneOrder.map(() => 0);
+  const consumedSorted = byLaneOrder.map(() => 0);
+  const items: T[] = [];
+
+  while (items.length < limit) {
+    let winner = -1;
+    let winnerKey: string | undefined;
+    for (let i = 0; i < byLaneOrder.length; i++) {
+      const page = byLaneOrder[i];
+      if (pointers[i] >= page.items.length) continue;
+      const key = page.items[pointers[i]].key;
+      if (winnerKey === undefined || key < winnerKey) {
+        winnerKey = key;
+        winner = i;
+      }
+    }
+    if (winner === -1) break;
+    items.push(byLaneOrder[winner].items[pointers[winner]]);
+    // Advance every page currently pointing at the winning key — the winner
+    // itself, and any lower-priority duplicates, which are discarded here
+    // rather than ever being emitted.
+    for (let i = 0; i < byLaneOrder.length; i++) {
+      const page = byLaneOrder[i];
+      if (pointers[i] < page.items.length && page.items[pointers[i]].key === winnerKey) {
+        pointers[i]++;
+        consumedSorted[i]++;
+      }
+    }
+  }
+
+  const consumed = pages.map(() => 0);
+  byLaneOrder.forEach((page, sortedIndex) => {
+    const originalIndex = pages.indexOf(page);
+    consumed[originalIndex] = consumedSorted[sortedIndex];
+  });
+  return { items, consumed };
+}
+
+/**
+ * Merge multiple lane pages into one ascending-key sequence with the same
+ * duplicate-resolution rule as `listObjects`'s fan-out (`mergeBounded`), with
+ * no trim. The pure, easy-to-unit-test form; `listObjects` itself uses
+ * `mergeBounded` directly so it can also track per-lane cursor advancement.
+ */
+export function mergeLaneListings<T extends { key: string }>(pages: Array<LanePage<T>>): T[] {
+  return mergeBounded(pages, Number.POSITIVE_INFINITY).items;
+}

--- a/apps/api/src/reconcile.ts
+++ b/apps/api/src/reconcile.ts
@@ -9,6 +9,7 @@
  * The in-memory `files-sdk/usage` plugin is not used: it does not survive
  * across Worker isolates and does not track net storage after deletes.
  */
+import { ConflictError } from "@uploads/errors";
 import { storage } from "./storage";
 import { getWorkspaceUsage, setUsageTotals, type WorkspaceUsage } from "./usage";
 import { isUnprefixedDedicatedBucket, type WorkspaceRecord } from "./workspace";
@@ -41,13 +42,25 @@ export async function reconcileWorkspaceUsage(
   workspaceName: string,
   now = new Date(),
 ): Promise<ReconcileResult> {
-  const previous = await getWorkspaceUsage(env.DB, workspaceName, now);
   // PR D: walks the active lane only. Two-lane storage (PR C) means a
   // workspace can also have fallback lanes holding objects, which this scan
   // does not see — reconcile stays active-lane-only until PR D's
   // `shared_bytes` ledger work makes it lane-aware (spec: "Usage / budget
-  // attribution"). Not a regression: this function's only caller today is
-  // on-demand, single-workspace, and always was active-lane-only.
+  // attribution"). A fallback lane (`lastActiveAt` set — it may hold
+  // objects) is refused outright rather than silently ignored: walking only
+  // the active lane would zero out the fallback lane's bytes/objects from
+  // the ledger, and a later delete against that lane would then debit an
+  // already-zeroed total (CodeRabbit review, PR #771). A standby lane (no
+  // `lastActiveAt` — pure saved config, never a read source) doesn't trigger
+  // this, since reconcile genuinely has nothing to miss there.
+  if ((ws.storageLanes ?? []).some((lane) => lane.lastActiveAt)) {
+    throw new ConflictError(
+      "storage reconcile is not yet lane-aware for a workspace with a fallback storage lane",
+      { code: "reconcile_multi_lane_unsupported" },
+    );
+  }
+
+  const previous = await getWorkspaceUsage(env.DB, workspaceName, now);
   const store = await storage(env, ws);
   const unprefixedBucket = isUnprefixedDedicatedBucket(ws);
   if (unprefixedBucket) {

--- a/apps/api/src/reconcile.ts
+++ b/apps/api/src/reconcile.ts
@@ -42,6 +42,12 @@ export async function reconcileWorkspaceUsage(
   now = new Date(),
 ): Promise<ReconcileResult> {
   const previous = await getWorkspaceUsage(env.DB, workspaceName, now);
+  // PR D: walks the active lane only. Two-lane storage (PR C) means a
+  // workspace can also have fallback lanes holding objects, which this scan
+  // does not see — reconcile stays active-lane-only until PR D's
+  // `shared_bytes` ledger work makes it lane-aware (spec: "Usage / budget
+  // attribution"). Not a regression: this function's only caller today is
+  // on-demand, single-workspace, and always was active-lane-only.
   const store = await storage(env, ws);
   const unprefixedBucket = isUnprefixedDedicatedBucket(ws);
   if (unprefixedBucket) {

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -15,7 +15,7 @@ import {
 import { getFileMetadata, META_MAX_KEYS, setFileMetadata } from "../file-metadata";
 import { checkDeclaredLength, maxBytesForContentType, resolveUploadPolicy } from "../guards";
 import { splitUploadMetaHeaders } from "../provenance";
-import { objectPublicUrls, storage, storageConfig } from "../storage";
+import { objectPublicUrls, resolveObjectLane, storage, storageConfig } from "../storage";
 import { hasGithubTags, uploaderTags } from "../uploader-identity";
 import { sanitizeVisibility } from "../visibility";
 import type { WorkspaceVars } from "../workspace";
@@ -97,10 +97,12 @@ export async function signFileHandler(c: Context<WorkspaceVars>) {
     // hot-swap exemption, but it is NOT a security boundary: a signed URL
     // for a free key can still land on an object created after signing.
     // Treat this as UX guardrail parity with PUT, not a guarantee.
-    const replaced = await store.exists(key);
-    if (replaced && !body.replace && !isManagedGithubKey(key)) {
-      const cfg = await storageConfig(c.env, ws);
-      const urls = objectPublicUrls(c.env, cfg, key);
+    // Two-lane storage: an existing object may live in a fallback lane rather
+    // than the active one this presign will write to — the conflict check
+    // (and the URL it reports) must still find it there.
+    const existingLane = await resolveObjectLane(c.env, ws, key);
+    if (existingLane && !body.replace && !isManagedGithubKey(key)) {
+      const urls = objectPublicUrls(c.env, existingLane.config, key);
       throw new ConflictError(
         `An object already exists at "${key}". Pass replace: true to sign an overwrite.`,
         { code: "key_exists", details: { key, url: urls.url, embedUrl: urls.embedUrl } },
@@ -154,10 +156,14 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
   if (dryRun === "1" || dryRun === "true") {
     const ws = c.get("workspace");
     const finalKey = finalizeUploadKey(key, ws);
-    const store = await storage(c.env, ws);
-    const replaced = await store.exists(finalKey);
+    // Two-lane storage: preview against whichever lane actually holds the
+    // key today (a fallback-only key still counts as "would overwrite").
+    const existingLane = await resolveObjectLane(c.env, ws, finalKey);
+    const replaced = existingLane !== null;
     const wouldRefuse = replaced && !wantReplace && !isManagedGithubKey(finalKey);
-    const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), finalKey);
+    const urls = existingLane
+      ? objectPublicUrls(c.env, existingLane.config, finalKey)
+      : objectPublicUrls(c.env, await storageConfig(c.env, ws), finalKey);
     return c.json({
       workspace: c.get("workspaceName"),
       key: finalKey,
@@ -215,8 +221,10 @@ export async function getFileHandler(c: Context<WorkspaceVars>) {
   const key = c.req.param("key")!;
   if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
   const ws = c.get("workspace");
-  const store = await storage(c.env, ws);
-  if (!(await store.exists(key))) throw new NotFoundError();
+  // Two-lane storage: a key uploaded before a storage switch still resolves,
+  // from whichever lane actually holds it.
+  const lane = await resolveObjectLane(c.env, ws, key);
+  if (!lane) throw new NotFoundError();
 
   const metadataParam = c.req.query("metadata");
   if (metadataParam === "1" || metadataParam === "true") {
@@ -224,8 +232,8 @@ export async function getFileHandler(c: Context<WorkspaceVars>) {
     return c.json({ metadata });
   }
 
-  const meta = await store.head(key);
-  const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), key);
+  const meta = await lane.store.head(key);
+  const urls = objectPublicUrls(c.env, lane.config, key);
   return c.json(headObjectJson(key, meta, urls.url, urls.embedUrl));
 }
 

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -15,7 +15,7 @@ import {
 import { getFileMetadata, META_MAX_KEYS, setFileMetadata } from "../file-metadata";
 import { checkDeclaredLength, maxBytesForContentType, resolveUploadPolicy } from "../guards";
 import { splitUploadMetaHeaders } from "../provenance";
-import { objectPublicUrls, resolveObjectLane, storage, storageConfig } from "../storage";
+import { createLaneResolver, objectPublicUrls, resolveObjectLane, storage } from "../storage";
 import { hasGithubTags, uploaderTags } from "../uploader-identity";
 import { sanitizeVisibility } from "../visibility";
 import type { WorkspaceVars } from "../workspace";
@@ -84,7 +84,17 @@ export async function signFileHandler(c: Context<WorkspaceVars>) {
       : 3600;
 
   try {
-    const store = await storage(c.env, ws);
+    // Two-lane storage: an existing object may live in a fallback lane
+    // rather than the active one this presign will write to — the conflict
+    // check (and the URL it reports) must still find it there. `resolver`
+    // caches the active lane's store/config, so the conflict-check walk and
+    // the trailing URL derivation below resolve the active lane exactly
+    // once between them, not once each.
+    const resolver = createLaneResolver(c.env, ws);
+    const [store, existingLane] = await Promise.all([
+      resolver.activeStore(),
+      resolver.resolve(key),
+    ]);
 
     // Strict-overwrite gate (issue #174), best-effort here: /sign mints a
     // presigned URL for a direct-to-bucket PUT that happens later (up to
@@ -97,10 +107,6 @@ export async function signFileHandler(c: Context<WorkspaceVars>) {
     // hot-swap exemption, but it is NOT a security boundary: a signed URL
     // for a free key can still land on an object created after signing.
     // Treat this as UX guardrail parity with PUT, not a guarantee.
-    // Two-lane storage: an existing object may live in a fallback lane rather
-    // than the active one this presign will write to — the conflict check
-    // (and the URL it reports) must still find it there.
-    const existingLane = await resolveObjectLane(c.env, ws, key);
     if (existingLane && !body.replace && !isManagedGithubKey(key)) {
       const urls = objectPublicUrls(c.env, existingLane.config, key);
       throw new ConflictError(
@@ -114,7 +120,7 @@ export async function signFileHandler(c: Context<WorkspaceVars>) {
       contentType,
       maxSize,
     });
-    const cfg = await storageConfig(c.env, ws);
+    const cfg = await resolver.activeConfig();
     const urls = objectPublicUrls(c.env, cfg, key);
     return c.json({
       workspace: c.get("workspaceName"),
@@ -158,12 +164,16 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
     const finalKey = finalizeUploadKey(key, ws);
     // Two-lane storage: preview against whichever lane actually holds the
     // key today (a fallback-only key still counts as "would overwrite").
-    const existingLane = await resolveObjectLane(c.env, ws, finalKey);
+    // `resolver` caches the active lane's config, so the not-found branch
+    // below reuses the same resolve `resolve()` already did internally,
+    // rather than a second `storageConfig` call.
+    const resolver = createLaneResolver(c.env, ws);
+    const existingLane = await resolver.resolve(finalKey);
     const replaced = existingLane !== null;
     const wouldRefuse = replaced && !wantReplace && !isManagedGithubKey(finalKey);
     const urls = existingLane
       ? objectPublicUrls(c.env, existingLane.config, finalKey)
-      : objectPublicUrls(c.env, await storageConfig(c.env, ws), finalKey);
+      : objectPublicUrls(c.env, await resolver.activeConfig(), finalKey);
     return c.json({
       workspace: c.get("workspaceName"),
       key: finalKey,

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -13,7 +13,7 @@ import { resolveTitles, withPublicTitleBudget } from "../github-titles";
 import { videoPresentation } from "../poster";
 import { objectPublicUrls, resolveObjectLane } from "../storage";
 import { objectVisibility } from "../visibility";
-import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
+import { loadWorkspaceRecord, type WorkspaceRecord, type WorkspaceVars } from "../workspace";
 import { requestOrigin } from "../well-known";
 
 type GithubKind = "pull" | "issue";
@@ -82,6 +82,8 @@ interface ResolvedPublicObject {
   urls: { url: string | null; embedUrl: string | null };
   env: Env;
   cfg: StorageConfig;
+  /** The workspace record, so a caller resolving a second key (e.g. a before/after counterpart) doesn't repeat the KV lookup. */
+  record: WorkspaceRecord;
 }
 
 /**
@@ -127,7 +129,7 @@ async function resolvePublicObject(
     throw new UnauthorizedError("sign in to view this file", { code: "auth_required" });
   }
 
-  return { store: lane.store, meta, urls, env, cfg: lane.config };
+  return { store: lane.store, meta, urls, env, cfg: lane.config, record };
 }
 
 /**
@@ -164,7 +166,7 @@ async function resolvePublicObject(
 export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}", async (c) => {
   const workspace = c.req.param("workspace");
   const key = c.req.param("key");
-  const { store, meta, urls, env, cfg } = await resolvePublicObject(c.env, workspace, key);
+  const { store, meta, urls, env, cfg, record } = await resolvePublicObject(c.env, workspace, key);
 
   const downloadParam = c.req.query("download");
   if (downloadParam === "1" || downloadParam === "true") {
@@ -191,21 +193,25 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
   // response. Skipping any of those would either leak the existence of a
   // private counterpart object, or hand the web page's static side-by-side
   // layout (issue #420 v1 renders both sides as an image element) a video
-  // or other non-image file it can't render that way.
+  // or other non-image file it can't render that way. Two-lane storage
+  // (CodeRabbit review, PR #771): the counterpart is resolved via its OWN
+  // lane, not the primary object's `store`/`cfg` — a before/after pair can
+  // straddle a storage switch just like any other pair of keys.
   let counterpart: { key: string; url: string; state: BeforeAfterState } | undefined;
   const ownContentType = meta.type ?? "application/octet-stream";
   const candidate = isPairableImageContentType(ownContentType)
     ? await findCounterpartCandidate(c.env.DB, workspace, key, metadata)
     : null;
   if (candidate && candidate.key !== key) {
-    if (await store.exists(candidate.key)) {
-      const counterpartMeta = await store.head(candidate.key);
+    const counterpartLane = await resolveObjectLane(env, record, candidate.key);
+    if (counterpartLane) {
+      const counterpartMeta = await counterpartLane.store.head(candidate.key);
       const counterpartType = counterpartMeta.type ?? "application/octet-stream";
       if (
         isPairableImageContentType(counterpartType) &&
         !objectVisibility(counterpartMeta.metadata ?? undefined)
       ) {
-        const counterpartUrls = objectPublicUrls(env, cfg, candidate.key);
+        const counterpartUrls = objectPublicUrls(env, counterpartLane.config, candidate.key);
         if (counterpartUrls.url) {
           counterpart = { key: candidate.key, url: counterpartUrls.url, state: candidate.state };
         }

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -1,6 +1,6 @@
 import { NotFoundError, UnauthorizedError } from "@uploads/errors";
 import { Hono } from "hono";
-import type { Files } from "@uploads/storage";
+import type { Files, StorageConfig } from "@uploads/storage";
 import {
   findCounterpartCandidate,
   isPairableImageContentType,
@@ -11,7 +11,7 @@ import { displayTitle, getFileMetadata, isServerMetaKey } from "../file-metadata
 import { githubAvatarProxyUrl, ownerFromRepo } from "../github-avatars";
 import { resolveTitles, withPublicTitleBudget } from "../github-titles";
 import { videoPresentation } from "../poster";
-import { objectPublicUrls, storage, storageConfig } from "../storage";
+import { objectPublicUrls, resolveObjectLane } from "../storage";
 import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
 import { requestOrigin } from "../well-known";
@@ -81,15 +81,22 @@ interface ResolvedPublicObject {
   meta: { size?: number; type?: string; lastModified?: number; metadata?: Record<string, string> };
   urls: { url: string | null; embedUrl: string | null };
   env: Env;
-  cfg: Awaited<ReturnType<typeof storageConfig>>;
+  cfg: StorageConfig;
 }
 
 /**
  * Shared lookup + visibility gate for the `/public/files/:workspace/:key*` GET
- * handler below: workspace record → publicUrl existence → store.exists/head →
+ * handler below: workspace record → lane resolution → publicUrl existence →
  * objectVisibility 401. Both the JSON-metadata response and the `?download=1`
  * streaming branch call this exact same gate (run once per request) so the
  * two can never disagree about who gets to see — or download — an object.
+ *
+ * Two-lane storage (spec: "Read path"): `resolveObjectLane` finds whichever
+ * lane actually holds the key — a file uploaded before a storage switch keeps
+ * resolving from its original lane — and the public URL is derived from that
+ * lane's config, not the workspace's current active lane. Single-lane records
+ * (no `storageLanes`) take the exact path this always has: one `exists` call
+ * against the active lane.
  */
 async function resolvePublicObject(
   env: Env,
@@ -103,22 +110,24 @@ async function resolvePublicObject(
   const record = await loadWorkspaceRecord(env, workspace);
   if (!record) throw new NotFoundError();
 
+  const lane = await resolveObjectLane(env, record, key);
+  if (!lane) throw new NotFoundError();
+
   // Phase 1 is public-workspace-only: resolving the public URL doubles as the
-  // visibility gate. A workspace without a public base URL cannot be wrapped
-  // here — that is #123's signed-URL territory, swapped in when it lands.
-  const cfg = await storageConfig(env, record);
-  const urls = objectPublicUrls(env, cfg, key);
+  // visibility gate. A lane without a public base URL cannot be wrapped here
+  // — that is #123's signed-URL territory, swapped in when it lands. Kept
+  // per-lane: a lane hit whose config lacks `publicBaseUrl` still 404s, even
+  // though a different lane on this same workspace might have one.
+  const urls = objectPublicUrls(env, lane.config, key);
   if (!urls.url) throw new NotFoundError();
 
-  const store = await storage(env, record);
-  if (!(await store.exists(key))) throw new NotFoundError();
-  const meta = await store.head(key);
+  const meta = await lane.store.head(key);
 
   if (objectVisibility(meta.metadata ?? undefined)) {
     throw new UnauthorizedError("sign in to view this file", { code: "auth_required" });
   }
 
-  return { store, meta, urls, env, cfg };
+  return { store: lane.store, meta, urls, env, cfg: lane.config };
 }
 
 /**

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -52,7 +52,7 @@ import {
 import { writeRateLimit } from "../guards";
 import { memberWorkspaceOr404 } from "../org-workspaces";
 import type { SessionVars } from "../session-auth";
-import { objectPublicUrls, publicUrl, storage, storageConfig } from "../storage";
+import { objectPublicUrls, publicUrl, resolveObjectLane, storage, storageConfig } from "../storage";
 import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
 import { loadWorkspaceRecord, requireScope } from "../workspace";
 import {
@@ -271,18 +271,22 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // when the workspace has one; otherwise a short-lived signed download URL
   // when the provider can sign; otherwise a typed error rather than a 200
   // with `url: null`.
+  //
+  // Two-lane storage: resolves across lanes so a fallback-only key (uploaded
+  // before a storage switch) still gets a usable URL — the public URL, or the
+  // signed URL, is minted against the lane that actually holds the object,
+  // not the workspace's current active lane.
   .get("/:workspace/files/file-url", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
     const record = c.get("workspace");
     const key = c.req.query("key") ?? "";
     if (badKey(key)) throw new NotFoundError();
-    const store = await storage(c.env, record);
-    if (!(await store.exists(key))) throw new NotFoundError();
+    const lane = await resolveObjectLane(c.env, record, key);
+    if (!lane) throw new NotFoundError();
 
-    const cfg = await storageConfig(c.env, record);
-    const url = publicUrl(cfg, key);
+    const url = publicUrl(lane.config, key);
     if (url) return c.json({ url });
 
-    const signed = await signedDownloadUrl(store, key);
+    const signed = await signedDownloadUrl(lane.store, key);
     if (signed) return c.json({ url: signed });
 
     throw new ValidationError(

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -159,39 +159,98 @@ export interface ResolvedLane extends LaneConfig {
 }
 
 /**
- * Walk lanes in order (active, then fallbacks) — first `store.exists(key)`
- * hit wins. Returns `null` when the key exists in no lane. Resolves lazily:
- * a fallback lane's config (and its credential decrypt) is only resolved
- * once every earlier lane has missed, so the common case — the active lane
- * has the key — never touches fallback credentials at all. Single-lane
- * records short-circuit to the current behavior: exactly one `exists` call.
+ * Resolves and caches each lane's store/config at most once per resolver
+ * instance — a batch of `resolve()` calls against many keys (gallery
+ * hydration, comment poster URLs, …) shares one active-lane resolve and one
+ * resolve per *distinct* fallback lane actually needed, instead of
+ * re-decrypting the same lane's credentials on every call. `resolveObjectLane`
+ * below is exactly `createLaneResolver(env, ws).resolve(key)` for a single
+ * lookup — both share this same lazy, cached machinery.
  */
+export interface LaneResolver {
+  /**
+   * Walk lanes in order (active, then fallbacks) — first `store.exists(key)`
+   * hit wins. Returns `null` when the key exists in no lane. Resolves
+   * lazily: a fallback lane's config (and its credential decrypt) is only
+   * resolved once some earlier call has missed every lane before it, so the
+   * common case — the active lane has the key — never touches fallback
+   * credentials at all. Single-lane records short-circuit to exactly one
+   * `exists` call.
+   */
+  resolve(key: string): Promise<ResolvedLane | null>;
+  /** The active lane's store, resolved (and cached) the same way `resolve` would — for a caller that already knows it's writing to (or otherwise doesn't need to search past) the active lane. */
+  activeStore(): Promise<Files>;
+  /** The active lane's config, resolved (and cached) the same way `resolve` would. */
+  activeConfig(): Promise<StorageConfig>;
+}
+
+export function createLaneResolver(env: Env, ws: WorkspaceRecord): LaneResolver {
+  let activePromise: Promise<{ store: Files; config: StorageConfig }> | undefined;
+  const active = () => {
+    activePromise ??= (async () => {
+      const config = await storageConfig(env, ws);
+      return { store: createStorage(config), config };
+    })();
+    return activePromise;
+  };
+
+  const fallbackPromises = new Map<
+    string,
+    Promise<{ store: Files; config: StorageConfig } | null>
+  >();
+  const fallback = (lane: StorageLane) => {
+    let promise = fallbackPromises.get(lane.id);
+    if (!promise) {
+      promise = (async () => {
+        const config = await resolveFallbackLane(env, lane);
+        return config ? { store: createStorage(config), config } : null;
+      })();
+      fallbackPromises.set(lane.id, promise);
+    }
+    return promise;
+  };
+
+  return {
+    async activeStore() {
+      return (await active()).store;
+    },
+    async activeConfig() {
+      return (await active()).config;
+    },
+    async resolve(key) {
+      const { store: activeStore, config: activeConfig } = await active();
+      if (await activeStore.exists(key)) {
+        return {
+          store: activeStore,
+          config: activeConfig,
+          laneId: ws.storageLaneId ?? null,
+          role: "active",
+        };
+      }
+      for (const lane of ws.storageLanes ?? []) {
+        const resolved = await fallback(lane);
+        if (!resolved) continue;
+        if (await resolved.store.exists(key)) {
+          return {
+            store: resolved.store,
+            config: resolved.config,
+            laneId: lane.id,
+            role: "fallback",
+          };
+        }
+      }
+      return null;
+    },
+  };
+}
+
+/** Single-lookup convenience wrapper over `createLaneResolver` — see its docs for the lazy/cached resolution contract. A caller resolving several keys against the same `ws` should build one resolver and call `.resolve()` on it directly instead. */
 export async function resolveObjectLane(
   env: Env,
   ws: WorkspaceRecord,
   key: string,
 ): Promise<ResolvedLane | null> {
-  const activeConfig = await storageConfig(env, ws);
-  const activeStore = createStorage(activeConfig);
-  if (await activeStore.exists(key)) {
-    return {
-      store: activeStore,
-      config: activeConfig,
-      laneId: ws.storageLaneId ?? null,
-      role: "active",
-    };
-  }
-
-  for (const lane of ws.storageLanes ?? []) {
-    const config = await resolveFallbackLane(env, lane);
-    if (!config) continue;
-    const store = createStorage(config);
-    if (await store.exists(key)) {
-      return { store, config, laneId: lane.id, role: "fallback" };
-    }
-  }
-
-  return null;
+  return createLaneResolver(env, ws).resolve(key);
 }
 
 export { publicUrl };

--- a/apps/api/test/fake-r2.ts
+++ b/apps/api/test/fake-r2.ts
@@ -110,7 +110,7 @@ export class FakeR2Bucket {
     for (const k of Array.isArray(keys) ? keys : [keys]) this.store.delete(k);
   }
 
-  async list(opts?: { prefix?: string; delimiter?: string }) {
+  async list(opts?: { prefix?: string; delimiter?: string; limit?: number; cursor?: string }) {
     this.listCalls++;
     const prefix = opts?.prefix ?? "";
     // oxlint-disable-next-line unicorn/no-array-sort -- mirror R2's ordered listing in an ES2022 test fake
@@ -125,9 +125,19 @@ export class FakeR2Bucket {
           return false;
         })
       : keys;
+    // `cursor` is just the index to resume from in this fake — opaque to
+    // callers, stable only within one `list()` call chain, matching the only
+    // contract R2's real (opaque) cursor promises.
+    const start = opts?.cursor ? Number(opts.cursor) || 0 : 0;
+    const page =
+      opts?.limit !== undefined
+        ? objectKeys.slice(start, start + opts.limit)
+        : objectKeys.slice(start);
+    const truncated = opts?.limit !== undefined && start + opts.limit < objectKeys.length;
     return {
-      objects: objectKeys.map((k) => this.meta(k, this.store.get(k)!)),
-      truncated: false as const,
+      objects: page.map((k) => this.meta(k, this.store.get(k)!)),
+      truncated,
+      cursor: truncated ? String(start + opts!.limit!) : undefined,
       delimitedPrefixes: [...delimitedPrefixes],
     };
   }

--- a/apps/api/test/files-core-delete-lanes.test.ts
+++ b/apps/api/test/files-core-delete-lanes.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Task C3 (two-lane storage, PR C): `deleteObject` deletes a key from every
+ * lane that holds it, not just the active one — after a detach/re-attach
+ * cycle a key can exist in more than one lane, and every copy must go so the
+ * file actually disappears. See
+ * docs/superpowers/specs/2026-08-22-two-lane-storage-design.md, "Read path".
+ */
+import { describe, expect, it } from "vitest";
+import { FakeR2Bucket } from "./fake-r2";
+import { deleteObject, putObject } from "../src/files-core";
+import { makePosterEnv, PNG, WORKSPACE } from "./poster-fixtures";
+import type { StorageLane, WorkspaceRecord } from "../src/workspace";
+
+const FALLBACK_LANE: StorageLane = {
+  id: "lane_fallback1",
+  provider: "r2",
+  bucket: "customer-bucket",
+  binding: "UPLOADS_FALLBACK",
+  lastActiveAt: "2026-08-01T00:00:00.000Z",
+  publicBaseUrl: "https://storage.customer.example.com",
+};
+
+describe("deleteObject across storage lanes", () => {
+  it("deletes a key present in both the active and fallback lanes", async () => {
+    const { env, bucket, db, ws } = makePosterEnv();
+    const fallback = new FakeR2Bucket();
+    (env as unknown as Record<string, FakeR2Bucket>).UPLOADS_FALLBACK = fallback;
+    // No `prefix` on FALLBACK_LANE, unlike the active lane's "default/" —
+    // raw fallback keys are unprefixed.
+    await fallback.put("screenshots/shot.png", PNG);
+
+    const wsWithLanes: WorkspaceRecord = { ...ws, storageLanes: [FALLBACK_LANE] };
+    await putObject(env, wsWithLanes, "screenshots/shot.png", PNG, WORKSPACE);
+    expect(bucket.store.has("default/screenshots/shot.png")).toBe(true);
+    expect(fallback.store.has("screenshots/shot.png")).toBe(true);
+
+    await deleteObject(env, wsWithLanes, "screenshots/shot.png", WORKSPACE);
+    expect(bucket.store.has("default/screenshots/shot.png")).toBe(false);
+    expect(fallback.store.has("screenshots/shot.png")).toBe(false);
+    // Ledger counted the object once (active-lane hit, active-first order).
+    expect(db.usage.get(WORKSPACE)).toMatchObject({ bytes: 0, objects: 0 });
+  });
+
+  it("deletes a key present only in the fallback lane (no 404, active lane untouched)", async () => {
+    const { env, bucket, ws } = makePosterEnv();
+    const fallback = new FakeR2Bucket();
+    (env as unknown as Record<string, FakeR2Bucket>).UPLOADS_FALLBACK = fallback;
+    await fallback.put("legacy/only-fallback.png", PNG);
+
+    const wsWithLanes: WorkspaceRecord = { ...ws, storageLanes: [FALLBACK_LANE] };
+    await expect(
+      deleteObject(env, wsWithLanes, "legacy/only-fallback.png", WORKSPACE),
+    ).resolves.toEqual({ key: "legacy/only-fallback.png", deleted: true });
+    expect(fallback.store.has("legacy/only-fallback.png")).toBe(false);
+    expect(bucket.store.size).toBe(0);
+  });
+
+  it("single-lane record deletes exactly as before (control)", async () => {
+    const { env, bucket, db, ws } = makePosterEnv();
+    const put = await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+    await deleteObject(env, ws, put.key, WORKSPACE);
+    expect(bucket.store.has(`default/${put.key}`)).toBe(false);
+    expect(db.usage.get(WORKSPACE)).toMatchObject({ bytes: 0, objects: 0 });
+  });
+});

--- a/apps/api/test/gallery-service-lanes.test.ts
+++ b/apps/api/test/gallery-service-lanes.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Task C4 audit (two-lane storage, PR C): `hydrateGalleryItems`
+ * (gallery-service.ts) resolves pre-existing keys, so it's converted to
+ * per-item lane resolution — a gallery can reference objects uploaded
+ * before a storage switch. See the PR C body's per-site audit table.
+ */
+import { describe, expect, it } from "vitest";
+import { FakeR2Bucket } from "./fake-r2";
+import { hydrateGalleryItems } from "../src/gallery-service";
+import type { GalleryItemRecord } from "../src/galleries";
+import type { StorageLane, WorkspaceRecord } from "../src/workspace";
+
+function item(overrides: Partial<GalleryItemRecord> = {}): GalleryItemRecord {
+  return {
+    id: "item-1",
+    gallery_id: "gal-1",
+    object_key: "shots/a.png",
+    position: 0,
+    caption: null,
+    alt_text: null,
+    created_at: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const FALLBACK_LANE: StorageLane = {
+  id: "lane_fallback1",
+  provider: "r2",
+  bucket: "customer-bucket",
+  binding: "UPLOADS_FALLBACK",
+  lastActiveAt: "2026-08-01T00:00:00.000Z",
+  publicBaseUrl: "https://storage.customer.example.com",
+};
+
+describe("hydrateGalleryItems across storage lanes", () => {
+  it("resolves a fallback-only item to that lane's public URL", async () => {
+    const active = new FakeR2Bucket();
+    const fallback = new FakeR2Bucket();
+    await fallback.put("shots/a.png", new Uint8Array([1, 2, 3]));
+    const env = {
+      UPLOADS_DEFAULT: active,
+      UPLOADS_FALLBACK: fallback,
+      DB: { prepare: () => ({ bind: () => ({ all: async () => ({ results: [] }) }) }) },
+    } as unknown as Env;
+    const workspace: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "uploads-default",
+      binding: "UPLOADS_DEFAULT",
+      publicBaseUrl: "https://storage.uploads.sh",
+      storageLaneId: "lane_active1",
+      storageLanes: [FALLBACK_LANE],
+    };
+
+    const [dto] = await hydrateGalleryItems(env, workspace, [item()]);
+    expect(dto.status).toBe("available");
+    expect(dto.url).toBe("https://storage.customer.example.com/shots/a.png");
+  });
+
+  it("single-lane record behaves as today (control)", async () => {
+    const active = new FakeR2Bucket();
+    await active.put("shots/a.png", new Uint8Array([1, 2, 3]));
+    const env = {
+      UPLOADS_DEFAULT: active,
+      DB: { prepare: () => ({ bind: () => ({ all: async () => ({ results: [] }) }) }) },
+    } as unknown as Env;
+    const workspace: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "uploads-default",
+      binding: "UPLOADS_DEFAULT",
+      publicBaseUrl: "https://storage.uploads.sh",
+    };
+
+    const [dto] = await hydrateGalleryItems(env, workspace, [item()]);
+    expect(dto.status).toBe("available");
+    expect(dto.url).toBe("https://storage.uploads.sh/shots/a.png");
+  });
+
+  it("reports a key present in neither lane as missing", async () => {
+    const active = new FakeR2Bucket();
+    const fallback = new FakeR2Bucket();
+    const env = {
+      UPLOADS_DEFAULT: active,
+      UPLOADS_FALLBACK: fallback,
+      DB: { prepare: () => ({ bind: () => ({ all: async () => ({ results: [] }) }) }) },
+    } as unknown as Env;
+    const workspace: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "uploads-default",
+      binding: "UPLOADS_DEFAULT",
+      publicBaseUrl: "https://storage.uploads.sh",
+      storageLanes: [FALLBACK_LANE],
+    };
+
+    const [dto] = await hydrateGalleryItems(env, workspace, [item()]);
+    expect(dto.status).toBe("missing");
+  });
+});

--- a/apps/api/test/gallery-service-lanes.test.ts
+++ b/apps/api/test/gallery-service-lanes.test.ts
@@ -6,9 +6,12 @@
  */
 import { describe, expect, it } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
-import { hydrateGalleryItems } from "../src/gallery-service";
-import type { GalleryItemRecord } from "../src/galleries";
+import { database, SqliteD1 } from "./helpers/sqlite-d1";
+import { galleryListSummaries, hydrateGalleryItems } from "../src/gallery-service";
+import { addGalleryItem, createGallery, type GalleryItemRecord } from "../src/galleries";
 import type { StorageLane, WorkspaceRecord } from "../src/workspace";
+
+const GALLERIES_MIGRATION = ["migrations/20260711180000_galleries.sql"];
 
 function item(overrides: Partial<GalleryItemRecord> = {}): GalleryItemRecord {
   return {
@@ -93,5 +96,81 @@ describe("hydrateGalleryItems across storage lanes", () => {
 
     const [dto] = await hydrateGalleryItems(env, workspace, [item()]);
     expect(dto.status).toBe("missing");
+  });
+});
+
+// Task 9 (simplify follow-up on PR #771): galleryListSummaries' cover
+// preview must also resolve across lanes — previously it derived the
+// preview URL from the active lane's config unconditionally, which was
+// wrong (or 404s) for a cover uploaded before a storage switch.
+describe("galleryListSummaries across storage lanes", () => {
+  it("resolves a fallback-only cover to that lane's public URL", async () => {
+    const sqlite = new SqliteD1(GALLERIES_MIGRATION);
+    const db = database(sqlite);
+    const created = await createGallery(db, { workspace: "acme", title: "Shots" });
+    if (created.status !== "ok") throw new Error("gallery create failed");
+    const added = await addGalleryItem(db, "acme", created.value.id, {
+      expectedVersion: created.value.version,
+      objectKey: "shots/cover.png",
+    });
+    if (added.status !== "ok" && added.status !== "unchanged") {
+      throw new Error("gallery item add failed");
+    }
+
+    const active = new FakeR2Bucket();
+    const fallback = new FakeR2Bucket();
+    await fallback.put("shots/cover.png", new Uint8Array([1]));
+    const env = {
+      UPLOADS_DEFAULT: active,
+      UPLOADS_FALLBACK: fallback,
+      DB: db,
+      WEB_ORIGIN: "https://uploads.sh",
+    } as unknown as Env;
+    const workspace: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "uploads-default",
+      binding: "UPLOADS_DEFAULT",
+      publicBaseUrl: "https://storage.uploads.sh",
+      name: "acme",
+      storageLaneId: "lane_active1",
+      storageLanes: [FALLBACK_LANE],
+    };
+
+    const [summary] = await galleryListSummaries(env, workspace, [created.value]);
+    expect(summary.previewUrl).toBe("https://storage.customer.example.com/shots/cover.png");
+  });
+
+  it("single-lane record behaves as today (control)", async () => {
+    const sqlite = new SqliteD1(GALLERIES_MIGRATION);
+    const db = database(sqlite);
+    const created = await createGallery(db, { workspace: "acme", title: "Shots" });
+    if (created.status !== "ok") throw new Error("gallery create failed");
+    const added = await addGalleryItem(db, "acme", created.value.id, {
+      expectedVersion: created.value.version,
+      objectKey: "shots/cover.png",
+    });
+    if (added.status !== "ok" && added.status !== "unchanged") {
+      throw new Error("gallery item add failed");
+    }
+
+    const active = new FakeR2Bucket();
+    await active.put("shots/cover.png", new Uint8Array([1]));
+    const env = {
+      UPLOADS_DEFAULT: active,
+      DB: db,
+      WEB_ORIGIN: "https://uploads.sh",
+    } as unknown as Env;
+    const workspace: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "uploads-default",
+      binding: "UPLOADS_DEFAULT",
+      publicBaseUrl: "https://storage.uploads.sh",
+      name: "acme",
+    };
+
+    const [summary] = await galleryListSummaries(env, workspace, [created.value]);
+    // previewUrlForKey prefers embedUrl — the shared lane's default embed
+    // twin — over the plain public URL.
+    expect(summary.previewUrl).toBe("https://embed.uploads.sh/shots/cover.png");
   });
 });

--- a/apps/api/test/lane-list.test.ts
+++ b/apps/api/test/lane-list.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Task C4 (two-lane storage, PR C): the composite-cursor codec and the
+ * k-way merge across lane pages. See
+ * docs/superpowers/specs/2026-08-22-two-lane-storage-design.md, "Listing:
+ * merged fan-out".
+ */
+import { describe, expect, it } from "vitest";
+import {
+  decodeLaneCursor,
+  encodeLaneCursor,
+  mergeBounded,
+  mergeLaneListings,
+  type LaneCursorMap,
+} from "../src/lane-list";
+
+describe("encodeLaneCursor / decodeLaneCursor", () => {
+  it("round-trips a composite cursor", () => {
+    const map: LaneCursorMap = { v: 1, lanes: { active: "cursor-a", lane_fallback1: "cursor-b" } };
+    const encoded = encodeLaneCursor(map);
+    expect(decodeLaneCursor(encoded)).toEqual(map);
+  });
+
+  it("round-trips an empty lanes map", () => {
+    const map: LaneCursorMap = { v: 1, lanes: {} };
+    expect(decodeLaneCursor(encodeLaneCursor(map))).toEqual(map);
+  });
+
+  it("returns null for undefined", () => {
+    expect(decodeLaneCursor(undefined)).toBeNull();
+  });
+
+  it("returns null for garbage (not base64url JSON)", () => {
+    expect(decodeLaneCursor("not-a-cursor!!!")).toBeNull();
+  });
+
+  it("returns null for a plain (non-composite) opaque provider cursor", () => {
+    // A single-lane era cursor happens to not decode to `{ v: 1, lanes }`.
+    expect(decodeLaneCursor("opaque-r2-cursor-token")).toBeNull();
+  });
+
+  it("returns null for well-formed JSON missing v:1", () => {
+    const encoded = encodeLaneCursor({ v: 2, lanes: {} } as unknown as LaneCursorMap);
+    expect(decodeLaneCursor(encoded)).toBeNull();
+  });
+});
+
+describe("mergeLaneListings", () => {
+  it("interleaves ascending keys from multiple lanes", () => {
+    const merged = mergeLaneListings([
+      { laneOrder: 0, items: [{ key: "b" }, { key: "d" }] },
+      { laneOrder: 1, items: [{ key: "a" }, { key: "c" }] },
+    ]);
+    expect(merged.map((i) => i.key)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("keeps the lower-laneOrder entry on a duplicate key", () => {
+    const active = { key: "shot.png", from: "active" };
+    const fallback = { key: "shot.png", from: "fallback" };
+    const merged = mergeLaneListings([
+      { laneOrder: 0, items: [active] },
+      { laneOrder: 1, items: [fallback] },
+    ]);
+    expect(merged).toEqual([active]);
+  });
+
+  it("is stable within a lane", () => {
+    const merged = mergeLaneListings([
+      {
+        laneOrder: 0,
+        items: [
+          { key: "a", n: 1 },
+          { key: "a", n: 2 },
+        ],
+      },
+    ]);
+    expect(merged.map((i) => (i as { n: number }).n)).toEqual([1, 2]);
+  });
+});
+
+describe("mergeBounded", () => {
+  it("stops at the limit and reports how far each lane's pointer advanced", () => {
+    const active = { laneOrder: 0, items: [{ key: "a" }, { key: "c" }, { key: "e" }] };
+    const fallback = { laneOrder: 1, items: [{ key: "b" }, { key: "d" }, { key: "f" }] };
+    const result = mergeBounded([active, fallback], 4);
+    expect(result.items.map((i) => i.key)).toEqual(["a", "b", "c", "d"]);
+    // 2 of active's 3 items consumed (a, c); 2 of fallback's 3 (b, d).
+    expect(result.consumed).toEqual([2, 2]);
+  });
+
+  it("counts a discarded duplicate as consumed on the losing lane", () => {
+    const active = { laneOrder: 0, items: [{ key: "a" }] };
+    const fallback = { laneOrder: 1, items: [{ key: "a" }, { key: "b" }] };
+    const result = mergeBounded([active, fallback], 2);
+    expect(result.items.map((i) => i.key)).toEqual(["a", "b"]);
+    // fallback's "a" was scanned (and discarded as a dup) plus "b" emitted.
+    expect(result.consumed).toEqual([1, 2]);
+  });
+
+  it("consumed is 0 for a lane whose page was never reached", () => {
+    const active = { laneOrder: 0, items: [{ key: "a" }, { key: "b" }] };
+    const fallback = { laneOrder: 1, items: [{ key: "z" }] };
+    const result = mergeBounded([active, fallback], 1);
+    expect(result.items.map((i) => i.key)).toEqual(["a"]);
+    expect(result.consumed).toEqual([1, 0]);
+  });
+});

--- a/apps/api/test/lane-list.test.ts
+++ b/apps/api/test/lane-list.test.ts
@@ -1,26 +1,32 @@
 /**
- * Task C4 (two-lane storage, PR C): the composite-cursor codec and the
- * k-way merge across lane pages. See
+ * Task C4 (two-lane storage, PR C): the composite-cursor codec, the
+ * per-lane resume-state codec, and the k-way merge across lane pages. See
  * docs/superpowers/specs/2026-08-22-two-lane-storage-design.md, "Listing:
  * merged fan-out".
  */
 import { describe, expect, it } from "vitest";
 import {
   decodeLaneCursor,
+  decodeLaneResumeState,
   encodeLaneCursor,
+  encodeLaneResumeState,
+  LANE_DONE,
   mergeBounded,
-  mergeLaneListings,
   type LaneCursorMap,
 } from "../src/lane-list";
 
 describe("encodeLaneCursor / decodeLaneCursor", () => {
   it("round-trips a composite cursor", () => {
-    const map: LaneCursorMap = { v: 1, lanes: { active: "cursor-a", lane_fallback1: "cursor-b" } };
+    const map: LaneCursorMap = {
+      v: 1,
+      lanes: { active: "cursor-a", lane_fallback1: "cursor-b" },
+      after: "shot.png",
+    };
     const encoded = encodeLaneCursor(map);
     expect(decodeLaneCursor(encoded)).toEqual(map);
   });
 
-  it("round-trips an empty lanes map", () => {
+  it("round-trips an empty lanes map with no `after`", () => {
     const map: LaneCursorMap = { v: 1, lanes: {} };
     expect(decodeLaneCursor(encodeLaneCursor(map))).toEqual(map);
   });
@@ -42,63 +48,120 @@ describe("encodeLaneCursor / decodeLaneCursor", () => {
     const encoded = encodeLaneCursor({ v: 2, lanes: {} } as unknown as LaneCursorMap);
     expect(decodeLaneCursor(encoded)).toBeNull();
   });
+
+  it("returns null when a lanes value is not a string (crafted cursor)", () => {
+    const raw = JSON.stringify({ v: 1, lanes: { active: 5 } });
+    const encoded = Buffer.from(raw, "utf8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(decodeLaneCursor(encoded)).toBeNull();
+  });
+
+  it("returns null when lanes is an array instead of an object", () => {
+    const raw = JSON.stringify({ v: 1, lanes: ["not-an-object"] });
+    const encoded = Buffer.from(raw, "utf8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(decodeLaneCursor(encoded)).toBeNull();
+  });
+
+  it("returns null when `after` is present but not a string", () => {
+    const raw = JSON.stringify({ v: 1, lanes: {}, after: 5 });
+    const encoded = Buffer.from(raw, "utf8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(decodeLaneCursor(encoded)).toBeNull();
+  });
 });
 
-describe("mergeLaneListings", () => {
-  it("interleaves ascending keys from multiple lanes", () => {
-    const merged = mergeLaneListings([
-      { laneOrder: 0, items: [{ key: "b" }, { key: "d" }] },
-      { laneOrder: 1, items: [{ key: "a" }, { key: "c" }] },
-    ]);
-    expect(merged.map((i) => i.key)).toEqual(["a", "b", "c", "d"]);
+describe("encodeLaneResumeState / decodeLaneResumeState", () => {
+  it("round-trips a provider cursor", () => {
+    expect(decodeLaneResumeState(encodeLaneResumeState("provider-cursor-123"))).toEqual({
+      cursor: "provider-cursor-123",
+      done: false,
+    });
   });
 
-  it("keeps the lower-laneOrder entry on a duplicate key", () => {
-    const active = { key: "shot.png", from: "active" };
-    const fallback = { key: "shot.png", from: "fallback" };
-    const merged = mergeLaneListings([
-      { laneOrder: 0, items: [active] },
-      { laneOrder: 1, items: [fallback] },
-    ]);
-    expect(merged).toEqual([active]);
+  it("round-trips 'start of listing' (undefined cursor)", () => {
+    expect(decodeLaneResumeState(encodeLaneResumeState(undefined))).toEqual({
+      cursor: undefined,
+      done: false,
+    });
   });
 
-  it("is stable within a lane", () => {
-    const merged = mergeLaneListings([
-      {
-        laneOrder: 0,
-        items: [
-          { key: "a", n: 1 },
-          { key: "a", n: 2 },
-        ],
-      },
-    ]);
-    expect(merged.map((i) => (i as { n: number }).n)).toEqual([1, 2]);
+  it("decodes LANE_DONE as done, regardless of cursor", () => {
+    expect(decodeLaneResumeState(LANE_DONE)).toEqual({ cursor: undefined, done: true });
+  });
+
+  it("decodes an absent (undefined) raw value as 'start of listing', not done", () => {
+    // The bug this guards: an earlier version of this cursor used "absent
+    // from the map" to mean exhausted, which collided with "never started"
+    // and caused an exhausted lane to restart from the beginning.
+    expect(decodeLaneResumeState(undefined)).toEqual({ cursor: undefined, done: false });
   });
 });
 
 describe("mergeBounded", () => {
-  it("stops at the limit and reports how far each lane's pointer advanced", () => {
-    const active = { laneOrder: 0, items: [{ key: "a" }, { key: "c" }, { key: "e" }] };
-    const fallback = { laneOrder: 1, items: [{ key: "b" }, { key: "d" }, { key: "f" }] };
+  it("interleaves ascending keys from multiple lanes", () => {
+    const merged = mergeBounded(
+      [{ items: [{ key: "b" }, { key: "d" }] }, { items: [{ key: "a" }, { key: "c" }] }],
+      Number.POSITIVE_INFINITY,
+    );
+    expect(merged.items.map((i) => i.key)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("keeps the lowest-priority (index 0) entry on a duplicate key", () => {
+    const active = { key: "shot.png", from: "active" };
+    const fallback = { key: "shot.png", from: "fallback" };
+    const merged = mergeBounded(
+      [{ items: [active] }, { items: [fallback] }],
+      Number.POSITIVE_INFINITY,
+    );
+    expect(merged.items).toEqual([active]);
+  });
+
+  it("is stable within a page", () => {
+    const merged = mergeBounded(
+      [
+        {
+          items: [
+            { key: "a", n: 1 },
+            { key: "a", n: 2 },
+          ],
+        },
+      ],
+      Number.POSITIVE_INFINITY,
+    );
+    expect(merged.items.map((i) => (i as { n: number }).n)).toEqual([1, 2]);
+  });
+
+  it("stops at the limit and reports how far each page's pointer advanced", () => {
+    const active = { items: [{ key: "a" }, { key: "c" }, { key: "e" }] };
+    const fallback = { items: [{ key: "b" }, { key: "d" }, { key: "f" }] };
     const result = mergeBounded([active, fallback], 4);
     expect(result.items.map((i) => i.key)).toEqual(["a", "b", "c", "d"]);
     // 2 of active's 3 items consumed (a, c); 2 of fallback's 3 (b, d).
     expect(result.consumed).toEqual([2, 2]);
   });
 
-  it("counts a discarded duplicate as consumed on the losing lane", () => {
-    const active = { laneOrder: 0, items: [{ key: "a" }] };
-    const fallback = { laneOrder: 1, items: [{ key: "a" }, { key: "b" }] };
+  it("counts a discarded duplicate as consumed on the losing page", () => {
+    const active = { items: [{ key: "a" }] };
+    const fallback = { items: [{ key: "a" }, { key: "b" }] };
     const result = mergeBounded([active, fallback], 2);
     expect(result.items.map((i) => i.key)).toEqual(["a", "b"]);
     // fallback's "a" was scanned (and discarded as a dup) plus "b" emitted.
     expect(result.consumed).toEqual([1, 2]);
   });
 
-  it("consumed is 0 for a lane whose page was never reached", () => {
-    const active = { laneOrder: 0, items: [{ key: "a" }, { key: "b" }] };
-    const fallback = { laneOrder: 1, items: [{ key: "z" }] };
+  it("consumed is 0 for a page whose items were never reached", () => {
+    const active = { items: [{ key: "a" }, { key: "b" }] };
+    const fallback = { items: [{ key: "z" }] };
     const result = mergeBounded([active, fallback], 1);
     expect(result.items.map((i) => i.key)).toEqual(["a"]);
     expect(result.consumed).toEqual([1, 0]);

--- a/apps/api/test/list-page-url.test.ts
+++ b/apps/api/test/list-page-url.test.ts
@@ -103,6 +103,49 @@ describe("listObjects two-lane fan-out", () => {
     expect(page2.cursor).toBeNull();
   });
 
+  // CodeRabbit review (PR #771): an exhausted lane that was simply omitted
+  // from the composite cursor's lane map was indistinguishable from a lane
+  // that had never started, and restarted from the beginning on the next
+  // page — duplicating everything it had already emitted. Repro: limit 2,
+  // active [a, e], fallback [b, c, e] (duplicate key "e"). Without the fix,
+  // the third page re-returns [a, e] instead of terminating.
+  it("does not restart an exhausted lane on a later page (CodeRabbit regression)", async () => {
+    const active = new FakeR2Bucket();
+    const fallback = new FakeR2Bucket();
+    await active.put("a.png", new Uint8Array([1]));
+    await active.put("e.png", new Uint8Array([1]));
+    await fallback.put("b.png", new Uint8Array([1]));
+    await fallback.put("c.png", new Uint8Array([1]));
+    await fallback.put("e.png", new Uint8Array([1, 2, 3, 4, 5]));
+
+    const ws: WorkspaceRecord = {
+      ...baseRecord,
+      prefix: undefined,
+      storageLaneId: "lane_active1",
+      storageLanes: [FALLBACK_LANE],
+    };
+    const env = twoLaneEnv(active, fallback);
+
+    const page1 = await listObjects(env, ws, { limit: 2 });
+    expect(page1.items.map((i) => i.key)).toEqual(["a.png", "b.png"]);
+    expect(page1.cursor).not.toBeNull();
+
+    const page2 = await listObjects(env, ws, { limit: 2, cursor: page1.cursor! });
+    expect(page2.items.map((i) => i.key)).toEqual(["c.png", "e.png"]);
+    // Active's copy of the duplicate "e.png" won.
+    expect(page2.items[1].size).toBe(1);
+
+    // Bug repro: page2.cursor may still be non-null here (fallback's own
+    // duplicate "e" hasn't been filtered out yet) — a caller must keep
+    // following the cursor until it's null. The fix is that this next page
+    // is empty and terminal, never a re-emission of "a.png"/"e.png".
+    if (page2.cursor) {
+      const page3 = await listObjects(env, ws, { limit: 2, cursor: page2.cursor });
+      expect(page3.items).toEqual([]);
+      expect(page3.cursor).toBeNull();
+    }
+  });
+
   it("excludes a standby lane (no lastActiveAt) from the fan-out — behaves single-lane", async () => {
     const active = new FakeR2Bucket();
     await active.put("a.png", new Uint8Array([1]));

--- a/apps/api/test/list-page-url.test.ts
+++ b/apps/api/test/list-page-url.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
 import { listObjects } from "../src/files-core";
-import type { WorkspaceRecord } from "../src/workspace";
+import type { StorageLane, WorkspaceRecord } from "../src/workspace";
 
 // `Env` is a global ambient type (apps/api/src/env.d.ts) — no import needed.
 function makeEnv(bucket: FakeR2Bucket) {
@@ -35,5 +35,81 @@ describe("listObjects pageUrl", () => {
       prefix: "gh/o/r/pull/1/",
     });
     expect(items[0].pageUrl).toBeUndefined();
+  });
+});
+
+// Task C4 (two-lane storage, PR C): merged multi-lane listing with a
+// composite cursor. See
+// docs/superpowers/specs/2026-08-22-two-lane-storage-design.md, "Listing:
+// merged fan-out".
+describe("listObjects two-lane fan-out", () => {
+  const FALLBACK_LANE: StorageLane = {
+    id: "lane_fallback1",
+    provider: "r2",
+    bucket: "customer-bucket",
+    binding: "UPLOADS_FALLBACK",
+    lastActiveAt: "2026-08-01T00:00:00.000Z",
+    publicBaseUrl: "https://storage.customer.example.com",
+  };
+
+  function twoLaneEnv(active: FakeR2Bucket, fallback: FakeR2Bucket) {
+    return {
+      UPLOADS_DEFAULT: active,
+      UPLOADS_FALLBACK: fallback,
+      WEB_ORIGIN: "https://uploads.sh",
+    } as unknown as Env;
+  }
+
+  it("single-lane record keeps today's shape (no envelope) — control", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("default/a.png", new Uint8Array([1]));
+    await bucket.put("default/b.png", new Uint8Array([1]));
+    const { items, cursor } = await listObjects(makeEnv(bucket), baseRecord, { limit: 100 });
+    expect(items.map((i) => i.key)).toEqual(["a.png", "b.png"]);
+    expect(cursor).toBeNull();
+  });
+
+  it("merges interleaved keys across lanes, active wins the duplicate, and paginates via the composite cursor", async () => {
+    const active = new FakeR2Bucket();
+    const fallback = new FakeR2Bucket();
+    // Active: a, c, e (no prefix on either lane here — keeps the fixture's
+    // raw keys identical to what listObjects reports).
+    await active.put("a.png", new Uint8Array([1]));
+    await active.put("c.png", new Uint8Array([1]));
+    // Duplicate key "e.png" in both lanes — active's copy must win. Distinct
+    // sizes make the winning copy distinguishable in the DTO (`size`).
+    await active.put("e.png", new Uint8Array([1]));
+    // Fallback: b, d, e
+    await fallback.put("b.png", new Uint8Array([1]));
+    await fallback.put("d.png", new Uint8Array([1]));
+    await fallback.put("e.png", new Uint8Array([1, 2, 3, 4, 5]));
+
+    const ws: WorkspaceRecord = {
+      ...baseRecord,
+      prefix: undefined,
+      storageLaneId: "lane_active1",
+      storageLanes: [FALLBACK_LANE],
+    };
+    const env = twoLaneEnv(active, fallback);
+
+    const page1 = await listObjects(env, ws, { limit: 4 });
+    expect(page1.items.map((i) => i.key)).toEqual(["a.png", "b.png", "c.png", "d.png"]);
+    expect(page1.cursor).not.toBeNull();
+
+    const page2 = await listObjects(env, ws, { limit: 4, cursor: page1.cursor! });
+    expect(page2.items.map((i) => i.key)).toEqual(["e.png"]);
+    // Active's 1-byte copy won over fallback's 5-byte copy.
+    expect(page2.items[0].size).toBe(1);
+    expect(page2.cursor).toBeNull();
+  });
+
+  it("excludes a standby lane (no lastActiveAt) from the fan-out — behaves single-lane", async () => {
+    const active = new FakeR2Bucket();
+    await active.put("a.png", new Uint8Array([1]));
+    const standby: StorageLane = { ...FALLBACK_LANE, lastActiveAt: undefined };
+    const ws: WorkspaceRecord = { ...baseRecord, prefix: undefined, storageLanes: [standby] };
+    const { items, cursor } = await listObjects(makeEnv(active), ws, { limit: 100 });
+    expect(items.map((i) => i.key)).toEqual(["a.png"]);
+    expect(cursor).toBeNull();
   });
 });

--- a/apps/api/test/reconcile-lanes.test.ts
+++ b/apps/api/test/reconcile-lanes.test.ts
@@ -1,0 +1,61 @@
+/**
+ * CodeRabbit review (PR #771): `reconcileWorkspaceUsage` walks the active
+ * lane only (`// PR D:` marker in reconcile.ts) — for a workspace with a
+ * fallback lane that may hold objects, that would zero the fallback's
+ * bytes/objects out of the ledger. Until PR D makes reconcile lane-aware, it
+ * must refuse rather than silently corrupt the ledger.
+ */
+import { describe, expect, it } from "vitest";
+import { reconcileWorkspaceUsage } from "../src/reconcile";
+import { makePosterEnv, PNG, WORKSPACE } from "./poster-fixtures";
+import { putObject } from "../src/files-core";
+import type { StorageLane } from "../src/workspace";
+
+describe("reconcileWorkspaceUsage and multi-lane records", () => {
+  it("refuses a record with a fallback lane, leaving the ledger untouched", async () => {
+    const { env, ws, db } = makePosterEnv();
+    await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+    const before = db.usage.get(WORKSPACE);
+
+    const fallback: StorageLane = {
+      id: "lane_fallback1",
+      provider: "r2",
+      bucket: "customer-bucket",
+      binding: "UPLOADS_FALLBACK",
+      lastActiveAt: "2026-08-01T00:00:00.000Z",
+    };
+    const wsWithFallback = { ...ws, storageLanes: [fallback] };
+
+    await expect(reconcileWorkspaceUsage(env, wsWithFallback, WORKSPACE)).rejects.toMatchObject({
+      code: "reconcile_multi_lane_unsupported",
+    });
+    expect(db.usage.get(WORKSPACE)).toEqual(before);
+  });
+
+  it("does not refuse a record with only a standby lane (no lastActiveAt)", async () => {
+    const { env, ws } = makePosterEnv();
+    await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+
+    const standby: StorageLane = {
+      id: "lane_standby1",
+      provider: "r2",
+      bucket: "customer-bucket",
+      binding: "UPLOADS_FALLBACK",
+      // No `lastActiveAt` — saved config, never a read source.
+    };
+    const wsWithStandby = { ...ws, storageLanes: [standby] };
+
+    const result = await reconcileWorkspaceUsage(env, wsWithStandby, WORKSPACE);
+    expect(result.bytes).toBe(PNG.byteLength);
+    expect(result.objects).toBe(1);
+  });
+
+  it("single-lane record reconciles as today (control)", async () => {
+    const { env, ws, db } = makePosterEnv();
+    await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+    const result = await reconcileWorkspaceUsage(env, ws, WORKSPACE);
+    expect(result.bytes).toBe(PNG.byteLength);
+    expect(result.objects).toBe(1);
+    expect(db.usage.get(WORKSPACE)).toMatchObject({ bytes: PNG.byteLength, objects: 1 });
+  });
+});

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -102,6 +102,7 @@ async function makeEnv(
   opts: {
     rateLimitOk?: boolean;
     scopedToken?: { rawToken: string; scopes: string[]; mintingUserId?: string };
+    extraBindings?: Record<string, FakeR2Bucket>;
   } = {},
 ) {
   const record: WorkspaceRecord = {
@@ -133,6 +134,7 @@ async function makeEnv(
     // metering; file_metadata reads/writes are backed by makeFakeDB's store.
     DB: db,
     UPLOADS_DEFAULT: bucket,
+    ...opts.extraBindings,
     WRITE_LIMITER: { limit: async () => ({ success: opts.rateLimitOk ?? true }) },
     WEB_ORIGIN: "https://uploads.sh",
     // Uploader attribution (issue #340) defaults: empty login cache, no
@@ -146,6 +148,21 @@ async function makeEnv(
     },
   };
   return { env, bucket, db };
+}
+
+/** A fallback `StorageLane` (customer bucket, binding-mode) demoted after a
+ * storage switch — used by the PR C lane-aware read-path tests below. */
+function fallbackLane(overrides: Partial<import("../src/workspace").StorageLane> = {}) {
+  return {
+    id: "lane_fallback1",
+    provider: "r2",
+    bucket: "customer-bucket",
+    binding: "UPLOADS_FALLBACK",
+    prefix: "legacy/",
+    lastActiveAt: "2026-08-01T00:00:00.000Z",
+    publicBaseUrl: "https://storage.customer.example.com",
+    ...overrides,
+  };
 }
 
 /** PUT the standard test key with auth, letting each test vary body/headers/env. */
@@ -312,6 +329,28 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     expect(res.status).toBe(400);
   });
 
+  // Task C2 (two-lane storage, PR C): a strict key that exists only in a
+  // fallback lane still counts as "would overwrite" — the preview URL comes
+  // from that lane, not the (empty, on this key) active lane.
+  it("dry run reports replaced=true from a fallback-only key, with that lane's URL", async () => {
+    const fallbackBucket = new FakeR2Bucket();
+    await fallbackBucket.put("legacy/screenshots/shot.png", PNG);
+    const { env } = await makeEnv(
+      { storageLaneId: "lane_active1", storageLanes: [fallbackLane()] },
+      { extraBindings: { UPLOADS_FALLBACK: fallbackBucket } },
+    );
+    const res = await app.request(
+      "/v1/default/files/screenshots/shot.png?dryRun=1",
+      { method: "PUT", headers: { Authorization: `Bearer ${TOKEN}` }, body: new Uint8Array(0) },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { replaced: boolean; wouldRefuse: boolean; url: string };
+    expect(json.replaced).toBe(true);
+    expect(json.wouldRefuse).toBe(true);
+    expect(json.url).toBe("https://storage.customer.example.com/legacy/screenshots/shot.png");
+  });
+
   it("stores allowlisted provenance metadata and returns it on put + head", async () => {
     const { env, bucket } = await makeEnv();
     const res = await putShot(env, {
@@ -418,6 +457,33 @@ describe("POST /v1/:workspace/files/sign strict-overwrite gate (review follow-up
     expect(res.status).toBe(409);
     const json = (await res.json()) as { error: { code: string } };
     expect(json.error.code).toBe("key_exists");
+  });
+
+  // Task C2 (two-lane storage, PR C): a key that already exists only in a
+  // fallback lane is still a conflict — reported with that lane's URL.
+  it("refuses to sign an overwrite of a fallback-only key, reporting that lane's URL", async () => {
+    const fallbackBucket = new FakeR2Bucket();
+    await fallbackBucket.put("legacy/screenshots/shot.png", PNG);
+    const { env } = await makeEnv(
+      { storageLaneId: "lane_active1", storageLanes: [fallbackLane()] },
+      { extraBindings: { UPLOADS_FALLBACK: fallbackBucket } },
+    );
+
+    const res = await app.request(
+      "/v1/default/files/sign",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({ key: "screenshots/shot.png", contentType: "image/png" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(409);
+    const json = (await res.json()) as { error: { code: string; details?: { url?: string } } };
+    expect(json.error.code).toBe("key_exists");
+    expect(json.error.details?.url).toBe(
+      "https://storage.customer.example.com/legacy/screenshots/shot.png",
+    );
   });
 
   it("signs an overwrite when replace: true is passed", async () => {
@@ -866,6 +932,51 @@ describe("PUT /v1/:workspace/files custom metadata capture + cascade", () => {
     await expect(
       getFileMetadata(db as unknown as D1Database, "default", "screenshots/shot.png"),
     ).resolves.toEqual({ app: "web" });
+  });
+});
+
+function getFile(env: Parameters<typeof app.request>[2], key: string, token = TOKEN) {
+  return app.request(
+    `/v1/default/files/${key}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+    env,
+  );
+}
+
+describe("GET /v1/:workspace/files/:key (head)", () => {
+  it("resolves an active-lane object (single-lane control)", async () => {
+    const { env } = await makeEnv();
+    expect((await putShot(env)).status).toBe(201);
+
+    const res = await getFile(env, "screenshots/shot.png");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { key: string; url: string };
+    expect(json.url).toBe("https://storage.uploads.sh/default/screenshots/shot.png");
+  });
+
+  // Task C2 (two-lane storage, PR C): a key uploaded before a storage switch
+  // still resolves via HEAD, from its owning (fallback) lane's URL.
+  it("resolves a fallback-only object from the owning lane's URL", async () => {
+    const fallbackBucket = new FakeR2Bucket();
+    await fallbackBucket.put("legacy/screenshots/old.png", PNG);
+    const { env } = await makeEnv(
+      { storageLaneId: "lane_active1", storageLanes: [fallbackLane()] },
+      { extraBindings: { UPLOADS_FALLBACK: fallbackBucket } },
+    );
+
+    const res = await getFile(env, "screenshots/old.png");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { url: string };
+    expect(json.url).toBe("https://storage.customer.example.com/legacy/screenshots/old.png");
+  });
+
+  it("404s a key present in neither lane", async () => {
+    const { env } = await makeEnv({
+      storageLaneId: "lane_active1",
+      storageLanes: [fallbackLane()],
+    });
+    const res = await getFile(env, "screenshots/missing.png");
+    expect(res.status).toBe(404);
   });
 });
 

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -3,7 +3,7 @@ import { FakeR2Bucket } from "./fake-r2";
 import { FakeKv } from "./fake-kv";
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
 import { app } from "../src/index";
-import { setServerFileMetadata } from "../src/file-metadata";
+import { setFileMetadata, setServerFileMetadata } from "../src/file-metadata";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
 
 // The public file page (issue #135) is served over HTTP from this endpoint:
@@ -834,6 +834,68 @@ describe("GET /public/files/:workspace/:key — before/after counterpart (issue 
     expect(json.counterpart).toEqual({
       key: "gh/acme/web/pull/12/hero-after.webp",
       url: "https://storage.uploads.sh/default/gh/acme/web/pull/12/hero-after.webp",
+      state: "after",
+    });
+  });
+
+  // CodeRabbit review (PR #771): the counterpart previously resolved via the
+  // PRIMARY object's store/cfg, so a counterpart living in a different
+  // (fallback) lane was missed entirely.
+  it("pairs a counterpart that lives in a different (fallback) lane", async () => {
+    const fallbackBucket = new FakeR2Bucket();
+    const beforeKey = "gh/acme/web/pull/12/hero-before.webp";
+    const afterKey = "gh/acme/web/pull/12/hero-after.webp";
+    await fallbackBucket.put(`legacy/${afterKey}`, PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+
+    const db = makeFakeDB();
+    await setFileMetadata(db as unknown as D1Database, "default", afterKey, {
+      path: "hero.webp",
+      state: "after",
+    });
+
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "uploads-default",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "default/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokenHash: await sha256Hex(TOKEN),
+      storageLaneId: "lane_active1",
+      storageLanes: [
+        {
+          id: "lane_fallback1",
+          provider: "r2",
+          bucket: "customer-bucket",
+          binding: "UPLOADS_FALLBACK",
+          prefix: "legacy/",
+          lastActiveAt: "2026-08-01T00:00:00.000Z",
+          publicBaseUrl: "https://storage.customer.example.com",
+        },
+      ],
+    };
+    const activeBucket = new FakeR2Bucket();
+    const env = {
+      REGISTRY: { get: async () => record, put: async () => undefined },
+      DB: db,
+      UPLOADS_DEFAULT: activeBucket,
+      UPLOADS_FALLBACK: fallbackBucket,
+      WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    };
+    await seedFile(env, beforeKey, {
+      "X-Uploads-Meta-path": "hero.webp",
+      "X-Uploads-Meta-state": "before",
+    });
+
+    const res = await app.request(`/public/files/default/${beforeKey}`, {}, env);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      counterpart?: { key: string; url: string; state: string };
+    };
+    expect(json.counterpart).toEqual({
+      key: afterKey,
+      url: `https://storage.customer.example.com/legacy/${afterKey}`,
       state: "after",
     });
   });

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -217,6 +217,119 @@ describe("GET /public/files/:workspace/:key", () => {
     expect(res.status).toBe(404);
   });
 
+  // Task C1 (two-lane storage, PR C): a file that lives only in a fallback
+  // lane (e.g. uploaded before a storage switch — spec: "Read path") must
+  // still resolve, from that lane's own public URL, not the active lane's.
+  it("resolves a fallback-only object to the owning lane's public URL", async () => {
+    const fallbackBucket = new FakeR2Bucket();
+    await fallbackBucket.put("legacy/screenshots/shot.png", PNG);
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "uploads-default",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "default/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokenHash: await sha256Hex(TOKEN),
+      storageLaneId: "lane_active1",
+      storageLanes: [
+        {
+          id: "lane_fallback1",
+          provider: "r2",
+          bucket: "customer-bucket",
+          binding: "UPLOADS_FALLBACK",
+          prefix: "legacy/",
+          lastActiveAt: "2026-08-01T00:00:00.000Z",
+          publicBaseUrl: "https://storage.customer.example.com",
+        },
+      ],
+    };
+    const noopDb = {
+      prepare: () => ({
+        bind() {
+          return this;
+        },
+        async first() {
+          return null;
+        },
+        async run() {
+          return { success: true, meta: { changes: 0 }, results: [] };
+        },
+        async all() {
+          return { success: true, results: [], meta: {} };
+        },
+      }),
+      async batch(stmts: { run: () => Promise<unknown> }[]) {
+        return Promise.all(stmts.map((s) => s.run()));
+      },
+    };
+    const env = {
+      REGISTRY: { get: async () => record, put: async () => undefined },
+      DB: noopDb,
+      UPLOADS_DEFAULT: new FakeR2Bucket(),
+      UPLOADS_FALLBACK: fallbackBucket,
+      WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    };
+
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { url: string };
+    expect(json.url).toBe("https://storage.customer.example.com/legacy/screenshots/shot.png");
+  });
+
+  it("404s a fallback-lane hit whose lane has no publicBaseUrl (per-lane gate)", async () => {
+    const fallbackBucket = new FakeR2Bucket();
+    await fallbackBucket.put("legacy/screenshots/shot.png", PNG);
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "uploads-default",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "default/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokenHash: await sha256Hex(TOKEN),
+      storageLaneId: "lane_active1",
+      storageLanes: [
+        {
+          id: "lane_fallback1",
+          provider: "r2",
+          bucket: "customer-bucket",
+          binding: "UPLOADS_FALLBACK",
+          prefix: "legacy/",
+          lastActiveAt: "2026-08-01T00:00:00.000Z",
+          // No publicBaseUrl on this lane — the per-lane 404 gate must still apply.
+        },
+      ],
+    };
+    const noopDb = {
+      prepare: () => ({
+        bind() {
+          return this;
+        },
+        async first() {
+          return null;
+        },
+        async run() {
+          return { success: true, meta: { changes: 0 }, results: [] };
+        },
+        async all() {
+          return { success: true, results: [], meta: {} };
+        },
+      }),
+      async batch(stmts: { run: () => Promise<unknown> }[]) {
+        return Promise.all(stmts.map((s) => s.run()));
+      },
+    };
+    const env = {
+      REGISTRY: { get: async () => record, put: async () => undefined },
+      DB: noopDb,
+      UPLOADS_DEFAULT: new FakeR2Bucket(),
+      UPLOADS_FALLBACK: fallbackBucket,
+      WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    };
+
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(404);
+  });
+
   it("exposes no listing/enumeration surface (workspace root has no route)", async () => {
     const { env } = await makeEnv();
     const res = await app.request("/public/files/default", {}, env);

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -9,14 +9,29 @@
  * is scoped to what's new: both credential types reaching the SAME handler,
  * and the auth rejections specific to the dual-auth guard.
  */
-import { beforeAll, describe, expect, it } from "vitest";
-import { app } from "../src/index";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { Files } from "@uploads/storage";
 import { FakeR2Bucket } from "./fake-r2";
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
 
+// `resolveObjectLane` delegates to the real implementation everywhere except
+// the one test below that needs an HTTP-mode fallback lane's signed URL
+// without dialing out for a real S3 HEAD probe.
+vi.mock("../src/storage", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../src/storage")>();
+  return { ...original, resolveObjectLane: vi.fn(original.resolveObjectLane) };
+});
+
+const { app } = await import("../src/index");
+const storageModule = await import("../src/storage");
+
 const TOKEN = "canonical-secret-token";
 const USER = { id: "u-1", email: "member@example.com", name: "Member" };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 beforeAll(() => {
   if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
@@ -72,9 +87,15 @@ function makeFakeDB() {
  * user with an `acme` org membership.
  */
 async function makeEnv(
-  opts: { member?: boolean; session?: boolean; getSessionCalls?: { count: number } } = {},
+  opts: {
+    member?: boolean;
+    session?: boolean;
+    getSessionCalls?: { count: number };
+    recordOverrides?: Partial<WorkspaceRecord>;
+    extraBindings?: Record<string, FakeR2Bucket>;
+  } = {},
 ): Promise<{ env: Parameters<typeof app.request>[2]; bucket: FakeR2Bucket }> {
-  const { member = true, session = true, getSessionCalls } = opts;
+  const { member = true, session = true, getSessionCalls, recordOverrides, extraBindings } = opts;
   const record: WorkspaceRecord = {
     provider: "r2",
     bucket: "uploads-default",
@@ -82,6 +103,7 @@ async function makeEnv(
     prefix: "acme/",
     publicBaseUrl: "https://storage.uploads.sh",
     tokenHash: await sha256Hex(TOKEN),
+    ...recordOverrides,
   };
   const bucket = new FakeR2Bucket();
   const db = makeFakeDB();
@@ -90,6 +112,7 @@ async function makeEnv(
       get: async (key: string) => (key === "ws:acme" ? record : null),
     },
     UPLOADS_DEFAULT: bucket,
+    ...extraBindings,
     DB: db,
     WRITE_LIMITER: { limit: async () => ({ success: true }) },
     WEB_ORIGIN: "https://uploads.sh",
@@ -209,6 +232,75 @@ describe("GET /v1/workspaces/:workspace/files/file-url (dual auth)", () => {
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ url: "https://storage.uploads.sh/acme/shots/a.png" });
+  });
+
+  // Task C2 (two-lane storage, PR C): a key that only exists in a fallback
+  // lane (e.g. detached BYO storage that still holds objects) resolves to
+  // that lane's own public URL, not a 404 against the active lane.
+  it("resolves a fallback-only key to the fallback lane's public URL", async () => {
+    const fallbackBucket = new FakeR2Bucket();
+    await fallbackBucket.put("legacy/shots/old.png", new Uint8Array([9]).buffer);
+    const { env } = await makeEnv({
+      recordOverrides: {
+        storageLaneId: "lane_active1",
+        storageLanes: [
+          {
+            id: "lane_fallback1",
+            provider: "r2",
+            bucket: "customer-bucket",
+            binding: "UPLOADS_FALLBACK",
+            prefix: "legacy/",
+            lastActiveAt: "2026-08-01T00:00:00.000Z",
+            publicBaseUrl: "https://storage.customer.example.com",
+          },
+        ],
+      },
+      extraBindings: { UPLOADS_FALLBACK: fallbackBucket },
+    });
+    const res = await app.request(
+      "/v1/workspaces/acme/files/file-url?key=shots/old.png",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      url: "https://storage.customer.example.com/legacy/shots/old.png",
+    });
+  });
+
+  // A fallback lane without a public URL (HTTP-credential mode) must still
+  // resolve — via a signed URL minted from that owning lane's store, not the
+  // active lane's. `resolveObjectLane` itself is proven lane-aware by
+  // storage-lanes.test.ts; this stubs it to hand the route a fallback
+  // `ResolvedLane` directly, so the route's "sign against the *owning* lane"
+  // wiring is exercised without a real S3 HEAD probe over the network.
+  it("mints a signed URL from the owning fallback lane when it has no publicBaseUrl", async () => {
+    const fallbackStore = {
+      capabilities: { signedUrl: { supported: true } },
+      url: vi.fn(async (key: string) => `https://customer-bucket.example.com/signed/${key}`),
+    } as unknown as Files;
+    vi.mocked(storageModule.resolveObjectLane).mockResolvedValueOnce({
+      store: fallbackStore,
+      // No publicBaseUrl — HTTP-credential mode, must sign instead.
+      config: { provider: "r2", bucket: "customer-bucket" } as never,
+      laneId: "lane_fallback1",
+      role: "fallback",
+    });
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/files/file-url?key=shots/old.png",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    // Not the active lane's public base, and not a plain unsigned URL.
+    expect(body.url).not.toContain("storage.uploads.sh");
+    expect(body.url).toBe("https://customer-bucket.example.com/signed/shots/old.png");
+    expect(fallbackStore.url).toHaveBeenCalledWith(
+      "shots/old.png",
+      expect.objectContaining({ responseContentDisposition: "attachment" }),
+    );
   });
 });
 


### PR DESCRIPTION
## Two-lane storage — lane-aware read paths (PR C of 4)

Spec: `docs/superpowers/specs/2026-08-22-two-lane-storage-design.md` ("Read path", "Listing: merged fan-out")
Plan: `docs/superpowers/plans/2026-08-22-two-lane-storage.md` ("PR C — lane-aware read paths")

Builds on #770 (the storage-lane primitive: `StorageLane`, `storageConfigs`, `resolveObjectLane`). This PR threads that primitive through every read path that resolves an object's location or URL — public files, authenticated head/download/URL, delete, and listing — so a file uploaded before a storage switch keeps resolving from wherever it actually lives.

### Contract: zero behavior change for single-lane records

Every record without `storageLanes` (the entire fleet at merge time) takes the exact code path it always has:
- `resolveObjectLane` short-circuits to one `exists()` call against the active lane.
- `listObjects` returns today's raw provider cursor, no composite envelope — an in-flight cursor from before this PR keeps working.
- `deleteObject` deletes from the one lane it always deleted from.

All existing tests pass unmodified; every new test below pairs a two-lane case with a single-lane control.

### Per-task summary

**C1 — public files resolve across lanes** (`routes/public-files.ts`)
`resolvePublicObject` now calls `resolveObjectLane` instead of resolving the active lane's config directly. The public URL, and the "no `publicBaseUrl` ⇒ 404" gate, both apply to the lane the object was actually found in — not the workspace's current active lane.

**C2 — authenticated head, download, and file-URL resolution**
- `files-shared-handlers.ts`: `getFileHandler` (HEAD) resolves via `resolveObjectLane`; `signFileHandler`'s and the PUT `dryRun` branch's strict-overwrite conflict checks now find an existing object in a fallback lane too, reporting that lane's URL.
- `workspace-files.ts`: `GET /files/file-url` resolves the owning lane, then tries that lane's public URL before falling back to a signed URL minted from that same lane's store/credentials (never the active lane's).

**C3 — delete removes an object from every lane that holds it** (`files-core.ts`)
`deleteObject` walks `storageConfigs` (active first, then fallbacks) and deletes the key from every lane whose store has it — covers the case where a key exists in more than one lane after a detach/re-attach cycle. Ledger accounting counts the object once, using the size from the first lane hit (active-first order). The poster sidecar gets the same every-lane treatment. `claimDeleteUsageSafe`/ledger flow is unchanged.

**C4 — merged multi-lane listing with composite cursors**
- `lane-list.ts`: a composite-cursor codec (`encodeLaneCursor`/`decodeLaneCursor`, base64url JSON, `{ v: 1, lanes: {...}, after? }`), a per-lane resume-state codec (`encodeLaneResumeState`/`decodeLaneResumeState`, with an explicit `LANE_DONE` sentinel), and a bounded k-way merge (`mergeBounded`) that resolves duplicate keys to the lowest-priority (active) lane, matching write-lane reality.
- `listObjects` fans the same prefix/limit query out to every lane on a multi-lane record, merges by key, and emits a composite cursor. See "Review follow-ups" below for the cursor-correctness fix that landed after the initial pass.
- `reconcile.ts`'s `listAll` walk is left active-lane-only, marked `// PR D:` — see "Review follow-ups" for the guard that now makes this safe.

### C4 audit — URL-derivation call sites (spec §"Read path")

| Site | Resolves pre-existing keys? | Changed? |
|---|---|---|
| `gallery-service.ts:hydrateGalleryItems` (item head/URL) | Yes — gallery items reference keys uploaded earlier, possibly in a fallback lane | **Changed** — per-item lane resolution via a shared `LaneResolver`, replacing the single active-lane store/config |
| `gallery-service.ts:galleryListSummaries` cover preview (`previewUrlForKey`) | Yes — a gallery cover key can predate a storage switch | **Changed** (review follow-up, see below) — now resolves the cover's owning lane via the same `LaneResolver` mechanism, instead of deriving from the active lane unconditionally |
| `poster.ts:videoPresentation` | N/A — pure function, takes an already-resolved `cfg` from its caller | **Not changed** — correctness depends on the caller passing the owning lane's config. Both callers (`public-files.ts` via C1, `gallery-service.ts` above) now do |
| `github-comment.ts:gatherAttachments` (poster URL in managed comment) | Yes — the poster is a distinct key from the primary attachment and can live in a different lane | **Changed** (review follow-up, see below) — resolves the poster key's own lane via the same `LaneResolver` mechanism |

### Review follow-ups (simplify pass + CodeRabbit)

A 4-angle simplify pass and CodeRabbit's review both landed after the initial C1–C4 implementation. Summary of what changed on top:

**Efficiency — dedupe config resolution on lane-aware paths**
- New `createLaneResolver(env, ws)` in `storage.ts`: resolves and caches each lane's store/config once per resolver instance (not once per call) — a batch of `.resolve()` calls shares one active-lane resolve and one resolve per *distinct* fallback lane, instead of re-decrypting the same lane's credentials repeatedly. `resolveObjectLane` is now a single-lookup wrapper over it.
- `signFileHandler` and the PUT `dryRun` branch (`files-shared-handlers.ts`) each used to resolve the active lane's config up to 3x per request; both now build one resolver and reuse it throughout.
- `deleteObject`/`deleteFromEveryLane` (`files-core.ts`): `storageConfigs` is resolved once and passed into both the primary-key and poster-key delete calls; per-lane existence probes and deletes each run via `Promise.all` instead of a sequential loop.
- `hydrateGalleryItems` (`gallery-service.ts`): uses one shared `LaneResolver` across all of a gallery's items instead of resolving fresh per item.

**Reuse / simplification — `lane-list.ts`**
- b64url encode/decode now reuse `secrets.ts`'s existing `b64urlEncode`/`b64urlDecode` instead of a duplicate local pair.
- `mergeBounded`'s `LanePage` no longer carries a `laneOrder` field — pages must be pre-ordered by priority (array index), removing a sort and an O(n²) `indexOf` remap.
- `mergeLaneListings` deleted (zero production callers; `listObjects` uses `mergeBounded` directly); its tests folded into the `mergeBounded` describe block.

**CodeRabbit finding 1 (major) — cross-page duplicate bug in the composite cursor.** An exhausted lane that was simply omitted from the cursor's lane map was indistinguishable from a lane that had never started, and restarted from the beginning on a later page — duplicating everything it had already emitted. Fixed by encoding exhausted lanes explicitly (`LANE_DONE` sentinel, moved into `lane-list.ts` alongside the outer codec) and adding a global high-water key (`LaneCursorMap.after`) that every fresh fetch filters against, as defense in depth. The skip-counter resume-state format from the first pass was dropped entirely — no longer needed once the high-water key does the dedup work. A three-page regression test reproduces the exact repro from the review (`list-page-url.test.ts`).

**CodeRabbit finding 2 (minor) — crafted-cursor 500.** `decodeLaneCursor` now validates that every `lanes` value is a string (and rejects `lanes` being an array), plus that `after` is a string when present, instead of reaching the resume-state decoder with the wrong type. Malformed-cursor tests added.

**CodeRabbit finding 3 (major) — reconcile would corrupt the ledger for a multi-lane workspace.** `reconcileWorkspaceUsage` walking the active lane only would zero a fallback lane's objects out of the ledger. It now refuses (`ConflictError`, code `reconcile_multi_lane_unsupported`) a record with any fallback lane (`lastActiveAt` set) rather than silently doing that; a standby lane doesn't trigger the refusal. The `// PR D:` marker stays — this becomes lane-aware there. Tests in `reconcile-lanes.test.ts`.

**CodeRabbit finding 4 (minor) — before/after counterpart missed a cross-lane pair.** `public-files.ts`'s counterpart lookup reused the primary object's store/cfg; it now resolves the counterpart's own lane via `resolveObjectLane`. `ResolvedPublicObject` gained a `record` field so this doesn't repeat the workspace KV read. Cross-lane pair test added.

**Deliberate contract change (simplify item 9, supersedes an earlier revert in this PR's history):** the gallery cover preview and comment poster URL now resolve their key's owning lane rather than deriving from the active lane unconditionally. This *is* a lane-aware existence check (not a pure derivation anymore) in both cases — the earlier attempt at this for the comment poster was reverted because it broke a test asserting the URL rendered from the `video.poster` metadata flag alone; that test has been updated to seed the poster bytes, reflecting the real invariant that `generateAndStorePoster` always writes them together. New fallback-lane tests cover both sites.

### Verification

- `pnpm --filter @uploads/api test` — 2103 tests passed
- `pnpm --filter @uploads/api run types && pnpm --filter @uploads/api exec tsc --noEmit` — clean
- root `pnpm test` — 4836 tests passed

### Deviations from the plan text

- C4's cursor packing: the plan's `LaneCursorMap.lanes` value type is `string` (opaque per lane); this implementation packs either a provider cursor or the `LANE_DONE` sentinel into that string, and the map gained an optional top-level `after` (global high-water key) — both still exactly `Record<string, string>`/`string` at the type level, and both were needed to fix the cross-page duplicate bug CodeRabbit found.
- `files-shared-handlers.ts`'s `patchFileHandler` (metadata PATCH) was left untouched — metadata is keyed by `(workspace, key)` and is lane-agnostic (spec, "Read path"), and it wasn't in the plan's explicit line-reference list for C2.
