### PR TITLE
fix: BYO bucket verify in the Workers runtime + inline verify failures

### DIFF
--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -337,7 +337,7 @@ export async function verifyStorageConfig(
     required: true,
     hint: notEmptyOk
       ? undefined
-      : "this bucket already has objects in it — pass adoptExistingContents to attach it anyway, or point at an empty bucket",
+      : "this bucket already has objects in it — confirm you want this workspace to expose the existing contents (adoptExistingContents), or point at an empty bucket",
   });
 
   if (candidate.publicBaseUrl) {

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -211,6 +211,19 @@ if (!workspace) return Astro.redirect("/account/workspaces");
               </p>
             </div>
 
+            <div class="ul-field" id="storage-adopt-row" hidden>
+              <label class="storage-adopt-label">
+                <input type="checkbox" id="storage-adopt" />
+                This bucket already contains files — show them in this workspace
+              </label>
+              <p class="ul-field__hint">
+                Everything already in the bucket becomes part of this workspace once you switch to
+                it.
+              </p>
+            </div>
+
+            <ul class="storage-checklist" id="storage-form-checklist" aria-live="polite"></ul>
+
             <div class="storage-actions">
               <button type="submit" class="ul-btn ul-btn--solid" id="storage-verify-btn"
                 >Verify</button
@@ -227,7 +240,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         </div>
 
         <div class="storage-wizard-step" id="storage-step-3" hidden>
-          <h3>3. Verify</h3>
+          <h3>3. Review &amp; save</h3>
           <ul class="storage-checklist" id="storage-checklist" aria-live="polite"></ul>
           <div class="storage-actions">
             <button type="button" class="ul-btn ul-btn--solid" id="storage-save-btn" disabled
@@ -326,6 +339,14 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       gap: 8px;
       max-width: 32rem;
       padding: 0;
+    }
+    .storage-checklist:empty {
+      display: none;
+    }
+    .storage-adopt-label {
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
     }
     .storage-checklist li {
       display: flex;
@@ -462,6 +483,9 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const storageVerifyBtn = requireElement<HTMLButtonElement>("#storage-verify-btn", page);
       const storageVerifyStatus = requireElement<HTMLElement>("#storage-verify-status", page);
       const storageChecklist = requireElement<HTMLElement>("#storage-checklist", page);
+      const storageFormChecklist = requireElement<HTMLElement>("#storage-form-checklist", page);
+      const storageAdoptRow = requireElement<HTMLElement>("#storage-adopt-row", page);
+      const storageAdopt = requireElement<HTMLInputElement>("#storage-adopt", page);
       const storageSaveBtn = requireElement<HTMLButtonElement>("#storage-save-btn", page);
       const storageSaveStatus = requireElement<HTMLElement>("#storage-save-status", page);
       const storageCancelBtns = [
@@ -545,6 +569,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         storageForm.reset();
         lastVerify = null;
         storageChecklist.innerHTML = "";
+        storageFormChecklist.innerHTML = "";
+        storageAdoptRow.hidden = true;
         storageVerifyStatus.textContent = "";
         storageVerifyStatus.removeAttribute("data-state");
         storageSaveStatus.textContent = "";
@@ -603,13 +629,15 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           // owns and is actively serving from, so its non-empty contents are
           // expected, not a mistake — same rationale as the PUT route's
           // `adoptExistingContents` escape hatch for the empty-workspace guard.
-          adoptExistingContents: wizardMode === "rotate" ? true : undefined,
+          // In connect mode the user opts in via the checkbox that appears
+          // when the not-empty check fails.
+          adoptExistingContents: wizardMode === "rotate" || storageAdopt.checked ? true : undefined,
         };
       }
 
       /** Required checks gate save; a failing recommended check (public-url) only warns. */
-      function renderChecklist(result: StorageVerifyResult): void {
-        storageChecklist.innerHTML = result.checks
+      function renderChecklist(result: StorageVerifyResult, target: HTMLElement): void {
+        target.innerHTML = result.checks
           .map((check) => {
             const label = STORAGE_CHECK_LABELS[check.id] ?? check.id;
             const badgeClass = check.ok
@@ -625,7 +653,17 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             return `<li><div class="storage-check-row"><span class="ul-badge ${badgeClass}">${escapeHtml(badgeText)}</span><strong>${escapeHtml(label)}</strong></div>${hint}</li>`;
           })
           .join("");
-        storageSaveBtn.disabled = !result.ok;
+      }
+
+      /**
+       * A failing not-empty check is fixable in place: reveal the adopt
+       * checkbox so the user can opt in and re-verify without retyping
+       * anything. Once revealed it stays visible for the rest of the wizard
+       * session — hiding a ticked checkbox again would silently drop consent.
+       */
+      function revealAdoptRowIfNotEmpty(result: StorageVerifyResult): void {
+        const notEmpty = result.checks.find((check) => check.id === "not-empty");
+        if (notEmpty && !notEmpty.ok) storageAdoptRow.hidden = false;
       }
 
       storageStep1Next.addEventListener("click", () => goToWizardStep(2));
@@ -651,9 +689,21 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             storageVerifyStatus.dataset.state = "error";
             return;
           }
-          storageVerifyStatus.textContent = "";
           lastVerify = result.result;
-          renderChecklist(result.result);
+          if (!result.result.ok) {
+            // Stay on the credentials step: the fix is almost always a field
+            // edit, so show the failing checks right under the form instead
+            // of moving to a page the user has to back out of.
+            renderChecklist(result.result, storageFormChecklist);
+            revealAdoptRowIfNotEmpty(result.result);
+            storageVerifyStatus.textContent = "Verification failed — see the checks below.";
+            storageVerifyStatus.dataset.state = "error";
+            return;
+          }
+          storageVerifyStatus.textContent = "";
+          storageFormChecklist.innerHTML = "";
+          renderChecklist(result.result, storageChecklist);
+          storageSaveBtn.disabled = false;
           goToWizardStep(3);
         })();
       });
@@ -682,7 +732,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           storageSaveBtn.disabled = false;
           if (result.kind === "invalid") {
             lastVerify = result.result;
-            renderChecklist(result.result);
+            renderChecklist(result.result, storageChecklist);
+            storageSaveBtn.disabled = !result.result.ok;
             storageSaveStatus.textContent = "Verification failed — see the checklist above.";
             storageSaveStatus.dataset.state = "error";
             return;

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -67,9 +67,14 @@ export function createStorage(config: StorageConfig): Files {
         }),
       };
       // Binding mode (hybrid when HTTP creds are also set) vs pure HTTP mode.
+      // Pure HTTP mode pins `client: "fetch"` (aws4fetch): the default
+      // aws-sdk client parses S3 XML with DOMParser in Workers-style bundles,
+      // which workerd doesn't provide — list() throws "DOMParser is not
+      // defined" at runtime. Binding mode never touches an S3 client for I/O
+      // and its hybrid signer is already aws4fetch, so it needs no override.
       const adapter = config.r2Binding
         ? r2({ binding: config.r2Binding, bucket: config.bucket, ...shared })
-        : r2({ bucket: config.bucket, ...shared });
+        : r2({ bucket: config.bucket, client: "fetch", ...shared });
       return new Files({ adapter, prefix: config.prefix });
     }
     default:

--- a/packages/storage/test/index.test.ts
+++ b/packages/storage/test/index.test.ts
@@ -19,6 +19,22 @@ const base: StorageConfig = {
   secretAccessKey: "secret",
 };
 
+describe("createStorage client selection", () => {
+  it("pure HTTP mode uses the aws4fetch client, not the aws-sdk one", () => {
+    // The default aws-sdk client parses S3 XML with DOMParser in
+    // Workers-style bundles, which workerd doesn't provide — every HTTP
+    // list()/error-body parse would throw "DOMParser is not defined" at
+    // runtime (hit by BYO bucket verify, the first HTTP-mode read in prod).
+    const files = createStorage(base);
+    expect(files.adapter.name).toBe("r2-http-fetch");
+  });
+
+  it("binding mode keeps the binding adapter", () => {
+    const files = createStorage({ ...base, r2Binding: new FakeR2Bucket() as unknown as R2Bucket });
+    expect(files.adapter.name).not.toBe("r2-http-fetch");
+  });
+});
+
 describe("createStorage prefix", () => {
   it("applies the prefix to the Files instance (normalized, no trailing slash)", () => {
     const files = createStorage({ ...base, prefix: "myws/" });


### PR DESCRIPTION
Real-world BYO bucket connect attempts fail at the Authentication check with the generic "could not reach the bucket" hint even when the credentials are correct.

## Root cause

`createStorage` in pure HTTP mode uses files-sdk's default `aws-sdk` client. `@aws-sdk/client-s3`'s Workers-style bundle resolves `@aws-sdk/xml-builder`'s **browser** XML parser, which needs `DOMParser` — undefined in workerd. Every HTTP-mode `list()` throws `DOMParser is not defined`, which the verify pipeline maps to the generic reachability hint. Prod never hit this before because the shared lane is binding-mode; BYO verify is the first HTTP-mode read in the Workers runtime.

Reproduced in a scratch workerd worker against a real bucket (aws CLI and Node with the same code path both succeed; workerd fails), and confirmed fixed by pinning files-sdk's `client: "fetch"` (aws4fetch) for pure HTTP mode. Binding mode is untouched — its hybrid signer already uses aws4fetch, and `maxSize` is rejected identically by every R2 path, so nothing regresses.

## Wizard UX

- A failing verify no longer advances to the results step (which forced a Back trip to fix a field) — failures render the checklist inline under the credentials form.
- When the only failure is the empty-bucket guard, the form reveals an opt-in checkbox ("This bucket already contains files — show them in this workspace") wired to the existing `adoptExistingContents` escape hatch, which was previously unreachable from the connect flow — a populated bucket was a dead end.
- The not-empty hint no longer tells UI users to "pass adoptExistingContents".

## Verification

Walked the full flow in the local stack against a real, populated R2 bucket: verify → auth passes, not-empty fails inline with the checkbox revealed → adopt → verify passes → review & save → "Saved · not in use" card. `@uploads/storage` gains regression tests asserting the client selection per mode.
