### PR TITLE
docs: two-lane storage spec and implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-08-22-two-lane-storage.md
+++ b/docs/superpowers/plans/2026-08-22-two-lane-storage.md
@@ -1,0 +1,352 @@
+# Two-Lane Workspace Storage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a populated workspace save, verify, and explicitly switch to a BYO R2 bucket — old files keep resolving from their original lane, new uploads go to the active lane, and switching back is the same primitive in reverse.
+
+**Architecture:** `WorkspaceRecord` keeps its top-level storage fields as the active write lane and gains `storageLanes: StorageLane[]` for inactive lanes (standby = saved config, fallback = former active that may hold objects). Reads resolve through an ordered lane walk; lists fan out and merge; a new activate endpoint swaps lanes. All storage IO stays inside the files-sdk-backed `packages/storage` wrapper.
+
+**Tech Stack:** Cloudflare Workers (Hono), KV workspace records via `mutateWorkspaceRecord`, D1 usage ledger, files-sdk 2.2.4 via `@uploads/storage`, vitest with in-process fakes.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-two-lane-storage-design.md` — read it first; every task argues from it.
+
+## Global Constraints
+
+- Four separate PRs, **each based on `main`** — stacked PRs skip Test/Lint CI in this repo. PR order: A (#619 fix) → B (primitive) → C (read paths) → D (transitions/UI). B, C, D each start from main after the previous merges.
+- All KV workspace-record mutations go through `mutateWorkspaceRecord` (apps/api/src/workspace.ts) — never bare `REGISTRY.put`.
+- All storage IO goes through `createStorage` / helpers in `packages/storage` (files-sdk). Never construct S3/R2 clients directly.
+- Credentials seal with `sealCredentialFieldsStrict` (self-serve writes) and open with `openCredentialFields` (apps/api/src/secrets.ts). Plaintext credential fields must never be written to KV.
+- `StorageLane.provider` is a `string` validated to `"r2"` at the boundary (spec: N-lane readiness). `packages/storage`'s `StorageProvider` union stays `"r2"`.
+- PRs B and C must be **zero behavior change** for every record with no `storageLanes` (the entire fleet at merge time). Existing tests must pass unmodified.
+- Tests: plain vitest with in-process fakes (`pnpm test` at root, or `pnpm --filter @uploads/api test`). Follow existing patterns in `apps/api/test/`. TypeScript check: `pnpm --filter @uploads/api exec tsc --noEmit` (repo `pnpm types` generates wrangler types, it is NOT a typecheck).
+- Formatting: `.ts` via oxfmt (lint-staged handles it on commit); do not run prettier on TS files.
+- Commit messages: conventional (`fix:`, `feat:`, `docs:`), no "comprehensive"/"world-class" superlatives.
+
+---
+
+## PR A — #619: detach must survive flag revocation
+
+Branch: `claude/619-detach-after-flag-revoke`. One task. Ships first, independent of everything below.
+
+### Task A1: allow storage detach when the record is already BYO
+
+**Files:**
+
+- Modify: `apps/api/src/routes/workspace-settings.ts:527-531` (`storageDeleteHandler` flag gate)
+- Test: `apps/api/test/` — find the existing storage-route test file (`grep -rl "workspace_storage_not_empty\|storageDeleteHandler\|byo_bucket_disabled" apps/api/test/`) and add cases there.
+
+**Interfaces:**
+
+- Consumes: `byoBucketAllowed(record)` (apps/api/src/workspace.ts:200), `record.storageConfiguredAt` (set by every successful PUT, cleared on detach).
+- Produces: no new exports; behavior change only.
+
+- [ ] **Step 1: Write the failing test.** In the existing storage-route test file, add: seed a workspace record that is BYO-configured (`accountId`, sealed `accessKeyId`/`secretAccessKey`, `storageConfiguredAt` set, no `binding`) with `byoBucketEnabled: false` (or the flag field absent so `byoBucketAllowed` is false — match how neighboring tests build allowed records and invert it). Call `DELETE` on the storage route the way the file's existing detach tests do. Assert status 200 and response `mode: "shared"`. Add a companion test: same flag-off record but **shared-mode** (no BYO fields) still gets 403 `byo_bucket_disabled` on DELETE, so the gate isn't just deleted.
+- [ ] **Step 2: Run to verify it fails.** `pnpm --filter @uploads/api test -- <testfile>` — expect the new test to fail with 403 `byo_bucket_disabled`.
+- [ ] **Step 3: Implement.** In `storageDeleteHandler`, replace the gate with:
+
+```ts
+// Detach must stay available after the flag is revoked, otherwise the
+// workspace is stranded on the customer bucket (#619).
+if (!byoBucketAllowed(record) && !record.storageConfiguredAt) {
+  throw new ForbiddenError("BYO storage is not enabled for this workspace", {
+    code: "byo_bucket_disabled",
+  });
+}
+```
+
+- [ ] **Step 4: Run the full api test suite + typecheck.** `pnpm --filter @uploads/api test` and `pnpm --filter @uploads/api exec tsc --noEmit` — all green.
+- [ ] **Step 5: Commit + PR.** `fix(api): allow BYO storage detach after byoBucketEnabled is revoked (#619)`. PR body links #619 and quotes the stranding scenario. This is auth-adjacent but tiny and pre-reviewed by CodeRabbit on #617 — do not request a CodeRabbit review.
+
+---
+
+## PR B — lanes primitive (zero behavior change)
+
+Branch: `claude/two-lane-storage-primitive`.
+
+### Task B1: `StorageLane` type + record fields + seal/reseal coverage
+
+**Files:**
+
+- Modify: `apps/api/src/workspace.ts` (WorkspaceRecord fields, near the existing storage fields at :36-53)
+- Modify: `apps/api/src/secrets.ts` (reseal walk) — read `resealCredentialFields` (:201) first; also check `scripts/reencrypt-workspace-secrets.mjs` and `apps/api/src/reencrypt-registry.ts` for the sweep that must now include lanes.
+- Test: `apps/api/test/secrets.test.ts` (or wherever `resealCredentialFields` is tested — `grep -rl resealCredentialFields apps/api/test/`)
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+// workspace.ts
+export interface StorageLane {
+  id: string; // "lane_" + 8 lowercase hex chars
+  verifiedAt?: string; // ISO — last successful verify against this config
+  lastActiveAt?: string; // ISO — set at demotion; absence = never held writes (standby)
+  provider: string; // validated to "r2" at every boundary today
+  bucket: string;
+  binding?: string;
+  prefix?: string;
+  publicBaseUrl?: string;
+  accountId?: string;
+  accessKeyId?: string; // sealed enc:v1:
+  secretAccessKey?: string; // sealed enc:v1:
+  jurisdiction?: string;
+  // Display/provenance mirrors of the top-level fields:
+  storageAccessKeyIdLast4?: string;
+  storageConfiguredAt?: string;
+  storageConfiguredBy?: string;
+}
+export function newLaneId(): string; // "lane_" + crypto.getRandomValues-derived 8 hex
+// WorkspaceRecord gains:
+//   storageLanes?: StorageLane[];
+//   storageLaneId?: string;   // id of the active lane; absent = pre-lanes record
+```
+
+- [ ] **Step 1: Failing test for reseal.** Build a record with one HTTP-mode lane in `storageLanes` whose `accessKeyId`/`secretAccessKey` are sealed under an old key; run the reseal path the existing tests use; assert the lane's fields decrypt under the new key afterward.
+- [ ] **Step 2: Run to verify fail.**
+- [ ] **Step 3: Implement.** Add the interface + fields + `newLaneId()` to `workspace.ts`. Extend the reseal walk(s) so any `storageLanes[i].accessKeyId/secretAccessKey` are re-sealed alongside the top-level pair. Search for every place that reseals or strips credentials (`grep -rn "accessKeyId" apps/api/src --include=*.ts -l`) and audit each for lane coverage — in particular any admin/status projection that must NOT leak lane credentials (mirror the masking posture of `storageStatusResponse`).
+- [ ] **Step 4: Suite + typecheck green.**
+- [ ] **Step 5: Commit** `feat(api): StorageLane record shape with sealed-credential reseal coverage`.
+
+### Task B2: `storageConfigs` resolver + `resolveObjectLane`
+
+**Files:**
+
+- Modify: `apps/api/src/storage.ts` (beside `storageConfig`)
+- Test: `apps/api/test/` new file `storage-lanes.test.ts`
+
+**Interfaces:**
+
+- Consumes: `storageConfig(env, ws)` (storage.ts:27), `createStorage`, `openCredentialFields`.
+- Produces:
+
+```ts
+// storage.ts
+export interface LaneConfig {
+  laneId: string | null; // null = pre-lanes implicit active lane
+  role: "active" | "fallback";
+  config: StorageConfig;
+}
+/** Active lane first, then fallback lanes (lastActiveAt set) in array order.
+ *  Standby lanes (no lastActiveAt) are excluded. A fallback lane that fails
+ *  to resolve (bad binding name, undecryptable creds) is logged and skipped —
+ *  never throws; active-lane failures still throw exactly as storageConfig does. */
+export async function storageConfigs(env: Env, ws: WorkspaceRecord): Promise<LaneConfig[]>;
+
+export interface ResolvedLane {
+  store: Files;
+  config: StorageConfig;
+  laneId: string | null;
+  role: "active" | "fallback";
+}
+/** Walk lanes in order, first store.exists(key) hit wins. Null = nowhere.
+ *  Single-lane records short-circuit to the current behavior (one exists call). */
+export async function resolveObjectLane(
+  env: Env,
+  ws: WorkspaceRecord,
+  key: string,
+): Promise<ResolvedLane | null>;
+```
+
+- [ ] **Step 1: Failing tests.** Use the repo's existing fake-R2 pattern (`grep -rn "FakeR2Bucket" apps/api/test | head` — reuse it). Cases: (a) record with no lanes → `storageConfigs` returns one entry, role active, laneId null; (b) record with one fallback lane bound to a second FakeR2Bucket → two entries in order; (c) standby lane (no `lastActiveAt`) excluded; (d) `resolveObjectLane` finds a key present only in the fallback bucket and returns that lane's config; returns active lane when present in both; null when in neither; (e) fallback lane naming a nonexistent binding is skipped without throwing while active still resolves.
+- [ ] **Step 2: Run to verify fail.**
+- [ ] **Step 3: Implement.** Extract the body of `storageConfig` into a helper that takes the storage-field bag (top-level record or a `StorageLane`) so both paths share binding lookup + credential opening; `storageConfig` keeps its exact signature and error behavior. `storageConfigs` maps lanes through it with try/catch → `console.error` + skip for fallbacks. Validate `lane.provider === "r2"` before use; skip+log otherwise.
+- [ ] **Step 4: Suite + typecheck green** (existing storage tests untouched).
+- [ ] **Step 5: Commit** `feat(api): lane-aware storage resolution (storageConfigs, resolveObjectLane)`.
+
+### Task B3: provenance lane stamp on upload
+
+**Files:**
+
+- Modify: `apps/api/src/files-core.ts` `putObject` (:318) — find where the R2 customMetadata/provenance bag is assembled (search `metadata` within putObject) and add the stamp.
+- Test: extend the existing putObject test file (`grep -rln "putObject" apps/api/test | head -3`).
+
+**Interfaces:**
+
+- Consumes: `ws.storageLaneId` from Task B1.
+- Produces: provenance key `"storage-lane"` in object customMetadata; value = `ws.storageLaneId ?? "lane_origin"`.
+
+- [ ] **Step 1: Failing test.** Upload via `putObject` against a record with `storageLaneId: "lane_ab12cd34"`; head the object through the fake store; assert `metadata["storage-lane"] === "lane_ab12cd34"`. Second case: record without `storageLaneId` stamps `"lane_origin"`.
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement** (one line in the provenance bag; follow the naming style of the neighboring provenance keys — check whether they're kebab or dotted and match).
+- [ ] **Step 4: Suite + typecheck green.**
+- [ ] **Step 5: Commit** `feat(api): stamp storage lane id into upload provenance`. Open PR B: `feat(api): storage-lane primitive (no behavior change)` — body states the zero-behavior-change contract and cites the spec path.
+
+---
+
+## PR C — lane-aware read paths (still zero behavior change for single-lane records)
+
+Branch: `claude/two-lane-read-paths`. Every task's tests build a two-lane record (active BYO-style FakeR2 + fallback shared-style FakeR2) plus a single-lane control record.
+
+### Task C1: public files resolve across lanes
+
+**Files:**
+
+- Modify: `apps/api/src/routes/public-files.ts` `resolvePublicObject` (:94-122)
+- Test: the existing public-files test file.
+
+**Interfaces:**
+
+- Consumes: `resolveObjectLane` (B2).
+- Produces: `ResolvedPublicObject` unchanged in shape — but `store`/`cfg`/`urls` now come from the owning lane.
+
+- [ ] **Step 1: Failing test.** Two-lane record; key exists only in fallback store with fallback `publicBaseUrl: "https://storage.uploads.sh"`; GET the public file JSON; assert 200 and `url` starts with the fallback base, not the active one. Control: single-lane behavior byte-identical to today (reuse an existing test unchanged).
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement.** Replace the storageConfig/exists/head block with `resolveObjectLane`; derive `urls` via `objectPublicUrls(env, lane.config, key)`. Keep the "no public URL ⇒ 404" gate per-lane: a lane hit whose config lacks `publicBaseUrl` still 404s exactly as today. `?download=1` streams from the owning lane's store automatically (same `store`).
+- [ ] **Step 4: Suite + typecheck green.**
+- [ ] **Step 5: Commit** `feat(api): public file pages resolve objects across storage lanes`.
+
+### Task C2: authenticated head/download/URL paths
+
+**Files:**
+
+- Modify: `apps/api/src/files-core.ts` — `downloadResponse` callers, `headObjectJson` (:741) call sites; `apps/api/src/routes/files-shared-handlers.ts` (:103,116,160,228); `apps/api/src/routes/workspace-files.ts` (:274-291 signed-URL fallback).
+- Test: existing files-route test files for head/download.
+
+**Interfaces:**
+
+- Consumes: `resolveObjectLane`, `signedDownloadUrl` (packages/storage).
+- Produces: no signature changes; handlers accept a `ResolvedLane` where they previously built `store`+`cfg` themselves.
+
+- [ ] **Step 1: Failing tests.** (a) HEAD on a fallback-only key returns 200 with the fallback lane's URL fields; (b) authenticated download streams fallback bytes; (c) `workspace-files` single-file URL resolution: fallback-only key on a lane with `publicBaseUrl` → that public URL; fallback lane _without_ `publicBaseUrl` but with HTTP creds → signed URL minted from the **fallback** lane's store (assert host/params differ from active).
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement.** Thread lane resolution through the shared handlers. Where a handler previously did `storage(env, ws)` + `exists`, call `resolveObjectLane` once and pass the resolved store/config down.
+- [ ] **Step 4: Suite + typecheck green.**
+- [ ] **Step 5: Commit** `feat(api): lane-aware head, download, and file URL resolution`.
+
+### Task C3: deletion targets every owning lane
+
+**Files:**
+
+- Modify: `apps/api/src/files-core.ts` `deleteObject` (:848)
+- Test: existing delete tests.
+
+**Interfaces:**
+
+- Consumes: `storageConfigs` (B2).
+- Produces: `deleteObject` deletes the key from **every** lane whose store has it (active + fallbacks); returns as deleted if any lane had it. Usage delta counts the object once (bytes from the first lane hit, matching what list/reads report).
+
+- [ ] **Step 1: Failing test.** Key present in both active and fallback stores → delete → gone from both; key present only in fallback → delete succeeds (no 404) and fallback store is empty.
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement.** Iterate `storageConfigs`, `exists` → `delete` per lane. Preserve the existing delete-usage-claim flow (`claimDeleteUsageSafe`) unchanged.
+- [ ] **Step 4: Suite + typecheck green.**
+- [ ] **Step 5: Commit** `feat(api): delete removes an object from every storage lane that holds it`.
+
+### Task C4: merged listing with composite cursor
+
+**Files:**
+
+- Modify: `apps/api/src/files-core.ts` `listObjects` (:800-846)
+- Create: `apps/api/src/lane-list.ts` (merge + cursor codec, pure functions)
+- Test: new `apps/api/test/lane-list.test.ts` + extend list-route tests.
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+// lane-list.ts
+export interface LaneCursorMap {
+  v: 1;
+  lanes: Record<string, string>;
+} // laneId ("active" for null) → provider cursor
+export function encodeLaneCursor(map: LaneCursorMap): string; // base64url(JSON)
+export function decodeLaneCursor(raw: string | undefined): LaneCursorMap | null; // null on garbage
+/** k-way merge by key asc; on duplicate key keep the entry from the earliest lane in `order`. */
+export function mergeLaneListings<T extends { key: string }>(
+  pages: Array<{ laneOrder: number; items: T[] }>,
+): T[];
+```
+
+- `listObjects` behavior: single-lane record → exactly today's path and today's opaque provider cursor (no envelope — **backward compatible with in-flight cursors**). Multi-lane record → fan out the same prefix/limit to each lane, merge, trim to limit, emit composite cursor; accept either cursor form (composite detected by successful decode with `v: 1`).
+- [ ] **Step 1: Failing unit tests** for the codec (round-trip, garbage → null) and merge (interleave, duplicate key keeps lower laneOrder, stable within lane).
+- [ ] **Step 2: Verify fail; implement lane-list.ts; unit tests green.**
+- [ ] **Step 3: Failing integration test.** Two-lane record, 3 keys in active + 3 in fallback with interleaved names + 1 duplicated key, page size 4: first page = first 4 merged keys with the duplicate appearing once (active copy — compare a distinguishing metadata field); second page via returned cursor = remaining keys; single-lane control returns today's shape.
+- [ ] **Step 4: Implement in `listObjects`; suite + typecheck green.** Also audit `reconcile.ts` `listAll` walk (:38+) — it must walk **only the active lane** until PR D makes it lane-aware (leave a `// PR D:` marker comment referencing the plan).
+- [ ] **Step 5: Commit** `feat(api): merged multi-lane listing with composite cursors`. Open PR C: `feat(api): lane-aware read paths` — body restates single-lane-unchanged contract. Galleries/posters/github-comment URL derivation (spec §read path) work on keys they just uploaded or already-resolved URLs — audit each call site listed in the spec (gallery-service.ts:313,423; poster.ts:77; github-comment.ts:191), convert any that resolves _pre-existing_ keys to `resolveObjectLane`, and note per-site in the PR body whether it changed or why not. **Request a CodeRabbit review on PR C** (`coderabbit:review` label) — it touches the serving path.
+
+---
+
+## PR D — save/activate/remove transitions, usage attribution, UI, docs
+
+Branch: `claude/two-lane-transitions`.
+
+### Task D1: shared-lane usage subset (D1 migration + ledger)
+
+**Files:**
+
+- Create: `apps/api/migrations/<timestamp>_workspace_usage_shared_subset.sql`
+- Modify: `apps/api/src/usage.ts` (`WorkspaceUsage`, `getWorkspaceUsage` :71, `applyUsageDelta` :93, `recordUsageSafe` :332, reservation helpers only if they write totals), `apps/api/src/reconcile.ts` (walk all lanes, rebuild both totals and shared subset), `apps/api/src/budget.ts` (`enforcedMaxStorageBytes` :65).
+- Test: usage/budget/reconcile test files.
+
+**Interfaces:**
+
+- Migration:
+
+```sql
+ALTER TABLE workspace_usage ADD COLUMN shared_bytes INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE workspace_usage ADD COLUMN shared_objects INTEGER NOT NULL DEFAULT 0;
+```
+
+- `WorkspaceUsage` gains `sharedBytes: number; sharedObjects: number`.
+- `applyUsageDelta(db, workspace, delta, opts?: { sharedLane?: boolean })` — when `sharedLane` (the mutated lane is binding-mode), the delta also applies to the shared subset. Callers: putObject passes `sharedLane: !!ws.binding` (active lane); deleteObject passes the owning lane's binding-mode per lane hit.
+- Budget: active lane BYO (`!storageBudgetApplies(record)`) → enforce `maxStorageBytes` against `sharedBytes`; active lane shared → against `bytes` (today's behavior). Implement as a new `enforcedStorageUsageBytes(record, usage): number` in budget.ts used by `checkPutBudget`/`storageBudgetDenial` call sites.
+- Backfill: existing rows get `shared_bytes = bytes`, `shared_objects = objects` **only for shared-mode workspaces**; BYO workspaces get 0s. This can't be expressed in the SQL migration (mode lives in KV) — reconcile is the backfill: extend `reconcileWorkspaceUsage` to write the subset, and note in the PR body that BYO workspaces (a handful) need a one-time reconcile; defaults of 0 are safe in the meantime because today's BYO enforcement is "none".
+- [ ] **Step 1: Failing tests** for delta bookkeeping (shared vs non-shared deltas), reconcile rebuilding both numbers across two fake lanes, and budget: BYO-active record with `sharedBytes` over `maxStorageBytes` denies a put; same record with big `bytes` but small `sharedBytes` allows.
+- [ ] **Step 2: Verify fail. Step 3: Implement. Step 4: Suite + typecheck green.** (Migrations auto-apply to prod on merge to main — no manual step.)
+- [ ] **Step 5: Commit** `feat(api): shared-lane usage subset with lane-aware budget enforcement`.
+
+### Task D2: save-as-standby (PUT), activate endpoint, lane-aware remove (DELETE)
+
+**Files:**
+
+- Modify: `apps/api/src/routes/workspace-settings.ts` (`storagePutHandler` :421, `storageDeleteHandler` :522, mount block :789-792 gains the activate route), `apps/api/src/routes/workspace-storage.ts` (`storageStatusResponse` gains lanes projection), `apps/api/src/routes/me.ts` (:446-457 forwards the new route).
+- Test: the storage-route test file (same one as PR A).
+
+**Interfaces:**
+
+- `PUT /:workspace/storage` — verify (unchanged pipeline via `storageVerify`), then write a **standby lane**: seal creds, build a `StorageLane` with `id: newLaneId()`, `verifiedAt: nowIso`, `storageConfiguredBy: userId`, no `lastActiveAt`. Upsert by bucket+accountId (replace an existing standby/fallback lane for the same bucket in place, preserving its `id` and `lastActiveAt`). **Top-level fields untouched. The `workspace_storage_not_empty` 409 and the `getWorkspaceUsage` pre-check are deleted from this handler.** Response: `{ ...storageStatusResponse(updated, true), verify: result }`.
+- `POST /:workspace/storage/activate` body `{ laneId: string }` — gates: `byoBucketAllowed` unless target lane is binding-mode (switching back must survive flag revocation, same #619 posture), `allowWrite` rate limit. If target lane is HTTP-mode and `verifiedAt` older than 10 minutes, re-run `storageVerify` against the opened (decrypted) lane credentials; 422 with the verify result on fail. Then inside one `mutateWorkspaceRecord`: demote current top-level fields into a lane (reuse existing `storageLaneId` as its id, else `newLaneId()`; stamp `lastActiveAt: nowIso`; upsert by bucket), promote target lane's fields to top-level (delete it from `storageLanes`), set `storageLaneId` to the promoted lane's id. Log event `workspace_storage_lane_activated`.
+- `DELETE /:workspace/storage` body/query gains optional `laneId`. With `laneId`: remove that lane from `storageLanes`; if it has `lastActiveAt`, first check emptiness — run a `store.list({ limit: 1 })` against that lane (build via the shared config helper from B2); non-empty → 409 `workspace_storage_not_empty` unless `force`. Without `laneId` (legacy shape): if active lane is BYO → behave as today's detach (restore `selfServeWorkspaceRecord` fields) but **keep** the BYO config as a fallback lane when the D1 ledger has objects, drop it when `force`. Keep the PR A gate exactly (`!byoBucketAllowed && !record.storageConfiguredAt` → 403).
+- `storageStatusResponse` gains `lanes: Array<{ laneId: string; role: "standby" | "fallback"; bucket: string; publicBaseUrl?: string; verifiedAt?: string; lastActiveAt?: string; accountIdMasked?: string; accessKeyIdLast4?: string }>` and `activeLaneId?: string`. Never credential values.
+- [ ] **Step 1: Failing tests.** (a) PUT on a populated workspace (usage.objects > 0) → 200, top-level fields unchanged, response lanes contains one standby; (b) activate → top-level = lane config, old config now a fallback lane with `lastActiveAt`; (c) activate with stale `verifiedAt` re-runs verify (assert via `setStorageVerifyForTests` call count) and 422s on fail without mutating; (d) activate back to the shared lane by its laneId → shared fields restored, BYO lane is a fallback; (e) DELETE laneId on an objects-holding fallback lane → 409; with force → lane gone; (f) legacy DELETE (no laneId) with empty ledger → today's behavior (config dropped).
+- [ ] **Step 2: Verify fail. Step 3: Implement. Step 4: Suite + typecheck green.**
+- [ ] **Step 5: Commit** `feat(api): decoupled storage save/activate/remove with lane transitions`.
+
+### Task D3: web client + settings UI
+
+**Files:**
+
+- Modify: `apps/web/src/lib/api-client.ts` (:1893-1960 storage methods; add `activateWorkspaceStorage(name, laneId)`; PUT loses its 409 branch; DELETE gains optional laneId)
+- Modify: `apps/web/src/pages/account/workspaces/[name]/settings/storage.astro` (remove `applySharedUsageGate` :739-748 and the `#storage-connect-note` at :77; wizard CTA becomes "Save & verify"; render saved-config card with "Use this bucket" / active-state card with "Switch back to uploads.sh storage"; a "previous storage" line listing fallback lanes)
+- Modify: `apps/web/src/pages/docs/byo-bucket.astro` (:72 empty-workspace note → two-lane explanation; serving matrix :76-115 gains "files uploaded before switching" row)
+- Modify: admin storage panel (`grep -rln "admin-ui/workspaces" apps/web/src | head`) — read-only lanes list.
+- Test: whatever component/route tests exist for these pages (`grep -rln "storage" apps/web/test 2>/dev/null || true`); otherwise browser-verify (Step 4).
+
+**Interfaces:**
+
+- Consumes: D2's `StorageStatusResponse.lanes` / `activeLaneId`, new activate endpoint.
+- Copy (verbatim, per spec): switch confirmation — "Existing files stay where they are and keep working. New uploads go to your bucket." Saved-card status line — "Saved · not in use". Buttons — "Save & verify", "Use this bucket", "Switch back to uploads.sh storage". Docs stay "in preview" phrasing; never say "flag".
+- [ ] **Step 1: Implement client methods + UI states.** Follow the page's existing vanilla-JS + `applyStatus()` pattern; no framework JS on this page beyond what exists.
+- [ ] **Step 2: Typecheck + unit tests green.** `pnpm --filter @uploads/web exec tsc --noEmit` (if web is still blocked on TS7/#610, run the repo's web check task instead — `grep '"check"' apps/web/package.json`).
+- [ ] **Step 3: Browser verification** against the local stack (memory: only the stack-raw 127.0.0.1 recipe gives a signed-in in-app-browser session — see `uploads-local-browser-verify-recipe`): populated workspace → Save & verify (fake/verify seam or real test bucket) → card shows saved-not-in-use → activate → old file page still renders with storage.uploads.sh URL → new upload lands on the BYO base URL → switch back. Screenshot the storage panel states for the PR (use the `/github-screenshots` skill — this is a visual settings change).
+- [ ] **Step 4: Commit** `feat(web): two-lane storage settings — save, verify, switch, switch back`.
+
+### Task D4: doctor line, docs page, issue hygiene
+
+**Files:**
+
+- Modify: CLI doctor storage line (`grep -rln "doctor" packages/cli/src | head`, find the storage/honesty line from PR #590) — report active lane + fallback count ("storage: your bucket (1 previous lane still serving old files)").
+- Modify: `apps/web/src/pages/docs/byo-bucket.astro` if not fully covered in D3.
+- Test: CLI doctor test file if one exists.
+
+- [ ] **Step 1: Implement + test.**
+- [ ] **Step 2: Commit** `feat(cli): doctor reports storage lanes`. Open PR D: `feat: two-lane workspace storage — save, switch, and fall back without migration`. **Request CodeRabbit review** (storage transitions + auth-gated routes). PR body: spec path, behavior contract, screenshots from D3.
+- [ ] **Step 3: After merge:** comment on #594 scoping it down to physical migration residue (link the spec; do not close without Zach), close #619 (PR A), update #630/#595 with a pointer to the N-lane-ready record shape. Reminder: never include user/upload counts in public issue comments.
+
+---
+
+## Self-review notes (already applied)
+
+- Spec §"Configure, then switch" maps to D2; §"N-lane readiness" is carried by B1/B2 types (id-addressed array, provider string); §"files-sdk" is a global constraint; §usage → D1; §listing → C4; §read path → C1–C3; §UI/docs/doctor → D3/D4; §testing cases distributed into each task's Step 1.
+- Type consistency: `StorageLane`, `LaneConfig`, `ResolvedLane`, `LaneCursorMap`, `newLaneId`, `storageConfigs`, `resolveObjectLane`, `encodeLaneCursor`/`decodeLaneCursor`/`mergeLaneListings`, `enforcedStorageUsageBytes` — defined once each, consumed by name in later tasks.
+- Known judgment calls left to implementers _with the spec as tiebreaker_: exact provenance key casing (match neighbors, B3); which gallery/poster/comment sites truly need lane resolution (C-final audit, reported per-site in the PR body).

--- a/docs/superpowers/specs/2026-08-22-two-lane-storage-design.md
+++ b/docs/superpowers/specs/2026-08-22-two-lane-storage-design.md
@@ -46,12 +46,13 @@ The existing top-level storage fields on `WorkspaceRecord` (`provider`, `bucket`
 New field:
 
 ```ts
-/** Ordered read-only fallback lanes, most recent demotion first. */
-fallbackLanes?: StorageLane[];
+/** All configured inactive lanes: saved-but-never-used configs and demoted former actives. */
+storageLanes?: StorageLane[];
 
 interface StorageLane {
   id: string;              // short opaque id, e.g. "lane_<8hex>"; stamped into new-upload provenance
-  demotedAt: string;       // ISO timestamp of the transition that demoted it
+  verifiedAt?: string;     // last successful verify run against this lane's config
+  lastActiveAt?: string;   // set when the lane is demoted from active; absence = never held writes
   provider: "r2";
   bucket: string;
   binding?: string;        // shared lane uses the binding; BYO lanes are HTTP-credential mode
@@ -66,9 +67,15 @@ interface StorageLane {
 
 - All writes go through `mutateWorkspaceRecord` (versioned KV writes — never bare
   `REGISTRY.put`).
-- Fallback-lane credentials are sealed/resealed exactly like active-lane credentials
-  (`sealCredentialFieldsStrict` on demotion of an HTTP-mode lane; `resealCredentialFields`
-  covers rotation sweeps — the reseal walk must include `fallbackLanes`).
+- Lane credentials are sealed/resealed exactly like active-lane credentials
+  (`sealCredentialFieldsStrict` when an HTTP-mode lane config is saved;
+  `resealCredentialFields` covers rotation sweeps — the reseal walk must include
+  `storageLanes`).
+- Lane states, derived rather than stored as an enum: **standby** = configured and
+  verified, `lastActiveAt` absent — a saved config that has never received writes;
+  **fallback** = `lastActiveAt` set — a former active lane that may hold objects.
+  Only fallback lanes participate in read resolution; standby lanes are pure
+  configuration and cost nothing at read time.
 - The active lane also gets a persisted `storageLaneId` (top-level field) so provenance
   stamping and future migration tooling can name it. On records that predate this
   design, absence of `storageLaneId` means the implicit original lane.
@@ -115,7 +122,7 @@ Call sites that change from "current store only" to lane-aware:
 - Metadata writes (`file_metadata`, `file_content_hash`) are keyed on
   `(workspace, object_key)` and are lane-agnostic — unchanged.
 
-Single-lane workspaces (no `fallbackLanes`) take the exact current code path; the
+Single-lane workspaces (no fallback lanes) take the exact current code path; the
 helper short-circuits. **No behavior change until a second lane exists.**
 
 ### Listing: merged fan-out
@@ -133,33 +140,53 @@ Thumbnails: `thumb-url.ts` wraps by host; shared-lane files keep getting cdn-cgi
 thumbs, BYO-lane files keep the existing BYO behavior (no thumbs) — per-file now
 instead of per-workspace.
 
-### Attach / detach flow changes
+### Configure, then switch (decoupled activation)
 
-Attach (`PUT /me/workspaces/:name/storage`, handler in `workspace-settings.ts`):
+Saving a BYO configuration and routing uploads to it are **two separate actions**
+(Zach, 2026-08-22). Verification sits between them, and switching is explicit,
+re-verified, and instantly reversible. Nothing changes about where uploads go until
+the user says so.
+
+**Save** (`PUT /me/workspaces/:name/storage`):
 
 1. Verify pipeline unchanged (shape/auth/round-trip/not-empty + public-URL probe;
    `adoptExistingContents` still bypasses the **bucket**-not-empty check).
-2. The `workspace_storage_not_empty` 409 (**workspace** ledger check) is **removed**.
-   Instead, when `workspace_usage.objects > 0`, the current active config is demoted
-   into `fallbackLanes` before the BYO config is written as active.
-   When the ledger is empty, behave exactly as today (overwrite, no fallback lane).
-3. Reconcile after attach becomes lane-aware (see Usage below).
+2. On success the config is written as a **standby lane** in `storageLanes` with
+   `verifiedAt` — the active lane is untouched. The `workspace_storage_not_empty`
+   409 disappears from this path entirely (saving a config is always safe).
+3. Saving again replaces the standby lane for that bucket (credential rotation is a
+   re-save). Re-verify on demand stamps a fresh `verifiedAt`.
 
-Detach (`DELETE /me/workspaces/:name/storage`):
+**Switch** (`POST /me/workspaces/:name/storage/activate`, body `{ laneId }`):
 
-1. #619 fix (ships first, standalone): allow detach whenever the record is currently
-   BYO-configured, regardless of `byoBucketEnabled`.
-2. Two-lane detach: if the BYO era produced objects (any object resolves only in the
-   BYO lane), demote the BYO lane to a fallback instead of dropping it; restore the
-   shared config as active. If the shared config is already present in `fallbackLanes`,
-   **promote it back** (remove from fallbacks) rather than duplicating it.
-3. `force=true` keeps its meaning of "drop without ceremony": it discards the BYO
-   config entirely (current behavior) — the escape hatch when the customer bucket is
-   gone or credentials are dead.
+1. Re-run verify against the target lane if it's HTTP-credential mode and
+   `verifiedAt` is stale (older than a short window) — a switch never lands on a
+   config that has silently rotted.
+2. Swap: the target lane's config becomes the top-level active fields; the outgoing
+   active config is written into `storageLanes` with `lastActiveAt` stamped (it may
+   hold objects, so it becomes a read fallback). If the workspace ledger is empty at
+   switch time, the outgoing lane is stored without read-fallback weight (nothing to
+   resolve) but the config is kept.
+3. Switching back is the same call with the other lane's `laneId` — the shared lane
+   is always present as a lane entry once any switch has happened. No separate
+   detach semantics needed for the common case.
+
+**Remove** (`DELETE /me/workspaces/:name/storage`, now takes a `laneId` for saved
+configs):
+
+1. #619 fix (ships first, standalone): allow removal/switch-back whenever the record
+   is currently BYO-configured, regardless of `byoBucketEnabled`.
+2. Removing a standby lane (never active) is always allowed — it's just saved config.
+3. Removing a fallback lane that still holds objects gets the
+   `workspace_storage_not_empty` 409 (the code moves here, where it's genuinely
+   protective), bypassed by `force=true` — the "my bucket is gone" escape hatch,
+   which orphans that lane's objects knowingly.
+4. Removing the _active_ BYO lane = switch back to shared first (or `force`).
 
 Lane hygiene: a fallback lane whose objects have all been deleted (reconcile finds
-zero keys) is pruned automatically during reconcile. Re-attach while a fallback BYO
-lane exists for the _same bucket_ promotes it instead of appending a duplicate.
+zero keys) drops its read-fallback role automatically; a BYO lane the user removed
+is gone entirely. Re-saving a config for the _same bucket_ as an existing lane
+updates that lane in place rather than appending a duplicate.
 
 ### Usage / budget attribution
 
@@ -188,13 +215,15 @@ stamp = uploaded before this design.
 
 ### Errors, UI, docs
 
-- `workspace_storage_not_empty` stays registered (detach-side and older clients) but
-  the attach path stops emitting it. Web client's 409 branch copy updates.
+- `workspace_storage_not_empty` stays registered but moves from the save path to
+  lane removal. Web client's 409 branch copy updates.
 - Settings Storage panel (`storage.astro`): remove `applySharedUsageGate` disable +
-  the "only available for an empty workspace" note; replace with transition copy
-  ("existing files stay on uploads.sh storage and keep working; new uploads go to
-  your bucket"). BYO-details view shows a small "previous storage" line when
-  `fallbackLanes` is non-empty. Detach copy gains the symmetric explanation.
+  the "only available for an empty workspace" note. The wizard ends at **"Save &
+  verify"** — saving never changes where uploads go. The saved config renders as a
+  card with verify status and a **"Use this bucket"** action; once switched, the
+  panel shows which lane is active with a **"Switch back to uploads.sh storage"**
+  action. Transition copy on switch: "existing files stay where they are and keep
+  working; new uploads go to <target>."
 - `/docs/byo-bucket` empty-workspace note replaced with the two-lane explanation;
   serving matrix gains a "files uploaded before connecting" row. Sitemap/llms.txt
   untouched (page exists).
@@ -203,15 +232,18 @@ stamp = uploaded before this design.
 
 ### Testing
 
-- Unit: lane resolution order, composite cursor round-trip, merge/dedupe collision
-  (active wins), fallback-lane resolve-failure degradation, seal/reseal walk over
-  `fallbackLanes`, budget shared-subset math.
-- Integration (vitest + in-process fakes, two fake R2 stores): attach-to-populated →
-  old key resolves with shared-lane URL, new put lands in BYO store with lane stamp,
-  list merges, delete targets owning lane; detach → symmetric; re-attach promotes
-  existing lane; reconcile rebuilds shared subset; force-detach drops lane.
+- Unit: lane resolution order (standby lanes skipped), composite cursor round-trip,
+  merge/dedupe collision (active wins), fallback-lane resolve-failure degradation,
+  seal/reseal walk over `storageLanes`, budget shared-subset math, stale-verify
+  re-check before activate.
+- Integration (vitest + in-process fakes, two fake R2 stores): save config on a
+  populated workspace → uploads still land in shared store; activate → old key
+  resolves with shared-lane URL, new put lands in BYO store with lane stamp, list
+  merges, delete targets owning lane; switch back → symmetric; re-activate reuses
+  the existing lane; reconcile rebuilds shared subset; force-remove drops the lane;
+  remove-with-objects 409s without force.
 - Contract: /f/ page + /public/files for a pre-switch key returns the shared-bucket
-  URL after attach (the headline behavior).
+  URL after the switch (the headline behavior).
 
 ## Phases / PR breakdown
 
@@ -219,18 +251,18 @@ stamp = uploaded before this design.
    `storageConfiguredAt` is set even if `byoBucketAllowed` is false. Test: flag
    revoked → detach 200.
 2. **PR B — lanes primitive, no behavior change**: `StorageLane` type +
-   `fallbackLanes`/`storageLaneId` on `WorkspaceRecord`, `storageConfigs`,
+   `storageLanes`/`storageLaneId` on `WorkspaceRecord`, `storageConfigs`,
    `resolveObjectLane`, seal/reseal coverage, provenance stamp on put. All existing
-   tests green; new unit tests. Nothing writes `fallbackLanes` yet.
+   tests green; new unit tests. Nothing writes `storageLanes` yet.
 3. **PR C — lane-aware read paths**: public-files, files-core, shared handlers,
    workspace-files, gallery/poster/comment URL derivation, delete-owning-lane,
    merged listing + composite cursor. Behavior still identical for single-lane
    records (the entire fleet).
-4. **PR D — two-lane transitions + usage + UI + docs**: attach demotion, detach
-   promotion, lane pruning, `shared_bytes` migration + delta/reconcile/budget wiring,
-   settings + admin UI, /docs/byo-bucket, doctor line. Closes the attach constraint;
-   update #594 (reduce to physical-migration residue or close in favor of a new
-   tracking issue).
+4. **PR D — save/activate/remove transitions + usage + UI + docs**: standby save
+   path, activate endpoint with stale-verify re-check, removal guards, lane pruning,
+   `shared_bytes` migration + delta/reconcile/budget wiring, settings + admin UI,
+   /docs/byo-bucket, doctor line. Closes the attach constraint; update #594 (reduce
+   to physical-migration residue or close in favor of a new tracking issue).
 
 Each PR bases on main (no stacking — stacked PRs skip CI in this repo).
 
@@ -242,3 +274,8 @@ Each PR bases on main (no stacking — stacked PRs skip CI in this repo).
   Provenance stamping of new uploads is kept as the zero-cost forward hook.
 - Two-lane only; profiles/routing deferred to #630 (Zach, 2026-08-22).
 - #619 first as its own PR; #597 billing not bundled (Zach, 2026-08-22).
+- Configuration decoupled from activation (Zach, 2026-08-22): saving a BYO config
+  never changes routing; an explicit, re-verified switch does, and switching back is
+  the same primitive pointed at the other lane. Chosen for safety (a bad config
+  can't break uploads by merely being saved) at negligible added complexity — the
+  read/list/budget design is unchanged.

--- a/docs/superpowers/specs/2026-08-22-two-lane-storage-design.md
+++ b/docs/superpowers/specs/2026-08-22-two-lane-storage-design.md
@@ -23,7 +23,9 @@ derivation side needs fixing.
   resolving from the shared bucket, new uploads land in the customer bucket.
 - Detach symmetrically: files uploaded during the BYO era keep resolving after a
   return to shared storage.
-- Record shape generalizes to future storage profiles/routing (#630) without redesign.
+- Record shape generalizes to future storage profiles/routing (#630) without redesign:
+  N saved lanes, per-project routing, and non-R2 providers must be reachable later by
+  adding behavior, never by migrating the record or the API shape.
 
 ## Non-goals (deferred)
 
@@ -53,7 +55,8 @@ interface StorageLane {
   id: string;              // short opaque id, e.g. "lane_<8hex>"; stamped into new-upload provenance
   verifiedAt?: string;     // last successful verify run against this lane's config
   lastActiveAt?: string;   // set when the lane is demoted from active; absence = never held writes
-  provider: "r2";
+  provider: string;        // "r2" is the only value accepted today; widened now so future
+                           // files-sdk-supported providers need no record-shape migration
   bucket: string;
   binding?: string;        // shared lane uses the binding; BYO lanes are HTTP-credential mode
   prefix?: string;
@@ -79,6 +82,25 @@ interface StorageLane {
 - The active lane also gets a persisted `storageLaneId` (top-level field) so provenance
   stamping and future migration tooling can name it. On records that predate this
   design, absence of `storageLaneId` means the implicit original lane.
+
+### N-lane readiness (cheap now, deliberately unexploited)
+
+`storageLanes` is an array and every lane operation addresses a `laneId` — nothing in
+the API shape assumes "the one BYO config". v1 product surfaces cap the experience at
+one saved BYO config + the shared lane, but that cap lives in UI/validation, not in
+the record, the endpoints, the cursor format, or the resolver. Adding a third saved
+lane, or later a per-project routing rule that picks a write lane, is additive.
+What we explicitly do NOT build now: routing rules, multi-config UI, per-lane budget
+UI beyond the shared subset.
+
+### files-sdk is the storage layer — no bespoke clients
+
+Every lane resolves through `packages/storage`'s `createStorage`, which is a thin
+wrapper over **files-sdk** (`Files` + the `r2` adapter; the config comment already
+reads "provider selects the files-sdk adapter"). Lane-aware code composes N
+`Storage` instances from that wrapper — it never talks S3/R2 directly. Future non-R2
+providers are "whatever files-sdk supports" plus a `provider` value and a verify-
+pipeline variant; the lane machinery itself stays provider-agnostic.
 
 ### Resolution: `storageConfigs(env, ws)`
 
@@ -279,3 +301,8 @@ Each PR bases on main (no stacking — stacked PRs skip CI in this repo).
   the same primitive pointed at the other lane. Chosen for safety (a bad config
   can't break uploads by merely being saved) at negligible added complexity — the
   read/list/budget design is unchanged.
+- Keep N-lane / multi-provider options open where free (Zach, 2026-08-22): lanes are
+  an id-addressed array, `provider` is a widened string validated to "r2" today, and
+  all storage IO goes through the files-sdk-backed `packages/storage` wrapper. The
+  one-saved-config limit is UI/validation only. Per-project routing and non-R2
+  providers stay future work (#630, #595) but require no schema or API migration.

--- a/docs/superpowers/specs/2026-08-22-two-lane-storage-design.md
+++ b/docs/superpowers/specs/2026-08-22-two-lane-storage-design.md
@@ -1,0 +1,244 @@
+# Two-lane workspace storage (layered read-fallback lanes)
+
+**Date:** 2026-08-22
+**Tracking:** supersedes the migration framing of #594; unblocks BYO attach for populated workspaces (#583 follow-up). #619 ships first as a standalone fix.
+**Prior art:** `docs/superpowers/plans/2026-07-31-self-serve-byo-r2-bucket.md` (the v1 BYO ship this extends).
+
+## Problem
+
+BYO storage (#583) only attaches at workspace creation or to an empty workspace. The
+constraint exists because storage is single-valued: `WorkspaceRecord` holds exactly one
+bucket config, public URLs are derived at read time from that one config, and no D1
+table records where a file physically lives. Switching the config would make the
+platform re-derive every pre-switch file's URL and existence check against the new
+bucket — 404s across file pages, lists, and downloads.
+
+Published links themselves never break: `storage.uploads.sh` is an R2 custom domain on
+the shared bucket and keeps serving copied-out URLs regardless. Only the platform's
+derivation side needs fixing.
+
+## Goals
+
+- Attach BYO storage to a **populated** workspace with zero migration: old files keep
+  resolving from the shared bucket, new uploads land in the customer bucket.
+- Detach symmetrically: files uploaded during the BYO era keep resolving after a
+  return to shared storage.
+- Record shape generalizes to future storage profiles/routing (#630) without redesign.
+
+## Non-goals (deferred)
+
+- Storage profiles UI, per-upload routing rules, >1 fallback lane exposed in product
+  surfaces (#630).
+- Physical migration / copy jobs between lanes (the residual scope of #594).
+- Other S3 providers (#595), embed twin for BYO domains (#592), billing gating (#597).
+- Constant hot-swapping. Attach/detach remain deliberate, verified transitions; the
+  lanes list stays short (in practice 2: active + one fallback per direction).
+
+## Design
+
+### Record shape: active config + fallback lanes
+
+The existing top-level storage fields on `WorkspaceRecord` (`provider`, `bucket`,
+`binding`, `prefix`, `publicBaseUrl`, `accountId`, `accessKeyId`, `secretAccessKey`,
+`jurisdiction`) remain **the active write lane** — every current consumer of
+`storageConfig(env, ws)` keeps working unchanged.
+
+New field:
+
+```ts
+/** Ordered read-only fallback lanes, most recent demotion first. */
+fallbackLanes?: StorageLane[];
+
+interface StorageLane {
+  id: string;              // short opaque id, e.g. "lane_<8hex>"; stamped into new-upload provenance
+  demotedAt: string;       // ISO timestamp of the transition that demoted it
+  provider: "r2";
+  bucket: string;
+  binding?: string;        // shared lane uses the binding; BYO lanes are HTTP-credential mode
+  prefix?: string;
+  publicBaseUrl?: string;
+  accountId?: string;
+  accessKeyId?: string;    // sealed (enc:v1:), same KEK ring as active-lane creds
+  secretAccessKey?: string; // sealed
+  jurisdiction?: string;
+}
+```
+
+- All writes go through `mutateWorkspaceRecord` (versioned KV writes — never bare
+  `REGISTRY.put`).
+- Fallback-lane credentials are sealed/resealed exactly like active-lane credentials
+  (`sealCredentialFieldsStrict` on demotion of an HTTP-mode lane; `resealCredentialFields`
+  covers rotation sweeps — the reseal walk must include `fallbackLanes`).
+- The active lane also gets a persisted `storageLaneId` (top-level field) so provenance
+  stamping and future migration tooling can name it. On records that predate this
+  design, absence of `storageLaneId` means the implicit original lane.
+
+### Resolution: `storageConfigs(env, ws)`
+
+New resolver beside `storageConfig`:
+
+```ts
+storageConfigs(env, ws): StorageConfig[]  // [active, ...fallbacks], each tagged with laneId
+```
+
+Same 503 semantics per lane (`storage_misconfigured`, `storage_credentials_unreadable`)
+— but a _fallback_ lane that fails to resolve degrades to a logged skip rather than a
+request-fatal 503, so a stale fallback can never take down the active lane. (Active
+lane failures stay fatal, as today.)
+
+### Read path: lane-aware object resolution
+
+New helper in `apps/api` (thin layer over `packages/storage`):
+
+```ts
+resolveObjectLane(env, ws, key): Promise<{ store, config, laneId } | null>
+```
+
+Tries lanes in order: `exists(key)` on active, then each fallback. First hit wins.
+Worst case for a pre-switch file: one extra R2 HEAD (bounded by lane count, which is
+1–2 extra in practice).
+
+Call sites that change from "current store only" to lane-aware:
+
+- `resolvePublicObject` in `apps/api/src/routes/public-files.ts` — the /f/ page and
+  `/public/files/*` JSON + download. Public URL must be derived from **the lane the
+  object was found in**, not the active lane.
+- `files-core` head/download/exists paths and the shared handlers in
+  `routes/files-shared-handlers.ts`.
+- `workspace-files.ts` single-file URL resolution (public URL else signed URL — the
+  signed URL must sign against the owning lane's credentials/binding).
+- URL derivation in `gallery-service.ts`, `poster.ts`, `github-comment.ts`: these
+  derive URLs for known keys; they route through the same lane-aware URL helper.
+- Deletion: delete must target the owning lane (delete from the lane that has the
+  object; if the key exists in multiple lanes — possible after detach/re-attach —
+  delete from all lanes that hold it, so the file actually disappears).
+- Metadata writes (`file_metadata`, `file_content_hash`) are keyed on
+  `(workspace, object_key)` and are lane-agnostic — unchanged.
+
+Single-lane workspaces (no `fallbackLanes`) take the exact current code path; the
+helper short-circuits. **No behavior change until a second lane exists.**
+
+### Listing: merged fan-out
+
+List endpoints fan out the same prefix query across lanes and merge by key; the
+**active lane wins on key collision** (a re-uploaded filename shadows the old lane's
+copy, matching write-lane reality).
+
+Pagination uses a composite cursor: base64url JSON of per-lane cursors
+(`{ v: 1, lanes: { [laneId]: cursor } }`). Merge is a k-way merge on key order per
+page. `listAll` (reconcile, teardown) concatenates lane walks with the same
+active-wins dedupe.
+
+Thumbnails: `thumb-url.ts` wraps by host; shared-lane files keep getting cdn-cgi
+thumbs, BYO-lane files keep the existing BYO behavior (no thumbs) — per-file now
+instead of per-workspace.
+
+### Attach / detach flow changes
+
+Attach (`PUT /me/workspaces/:name/storage`, handler in `workspace-settings.ts`):
+
+1. Verify pipeline unchanged (shape/auth/round-trip/not-empty + public-URL probe;
+   `adoptExistingContents` still bypasses the **bucket**-not-empty check).
+2. The `workspace_storage_not_empty` 409 (**workspace** ledger check) is **removed**.
+   Instead, when `workspace_usage.objects > 0`, the current active config is demoted
+   into `fallbackLanes` before the BYO config is written as active.
+   When the ledger is empty, behave exactly as today (overwrite, no fallback lane).
+3. Reconcile after attach becomes lane-aware (see Usage below).
+
+Detach (`DELETE /me/workspaces/:name/storage`):
+
+1. #619 fix (ships first, standalone): allow detach whenever the record is currently
+   BYO-configured, regardless of `byoBucketEnabled`.
+2. Two-lane detach: if the BYO era produced objects (any object resolves only in the
+   BYO lane), demote the BYO lane to a fallback instead of dropping it; restore the
+   shared config as active. If the shared config is already present in `fallbackLanes`,
+   **promote it back** (remove from fallbacks) rather than duplicating it.
+3. `force=true` keeps its meaning of "drop without ceremony": it discards the BYO
+   config entirely (current behavior) — the escape hatch when the customer bucket is
+   gone or credentials are dead.
+
+Lane hygiene: a fallback lane whose objects have all been deleted (reconcile finds
+zero keys) is pruned automatically during reconcile. Re-attach while a fallback BYO
+lane exists for the _same bucket_ promotes it instead of appending a duplicate.
+
+### Usage / budget attribution
+
+`workspace_usage` gains two columns: `shared_bytes INTEGER NOT NULL DEFAULT 0`,
+`shared_objects INTEGER NOT NULL DEFAULT 0` — the subset of totals living in
+shared-bucket lanes (binding-mode lanes).
+
+- `applyUsageDelta` learns which lane a mutation touched (put → active lane; delete →
+  owning lane) and updates the shared subset when that lane is binding-mode.
+- `reconcileWorkspaceUsage` walks all lanes and rebuilds both totals and the shared
+  subset.
+- Budget enforcement: `enforcedMaxStorageBytes` compares against `shared_bytes` when
+  the workspace's **active** lane is BYO (`storageBudgetApplies` false today becomes
+  "applies to the shared residue"), and against total bytes when the active lane is
+  shared. Net effect: customers can't park unlimited data on our bucket by attaching
+  BYO, and BYO bytes stay unmetered — same policy as v1, now correct across lanes.
+- Upload rate limits and size caps: unchanged, lane-independent.
+
+### Provenance stamping (cheap forward hook)
+
+New uploads write `storageLaneId` into the existing R2 provenance bag
+(customMetadata) at put time. Zero D1 schema, no read-path dependency — resolution
+stays fallback-based. The stamp exists for debugging and as the seed for any future
+per-file routing or physical migration tooling (#630/#594 residue). Absence of a
+stamp = uploaded before this design.
+
+### Errors, UI, docs
+
+- `workspace_storage_not_empty` stays registered (detach-side and older clients) but
+  the attach path stops emitting it. Web client's 409 branch copy updates.
+- Settings Storage panel (`storage.astro`): remove `applySharedUsageGate` disable +
+  the "only available for an empty workspace" note; replace with transition copy
+  ("existing files stay on uploads.sh storage and keep working; new uploads go to
+  your bucket"). BYO-details view shows a small "previous storage" line when
+  `fallbackLanes` is non-empty. Detach copy gains the symmetric explanation.
+- `/docs/byo-bucket` empty-workspace note replaced with the two-lane explanation;
+  serving matrix gains a "files uploaded before connecting" row. Sitemap/llms.txt
+  untouched (page exists).
+- Admin storage panel: show lane list read-only.
+- Doctor: the honest storage line reports active lane + fallback count.
+
+### Testing
+
+- Unit: lane resolution order, composite cursor round-trip, merge/dedupe collision
+  (active wins), fallback-lane resolve-failure degradation, seal/reseal walk over
+  `fallbackLanes`, budget shared-subset math.
+- Integration (vitest + in-process fakes, two fake R2 stores): attach-to-populated →
+  old key resolves with shared-lane URL, new put lands in BYO store with lane stamp,
+  list merges, delete targets owning lane; detach → symmetric; re-attach promotes
+  existing lane; reconcile rebuilds shared subset; force-detach drops lane.
+- Contract: /f/ page + /public/files for a pre-switch key returns the shared-bucket
+  URL after attach (the headline behavior).
+
+## Phases / PR breakdown
+
+1. **PR A — #619 detach gate fix** (standalone, first): allow detach when
+   `storageConfiguredAt` is set even if `byoBucketAllowed` is false. Test: flag
+   revoked → detach 200.
+2. **PR B — lanes primitive, no behavior change**: `StorageLane` type +
+   `fallbackLanes`/`storageLaneId` on `WorkspaceRecord`, `storageConfigs`,
+   `resolveObjectLane`, seal/reseal coverage, provenance stamp on put. All existing
+   tests green; new unit tests. Nothing writes `fallbackLanes` yet.
+3. **PR C — lane-aware read paths**: public-files, files-core, shared handlers,
+   workspace-files, gallery/poster/comment URL derivation, delete-owning-lane,
+   merged listing + composite cursor. Behavior still identical for single-lane
+   records (the entire fleet).
+4. **PR D — two-lane transitions + usage + UI + docs**: attach demotion, detach
+   promotion, lane pruning, `shared_bytes` migration + delta/reconcile/budget wiring,
+   settings + admin UI, /docs/byo-bucket, doctor line. Closes the attach constraint;
+   update #594 (reduce to physical-migration residue or close in favor of a new
+   tracking issue).
+
+Each PR bases on main (no stacking — stacked PRs skip CI in this repo).
+
+## Decisions log
+
+- Read-fallback over per-file lane stamping for resolution (Zach, 2026-08-22):
+  stamping adds a D1 sidecar and backfill semantics but cannot replace list fan-out
+  (there is no D1 file index), so it buys little until per-file routing exists.
+  Provenance stamping of new uploads is kept as the zero-cost forward hook.
+- Two-lane only; profiles/routing deferred to #630 (Zach, 2026-08-22).
+- #619 first as its own PR; #597 billing not bundled (Zach, 2026-08-22).


### PR DESCRIPTION
Design spec and implementation plan for the two-lane storage work shipped in #769/#770/#771/#774. Docs only.

- `docs/superpowers/specs/2026-08-22-two-lane-storage-design.md` — the approved design (read-fallback lanes, decoupled configure/activate, N-lane readiness, files-sdk constraint), with the decisions log.
- `docs/superpowers/plans/2026-08-22-two-lane-storage.md` — the 4-PR plan the implementation followed.

_🤖 Generated with [Claude Code](https://claude.com/claude-code)_