### PR TITLE
fix(scripts): finish #754 auth secret rename in bootstrap and doctor

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -139,10 +139,14 @@ if have openssl; then
   # Optional encryption key for BYO S3 credentials in REGISTRY — harmless if unused.
   ensure_secret "$DEV_VARS" "WORKSPACE_SECRETS_KEY" "$(openssl rand -base64 32)" \
     "local encryption for BYO workspace secrets in REGISTRY KV"
-  ensure_secret "$AUTH_DEV_VARS" "BETTER_AUTH_SECRET_DEV" "$(openssl rand -base64 32)" \
+  # #754 renamed the auth signing secret BETTER_AUTH_SECRET_DEV → BETTER_AUTH_SECRET;
+  # carry over an existing legacy value so local sessions stay valid.
+  AUTH_SECRET_VALUE="$(grep -E '^BETTER_AUTH_SECRET_DEV=.+$' "$AUTH_DEV_VARS" 2>/dev/null | head -n1 | cut -d= -f2-)"
+  [ -n "$AUTH_SECRET_VALUE" ] || AUTH_SECRET_VALUE="$(openssl rand -base64 32)"
+  ensure_secret "$AUTH_DEV_VARS" "BETTER_AUTH_SECRET" "$AUTH_SECRET_VALUE" \
     "local Better Auth signing secret (never used in production)"
 else
-  note "openssl not found — set API secrets and BETTER_AUTH_SECRET_DEV in local .dev.vars files by hand"
+  note "openssl not found — set API secrets and BETTER_AUTH_SECRET in local .dev.vars files by hand"
 fi
 
 # Point the root client .env at local wrangler if still on the prod defaults.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -183,11 +183,15 @@ fi
 AUTH_DEV_VARS="$ROOT/apps/auth/.dev.vars"
 if [ -f "$AUTH_DEV_VARS" ]; then
   pass "apps/auth/.dev.vars present"
-  if grep -qE '^BETTER_AUTH_SECRET_DEV=.+$' "$AUTH_DEV_VARS"; then
-    pass "BETTER_AUTH_SECRET_DEV is set (local Auth can issue stable sessions)"
+  if grep -qE '^BETTER_AUTH_SECRET=.+$' "$AUTH_DEV_VARS"; then
+    pass "BETTER_AUTH_SECRET is set (local Auth can issue stable sessions)"
   else
-    warn "BETTER_AUTH_SECRET_DEV is empty — local Auth returns 503" \
+    warn "BETTER_AUTH_SECRET is empty — local Auth returns 503" \
       "set a random 32+ character value in apps/auth/.dev.vars  (or: pnpm bootstrap)"
+  fi
+  # #754 rename: the old key is no longer read by apps/auth/src/secrets.ts.
+  if grep -qE '^BETTER_AUTH_SECRET_DEV=.+$' "$AUTH_DEV_VARS"; then
+    info "legacy BETTER_AUTH_SECRET_DEV found — unused since #754; safe to delete (pnpm bootstrap migrates its value to BETTER_AUTH_SECRET)"
   fi
   if grep -qE '^ENVIRONMENT=development$' "$AUTH_DEV_VARS"; then
     pass "Auth ENVIRONMENT is development"


### PR DESCRIPTION
## What

Completes the #754 Secrets Store → plain-secret migration for local dev tooling. `apps/auth/src/secrets.ts` reads `BETTER_AUTH_SECRET`, but the dev scripts still used the old `BETTER_AUTH_SECRET_DEV` name — so `pnpm doctor` passed while the auth worker 503'd `auth_unavailable` and `pnpm dev:stack` aborted at its dev-session smoke.

- **scripts/bootstrap.sh** now ensures `BETTER_AUTH_SECRET` in `apps/auth/.dev.vars`. If a legacy `BETTER_AUTH_SECRET_DEV` value is present, its value is carried over instead of minting a new secret, so existing local sessions stay valid.
- **scripts/doctor.sh** now checks `BETTER_AUTH_SECRET` (warning matches the real 503 failure mode) and prints an info line when a leftover legacy key is found.
- `apps/auth/.dev.vars.example` already used the new name; no change needed.

## Reviewer notes

- No secret values are touched or committed; bootstrap only writes to local `.dev.vars`.
- Migration block verified against three `.dev.vars` states: legacy value present (carried over, empty new line dropped), fresh scaffold (random secret minted), already set (untouched). `bash -n` passes on both scripts.
- Remaining `BETTER_AUTH_SECRET_DEV` mentions in the repo are the intentional legacy-migration lines here plus two historical planning docs.