### PR TITLE
feat(web): layout pass on workspace screenshots page

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,14 +6,6 @@
 
 web
 
-## Register
-
-product
-
-<!-- Split surface: the landing page, docs, guides, and changelog are brand
-     register; console/account/admin and packages/ui are product register.
-     Product is the default. -->
-
 ## Users
 
 **Primary: the coding agent.** Agents execute the loop — capture a visual the

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -19,6 +19,7 @@ import { Callout, Input, Select } from "@uploads/ui";
 import "@uploads/ui/styles.css";
 import {
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -502,35 +503,40 @@ function FilterBar({
           </ul>
         )}
       </div>
-      <div className="wsp-toggle" role="group" aria-label="Layout">
-        <button
-          type="button"
-          className="wsp-toggle__opt"
-          aria-pressed={feed === "grouped"}
-          onClick={() => onFeed("grouped")}
-        >
-          Grouped
-        </button>
-        <button
-          type="button"
-          className="wsp-toggle__opt"
-          aria-pressed={feed === "recent"}
-          onClick={() => onFeed("recent")}
-        >
-          Recent
-        </button>
-      </div>
-      {/* Persisted PR merge-state tagging: filters both the drill-in
-          (meta.gh.merged=true) and the grouped overview (?merged=1). */}
-      <div className="wsp-toggle" role="group" aria-label="Merge filter">
-        <button
-          type="button"
-          className="wsp-toggle__opt"
-          aria-pressed={merged}
-          onClick={() => onMerged(!merged)}
-        >
-          Merged only
-        </button>
+      {/* One flex item so the two toggle groups wrap together as a cluster —
+          separately they wrap independently and "Merged only" ends up
+          orphaned on its own row. */}
+      <div className="wsp-filter__toggles">
+        <div className="wsp-toggle" role="group" aria-label="Layout">
+          <button
+            type="button"
+            className="wsp-toggle__opt"
+            aria-pressed={feed === "grouped"}
+            onClick={() => onFeed("grouped")}
+          >
+            Grouped
+          </button>
+          <button
+            type="button"
+            className="wsp-toggle__opt"
+            aria-pressed={feed === "recent"}
+            onClick={() => onFeed("recent")}
+          >
+            Recent
+          </button>
+        </div>
+        {/* Persisted PR merge-state tagging: filters both the drill-in
+            (meta.gh.merged=true) and the grouped overview (?merged=1). */}
+        <div className="wsp-toggle" role="group" aria-label="Merge filter">
+          <button
+            type="button"
+            className="wsp-toggle__opt"
+            aria-pressed={merged}
+            onClick={() => onMerged(!merged)}
+          >
+            Merged only
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -845,6 +851,21 @@ function ScreenshotsByPathInner({
     };
   }, []);
 
+  // `shotPreviewPosition` places the pop-over from an ESTIMATED height, so a
+  // tall capture (or the async PR-title/meta lines) can run past the viewport
+  // bottom. Clamp the rendered box back inside after layout, and again when
+  // the full-size image or the resolved title changes its real height.
+  const previewRef = useRef<HTMLDivElement | null>(null);
+  const clampPreview = () => {
+    const el = previewRef.current;
+    if (!el) return;
+    const margin = 12;
+    const rect = el.getBoundingClientRect();
+    el.style.left = `${Math.max(margin, Math.min(rect.left, window.innerWidth - rect.width - margin))}px`;
+    el.style.top = `${Math.max(margin, Math.min(rect.top, window.innerHeight - rect.height - margin))}px`;
+  };
+  useLayoutEffect(clampPreview, [preview, titles]);
+
   const onPreviewLeave = () => {
     if (previewTimer.current !== null) window.clearTimeout(previewTimer.current);
     previewTimer.current = null;
@@ -977,10 +998,13 @@ function ScreenshotsByPathInner({
   const previewLayer = preview ? (
     <div
       className="wsp-preview"
+      ref={previewRef}
       style={{ left: preview.left, top: preview.top }}
       role="presentation"
     >
-      <img src={preview.src} alt="" />
+      {/* onLoad: the real image height is only known once bytes arrive —
+          re-clamp so a tall capture doesn't push the meta off-screen. */}
+      <img src={preview.src} alt="" onLoad={clampPreview} />
       <div className="wsp-preview__meta">
         <div className="wsp-preview__name">{preview.name}</div>
         {preview.pr && (
@@ -1027,10 +1051,12 @@ function ScreenshotsByPathInner({
     return (
       <div className="wsp" aria-busy={overviewRefreshing || undefined}>
         {filterBar}
-        <button type="button" className="text-btn" onClick={() => setView({ ...view, path: "" })}>
-          {view.project ? `← ${view.project}` : "← all projects"}
-        </button>
-        <h2 className="wsp-drill__heading">{view.path}</h2>
+        <div className="wsp-drill__head">
+          <button type="button" className="text-btn" onClick={() => setView({ ...view, path: "" })}>
+            {view.project ? `← ${view.project}` : "← all projects"}
+          </button>
+          <h2 className="wsp-drill__heading">{view.path}</h2>
+        </div>
         {drill.status === "loading" && (
           <div className="wsp-grid" aria-busy="true">
             {Array.from({ length: 8 }, (_, i) => (
@@ -1267,22 +1293,36 @@ function ProjectSection({
   const count = summary?.count ?? ghItems?.length ?? 0;
   const lastUpdated = summary?.lastUpdated;
 
+  const labelBody = (
+    <>
+      {/* 15px to sit proportionally beside the --text-h3 label; the default
+          12 was scaled for the old body-size head. */}
+      {isRepoLabel(label) && <GitHubMark size={15} />}
+      {label}
+    </>
+  );
+
   return (
     <div className="wsp-project">
       <div className="wsp-project__head">
-        <span className="wsp-project__label">
-          {isRepoLabel(label) && <GitHubMark />}
-          {label}
-        </span>
+        {/* The project name IS the "view project" control — a standing
+            "view project →" beside every section repeated the same text
+            down the page. The arrow affordance discloses on hover/focus
+            (always visible on hover-less devices). */}
+        {showViewProject ? (
+          <button type="button" className="wsp-project__label" onClick={onViewProject}>
+            {labelBody}
+            <span className="wsp-project__go" aria-hidden="true">
+              →
+            </span>
+          </button>
+        ) : (
+          <span className="wsp-project__label">{labelBody}</span>
+        )}
         <span className="wsp-group__meta">
           {count} {count === 1 ? "file" : "files"}
           {lastUpdated ? ` · ${lastUpdatedLabel(lastUpdated, new Date())}` : ""}
         </span>
-        {showViewProject && (
-          <button type="button" className="text-btn wsp-project__viewall" onClick={onViewProject}>
-            view project →
-          </button>
-        )}
       </div>
       {groups.map((group) => (
         <PathGroupSection
@@ -1355,7 +1395,9 @@ function PathGroupSection({
           {group.count} {group.count === 1 ? "file" : "files"} ·{" "}
           {lastUpdatedLabel(group.lastUpdated, new Date())}
         </span>
-        <span className="wsp-group__viewall">view all →</span>
+        <span className="wsp-group__viewall">
+          <span className="wsp-group__viewall-text">view all </span>→
+        </span>
       </button>
       {group.recent.length > 0 && (
         <div className="wsp-strip">

--- a/apps/web/src/lib/signed-in-page.ts
+++ b/apps/web/src/lib/signed-in-page.ts
@@ -120,7 +120,12 @@ export function signedInCsp(authOrigin: string, apiOrigin: string): string {
     `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
     `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
     "font-src 'self'",
-    "img-src data: https:",
+    // Local stack workspaces serve thumbnails from plain-http loopback
+    // origins, which `https:` alone rejects — without the DEV allowance
+    // every signed-in thumbnail is a broken image in `astro dev`.
+    import.meta.env.DEV
+      ? "img-src data: https: http://127.0.0.1:* http://localhost:*"
+      : "img-src data: https:",
     "base-uri 'none'",
     "form-action 'none'",
     "frame-ancestors 'none'",

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1911,9 +1911,13 @@ button.wft-card__name:focus-visible {
 /* Screenshots-by-path tab (Task 6) — sits beside the `wft-` file table;
    reuses its custom properties (--line/--muted/--fg/--panel/--mono) so the
    two tabs read as one system. */
+/* Spacing thesis: bond a group head to its strip (10px), stack a project's
+   groups (16px), zone the toolbar away from content (32px), and separate
+   projects decisively (32px gap + 8px margin = 40px, --space-6). The
+   between-projects interval must read a clear step above within-project. */
 .wsp {
   display: grid;
-  gap: 24px;
+  gap: 32px;
 }
 /* Overview project section — one level up from .wsp-group, so its head
    reads slightly larger and its children (.wsp-group rows) sit stacked
@@ -1922,26 +1926,55 @@ button.wft-card__name:focus-visible {
   display: grid;
   gap: 16px;
 }
+/* Each subsequent project opens with a full-width hairline: the section
+   boundary is structural, not just whitespace, so a project head can't be
+   misread as one more path row. */
+.wsp-project + .wsp-project {
+  border-top: 1px solid var(--line);
+  padding-top: 28px;
+}
 .wsp-project__head {
   display: flex;
   align-items: baseline;
   gap: 10px;
   width: 100%;
 }
+/* Rendered as a <button> on the overview (the name is the "view project"
+   control) and a plain <span> once that project is the active filter — the
+   reset below has to erase the button chrome for the first case. */
 .wsp-project__label {
-  font-weight: var(--weight-semibold);
-  font-size: var(--text-body);
-}
-.wsp-project__viewall {
-  margin-left: auto;
-  color: var(--muted);
-  font-size: var(--text-micro);
-  white-space: nowrap;
+  background: none;
+  border: 0;
   padding: 0;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: var(--weight-semibold);
+  /* A full scale step above the 13px path rows — at --text-body the two
+     levels blurred together and project names were easy to scan past. */
+  font-size: var(--text-h3);
+  line-height: 1.3;
+  overflow-wrap: anywhere;
 }
-.wsp-project__viewall:hover,
-.wsp-project__viewall:focus-visible {
-  color: var(--fg);
+span.wsp-project__label {
+  cursor: auto;
+}
+/* Pointer devices signal "the name is a link" with an underline on
+   hover/focus — an in-flow arrow reserved a dead gap between the name and
+   its meta at rest. The inline arrow exists only on hover-less devices
+   (below), where it is always visible and so never leaves a phantom gap. */
+.wsp-project__go {
+  display: none;
+  margin-left: 8px;
+  color: var(--muted);
+}
+button.wsp-project__label:hover,
+button.wsp-project__label:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-decoration-color: var(--muted);
+  text-decoration-thickness: 1px;
 }
 
 .wsp-group {
@@ -1964,27 +1997,59 @@ button.wft-card__name:focus-visible {
 .wsp-group__path {
   font-weight: var(--weight-semibold);
   font-size: var(--text-meta);
+  overflow-wrap: anywhere;
 }
 .wsp-group__meta {
   color: var(--muted);
   font-size: var(--text-micro);
   white-space: nowrap;
 }
+/* The whole group head is the drill-in button, so "view all →" is a hint,
+   not a control — disclose it on hover/focus instead of repeating the same
+   words on every row. Opacity (not display) keeps it in the accessible name
+   and keeps the row's layout stable. */
 .wsp-group__viewall {
   margin-left: auto;
   color: var(--muted);
   font-size: var(--text-micro);
   white-space: nowrap;
+  opacity: 0;
+  transition: opacity 120ms ease;
 }
 .wsp-group__head:hover .wsp-group__viewall,
 .wsp-group__head:focus-visible .wsp-group__viewall {
   color: var(--fg);
+  opacity: 1;
+}
+/* Hover-less (touch) devices: no reveal moment exists, so keep a compact
+   trailing chevron per row — the standard tappable-row disclosure — and
+   drop the repeated words. */
+@media (hover: none) {
+  .wsp-group__viewall {
+    opacity: 1;
+  }
+  .wsp-group__viewall-text {
+    display: none;
+  }
+  .wsp-project__go {
+    display: inline;
+  }
 }
 
+/* Drill-in header: breadcrumb back-link bonded tight above the path title.
+   `justify-items: start` keeps the back button shrink-wrapped — as a bare
+   grid child it stretched full-width and its centered label floated
+   mid-page. */
+.wsp-drill__head {
+  display: grid;
+  gap: 8px;
+  justify-items: start;
+}
 .wsp-drill__heading {
-  margin: 10px 0 4px;
+  margin: 0;
   font-size: var(--text-body);
   font-weight: var(--weight-semibold);
+  overflow-wrap: anywhere;
 }
 
 /* Horizontal strip of a group's recent thumbs (overview). Shared height,
@@ -2233,6 +2298,14 @@ button.wft-card__name:focus-visible {
 .wsp-preview__pr .wsp-ghicon {
   margin-right: 2px;
 }
+/* Both toggle groups wrap as one cluster — independently they orphan
+   "Merged only" onto its own row at intermediate widths. */
+.wsp-filter__toggles {
+  display: flex;
+  flex: none;
+  gap: 8px;
+  align-items: stretch;
+}
 .wsp-filter__skel {
   display: flex;
   align-items: center;
@@ -2246,6 +2319,19 @@ button.wft-card__name:focus-visible {
   .wsp-filter .wsp-filter__project,
   .wsp-filter .wsp-filter__q {
     font-size: var(--text-meta);
+  }
+}
+/* Long project labels (owner/repo) can't share one line with the meta and
+   action at phone widths — give the label the full first line and let
+   meta + "view project" settle underneath instead of stranding the label
+   below its own icon. */
+@media (max-width: 639px) {
+  .wsp-project__head {
+    flex-wrap: wrap;
+    row-gap: 2px;
+  }
+  .wsp-project__label {
+    flex: 1 0 100%;
   }
 }
 


### PR DESCRIPTION
Layout pass (`/impeccable layout`) on the workspace screenshots page (`/account/workspaces/[name]/screenshots`), plus two small fixes picked up along the way.

## Layout

- **Spatial cadence.** 10px head-to-strip, 16px group-to-group, 32px toolbar-to-content, and a hairline + 28px between projects so project boundaries read at a glance.
- **Project headings are now the drill-in control.** The project name is a button (hover/focus underline) instead of pairing every heading with an always-visible `view project →` text link; GitHub mark bumped to 15px and headings sit on the h3 size so they no longer compete with path rows.
- **Progressive disclosure for `view all →`.** Group-head links reveal on row hover/focus instead of repeating down the page. On touch devices (`hover: none`) the affordances stay always-visible: a chevron on project names and a bare `→` on group heads.
- **Small-screen behavior.** Filter toggles wrap as a cluster, the drill-in header stacks, and project heads wrap under 640px.

## Fixes

- **Hover-preview popover viewport clamp.** Tall previews could overflow the viewport; the popover now re-clamps to a 12px margin after render and again once the full-size image loads.
- **Dev-only CSP allowance** for plain-http loopback thumbnails in `astro dev` (`img-src` gains `http://127.0.0.1:* http://localhost:*` only when `import.meta.env.DEV`; prod header unchanged).
- PRODUCT.md: removed the deprecated `## Register` section.

## Verification

- `pnpm --filter web test` — 819 passed (55 files), including 19 signed-in-page CSP tests and 6 component tests.
- Verified rest/hover/drill/mobile states against a seeded local stack; touch branch verified under a `hover: none` viewport.

## Screenshots

### Desktop

| Before | After |
| --- | --- |
| <img width="420" alt="Screenshots page before: repeated view project / view all links, flat project boundaries" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/773/screenshots-desktop-before.webp"> | <img width="420" alt="Screenshots page after: hairline project boundaries, name-as-control headings, disclosed view all" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/773/screenshots-desktop-after.webp"> |

Hover state — project name underlines as the drill-in affordance, group `view all →` discloses on its row:

<img width="700" alt="Hover state: project-name underline drill-in affordance" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/773/screenshots-hover-after.webp">

### Mobile (touch affordances always visible)

| Before | After |
| --- | --- |
| <img width="340" alt="Mobile before" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/773/screenshots-mobile-before.webp"> | <img width="340" alt="Mobile after: chevron on project names, bare arrow on group heads" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/773/screenshots-mobile-after.webp"> |
