### PR TITLE
feat(web,api): minimal-fields BYO bucket wizard + verify copy (#783)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -45,6 +45,7 @@
     "@uploads/email": "workspace:^",
     "@uploads/errors": "workspace:^",
     "@uploads/storage": "workspace:^",
+    "aws4fetch": "^1.0.20",
     "hono": "^4.13.3",
     "mediabunny": "^1.50.9"
   },

--- a/apps/api/src/r2-list-buckets.test.ts
+++ b/apps/api/src/r2-list-buckets.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import { listR2Buckets, parseListBucketsXml } from "./r2-list-buckets";
+
+const CREDS = {
+  accountId: "a".repeat(32),
+  accessKeyId: "AKIAEXAMPLE",
+  secretAccessKey: "s3cr3t",
+};
+
+const LIST_BUCKETS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Owner><ID>abc</ID><DisplayName>abc</DisplayName></Owner>
+  <Buckets>
+    <Bucket><Name>my-bucket</Name><CreationDate>2026-01-01T00:00:00.000Z</CreationDate></Bucket>
+    <Bucket><Name>other-bucket</Name><CreationDate>2026-01-02T00:00:00.000Z</CreationDate></Bucket>
+  </Buckets>
+</ListAllMyBucketsResult>`;
+
+describe("parseListBucketsXml", () => {
+  it("extracts bucket names from a real-shaped ListBuckets response", () => {
+    expect(parseListBucketsXml(LIST_BUCKETS_XML)).toEqual(["my-bucket", "other-bucket"]);
+  });
+
+  it("returns an empty list for an account with no buckets", () => {
+    const xml = `<ListAllMyBucketsResult><Buckets></Buckets></ListAllMyBucketsResult>`;
+    expect(parseListBucketsXml(xml)).toEqual([]);
+  });
+
+  it("decodes XML entities in bucket names", () => {
+    const xml = `<Buckets><Bucket><Name>a&amp;b</Name></Bucket></Buckets>`;
+    expect(parseListBucketsXml(xml)).toEqual(["a&b"]);
+  });
+});
+
+describe("listR2Buckets", () => {
+  it("returns the bucket list on a 200 from the default endpoint", async () => {
+    const fetchImpl = vi.fn(async (req: Request) => {
+      expect(req.url).toBe(`https://${CREDS.accountId}.r2.cloudflarestorage.com/`);
+      return new Response(LIST_BUCKETS_XML, { status: 200 });
+    });
+    const result = await listR2Buckets(CREDS, { fetch: fetchImpl as unknown as typeof fetch });
+    expect(result).toEqual({
+      ok: true,
+      buckets: ["my-bucket", "other-bucket"],
+      jurisdiction: undefined,
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("uses the given jurisdiction's endpoint without probing when one is supplied", async () => {
+    const fetchImpl = vi.fn(async (req: Request) => {
+      expect(req.url).toBe(`https://${CREDS.accountId}.eu.r2.cloudflarestorage.com/`);
+      return new Response(LIST_BUCKETS_XML, { status: 200 });
+    });
+    const result = await listR2Buckets(
+      { ...CREDS, jurisdiction: "eu" },
+      { fetch: fetchImpl as unknown as typeof fetch },
+    );
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(result.ok).toBe(true);
+  });
+
+  it("probes default, then eu, then fedramp, and records whichever answers", async () => {
+    const seen: string[] = [];
+    const fetchImpl = vi.fn(async (req: Request) => {
+      seen.push(req.url);
+      if (req.url.includes(".fedramp.")) return new Response(LIST_BUCKETS_XML, { status: 200 });
+      return new Response("", { status: 400 });
+    });
+    const result = await listR2Buckets(CREDS, { fetch: fetchImpl as unknown as typeof fetch });
+    expect(seen).toEqual([
+      `https://${CREDS.accountId}.r2.cloudflarestorage.com/`,
+      `https://${CREDS.accountId}.eu.r2.cloudflarestorage.com/`,
+      `https://${CREDS.accountId}.fedramp.r2.cloudflarestorage.com/`,
+    ]);
+    expect(result).toMatchObject({ ok: true, jurisdiction: "fedramp" });
+  });
+
+  it("returns a distinguishable access_denied shape on a 403, so the UI can fall back to a plain bucket field", async () => {
+    const fetchImpl = vi.fn(async () => new Response("<Error/>", { status: 403 }));
+    const result = await listR2Buckets(CREDS, { fetch: fetchImpl as unknown as typeof fetch });
+    expect(result).toEqual({ ok: false, reason: "access_denied" });
+  });
+
+  it("treats a 403 at every jurisdiction as access_denied rather than a generic error", async () => {
+    const fetchImpl = vi.fn(async () => new Response("<Error/>", { status: 403 }));
+    const result = await listR2Buckets(CREDS, { fetch: fetchImpl as unknown as typeof fetch });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({ ok: false, reason: "access_denied" });
+  });
+
+  it("reports a non-403, non-200 status as a generic error", async () => {
+    const fetchImpl = vi.fn(async () => new Response("", { status: 500 }));
+    const result = await listR2Buckets(CREDS, { fetch: fetchImpl as unknown as typeof fetch });
+    expect(result).toEqual({
+      ok: false,
+      reason: "error",
+      message: expect.stringContaining("500"),
+    });
+  });
+
+  it("rejects a malformed account id before any request is made", async () => {
+    const fetchImpl = vi.fn();
+    const result = await listR2Buckets(
+      { ...CREDS, accountId: "not-hex" },
+      { fetch: fetchImpl as unknown as typeof fetch },
+    );
+    expect(result).toEqual({
+      ok: false,
+      reason: "error",
+      message: expect.stringContaining("accountId"),
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid jurisdiction before any request is made", async () => {
+    const fetchImpl = vi.fn();
+    const result = await listR2Buckets(
+      { ...CREDS, jurisdiction: "us" },
+      { fetch: fetchImpl as unknown as typeof fetch },
+    );
+    expect(result).toEqual({
+      ok: false,
+      reason: "error",
+      message: expect.stringContaining("jurisdiction"),
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("never echoes credential values in any result", async () => {
+    const fetchImpl = vi.fn(async () => new Response("", { status: 500 }));
+    const result = await listR2Buckets(CREDS, { fetch: fetchImpl as unknown as typeof fetch });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(CREDS.secretAccessKey);
+    expect(serialized).not.toContain(CREDS.accessKeyId);
+  });
+});

--- a/apps/api/src/r2-list-buckets.ts
+++ b/apps/api/src/r2-list-buckets.ts
@@ -1,0 +1,154 @@
+/**
+ * S3 `ListBuckets` against a Cloudflare R2 account (issue #783 Part A item
+ * 2: the wizard's bucket picker). files-sdk's R2 adapter is bucket-scoped —
+ * there's no `listBuckets` primitive to reuse — and `ListBuckets` is
+ * account-level, so this calls it directly.
+ *
+ * Deliberately NOT `@aws-sdk/client-s3`: its XML response parser reaches for
+ * `DOMParser`, which workerd doesn't provide (the same reason
+ * `packages/storage` pins `client: "fetch"` for HTTP-mode R2 — see its
+ * comment). `aws4fetch`'s `AwsClient` only signs the request; the response
+ * body is parsed here with a small string/regex scan instead of a DOM API.
+ *
+ * Also resolves jurisdiction the same way `storage-verify.ts` does when the
+ * caller doesn't already know it (a bare account id, no endpoint URL to
+ * parse): probe the default endpoint, then `eu`, then `fedramp`, and use
+ * whichever one actually answers.
+ */
+import { AwsClient } from "aws4fetch";
+import { isR2Jurisdiction, R2_JURISDICTIONS, type R2Jurisdiction } from "@uploads/storage";
+
+export interface ListBucketsCredentials {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  /** Skips auto-probing when already known (e.g. parsed from a pasted endpoint URL). */
+  jurisdiction?: string;
+}
+
+export type ListBucketsResult =
+  | { ok: true; buckets: string[]; jurisdiction?: R2Jurisdiction }
+  /**
+   * `access_denied` is the expected shape for a bucket-scoped token — R2
+   * only permits `ListBuckets` for account-scoped tokens — so the wizard
+   * treats it as a normal fallback trigger, not an error state.
+   */
+  | { ok: false; reason: "access_denied" }
+  | { ok: false; reason: "error"; message: string };
+
+const ACCOUNT_ID_RE = /^[0-9a-f]{32}$/;
+
+function r2Endpoint(accountId: string, jurisdiction: R2Jurisdiction | undefined): string {
+  return jurisdiction
+    ? `https://${accountId}.${jurisdiction}.r2.cloudflarestorage.com/`
+    : `https://${accountId}.r2.cloudflarestorage.com/`;
+}
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+/**
+ * Extracts `<Name>` values from `<Bucket>` entries in an S3 `ListBuckets`
+ * XML body — a small string scan rather than an XML parser (no `DOMParser`
+ * in workerd; see module doc). Exported so tests can exercise it directly
+ * against real-shaped R2 response bodies without a network fake.
+ */
+export function parseListBucketsXml(xml: string): string[] {
+  const names: string[] = [];
+  const bucketRe = /<Bucket>([\s\S]*?)<\/Bucket>/g;
+  let bucketMatch: RegExpExecArray | null;
+  while ((bucketMatch = bucketRe.exec(xml))) {
+    const nameMatch = /<Name>([^<]*)<\/Name>/.exec(bucketMatch[1]);
+    if (nameMatch) names.push(decodeXmlEntities(nameMatch[1]));
+  }
+  return names;
+}
+
+/** One S3 `GET /` (ListBuckets) attempt against a specific jurisdiction's endpoint. */
+async function attemptListBuckets(
+  creds: ListBucketsCredentials,
+  jurisdiction: R2Jurisdiction | undefined,
+  fetchImpl: typeof fetch,
+): Promise<{ status: number; body: string }> {
+  const client = new AwsClient({
+    accessKeyId: creds.accessKeyId,
+    secretAccessKey: creds.secretAccessKey,
+    service: "s3",
+    region: "auto",
+  });
+  const signed = await client.sign(r2Endpoint(creds.accountId, jurisdiction), { method: "GET" });
+  const res = await fetchImpl(signed);
+  return { status: res.status, body: await res.text() };
+}
+
+export interface ListR2BucketsOptions {
+  /** Defaults to `globalThis.fetch`. */
+  fetch?: typeof fetch;
+}
+
+/**
+ * Runs `ListBuckets`, auto-probing jurisdiction the same order
+ * `verifyStorageConfig` uses when `creds.jurisdiction` isn't already known.
+ * A 403 (Access Denied — the expected outcome for a bucket-scoped token) is
+ * reported distinctly from any other failure so the wizard can fall back to
+ * a plain "Bucket Name" field without treating it as an error.
+ */
+export async function listR2Buckets(
+  creds: ListBucketsCredentials,
+  opts: ListR2BucketsOptions = {},
+): Promise<ListBucketsResult> {
+  if (!ACCOUNT_ID_RE.test(creds.accountId)) {
+    return {
+      ok: false,
+      reason: "error",
+      message: "accountId must be a 32-character hex Cloudflare account id",
+    };
+  }
+  if (creds.jurisdiction !== undefined && !isR2Jurisdiction(creds.jurisdiction)) {
+    return {
+      ok: false,
+      reason: "error",
+      message: `jurisdiction must be one of: ${R2_JURISDICTIONS.join(", ")} (or omitted)`,
+    };
+  }
+  if (!creds.accessKeyId || !creds.secretAccessKey) {
+    return {
+      ok: false,
+      reason: "error",
+      message: "access key id and secret access key are both required",
+    };
+  }
+
+  const fetchImpl = opts.fetch ?? fetch;
+  const jurisdictionOrder: (R2Jurisdiction | undefined)[] =
+    creds.jurisdiction !== undefined ? [creds.jurisdiction] : [undefined, ...R2_JURISDICTIONS];
+
+  let sawAccessDenied = false;
+  let lastError: string | undefined;
+  for (const jurisdiction of jurisdictionOrder) {
+    let attempt: { status: number; body: string };
+    try {
+      attempt = await attemptListBuckets(creds, jurisdiction, fetchImpl);
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+      continue;
+    }
+    if (attempt.status === 200) {
+      return { ok: true, buckets: parseListBucketsXml(attempt.body), jurisdiction };
+    }
+    if (attempt.status === 403) {
+      sawAccessDenied = true;
+      continue;
+    }
+    lastError = `unexpected HTTP ${attempt.status} from ListBuckets`;
+  }
+
+  if (sawAccessDenied) return { ok: false, reason: "access_denied" };
+  return { ok: false, reason: "error", message: lastError ?? "could not list buckets" };
+}

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -5,7 +5,11 @@ import { Hono } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { respondError } from "../error-response";
 import { me } from "./me";
-import { setStorageReconcileForTests, setStorageVerifyForTests } from "./workspace-storage";
+import {
+  setListBucketsForTests,
+  setStorageReconcileForTests,
+  setStorageVerifyForTests,
+} from "./workspace-storage";
 import { fakeRegistry, FakeKv } from "../../test/fake-kv";
 import { UsageFakeD1 } from "../../test/usage-fake-d1";
 import { FakeR2Bucket } from "../../test/fake-r2";
@@ -2683,6 +2687,7 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
   afterEach(() => {
     setStorageVerifyForTests(undefined);
     setStorageReconcileForTests(undefined);
+    setListBucketsForTests(undefined);
   });
 
   /** Installs a reconcile spy so guard-bypassed transitions don't walk a real bucket. */
@@ -2787,6 +2792,81 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe("POST /me/workspaces/:name/storage/buckets", () => {
+    const CREDS_BODY = {
+      accountId: "a".repeat(32),
+      accessKeyId: "AKIAEXAMPLE",
+      secretAccessKey: "s3cr3t",
+    };
+
+    it("403s (byo_bucket_disabled) when the workspace flag is off", async () => {
+      const { env } = storageEnv({ role: "owner", record: SHARED_RECORD });
+      const res = await app().request(
+        "/me/workspaces/acme/storage/buckets",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CREDS_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("runs the injected ListBuckets lookup and returns its buckets", async () => {
+      const { env } = storageEnv({ role: "owner", record: BYO_RECORD });
+      setListBucketsForTests(async (creds) => {
+        expect(creds.accountId).toBe(CREDS_BODY.accountId);
+        return { ok: true, buckets: ["one", "two"] };
+      });
+      const res = await app().request(
+        "/me/workspaces/acme/storage/buckets",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CREDS_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, buckets: ["one", "two"] });
+    });
+
+    it("200s with the distinguishable access_denied shape (not an error) so the UI can fall back", async () => {
+      const { env } = storageEnv({ role: "owner", record: BYO_RECORD });
+      setListBucketsForTests(async () => ({ ok: false, reason: "access_denied" }));
+      const res = await app().request(
+        "/me/workspaces/acme/storage/buckets",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CREDS_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: false, reason: "access_denied" });
+    });
+
+    it("429s when the write limiter is over budget", async () => {
+      const { env: baseEnv } = storageEnv({ role: "owner", record: BYO_RECORD });
+      const env = {
+        ...baseEnv,
+        WRITE_LIMITER: { limit: async () => ({ success: false }) },
+      } as unknown as Env;
+      const res = await app().request(
+        "/me/workspaces/acme/storage/buckets",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CREDS_BODY),
         },
         env,
       );

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -449,6 +449,9 @@ export const me = new Hono<SessionVars>()
   .post("/workspaces/:name/storage/verify", (c) =>
     forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/storage/verify`),
   )
+  .post("/workspaces/:name/storage/buckets", (c) =>
+    forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/storage/buckets`),
+  )
   .put("/workspaces/:name/storage", (c) =>
     forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/storage`),
   )

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -103,9 +103,11 @@ import {
 } from "../workspace-lanes";
 import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { planResponse, planSourceFor } from "../workspace-plan";
+import type { ListBucketsResult } from "../r2-list-buckets";
 import {
   candidateFromBody,
   isByoRecord,
+  listBuckets,
   storageReconcile,
   storageStatusResponse,
   storageVerify,
@@ -423,6 +425,58 @@ export async function storageVerifyHandler(c: Context<SettingsVars>) {
   return c.json(result);
 }
 
+/** Body shape for `POST /:workspace/storage/buckets`. Never persisted — same in-flight-only posture as verify's candidate body. */
+interface ListBucketsBody {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  jurisdiction?: string;
+}
+
+function listBucketsCredentialsFromBody(body: unknown): ListBucketsBody {
+  const b = (body ?? {}) as Record<string, unknown>;
+  return {
+    accountId: typeof b.accountId === "string" ? b.accountId : "",
+    accessKeyId: typeof b.accessKeyId === "string" ? b.accessKeyId : "",
+    secretAccessKey: typeof b.secretAccessKey === "string" ? b.secretAccessKey : "",
+    jurisdiction:
+      typeof b.jurisdiction === "string" && b.jurisdiction !== "" ? b.jurisdiction : undefined,
+  };
+}
+
+/**
+ * `POST /:workspace/storage/buckets` — the wizard's bucket picker (issue
+ * #783 Part A item 2). Same auth/rate-limit tier as `storage/verify` (never
+ * persists anything; every call does real remote I/O), but calls S3
+ * `ListBuckets` directly (`../r2-list-buckets.ts`) rather than the verify
+ * pipeline — `ListBuckets` is account-level, not bucket-scoped, so it's a
+ * different request entirely from the round-trip probe.
+ *
+ * Always 200s with a `ListBucketsResult` body — including the
+ * `access_denied` shape a bucket-scoped token produces, which is the
+ * *expected*, common case (R2 only permits `ListBuckets` for account-scoped
+ * tokens) and the wizard's signal to fall back to a plain bucket-name field,
+ * not an error to surface.
+ */
+export async function storageBucketsHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  const record = await loadWorkspaceRecord(c.env, name);
+  if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  if (!byoBucketAllowed(record)) {
+    throw new ForbiddenError("BYO storage is not enabled for this workspace", {
+      code: "byo_bucket_disabled",
+    });
+  }
+  if (!(await allowWrite(c.env, name))) {
+    throw new RateLimitedError("rate limit exceeded");
+  }
+
+  const body = await c.req.json().catch(() => null);
+  const creds = listBucketsCredentialsFromBody(body);
+  const result: ListBucketsResult = await listBuckets(creds);
+  return c.json(result);
+}
+
 /**
  * `PUT /:workspace/storage` — verifies a candidate BYO config and saves it
  * as a **standby lane** (spec: "Configure, then switch"). Never trusts a
@@ -483,9 +537,16 @@ export async function storagePutHandler(c: Context<SettingsVars>) {
         accessKeyId: candidate.accessKeyId,
         secretAccessKey: candidate.secretAccessKey,
       });
-      // Cast is safe: `storageVerify` above already ran the shape check
-      // (storage-verify.ts) that 422s on anything outside R2_JURISDICTIONS.
-      const jurisdiction = candidate.jurisdiction as R2Jurisdiction | undefined;
+      // Prefer whatever the caller supplied explicitly (parsed client-side
+      // from a pasted endpoint URL) — cast is safe since `storageVerify`
+      // above already ran the shape check (storage-verify.ts) that 422s on
+      // anything outside R2_JURISDICTIONS. When the caller omitted it (the
+      // common case now that the wizard has no jurisdiction field),
+      // fall back to whichever jurisdiction the verify pipeline's auto-probe
+      // actually found live — never save a jurisdiction the bucket wasn't
+      // proven to answer at.
+      const jurisdiction =
+        (candidate.jurisdiction as R2Jurisdiction | undefined) ?? result.jurisdiction;
       // Display fragment for the settings UI, captured from the plaintext
       // before sealing — every sealed field below is ciphertext from here on.
       const accessKeyIdLast4 = candidate.accessKeyId.slice(-4);
@@ -984,6 +1045,7 @@ export const workspaceSettings = new Hono<SettingsVars>()
   .get("/:workspace/comment-preview", sessionAdminGate(), commentPreviewHandler)
   .get("/:workspace/storage", sessionAdminGate(), storageGetHandler)
   .post("/:workspace/storage/verify", sessionAdminGate(), storageVerifyHandler)
+  .post("/:workspace/storage/buckets", sessionAdminGate(), storageBucketsHandler)
   .put("/:workspace/storage", sessionAdminGate(), storagePutHandler)
   .post("/:workspace/storage/activate", sessionAdminGate(), storageActivateHandler)
   .delete("/:workspace/storage", sessionAdminGate(), storageDeleteHandler)

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -7,6 +7,11 @@
  * copy of masking and projection logic.
  */
 import {
+  listR2Buckets,
+  type ListBucketsCredentials,
+  type ListBucketsResult,
+} from "../r2-list-buckets";
+import {
   verifyStorageConfig,
   type StorageVerifyCandidate,
   type StorageVerifyOptions,
@@ -164,6 +169,26 @@ export function setStorageReconcileForTests(
   fn: ((env: Env, ws: WorkspaceRecord, name: string) => Promise<unknown>) | undefined,
 ): void {
   runStorageReconcile = fn ?? reconcileWorkspaceUsage;
+}
+
+/**
+ * `listR2Buckets` entry point `storageBucketsHandler` calls, indirected
+ * through this mutable binding for the same reason as `storageVerify` above
+ * — route tests need to substitute a fake instead of hitting the network.
+ * Restore the default with `setListBucketsForTests(undefined)` in an
+ * `afterEach`/`finally`.
+ */
+let runListBuckets: (creds: ListBucketsCredentials) => Promise<ListBucketsResult> = listR2Buckets;
+
+export function listBuckets(creds: ListBucketsCredentials): Promise<ListBucketsResult> {
+  return runListBuckets(creds);
+}
+
+/** Test-only: swap the ListBuckets implementation. Pass `undefined` to restore the real one. */
+export function setListBucketsForTests(
+  fn: ((creds: ListBucketsCredentials) => Promise<ListBucketsResult>) | undefined,
+): void {
+  runListBuckets = fn ?? listR2Buckets;
 }
 
 /** Parses the request body into a `StorageVerifyCandidate` shape (no validation — `verifyStorageConfig`'s `shape` check does that). */

--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -188,12 +188,24 @@ describe("verifyStorageConfig — auth/reachability", () => {
 });
 
 describe("verifyStorageConfig — round trip + empty-bucket guard", () => {
-  it("passes end to end on an empty bucket with no publicBaseUrl", async () => {
+  it("passes end to end on an empty bucket with no publicBaseUrl, flagging signed-only as a warning", async () => {
     const client = new FakeStorageClient();
     const result = await run(VALID, client);
     expect(result.ok).toBe(true);
-    expect(result.checks.map((c) => c.id)).toEqual(["shape", "auth", "round-trip", "not-empty"]);
-    expect(result.checks.every((c) => c.ok)).toBe(true);
+    expect(result.checks.map((c) => c.id)).toEqual([
+      "shape",
+      "auth",
+      "round-trip",
+      "not-empty",
+      "public-url",
+    ]);
+    // Every *required* check passed; the trailing public-url entry is a
+    // recommended warning (no publicBaseUrl configured) and doesn't gate ok.
+    const publicUrl = result.checks.find((c) => c.id === "public-url")!;
+    expect(publicUrl.ok).toBe(false);
+    expect(publicUrl.required).toBe(false);
+    expect(publicUrl.hint).toMatch(/no public base URL/);
+    expect(publicUrl.hint).toMatch(/expire after an hour/);
     // Probe object must not be left behind.
     expect(client.store.size).toBe(0);
     expect(client.deletedKeys).toHaveLength(1);
@@ -207,6 +219,11 @@ describe("verifyStorageConfig — round trip + empty-bucket guard", () => {
     const notEmpty = result.checks.find((c) => c.id === "not-empty")!;
     expect(notEmpty.ok).toBe(false);
     expect(notEmpty.hint).toMatch(/adoptExistingContents/);
+    // Plain-language explanation of what attaching a non-empty bucket
+    // actually does (issue #783 Part B item 1) — not just what to click.
+    expect(notEmpty.hint).toMatch(/nothing gets imported or copied/i);
+    expect(notEmpty.hint).toMatch(/becomes this workspace's root/);
+    expect(notEmpty.hint).toMatch(/saving now doesn't switch anything/i);
   });
 
   it("passes the empty-bucket guard when adoptExistingContents is set", async () => {
@@ -246,12 +263,62 @@ describe("verifyStorageConfig — round trip + empty-bucket guard", () => {
   });
 });
 
+describe("verifyStorageConfig — jurisdiction auto-probe", () => {
+  it("uses the candidate's own jurisdiction without probing when one is given", async () => {
+    const client = new FakeStorageClient();
+    const createClient = vi.fn(() => client);
+    const result = await verifyStorageConfig({ ...VALID, jurisdiction: "eu" }, { createClient });
+    expect(createClient).toHaveBeenCalledOnce();
+    expect(createClient).toHaveBeenCalledWith(expect.objectContaining({ jurisdiction: "eu" }));
+    expect(result.jurisdiction).toBe("eu");
+  });
+
+  it("probes default, then eu, then fedramp — in that order — and records whichever answers", async () => {
+    const attempts: (string | undefined)[] = [];
+    const createClient = vi.fn((c: StorageVerifyCandidate) => {
+      attempts.push(c.jurisdiction);
+      const client = new FakeStorageClient();
+      // Only the fedramp endpoint "has" this bucket in this scenario.
+      if (c.jurisdiction !== "fedramp") client.listError = new FakeError("NotFound", "no bucket");
+      return client;
+    });
+    const result = await verifyStorageConfig(VALID, { createClient });
+    expect(attempts).toEqual([undefined, "eu", "fedramp"]);
+    expect(result.jurisdiction).toBe("fedramp");
+    expect(result.checks.find((c) => c.id === "auth")!.ok).toBe(true);
+  });
+
+  it("stops probing at the first jurisdiction that answers (default)", async () => {
+    const createClient = vi.fn(() => new FakeStorageClient());
+    const result = await verifyStorageConfig(VALID, { createClient });
+    expect(createClient).toHaveBeenCalledOnce();
+    expect(result.jurisdiction).toBeUndefined();
+  });
+
+  it("falls back to the auth-error hint when no jurisdiction answers", async () => {
+    const createClient = vi.fn(() => {
+      const client = new FakeStorageClient();
+      client.listError = new FakeError("Unauthorized", "denied");
+      return client;
+    });
+    const result = await verifyStorageConfig(VALID, { createClient });
+    expect(createClient).toHaveBeenCalledTimes(3);
+    expect(result.ok).toBe(false);
+    expect(result.checks.find((c) => c.id === "auth")!.hint).toMatch(/access key was rejected/);
+    expect(result.jurisdiction).toBeUndefined();
+  });
+});
+
 describe("verifyStorageConfig — recommended public-URL probe", () => {
-  it("skips cleanly when no publicBaseUrl is supplied (signed-only mode)", async () => {
+  it("never fetches when no publicBaseUrl is supplied, and flags signed-only as a warning instead", async () => {
     const client = new FakeStorageClient();
     const fetchImpl = vi.fn();
     const result = await run(VALID, client, fetchImpl as unknown as typeof fetch);
-    expect(result.checks.find((c) => c.id === "public-url")).toBeUndefined();
+    const publicUrl = result.checks.find((c) => c.id === "public-url");
+    expect(publicUrl).toBeDefined();
+    expect(publicUrl!.ok).toBe(false);
+    expect(publicUrl!.required).toBe(false);
+    expect(publicUrl!.hint).toMatch(/no public base URL set/);
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
@@ -318,7 +385,7 @@ describe("verifyStorageConfig — recommended public-URL probe", () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
-  it("reports a fetch failure (DNS/timeout) as a recommended, non-gating failure", async () => {
+  it("reports a thrown fetch (DNS/timeout/subrequest failure) as 'couldn't verify from here', not 'domain is broken'", async () => {
     const client = new FakeStorageClient();
     const fetchImpl = vi.fn(async () => {
       throw new Error("network error: ENOTFOUND");
@@ -330,7 +397,9 @@ describe("verifyStorageConfig — recommended public-URL probe", () => {
     );
     const publicUrl = result.checks.find((c) => c.id === "public-url")!;
     expect(publicUrl.ok).toBe(false);
-    expect(publicUrl.hint).toMatch(/DNS/);
+    expect(publicUrl.hint).toMatch(/couldn't verify publicBaseUrl from here/);
+    expect(publicUrl.hint).not.toMatch(/not connected/);
+    expect(publicUrl.hint).toMatch(/known object/);
     expect(result.ok).toBe(true);
   });
 

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -20,6 +20,7 @@ import {
   createStorage,
   isR2Jurisdiction,
   R2_JURISDICTIONS,
+  type R2Jurisdiction,
   type StorageConfig,
 } from "@uploads/storage";
 
@@ -55,6 +56,16 @@ export interface StorageVerifyResult {
   /** True only when every required check passed. */
   ok: boolean;
   checks: StorageVerifyCheck[];
+  /**
+   * The jurisdiction the successful auth probe actually used — either the
+   * candidate's own `jurisdiction` echoed back, or whichever of the
+   * auto-probe order (default, `eu`, `fedramp`) answered first when the
+   * caller omitted it. Absent when auth never succeeded. Callers that persist
+   * a verified candidate (`storagePutHandler`) should save this value rather
+   * than `candidate.jurisdiction` — that field is often unset by design now
+   * that the wizard no longer shows a jurisdiction picker.
+   */
+  jurisdiction?: R2Jurisdiction;
 }
 
 /** Minimal surface the pipeline needs from a storage client — satisfied by files-sdk's `Files`. */
@@ -243,20 +254,34 @@ async function checkPublicUrl(
     }
     return { id: "public-url", ok: true, required: false };
   } catch {
+    // A thrown fetch means this probe — run from inside the API worker —
+    // couldn't reach the domain; it does NOT mean the domain is broken. A
+    // same-account/zone-set customer domain in particular can be unreachable
+    // as a Workers subrequest while serving the public internet fine (issue
+    // #783). Say "we couldn't verify it from here", not "your domain is
+    // broken", and point at the one check that actually settles it.
     return {
       id: "public-url",
       ok: false,
       required: false,
-      hint: "could not reach publicBaseUrl — domain not connected to the bucket yet (DNS can take a few minutes) or the request timed out",
+      hint: "we couldn't verify publicBaseUrl from here — this can happen even when the domain is working fine (a same-account custom domain isn't always reachable as a server-side request). Open a known object's URL in a browser to check for yourself; if that loads, the domain is fine.",
     };
   }
 }
 
+/** Warning shown when no `publicBaseUrl` is configured — signed-only mode is allowed but degraded (issue #783 follow-up comment). */
+const NO_PUBLIC_URL_HINT =
+  "no public base URL set — files will only be reachable through signed links that expire after an hour, and embeds/galleries won't work. Add one any time; it applies retroactively to files already uploaded (URLs are derived on request, nothing is stored per file).";
+
 /**
  * Runs the required + recommended check pipeline against `candidate`.
  * Required checks short-circuit on first failure (shape → auth → round-trip
- * → not-empty); the recommended public-URL check only runs when the
- * round-trip succeeded and a `publicBaseUrl` was supplied.
+ * → not-empty). When `candidate.jurisdiction` is omitted, the auth step
+ * auto-probes the default endpoint, then `eu`, then `fedramp`, and records
+ * whichever answers on `StorageVerifyResult.jurisdiction`. The public-URL
+ * check always runs last: a real reachability probe when `publicBaseUrl` is
+ * set (recommended — never gates `ok`), otherwise a recommended warning that
+ * signed-only mode is a degraded, not neutral, choice.
  */
 export async function verifyStorageConfig(
   candidate: StorageVerifyCandidate,
@@ -270,16 +295,38 @@ export async function verifyStorageConfig(
   checks.push(shape);
   if (!shape.ok) return { ok: false, checks };
 
-  const client = createClient(candidate);
+  // Auth + reachability probe, also resolving the jurisdiction. When the
+  // caller supplied one explicitly (parsed from a pasted endpoint URL), just
+  // use it — one client, one attempt. Otherwise auto-probe in the order the
+  // wizard promises (default endpoint, then `eu`, then `fedramp`) and use
+  // whichever answers first; a wrong-jurisdiction bucket reliably fails
+  // auth/lookup at the other endpoints, so trying in order costs at most two
+  // extra calls and never a false positive. Its `list()` result also seeds
+  // the empty-bucket guard below, so attaching a bucket costs one list call.
+  const jurisdictionOrder: (R2Jurisdiction | undefined)[] =
+    candidate.jurisdiction !== undefined
+      ? [candidate.jurisdiction as R2Jurisdiction]
+      : [undefined, ...R2_JURISDICTIONS];
 
-  // Auth + reachability probe. Its `list()` result also seeds the
-  // empty-bucket guard below, so attaching a bucket costs one list call.
-  let existingItems: { key: string }[];
-  try {
-    const listed = await client.list({ limit: 1000 });
-    existingItems = listed.items;
-  } catch (err) {
-    checks.push({ id: "auth", ok: false, required: true, hint: hintForAuthError(err) });
+  let client: StorageProbeClient | undefined;
+  let existingItems: { key: string }[] | undefined;
+  let jurisdiction: R2Jurisdiction | undefined;
+  let authErr: unknown;
+  for (const attemptJurisdiction of jurisdictionOrder) {
+    const attemptClient = createClient({ ...candidate, jurisdiction: attemptJurisdiction });
+    try {
+      const listed = await attemptClient.list({ limit: 1000 });
+      client = attemptClient;
+      existingItems = listed.items;
+      jurisdiction = attemptJurisdiction;
+      break;
+    } catch (err) {
+      authErr = err;
+    }
+  }
+
+  if (!client || !existingItems) {
+    checks.push({ id: "auth", ok: false, required: true, hint: hintForAuthError(authErr) });
     return { ok: false, checks };
   }
   checks.push({ id: "auth", ok: true, required: true });
@@ -337,7 +384,7 @@ export async function verifyStorageConfig(
     required: true,
     hint: notEmptyOk
       ? undefined
-      : "this bucket already has objects in it — confirm you want this workspace to expose the existing contents (adoptExistingContents), or point at an empty bucket",
+      : "this bucket already has objects in it. Nothing gets imported or copied — the bucket root simply becomes this workspace's root, so every existing object becomes visible here (and publicly reachable too, if you set a public base URL) once you switch to this bucket. Confirm that's what you want (adoptExistingContents), or point at an empty bucket instead. Saving now doesn't switch anything on its own — you do that separately, whenever you're ready.",
   });
 
   if (candidate.publicBaseUrl) {
@@ -349,7 +396,16 @@ export async function verifyStorageConfig(
         hint: "skipped — the write/read round-trip failed before the public URL could be verified",
       },
     );
+  } else {
+    // Signed-only mode is allowed, but it's a degraded state, not a neutral
+    // default — flag it the same warning-level way a failed recommended
+    // check would be (issue #783 follow-up comment).
+    checks.push({ id: "public-url", ok: false, required: false, hint: NO_PUBLIC_URL_HINT });
   }
 
-  return { ok: checks.filter((c) => c.required).every((c) => c.ok), checks };
+  return {
+    ok: checks.filter((c) => c.required).every((c) => c.ok),
+    checks,
+    jurisdiction,
+  };
 }

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -20,6 +20,7 @@ import {
   getWorkspaceSummary,
   inviteToWorkspace,
   listWorkspaceFolder,
+  listWorkspaceStorageBuckets,
   putWorkspaceStorage,
   removeWorkspaceMember,
   revokeWorkspaceInvite,
@@ -1532,6 +1533,59 @@ describe("verifyWorkspaceStorage", () => {
     );
     await expect(
       verifyWorkspaceStorage("http://127.0.0.1:8787", "acme", CANDIDATE),
+    ).resolves.toEqual({ kind: "unavailable", reason: "network" });
+  });
+});
+
+describe("listWorkspaceStorageBuckets", () => {
+  const CREDS = {
+    accountId: "a".repeat(32),
+    accessKeyId: "AKIA1234",
+    secretAccessKey: "shh",
+  };
+
+  it("POSTs the credentials and returns the bucket list", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("http://127.0.0.1:8787/v1/workspaces/acme/storage/buckets");
+      expect(init?.method).toBe("POST");
+      expect(init?.credentials).toBe("include");
+      expect(JSON.parse(init!.body as string)).toEqual(CREDS);
+      return Response.json({ ok: true, buckets: ["one", "two"] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      listWorkspaceStorageBuckets("http://127.0.0.1:8787", "acme", CREDS),
+    ).resolves.toEqual({ kind: "ok", buckets: ["one", "two"] });
+  });
+
+  it("maps the access_denied shape to its own kind, distinct from a generic error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ ok: false, reason: "access_denied" })),
+    );
+    await expect(
+      listWorkspaceStorageBuckets("http://127.0.0.1:8787", "acme", CREDS),
+    ).resolves.toEqual({ kind: "access_denied" });
+  });
+
+  it("reports 403 as forbidden — byo_bucket_disabled", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 403 })),
+    );
+    await expect(
+      listWorkspaceStorageBuckets("http://127.0.0.1:8787", "acme", CREDS),
+    ).resolves.toEqual({ kind: "unavailable", reason: "forbidden" });
+  });
+
+  it("propagates network failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new TypeError("network down"))),
+    );
+    await expect(
+      listWorkspaceStorageBuckets("http://127.0.0.1:8787", "acme", CREDS),
     ).resolves.toEqual({ kind: "unavailable", reason: "network" });
   });
 });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1855,6 +1855,8 @@ export interface StorageVerifyResult {
   /** True only when every required check passed. */
   ok: boolean;
   checks: StorageVerifyCheck[];
+  /** The jurisdiction the auth probe actually used — echoed back, or auto-detected when the candidate omitted it. Absent when auth never succeeded. */
+  jurisdiction?: string;
 }
 
 function toStorageVerifyResult(body: unknown): StorageVerifyResult | null {
@@ -1882,7 +1884,11 @@ function toStorageVerifyResult(body: unknown): StorageVerifyResult | null {
       },
     ];
   });
-  return { ok: b.ok, checks };
+  return {
+    ok: b.ok,
+    checks,
+    jurisdiction: typeof b.jurisdiction === "string" ? b.jurisdiction : undefined,
+  };
 }
 
 /** Candidate config the wizard is trying to attach — never saved until a PUT. */
@@ -1928,6 +1934,67 @@ export async function verifyWorkspaceStorage(
   const verify = toStorageVerifyResult(await response.json().catch(() => null));
   if (!verify) return { kind: "unavailable", reason: "server" };
   return { kind: "ok", result: verify };
+}
+
+/** Credentials the wizard has on hand once the account id/endpoint + key fields are filled — never saved. */
+export interface StorageBucketsCredentials {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  jurisdiction?: string;
+}
+
+export type StorageBucketsApiResult =
+  | { kind: "ok"; buckets: string[] }
+  /** R2 only permits `ListBuckets` for account-scoped tokens — the wizard's cue to fall back to a plain "Bucket Name" field. */
+  | { kind: "access_denied" }
+  | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
+
+function toStorageBucketsApiResult(body: unknown): StorageBucketsApiResult | null {
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, unknown>;
+  if (b.ok === true) {
+    return Array.isArray(b.buckets) && b.buckets.every((x) => typeof x === "string")
+      ? { kind: "ok", buckets: b.buckets }
+      : null;
+  }
+  if (b.ok === false && b.reason === "access_denied") return { kind: "access_denied" };
+  if (b.ok === false && b.reason === "error") return { kind: "unavailable", reason: "server" };
+  return null;
+}
+
+/**
+ * POST /v1/workspaces/:name/storage/buckets — the wizard's bucket picker
+ * (issue #783 Part A item 2): runs S3 `ListBuckets` against the given
+ * account/credentials and returns the bucket names, so the wizard can render
+ * a `<select>` instead of asking for a bucket name up front. Same
+ * auth/availability shape as `verifyWorkspaceStorage` (403 = BYO disabled),
+ * plus an `access_denied` outcome that's expected and common (bucket-scoped
+ * tokens can't list) — the caller should fall back to a plain text field,
+ * not show an error.
+ */
+export async function listWorkspaceStorageBuckets(
+  apiOrigin: string,
+  name: string,
+  creds: StorageBucketsCredentials,
+): Promise<StorageBucketsApiResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/storage/buckets`,
+    {
+      method: "POST",
+      credentials: "include",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(creds),
+    },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (response.status === 403) return { kind: "unavailable", reason: "forbidden" };
+  if (response.status === 404) return { kind: "unavailable", reason: "not_found" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const parsed = toStorageBucketsApiResult(await response.json().catch(() => null));
+  return parsed ?? { kind: "unavailable", reason: "server" };
 }
 
 export type StorageSaveResult =

--- a/apps/web/src/lib/r2-endpoint.test.ts
+++ b/apps/web/src/lib/r2-endpoint.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { parseAccountIdOrEndpoint } from "./r2-endpoint";
+
+const ACCOUNT_ID = "a".repeat(32);
+
+describe("parseAccountIdOrEndpoint", () => {
+  it("accepts a bare 32-char hex account id", () => {
+    expect(parseAccountIdOrEndpoint(ACCOUNT_ID)).toEqual({ accountId: ACCOUNT_ID });
+  });
+
+  it("uppercases in a bare account id are normalized to lowercase", () => {
+    expect(parseAccountIdOrEndpoint(ACCOUNT_ID.toUpperCase())).toEqual({ accountId: ACCOUNT_ID });
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseAccountIdOrEndpoint(`  ${ACCOUNT_ID}  `)).toEqual({ accountId: ACCOUNT_ID });
+  });
+
+  it("parses the default (no-jurisdiction) endpoint URL", () => {
+    expect(parseAccountIdOrEndpoint(`https://${ACCOUNT_ID}.r2.cloudflarestorage.com`)).toEqual({
+      accountId: ACCOUNT_ID,
+      jurisdiction: undefined,
+    });
+  });
+
+  it("parses an endpoint URL with a trailing slash", () => {
+    expect(parseAccountIdOrEndpoint(`https://${ACCOUNT_ID}.r2.cloudflarestorage.com/`)).toEqual({
+      accountId: ACCOUNT_ID,
+      jurisdiction: undefined,
+    });
+  });
+
+  it("parses the eu jurisdiction out of an endpoint URL", () => {
+    expect(parseAccountIdOrEndpoint(`https://${ACCOUNT_ID}.eu.r2.cloudflarestorage.com`)).toEqual({
+      accountId: ACCOUNT_ID,
+      jurisdiction: "eu",
+    });
+  });
+
+  it("parses the fedramp jurisdiction out of an endpoint URL", () => {
+    expect(
+      parseAccountIdOrEndpoint(`https://${ACCOUNT_ID}.fedramp.r2.cloudflarestorage.com`),
+    ).toEqual({ accountId: ACCOUNT_ID, jurisdiction: "fedramp" });
+  });
+
+  it("is case-insensitive on the endpoint host and normalizes to lowercase", () => {
+    expect(
+      parseAccountIdOrEndpoint(`https://${ACCOUNT_ID.toUpperCase()}.EU.R2.CLOUDFLARESTORAGE.COM`),
+    ).toEqual({ accountId: ACCOUNT_ID, jurisdiction: "eu" });
+  });
+
+  it("returns null for garbage input", () => {
+    expect(parseAccountIdOrEndpoint("not an account id or url")).toBeNull();
+  });
+
+  it("returns null for an empty/whitespace-only input", () => {
+    expect(parseAccountIdOrEndpoint("   ")).toBeNull();
+  });
+
+  it("returns null for a non-R2 https URL", () => {
+    expect(parseAccountIdOrEndpoint("https://example.com")).toBeNull();
+  });
+
+  it("returns null for an http (non-https) endpoint URL", () => {
+    expect(parseAccountIdOrEndpoint(`http://${ACCOUNT_ID}.r2.cloudflarestorage.com`)).toBeNull();
+  });
+
+  it("returns null for a too-short hex string", () => {
+    expect(parseAccountIdOrEndpoint("a".repeat(31))).toBeNull();
+  });
+});

--- a/apps/web/src/lib/r2-endpoint.ts
+++ b/apps/web/src/lib/r2-endpoint.ts
@@ -1,0 +1,39 @@
+/**
+ * Parses the wizard's single "Account ID or S3 endpoint URL" field (issue
+ * #783 Part A item 1). Cloudflare's R2 API token screen hands the user an
+ * endpoint URL — `https://<accountId>[.<jurisdiction>].r2.cloudflarestorage.com`
+ * — that encodes both the account id and the jurisdiction; a bare account id
+ * is also accepted for anyone who already knows theirs. Parsed client-side
+ * so the wizard never shows a separate jurisdiction field — the API contract
+ * still receives plain `accountId`/`jurisdiction`, unaware anything was
+ * merged on the client (`storage-verify.ts`'s shape check is unchanged).
+ */
+
+export interface ParsedAccountIdOrEndpoint {
+  accountId: string;
+  /** Present only when the pasted endpoint named one — a bare account id never implies a jurisdiction. */
+  jurisdiction?: string;
+}
+
+const ACCOUNT_ID_RE = /^[0-9a-f]{32}$/i;
+const ENDPOINT_RE = /^https:\/\/([0-9a-f]{32})(?:\.([a-z0-9]+))?\.r2\.cloudflarestorage\.com\/?$/i;
+
+/**
+ * `null` when the input is neither a 32-hex account id nor a recognizable R2
+ * endpoint URL — the caller should treat that as a validation error rather
+ * than guessing.
+ */
+export function parseAccountIdOrEndpoint(input: string): ParsedAccountIdOrEndpoint | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (ACCOUNT_ID_RE.test(trimmed)) {
+    return { accountId: trimmed.toLowerCase() };
+  }
+  const match = ENDPOINT_RE.exec(trimmed);
+  if (!match) return null;
+  const [, accountId, jurisdiction] = match;
+  return {
+    accountId: accountId.toLowerCase(),
+    jurisdiction: jurisdiction ? jurisdiction.toLowerCase() : undefined,
+  };
+}

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -58,7 +58,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             <div class="storage-summary__body">
               <div class="storage-summary__title">Enter the bucket's credentials</div>
               <div class="storage-summary__sub">
-                Account ID, bucket name, access keys — plus an optional public base URL.
+                Account ID (or endpoint URL) and access keys — we'll look up the bucket for you,
+                plus an optional public base URL.
               </div>
             </div>
           </div>
@@ -117,7 +118,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
               Create a bucket-scoped API token: <strong>R2</strong> →
               <strong>Manage API Tokens</strong> → <strong>Create API Token</strong>, permission
               <strong>Object Read & Write</strong>, scoped to that one bucket only. Copy the Access
-              Key ID, Secret Access Key, and your Account ID.
+              Key ID and Secret Access Key — and either the Account ID or the S3 endpoint URL
+              Cloudflare shows on the same screen (either works below).
             </li>
             <li>
               Optional — for public reads: bucket → <strong>Settings</strong> →
@@ -135,41 +137,27 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         </div>
 
         <div class="storage-wizard-step" id="storage-step-2" hidden>
-          <h3>2. Enter your bucket's credentials</h3>
+          <h3>2. Connect your bucket</h3>
+          <p class="settings-note muted">
+            Enter your bucket's credentials — checks run inline below.
+          </p>
           <form class="ws-form" id="storage-form">
             <div class="ul-field">
-              <label for="storage-account-id" class="ul-label">Account ID</label>
+              <label for="storage-account-id" class="ul-label">Account ID or endpoint URL</label>
               <input
                 type="text"
                 id="storage-account-id"
                 class="ul-input"
                 autocomplete="off"
                 spellcheck="false"
-                placeholder="32-character hex account id"
+                placeholder="32-character hex account id, or the endpoint URL from Cloudflare"
                 required
               />
-            </div>
-            <div class="ul-field">
-              <label for="storage-bucket" class="ul-label">Bucket name</label>
-              <input
-                type="text"
-                id="storage-bucket"
-                class="ul-input"
-                autocomplete="off"
-                spellcheck="false"
-                required
-              />
-            </div>
-            <div class="ul-field">
-              <label for="storage-jurisdiction" class="ul-label">Jurisdiction</label>
-              <select id="storage-jurisdiction" class="ul-select">
-                <option value="">Default (no jurisdiction)</option>
-                <option value="eu">European Union (eu)</option>
-                <option value="fedramp">FedRAMP (fedramp)</option>
-              </select>
               <p class="ul-field__hint">
-                Jurisdiction is chosen at bucket creation on Cloudflare and can't be changed later —
-                pick the one the bucket was created with.
+                Paste either one — the R2 API token screen hands you an endpoint URL (<code
+                  >https://&lt;account&gt;.r2.cloudflarestorage.com</code
+                >) that already carries your account id and jurisdiction, so there's nothing else to
+                figure out here.
               </p>
             </div>
             <div class="ul-field">
@@ -195,6 +183,23 @@ if (!workspace) return Astro.redirect("/account/workspaces");
               />
             </div>
             <div class="ul-field">
+              <label for="storage-bucket" class="ul-label" id="storage-bucket-label"
+                >Bucket Name</label
+              >
+              <select id="storage-bucket-select" class="ul-select" required hidden></select>
+              <input
+                type="text"
+                id="storage-bucket"
+                class="ul-input"
+                autocomplete="off"
+                spellcheck="false"
+                required
+              />
+              <p class="ul-field__hint" id="storage-bucket-hint">
+                Enter your access keys above and we'll look up your buckets.
+              </p>
+            </div>
+            <div class="ul-field">
               <label for="storage-public-base-url" class="ul-label"
                 >Public base URL (optional)</label
               >
@@ -207,18 +212,24 @@ if (!workspace) return Astro.redirect("/account/workspaces");
                 placeholder="https://media.example.com"
               />
               <p class="ul-field__hint">
-                Leave blank for signed-only access. <code>r2.dev</code> URLs aren't supported.
+                Without this, files are only reachable through signed links that expire after an
+                hour, and embeds/galleries won't work — connect a custom domain for stable,
+                embeddable links. You can add it any time; it applies to files already uploaded,
+                too.
+                <code>r2.dev</code> URLs aren't supported.
               </p>
             </div>
 
             <div class="ul-field" id="storage-adopt-row" hidden>
               <label class="storage-adopt-label">
                 <input type="checkbox" id="storage-adopt" />
-                This bucket already contains files — show them in this workspace
+                This bucket already has files in it — use them as-is
               </label>
               <p class="ul-field__hint">
-                Everything already in the bucket becomes part of this workspace once you switch to
-                it.
+                Nothing gets imported or copied. The bucket root becomes this workspace's root, so
+                every file already in it becomes part of the workspace (and publicly reachable too,
+                if you set a public base URL) once you switch to this bucket. Saving now doesn't
+                switch anything — you do that separately, whenever you're ready.
               </p>
             </div>
 
@@ -365,6 +376,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       font-size: var(--text-micro);
       color: var(--muted);
     }
+    .storage-signed-only-note {
+      display: block;
+      margin-top: 4px;
+      font-size: var(--text-micro);
+      color: var(--muted);
+    }
   </style>
 
   <script>
@@ -379,6 +396,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       activateWorkspaceStorage,
       deleteWorkspaceStorage,
       getWorkspaceStorageStatus,
+      listWorkspaceStorageBuckets,
       putWorkspaceStorage,
       verifyWorkspaceStorage,
       type StorageCandidate,
@@ -386,6 +404,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       type WorkspaceStorageLane,
       type WorkspaceStorageStatus,
     } from "../../../../../lib/api-client";
+    import { parseAccountIdOrEndpoint } from "../../../../../lib/r2-endpoint";
     import { loadWorkspaces } from "../../../../../lib/workspaces-nav";
     import { resolveActiveWorkspace } from "../../../../../lib/workspace-browse-url";
     import { renderDetailsHtml } from "../../../../../lib/workspace-rail";
@@ -464,13 +483,15 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const storageStep3Back = requireElement<HTMLButtonElement>("#storage-step3-back", page);
       const storageForm = requireElement<HTMLFormElement>("#storage-form", page);
       const storageAccountId = requireElement<HTMLInputElement>("#storage-account-id", page);
-      const storageBucket = requireElement<HTMLInputElement>("#storage-bucket", page);
+      const storageBucketText = requireElement<HTMLInputElement>("#storage-bucket", page);
       // Same worker-configuration.d.ts `Element.remove()` workaround as the
       // tri-state selects on the comment-settings page.
-      const storageJurisdiction = requireElement<HTMLElement>(
-        "#storage-jurisdiction",
+      const storageBucketSelect = requireElement<HTMLElement>(
+        "#storage-bucket-select",
         page,
       ) as unknown as HTMLSelectElement;
+      const storageBucketLabel = requireElement<HTMLLabelElement>("#storage-bucket-label", page);
+      const storageBucketHint = requireElement<HTMLElement>("#storage-bucket-hint", page);
       const storageAccessKeyId = requireElement<HTMLInputElement>("#storage-access-key-id", page);
       const storageSecretAccessKey = requireElement<HTMLInputElement>(
         "#storage-secret-access-key",
@@ -499,8 +520,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         shape: "Config looks valid",
         auth: "Authentication",
         "round-trip": "Upload / download round-trip",
-        "not-empty": "Bucket is empty",
-        "public-url": "Public URL reachable",
+        "not-empty": "Bucket contents",
+        "public-url": "Public base URL",
       };
 
       let wizardMode: "connect" | "rotate" = "connect";
@@ -520,30 +541,49 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         storageErrorEl.textContent = message;
       }
 
+      /**
+       * The "Public base URL" row's value — flagged as a warning (issue #783
+       * follow-up comment) rather than presented as a neutral default:
+       * signed-only mode loses stable links, embeds, and galleries. Adding a
+       * URL later upgrades every existing file's links retroactively, since
+       * URLs are derived at request time and nothing is stored per file.
+       */
+      function publicBaseUrlRowValue(publicBaseUrl: string | undefined): string {
+        if (publicBaseUrl) return escapeHtml(publicBaseUrl);
+        return (
+          `<span class="ul-badge ul-badge--accent">Signed-only</span> ` +
+          `<span class="storage-signed-only-note">no public base URL — links expire after an hour, ` +
+          `embeds/galleries won't work. Add one any time; it applies to files already uploaded, too.</span>`
+        );
+      }
+
       function renderByoDetails(status: WorkspaceStorageStatus): void {
         const rows: [string, string][] = [
-          ["Bucket", status.bucket ?? "—"],
-          ["Account ID", status.accountIdMasked ?? "—"],
-          ["Access key ID", status.accessKeyIdLast4 ? `…${status.accessKeyIdLast4}` : "—"],
-          ["Public base URL", status.publicBaseUrl ?? "Signed-only (no public URL)"],
-          ["Verified", formatTimestamp(status.verifiedAt)],
+          ["Bucket", escapeHtml(status.bucket ?? "—")],
+          ["Account ID", escapeHtml(status.accountIdMasked ?? "—")],
+          [
+            "Access key ID",
+            escapeHtml(status.accessKeyIdLast4 ? `…${status.accessKeyIdLast4}` : "—"),
+          ],
+          ["Public base URL", publicBaseUrlRowValue(status.publicBaseUrl)],
+          ["Verified", escapeHtml(formatTimestamp(status.verifiedAt))],
         ];
-        if (status.jurisdiction) rows.push(["Jurisdiction", status.jurisdiction]);
+        if (status.jurisdiction) rows.push(["Jurisdiction", escapeHtml(status.jurisdiction)]);
         storageByoDetails.innerHTML = rows
-          .map(([label, value]) => `<dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd>`)
+          .map(([label, value]) => `<dt>${escapeHtml(label)}</dt><dd>${value}</dd>`)
           .join("");
       }
 
       function renderSavedDetails(lane: WorkspaceStorageLane): void {
         const rows: [string, string][] = [
-          ["Bucket", lane.bucket],
-          ["Account ID", lane.accountIdMasked ?? "—"],
-          ["Access key ID", lane.accessKeyIdLast4 ? `…${lane.accessKeyIdLast4}` : "—"],
-          ["Public base URL", lane.publicBaseUrl ?? "Signed-only (no public URL)"],
-          ["Verified", formatTimestamp(lane.verifiedAt)],
+          ["Bucket", escapeHtml(lane.bucket)],
+          ["Account ID", escapeHtml(lane.accountIdMasked ?? "—")],
+          ["Access key ID", escapeHtml(lane.accessKeyIdLast4 ? `…${lane.accessKeyIdLast4}` : "—")],
+          ["Public base URL", publicBaseUrlRowValue(lane.publicBaseUrl)],
+          ["Verified", escapeHtml(formatTimestamp(lane.verifiedAt))],
         ];
         storageSavedDetails.innerHTML = rows
-          .map(([label, value]) => `<dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd>`)
+          .map(([label, value]) => `<dt>${escapeHtml(label)}</dt><dd>${value}</dd>`)
           .join("");
       }
 
@@ -565,6 +605,69 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         storagePrevious.textContent = `Previous storage still serving old files: ${names}.`;
       }
 
+      /** Which bucket control is live: a plain name field (default, and the 403/access-denied fallback) or the picker populated from a successful ListBuckets lookup. */
+      type BucketMode = "text" | "select";
+      let bucketMode: BucketMode = "text";
+      /** Invalidates an in-flight bucket lookup that resolves after the form has moved on (reset, closed, or fields changed again). */
+      let bucketLookupToken = 0;
+      /** `accountId:jurisdiction:accessKeyId:secretAccessKey` signature of the last lookup attempt — skips refiring on every blur while tabbing through unchanged fields. */
+      let lastBucketLookupKey = "";
+
+      function setBucketMode(mode: BucketMode, buckets?: string[]): void {
+        bucketMode = mode;
+        const isSelect = mode === "select";
+        storageBucketSelect.hidden = !isSelect;
+        storageBucketText.hidden = isSelect;
+        storageBucketSelect.required = isSelect;
+        storageBucketText.required = !isSelect;
+        storageBucketLabel.textContent = isSelect ? "Bucket" : "Bucket Name";
+        storageBucketLabel.htmlFor = isSelect ? "storage-bucket-select" : "storage-bucket";
+        if (isSelect) {
+          storageBucketSelect.innerHTML = (buckets ?? [])
+            .map((name) => `<option value="${escapeHtml(name)}">${escapeHtml(name)}</option>`)
+            .join("");
+        }
+      }
+
+      /**
+       * Fires on blur of the account id/endpoint, access key id, or secret
+       * key fields once all three are present — the wizard's bucket picker
+       * (issue #783 Part A item 2). A malformed account id/endpoint, or an
+       * `access_denied`/error result (a bucket-scoped token — the common,
+       * expected case, since R2 only permits `ListBuckets` for
+       * account-scoped tokens) falls back to the plain "Bucket Name" field
+       * with no apologetic prose, not an error state.
+       */
+      async function maybeLookupBuckets(): Promise<void> {
+        const parsed = parseAccountIdOrEndpoint(storageAccountId.value);
+        const accessKeyId = storageAccessKeyId.value.trim();
+        const secretAccessKey = storageSecretAccessKey.value;
+        if (!parsed || !accessKeyId || !secretAccessKey) return;
+        const key = `${parsed.accountId}:${parsed.jurisdiction ?? ""}:${accessKeyId}:${secretAccessKey}`;
+        if (key === lastBucketLookupKey) return;
+        lastBucketLookupKey = key;
+        const token = ++bucketLookupToken;
+        storageBucketHint.textContent = "Looking up your buckets…";
+        const result = await listWorkspaceStorageBuckets(apiOrigin, workspaceName, {
+          accountId: parsed.accountId,
+          accessKeyId,
+          secretAccessKey,
+          jurisdiction: parsed.jurisdiction,
+        });
+        if (token !== bucketLookupToken || !stillHere()) return;
+        if (result.kind === "ok" && result.buckets.length > 0) {
+          setBucketMode("select", result.buckets);
+          storageBucketHint.textContent = "";
+        } else {
+          setBucketMode("text");
+          storageBucketHint.textContent = "";
+        }
+      }
+
+      for (const el of [storageAccountId, storageAccessKeyId, storageSecretAccessKey]) {
+        el.addEventListener("blur", () => void maybeLookupBuckets());
+      }
+
       function resetWizardForm(): void {
         storageForm.reset();
         lastVerify = null;
@@ -576,6 +679,11 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         storageSaveStatus.textContent = "";
         storageSaveStatus.removeAttribute("data-state");
         storageSaveBtn.disabled = true;
+        bucketLookupToken++; // invalidate any in-flight lookup
+        lastBucketLookupKey = "";
+        storageBucketHint.textContent =
+          "Enter your access keys above and we'll look up your buckets.";
+        setBucketMode("text");
       }
 
       function goToWizardStep(step: 1 | 2 | 3): void {
@@ -587,7 +695,6 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       interface WizardPrefill {
         bucket?: string;
         publicBaseUrl?: string;
-        jurisdiction?: string;
       }
 
       function openWizard(mode: "connect" | "rotate", prefill?: WizardPrefill): void {
@@ -602,9 +709,11 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           // "Same form, keys only": bucket/public URL are already known and
           // prefilled; account id can't be — the API only ever returns the
           // masked tail, never the plaintext — so the field starts blank.
-          storageBucket.value = prefill.bucket ?? "";
+          // Jurisdiction is never prefilled either (no visible field any
+          // more) — re-verifying re-probes it the same way a fresh connect
+          // would, and `PUT` only overwrites the saved value on success.
+          storageBucketText.value = prefill.bucket ?? "";
           storagePublicBaseUrl.value = prefill.publicBaseUrl ?? "";
-          storageJurisdiction.value = prefill.jurisdiction ?? "";
           goToWizardStep(2);
         } else {
           goToWizardStep(1);
@@ -618,13 +727,19 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       }
 
       function collectCandidate(): StorageCandidate {
+        // Parsed client-side (issue #783 Part A item 1) — a bare account id
+        // or a pasted endpoint URL both land here as `{ accountId,
+        // jurisdiction }`; the API contract is unchanged, it just usually
+        // gets `jurisdiction: undefined` now and auto-probes it server-side.
+        const parsed = parseAccountIdOrEndpoint(storageAccountId.value);
         return {
-          bucket: storageBucket.value.trim(),
-          accountId: storageAccountId.value.trim(),
+          bucket:
+            bucketMode === "select" ? storageBucketSelect.value : storageBucketText.value.trim(),
+          accountId: parsed?.accountId ?? storageAccountId.value.trim(),
           accessKeyId: storageAccessKeyId.value.trim(),
           secretAccessKey: storageSecretAccessKey.value,
           publicBaseUrl: storagePublicBaseUrl.value.trim() || undefined,
-          jurisdiction: storageJurisdiction.value || undefined,
+          jurisdiction: parsed?.jurisdiction,
           // Rotating credentials targets the bucket this workspace already
           // owns and is actively serving from, so its non-empty contents are
           // expected, not a mistake — same rationale as the PUT route's
@@ -677,6 +792,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         event.preventDefault();
         void (async () => {
           showStorageError(null);
+          if (!parseAccountIdOrEndpoint(storageAccountId.value)) {
+            storageVerifyStatus.textContent =
+              "Enter a 32-character account id, or paste the R2 endpoint URL Cloudflare gave you.";
+            storageVerifyStatus.dataset.state = "error";
+            return;
+          }
           storageVerifyStatus.textContent = "Verifying…";
           storageVerifyStatus.removeAttribute("data-state");
           storageVerifyBtn.disabled = true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@uploads/storage':
         specifier: workspace:^
         version: link:../../packages/storage
+      aws4fetch:
+        specifier: ^1.0.20
+        version: 1.0.20
       hono:
         specifier: ^4.13.3
         version: 4.13.3


### PR DESCRIPTION
## Summary

Implements issue #783 in two parts.

### Part A — minimal-fields wizard

The connect wizard drops from 6 visible fields to 4:

| Before | After |
| --- | --- |
| Account ID | **Account ID or endpoint URL** (one field, parsed client-side) |
| Bucket name (text) | **Bucket** — a picker populated via `ListBuckets`, falling back to a plain "Bucket Name" field |
| Jurisdiction (select) | *(removed — auto-detected)* |
| Access key ID | Access key ID |
| Secret access key | Secret access key |
| Public base URL (optional) | Public base URL (optional) |

- `apps/web/src/lib/r2-endpoint.ts` parses either a 32-hex account id or a pasted `https://<account>[.<jurisdiction>].r2.cloudflarestorage.com` endpoint URL. The API contract is unchanged — it still receives plain `accountId`/`jurisdiction`.
- New `POST /v1/workspaces/:name/storage/buckets` (same auth/rate-limit tier as `storage/verify`) calls S3 `ListBuckets` directly via `aws4fetch` (`apps/api/src/r2-list-buckets.ts`) — files-sdk's R2 adapter is bucket-scoped, and `ListBuckets` is account-level. XML is parsed with a small regex scan rather than `@aws-sdk/client-s3` (its parser needs `DOMParser`, unavailable in workerd). A 403 comes back as a distinguishable `access_denied` result so the wizard falls back to a plain field instead of surfacing an error — bucket-scoped tokens are the expected, common case.
- `storage-verify.ts` now auto-probes jurisdiction (default endpoint, then `eu`, then `fedramp`) whenever the candidate omits it, and records whichever answered on `StorageVerifyResult.jurisdiction`. The `PUT` route persists that detected value when the caller didn't supply one explicitly (a parsed endpoint still wins).

### Part B — copy

- The not-empty guard's hint and the adopt checkbox now say plainly that attaching a bucket doesn't import or copy anything — the bucket root becomes the workspace root, and saving a lane never activates it.
- Softened the public-URL probe's catch-branch copy: a thrown fetch means "we couldn't verify it from here," not "your domain is broken" (a same-account custom domain can be unreachable as a Workers subrequest while serving the public internet fine) — points at checking a known object URL directly instead.
- Signed-only mode (no public base URL) is now a flagged warning state rather than a neutral default — in the verify/review checklist, on the public-base-URL field's hint, and on the saved lane card — per follow-up discussion added to the issue. Adding a URL later is called out as retroactive (URLs are derived at request time).

## Deviations

- Kept the check id `public-url` for both the real reachability probe and the new "no public base URL configured" warning — same recommended/non-gating semantics, so the wizard's existing checklist rendering (pass/fail/warning styling) covers both without new UI plumbing. Renamed its display label from "Public URL reachable" to "Public base URL" so it reads sensibly either way.
- `StorageVerifyCandidate.jurisdiction` stays a plain optional string field (unchanged); the wizard just stops showing a control for it.

## Test coverage

- `apps/web/src/lib/r2-endpoint.test.ts` — account id vs endpoint URL parsing, jurisdiction extraction, case/whitespace handling, rejection cases.
- `apps/api/src/r2-list-buckets.test.ts` — XML parsing against a real-shaped response, jurisdiction auto-probe order, the `access_denied` fallback shape, malformed-input rejection, no credential leakage.
- `apps/api/src/storage-verify.test.ts` — jurisdiction auto-probe order/short-circuit/fallback, the new signed-only warning check, the softened catch-branch copy, and the plain-language not-empty hint.
- `apps/api/src/routes/me.test.ts` — route-level coverage for the new `storage/buckets` endpoint (403 when BYO disabled, injected `ListBuckets` result, `access_denied` passthrough, rate limiting).
- `apps/web/src/lib/api-client.test.ts` — the new `listWorkspaceStorageBuckets` client function.

`pnpm test` (4907 tests) and `pnpm run typecheck` (Node 24, all packages) both pass; `pnpm run lint` and `pnpm run format:check` are clean.

Closes #783
