### PR TITLE
fix(web): flip-aware hover-preview placement + keyboard focus parity

### DIFF
--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -47,6 +47,7 @@ import { makeFileOpener, newTabLinkProps, type FileOpener } from "../lib/file-op
 import {
   backfillTargets,
   filterCatalog,
+  focusIsKeyboardDriven,
   groupsFromCatalog,
   isRepoLabel,
   lastUpdatedLabel,
@@ -63,6 +64,7 @@ import {
   shotsFromSearchItems,
   type ScreenshotsFeed,
   type ScreenshotsView,
+  type ShotPreviewBox,
 } from "../lib/workspace-screenshots";
 
 /** How many path groups a project section previews before "view project →". */
@@ -242,7 +244,12 @@ function ShotThumb({
   /** Known destination; when null the tile falls back to a button + `onOpen`. */
   href: string | null;
   onOpen: () => void;
-  onPreviewEnter?: (el: HTMLElement, src: string, caption: PreviewCaption) => void;
+  onPreviewEnter?: (
+    el: HTMLElement,
+    src: string,
+    caption: PreviewCaption,
+    opts?: { immediate?: boolean },
+  ) => void;
   onPreviewLeave?: () => void;
 }) {
   const name = leafName(item.key);
@@ -265,6 +272,17 @@ function ShotThumb({
       if (previewSrc) onPreviewEnter?.(event.currentTarget, previewSrc, caption);
     },
     onMouseLeave: () => onPreviewLeave?.(),
+    // Keyboard-focus parity for the hover preview: `:focus-visible` gates
+    // this to genuine keyboard navigation, so tapping a tile on a touch
+    // device (which also focuses it) never opens a preview it can't hover
+    // away from. Escape (handled globally below) dismisses it either way,
+    // and dismissal never moves focus, so tab order is untouched.
+    onFocus: (event: { currentTarget: HTMLElement }) => {
+      if (previewSrc && focusIsKeyboardDriven(event.currentTarget)) {
+        onPreviewEnter?.(event.currentTarget, previewSrc, caption, { immediate: true });
+      }
+    },
+    onBlur: () => onPreviewLeave?.(),
   };
   const body = (
     <>
@@ -553,7 +571,12 @@ type PreviewCaption = {
 };
 
 type PreviewHandlers = {
-  onPreviewEnter: (el: HTMLElement, src: string, caption: PreviewCaption) => void;
+  onPreviewEnter: (
+    el: HTMLElement,
+    src: string,
+    caption: PreviewCaption,
+    opts?: { immediate?: boolean },
+  ) => void;
   onPreviewLeave: () => void;
 };
 
@@ -598,6 +621,10 @@ function ScreenshotsByPathInner({
   const previewTimer = useRef<number | null>(null);
   const [preview, setPreview] = useState<{
     src: string;
+    /** Trigger tile's viewport box, kept around so a re-measure (image load,
+     * resolved title) can re-run `shotPreviewPosition` without re-reading a
+     * DOM node that may have scrolled or unmounted. */
+    thumb: ShotPreviewBox;
     left: number;
     top: number;
     name: string;
@@ -851,20 +878,33 @@ function ScreenshotsByPathInner({
     };
   }, []);
 
-  // `shotPreviewPosition` places the pop-over from an ESTIMATED height, so a
-  // tall capture (or the async PR-title/meta lines) can run past the viewport
-  // bottom. Clamp the rendered box back inside after layout, and again when
-  // the full-size image or the resolved title changes its real height.
+  // Flip-aware placement, measured rather than estimated: `shotPreviewPosition`
+  // needs the pop-over's real box (the image's intrinsic aspect ratio and the
+  // meta block's line count are both unknown before mount — a PR title can
+  // add a line, an error state adds none), so this measures the ACTUAL
+  // rendered element and only then decides which side/edge to place it on.
+  // Runs in a layout effect, which lands the corrected position before the
+  // browser paints — no visible jump — and re-runs whenever the full-size
+  // image finishes loading or a resolved title changes the box's height.
   const previewRef = useRef<HTMLDivElement | null>(null);
-  const clampPreview = () => {
+  const positionPreview = () => {
     const el = previewRef.current;
     if (!el) return;
-    const margin = 12;
     const rect = el.getBoundingClientRect();
-    el.style.left = `${Math.max(margin, Math.min(rect.left, window.innerWidth - rect.width - margin))}px`;
-    el.style.top = `${Math.max(margin, Math.min(rect.top, window.innerHeight - rect.height - margin))}px`;
+    setPreview((prev) => {
+      if (!prev) return prev;
+      const pos = shotPreviewPosition(
+        prev.thumb,
+        { width: window.innerWidth, height: window.innerHeight },
+        { width: rect.width, height: rect.height },
+      );
+      // Bail out to the same object when nothing moved — an unstable object
+      // identity here would re-trigger this effect every render.
+      if (pos.left === prev.left && pos.top === prev.top) return prev;
+      return { ...prev, left: pos.left, top: pos.top };
+    });
   };
-  useLayoutEffect(clampPreview, [preview, titles]);
+  useLayoutEffect(positionPreview, [preview, titles]);
 
   const onPreviewLeave = () => {
     if (previewTimer.current !== null) window.clearTimeout(previewTimer.current);
@@ -880,33 +920,49 @@ function ScreenshotsByPathInner({
       if (info) setTitles((prev) => ({ ...prev, [ref]: info }));
     });
   };
-  const onPreviewEnter = (el: HTMLElement, src: string, caption: PreviewCaption) => {
-    if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
+  const onPreviewEnter = (
+    el: HTMLElement,
+    src: string,
+    caption: PreviewCaption,
+    opts?: { immediate?: boolean },
+  ) => {
+    // Keyboard focus (`opts.immediate`) opens regardless of hover capability
+    // — `focusIsKeyboardDriven` at the call site already excludes touch taps.
+    if (!opts?.immediate && !window.matchMedia("(hover: hover) and (pointer: fine)").matches) {
+      return;
+    }
     if (previewTimer.current !== null) window.clearTimeout(previewTimer.current);
     // Prefetch the title now (not inside the timeout) so it's likely resolved
     // by the time the pop-over appears.
     ensureTitle(caption.ref);
-    const delay = window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : 250;
-    previewTimer.current = window.setTimeout(() => {
+    const open = () => {
       const rect = el.getBoundingClientRect();
-      const width = Math.min(560, window.innerWidth - 24);
-      const height = Math.min(width * 0.7, window.innerHeight * 0.7) + 40;
-      const pos = shotPreviewPosition(
-        { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom },
-        { width: window.innerWidth, height: window.innerHeight },
-        { width, height },
-      );
+      const thumb: ShotPreviewBox = {
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+      };
       setPreview({
         src,
-        left: pos.left,
-        top: pos.top,
+        thumb,
+        // Placeholder until the layout effect above measures the real box
+        // and repositions before paint.
+        left: thumb.right + 12,
+        top: thumb.top,
         name: caption.name,
         pr: caption.pr,
         kind: caption.kind,
         ref: caption.ref,
         uploadedAt: caption.uploadedAt,
       });
-    }, delay);
+    };
+    if (opts?.immediate) {
+      open();
+      return;
+    }
+    const delay = window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : 250;
+    previewTimer.current = window.setTimeout(open, delay);
   };
   const previewHandlers: PreviewHandlers = { onPreviewEnter, onPreviewLeave };
 
@@ -1004,7 +1060,7 @@ function ScreenshotsByPathInner({
     >
       {/* onLoad: the real image height is only known once bytes arrive —
           re-clamp so a tall capture doesn't push the meta off-screen. */}
-      <img src={preview.src} alt="" onLoad={clampPreview} />
+      <img src={preview.src} alt="" onLoad={positionPreview} />
       <div className="wsp-preview__meta">
         <div className="wsp-preview__name">{preview.name}</div>
         {preview.pr && (

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   backfillTargets,
   filterCatalog,
+  focusIsKeyboardDriven,
   groupsFromCatalog,
   isRepoLabel,
   lastUpdatedLabel,
@@ -368,6 +369,27 @@ describe("shotPreviewPosition", () => {
     );
     expect(pos.top).toBe(492); // 800 - 8 - 300
     expect(pos.left).toBe(200);
+  });
+});
+
+describe("focusIsKeyboardDriven", () => {
+  it("opens the preview for a genuine :focus-visible match", () => {
+    expect(focusIsKeyboardDriven({ matches: (s) => s === ":focus-visible" })).toBe(true);
+  });
+  it("skips a focus that isn't :focus-visible (e.g. a touch tap)", () => {
+    expect(focusIsKeyboardDriven({ matches: () => false })).toBe(false);
+  });
+  it("treats a missing element as not keyboard-driven", () => {
+    expect(focusIsKeyboardDriven(null)).toBe(false);
+  });
+  it("treats an engine that throws on :focus-visible as not keyboard-driven", () => {
+    expect(
+      focusIsKeyboardDriven({
+        matches: () => {
+          throw new DOMException("unsupported selector", "SyntaxError");
+        },
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -391,3 +391,23 @@ export function shotPreviewPosition(
   }
   return { left, top };
 }
+
+/**
+ * Whether a `focus` event on a `.wsp-tile` anchor should open its hover
+ * preview. True only for genuine keyboard-driven focus (`:focus-visible`) —
+ * a touch tap also focuses the anchor it activates, and without this guard
+ * that tap would leave a preview stuck open on a device with no hover to
+ * dismiss it with. Takes a `matches`-shaped object rather than a real
+ * `Element` so it stays unit-testable without a DOM.
+ */
+export function focusIsKeyboardDriven(el: { matches(selector: string): boolean } | null): boolean {
+  if (!el) return false;
+  try {
+    return el.matches(":focus-visible");
+  } catch {
+    // Older engines without :focus-visible support throw a SyntaxError from
+    // an unrecognized selector — treat that the same as "not keyboard-driven"
+    // rather than letting it break the tile's focus handling.
+    return false;
+  }
+}


### PR DESCRIPTION
The screenshots-by-path hover preview (`.wsp-preview` in
`ScreenshotsByPath.tsx`) placed itself from a guessed size and then clamped
the rendered box back into the viewport after the fact (#773). That worked,
but it was two mechanisms doing one job, and it left keyboard users with no
way to see the preview at all — it only ever opened on pointer hover.

## What it does

- Replaces the estimate-then-clamp placement with measured, flip-aware
  placement: the popover mounts, its real rendered box is measured (image
  aspect ratio and the meta block's line count are both unknown ahead of
  time — a resolved PR title, or a missing one, changes the height), and
  `shotPreviewPosition` runs against that real size. A `useLayoutEffect`
  applies the correction before the browser paints, so there's no visible
  jump, and it re-runs on image load and title resolution the same way the
  old clamp did.
- Adds keyboard-focus parity: focusing a `.wsp-tile` anchor now opens the
  same preview. It's gated by `:focus-visible` (`focusIsKeyboardDriven`), so
  a touch tap — which also focuses the anchor it activates — never leaves a
  preview stuck open with no hover to dismiss it. Escape (already wired
  globally) dismisses it without moving focus, so tab order is untouched.
- Lazy PR-title resolution (`ensureTitle` / the `titles` cache) and the
  hover-only, mouse-fine-pointer gate for pointer-triggered previews are
  unchanged.

## What it is not

- Not a switch to CSS anchor positioning. I looked at it, but this is a
  signed-in React island (not one of the public pages that ship no
  framework JS), cross-browser support for `anchor()`/`position-anchor` is
  still incomplete, and the repo has no existing `@supports`-gated
  progressive-enhancement pattern for layout-critical CSS to build on. A
  real fallback would mean shipping the same measured-JS logic anyway, so
  measured placement is the only mechanism rather than two.
- Local visual verification (does the popover actually look right against a
  full local stack with real thumbnails) needs the seeded-stack recipe from
  #777. Wiring up that full stack here would have cost more
  than it returns for this change.

## Test plan

- [x] `pnpm --filter web test` — 823 passed (819 pre-existing + 4 new for
      `focusIsKeyboardDriven`)
- [x] `pnpm --filter @uploads/web run typecheck` — 0 errors
- [x] `pnpm exec oxlint`/`oxfmt` on the changed files — clean
- [ ] Manual browser check against a local stack (see note above)

`ScreenshotsByPath.tsx` can't be imported under plain Vitest (jsx: preserve —
same limitation `ScreenshotsByPath.test.ts` already documents), so the new
coverage lives in `workspace-screenshots.test.ts` alongside the existing
`shotPreviewPosition` tests, which is where the component's positioning
logic is actually testable.
