### PR TITLE
fix(web,api): storage settings post-save cleanup + activation reliability (#788)

### DIFF
--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -127,6 +127,30 @@ export type SettingsVars = {
 };
 
 /**
+ * Best-effort usage reconcile off the response path. Activation/detach used
+ * to await this before responding, which pushed real switches past the
+ * browser's request timeout — the client reported "couldn't switch" for a
+ * switch that had already committed (#788). `waitUntil` keeps the rebuild
+ * running after the response; runtimes without an execution context (unit
+ * tests) fall back to awaiting so assertions still see the reconciled state.
+ */
+async function reconcileOffPath(
+  c: Context<SettingsVars>,
+  updated: WorkspaceRecord,
+  name: string,
+  label: string,
+): Promise<void> {
+  const task = storageReconcile(c.env, updated, name).catch((err) =>
+    console.error(`${label}: usage reconcile failed for`, name, err),
+  );
+  try {
+    c.executionCtx.waitUntil(task);
+  } catch {
+    await task;
+  }
+}
+
+/**
  * Session-only member gate for the billing/summary tier: a bearer
  * `Authorization` header 403s outright (no bearer capability exists for
  * either route and none is minted here), otherwise resolves the session +
@@ -685,12 +709,10 @@ export async function storageActivateHandler(c: Context<SettingsVars>) {
 
   // The promoted lane may already hold objects (a reactivated fallback, or a
   // standby saved via `adoptExistingContents`) that the ledger has never
-  // walked — rebuild totals/shared-subset now so `maxStorageBytes`
-  // enforcement and the settings UI are honest immediately. Best-effort,
-  // same rationale as the legacy attach/detach reconcile calls.
-  await storageReconcile(c.env, updated, name).catch((err) =>
-    console.error("workspace storage activate: usage reconcile failed for", name, err),
-  );
+  // walked — rebuild totals/shared-subset so `maxStorageBytes` enforcement
+  // and the settings UI are honest. Best-effort, same rationale as the
+  // legacy attach/detach reconcile calls.
+  await reconcileOffPath(c, updated, name, "workspace storage activate");
 
   return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));
 }
@@ -844,9 +866,7 @@ export async function storageDeleteHandler(c: Context<SettingsVars>) {
   // delete. Rebuild from the restored shared-bucket prefix (best-effort,
   // same rationale as the attach path above).
   if (force) {
-    await storageReconcile(c.env, updated, name).catch((err) =>
-      console.error("workspace storage detach: usage reconcile failed for", name, err),
-    );
+    await reconcileOffPath(c, updated, name, "workspace storage detach");
   }
 
   return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1902,6 +1902,16 @@ export interface StorageCandidate {
   jurisdiction?: string;
 }
 
+/**
+ * Storage verify/save/activate/detach run a live probe pipeline against the
+ * customer's bucket (auth list, round-trip write, a public-URL fetch with
+ * its own 5s budget, jurisdiction probing) — legitimately slower than any
+ * other call in this file. The default 8s browser timeout aborted real,
+ * ultimately-successful activations (#788): the worker kept going and
+ * committed the switch after the client had already reported failure.
+ */
+const STORAGE_PIPELINE_TIMEOUT_MS = 30_000;
+
 export type StorageVerifyApiResult =
   | { kind: "ok"; result: StorageVerifyResult }
   | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
@@ -1925,6 +1935,7 @@ export async function verifyWorkspaceStorage(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(candidate),
     },
+    { timeoutMs: STORAGE_PIPELINE_TIMEOUT_MS },
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -1987,6 +1998,7 @@ export async function listWorkspaceStorageBuckets(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(creds),
     },
+    { timeoutMs: STORAGE_PIPELINE_TIMEOUT_MS },
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -2026,6 +2038,7 @@ export async function putWorkspaceStorage(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(candidate),
     },
+    { timeoutMs: STORAGE_PIPELINE_TIMEOUT_MS },
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -2070,6 +2083,7 @@ export async function activateWorkspaceStorage(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ laneId }),
     },
+    { timeoutMs: STORAGE_PIPELINE_TIMEOUT_MS },
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;
@@ -2111,6 +2125,7 @@ export async function deleteWorkspaceStorage(
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/storage${qs}`,
     { method: "DELETE", credentials: "include", cache: "no-store" },
+    { timeoutMs: STORAGE_PIPELINE_TIMEOUT_MS },
   );
   if (result.kind === "unavailable") return result;
   const { response } = result;

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -31,67 +31,88 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       <div id="storage-error" class="ul-callout" data-state="error" role="alert" hidden></div>
 
       <div id="storage-shared">
-        <p class="settings-note muted">
-          Your files live on <code>storage.uploads.sh</code>. You can point this workspace at your
-          own Cloudflare R2 bucket instead — see the&#32;
-          <a href="/docs/byo-bucket">bring your own bucket</a> docs.
-        </p>
-        <div class="storage-actions">
-          <button type="button" class="ul-btn ul-btn--solid" id="storage-connect-btn"
-            >Connect your own bucket</button
-          >
-        </div>
+        <!-- Connect pitch + walkthrough: only when no bucket is saved yet.
+             Once a lane exists the lane card is the page (#788) — repeating
+             the pitch under it read as "you still need to do this". -->
+        <div id="storage-intro">
+          <p class="settings-note muted">
+            Your files live on <code>storage.uploads.sh</code>. You can point this workspace at your
+            own Cloudflare R2 bucket instead — see the&#32;
+            <a href="/docs/byo-bucket">bring your own bucket</a> docs.
+          </p>
+          <div class="storage-actions">
+            <button type="button" class="ul-btn ul-btn--solid" id="storage-connect-btn"
+              >Connect your own bucket</button
+            >
+          </div>
 
-        <div class="storage-summary" id="storage-summary">
-          <div class="storage-summary__step">
-            <span class="storage-summary__num">1</span>
-            <div class="storage-summary__body">
-              <div class="storage-summary__title">Set up your bucket on Cloudflare</div>
-              <div class="storage-summary__sub">
-                Dashboard → R2 → Create bucket, then a bucket-scoped API token with Object Read &
-                Write.
+          <div class="storage-summary" id="storage-summary">
+            <div class="storage-summary__step">
+              <span class="storage-summary__num">1</span>
+              <div class="storage-summary__body">
+                <div class="storage-summary__title">Set up your bucket on Cloudflare</div>
+                <div class="storage-summary__sub">
+                  Dashboard → R2 → Create bucket, then a bucket-scoped API token with Object Read &
+                  Write.
+                </div>
               </div>
             </div>
-          </div>
-          <div class="storage-summary__step">
-            <span class="storage-summary__num">2</span>
-            <div class="storage-summary__body">
-              <div class="storage-summary__title">Enter the bucket's credentials</div>
-              <div class="storage-summary__sub">
-                Account ID (or endpoint URL) and access keys — we'll look up the bucket for you,
-                plus an optional public base URL.
+            <div class="storage-summary__step">
+              <span class="storage-summary__num">2</span>
+              <div class="storage-summary__body">
+                <div class="storage-summary__title">Enter the bucket's credentials</div>
+                <div class="storage-summary__sub">
+                  Account ID (or endpoint URL) and access keys — we'll look up the bucket for you,
+                  plus an optional public base URL.
+                </div>
               </div>
             </div>
-          </div>
-          <div class="storage-summary__step">
-            <span class="storage-summary__num">3</span>
-            <div class="storage-summary__body">
-              <div class="storage-summary__title">Save & verify</div>
-              <div class="storage-summary__sub">
-                We run auth, round-trip, and public-URL checks. Saving never changes where uploads
-                go — switch to it whenever you're ready.
+            <div class="storage-summary__step">
+              <span class="storage-summary__num">3</span>
+              <div class="storage-summary__body">
+                <div class="storage-summary__title">Save & verify</div>
+                <div class="storage-summary__sub">
+                  We run auth, round-trip, and public-URL checks. Saving never changes where uploads
+                  go — switch to it whenever you're ready.
+                </div>
               </div>
             </div>
           </div>
         </div>
 
         <div id="storage-saved" hidden>
-          <h3>Saved bucket</h3>
+          <p class="settings-note muted">
+            Uploads currently go to shared storage on <code>storage.uploads.sh</code>.
+          </p>
+          <h3 class="storage-lane-heading">
+            Your bucket <span class="ul-badge ul-badge--accent">Not in use yet</span>
+          </h3>
           <dl class="kv" id="storage-saved-details"></dl>
-          <p class="muted" id="storage-saved-status">Saved · not in use</p>
-          <div class="storage-actions">
+          <div class="storage-actions" id="storage-saved-actions">
             <button type="button" class="ul-btn ul-btn--solid" id="storage-use-btn"
               >Use this bucket</button
             >
             <button type="button" class="ul-btn" id="storage-saved-rotate-btn"
               >Rotate credentials</button
             >
+            <button type="button" class="ul-btn" id="storage-replace-btn">Replace bucket</button>
+          </div>
+          <div class="storage-confirm" id="storage-saved-confirm" hidden>
+            <p class="storage-confirm__msg" data-confirm-msg></p>
+            <div class="storage-actions">
+              <button type="button" class="ul-btn ul-btn--solid" data-confirm-yes>Switch</button>
+              <button type="button" class="ul-btn" data-confirm-no>Cancel</button>
+            </div>
           </div>
           <p class="muted" id="storage-saved-action-status" role="status"></p>
         </div>
       </div>
 
       <div id="storage-byo" hidden>
+        <h3 class="storage-lane-heading">
+          Your bucket <span class="ul-badge ul-badge--ok">Active</span>
+        </h3>
+        <p class="settings-note muted">New uploads go to this bucket.</p>
         <dl class="kv" id="storage-byo-details"></dl>
         <div class="storage-actions">
           <button type="button" class="ul-btn" id="storage-reverify-btn">Re-run verification</button
@@ -100,6 +121,13 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           <button type="button" class="ul-btn ul-btn--danger" id="storage-disconnect-btn"
             >Switch back to uploads.sh storage</button
           >
+        </div>
+        <div class="storage-confirm" id="storage-byo-confirm" hidden>
+          <p class="storage-confirm__msg" data-confirm-msg></p>
+          <div class="storage-actions">
+            <button type="button" class="ul-btn ul-btn--solid" data-confirm-yes>Switch</button>
+            <button type="button" class="ul-btn" data-confirm-no>Cancel</button>
+          </div>
         </div>
         <p class="muted" id="storage-action-status" role="status"></p>
       </div>
@@ -382,6 +410,25 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       font-size: var(--text-micro);
       color: var(--muted);
     }
+    .storage-lane-heading {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .storage-confirm {
+      max-width: 32rem;
+      padding: 12px 16px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-md);
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .storage-confirm__msg {
+      margin: 0;
+      font-size: var(--text-meta);
+      color: var(--fg);
+    }
   </style>
 
   <script>
@@ -454,7 +501,11 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const storageByoEl = requireElement<HTMLElement>("#storage-byo", page);
       const storageByoDetails = requireElement<HTMLElement>("#storage-byo-details", page);
       const storageConnectBtn = requireElement<HTMLButtonElement>("#storage-connect-btn", page);
+      const storageIntro = requireElement<HTMLElement>("#storage-intro", page);
       const storageSummary = requireElement<HTMLElement>("#storage-summary", page);
+      const storageReplaceBtn = requireElement<HTMLButtonElement>("#storage-replace-btn", page);
+      const storageSavedConfirm = requireElement<HTMLElement>("#storage-saved-confirm", page);
+      const storageByoConfirm = requireElement<HTMLElement>("#storage-byo-confirm", page);
       const storageSaved = requireElement<HTMLElement>("#storage-saved", page);
       const storageSavedDetails = requireElement<HTMLElement>("#storage-saved-details", page);
       const storageUseBtn = requireElement<HTMLButtonElement>("#storage-use-btn", page);
@@ -590,6 +641,38 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       /** "Existing files stay where they are and keep working. New uploads go to <target>." — the switch confirmation copy from every direction (spec verbatim). */
       function switchConfirmMessage(targetLabel: string): string {
         return `Existing files stay where they are and keep working. New uploads go to ${targetLabel}.`;
+      }
+
+      /**
+       * In-page replacement for `window.confirm` (#788 — a native browser
+       * alert mid-flow read as something breaking). Shows `message` in the
+       * view's confirm box and resolves with the user's answer. One question
+       * at a time per box: re-asking while a previous ask is still open
+       * resolves the old one as declined first.
+       */
+      const pendingConfirms = new Map<HTMLElement, (answer: boolean) => void>();
+      function inlineConfirm(box: HTMLElement, message: string): Promise<boolean> {
+        pendingConfirms.get(box)?.(false);
+        const msgEl = box.querySelector<HTMLElement>("[data-confirm-msg]");
+        const yesBtn = box.querySelector<HTMLButtonElement>("[data-confirm-yes]");
+        const noBtn = box.querySelector<HTMLButtonElement>("[data-confirm-no]");
+        if (!msgEl || !yesBtn || !noBtn) return Promise.resolve(false);
+        msgEl.textContent = message;
+        box.hidden = false;
+        return new Promise((resolve) => {
+          const done = (answer: boolean): void => {
+            pendingConfirms.delete(box);
+            box.hidden = true;
+            yesBtn.removeEventListener("click", onYes);
+            noBtn.removeEventListener("click", onNo);
+            resolve(answer);
+          };
+          pendingConfirms.set(box, done);
+          const onYes = (): void => done(true);
+          const onNo = (): void => done(false);
+          yesBtn.addEventListener("click", onYes);
+          noBtn.addEventListener("click", onNo);
+        });
       }
 
       /** The "previous storage" line: fallback lanes (former actives that may still hold objects). */
@@ -843,11 +926,11 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             // Never leave the secret in form state once it's been sent.
             // Saving never switches the active lane — the workspace keeps
             // uploading wherever it already was; the saved config just
-            // becomes available to switch to (spec: "Configure, then switch").
+            // becomes available to switch to (spec: "Configure, then
+            // switch"). The lane card appearing IS the confirmation — no
+            // extra "Saved." status line lingering as page furniture (#788).
             closeWizard();
             applyStatus(result.status);
-            storageSavedActionStatus.textContent = "Saved.";
-            storageSavedActionStatus.dataset.state = "ok";
             return;
           }
           storageSaveBtn.disabled = false;
@@ -865,6 +948,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       });
 
       storageConnectBtn.addEventListener("click", () => openWizard("connect"));
+      storageReplaceBtn.addEventListener("click", () => openWizard("connect"));
 
       storageRotateBtn.addEventListener("click", () => {
         void (async () => {
@@ -933,8 +1017,9 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         laneId: string,
         targetLabel: string,
         statusEl: HTMLElement,
+        confirmBox: HTMLElement,
       ): Promise<void> {
-        if (!confirm(switchConfirmMessage(targetLabel))) return;
+        if (!(await inlineConfirm(confirmBox, switchConfirmMessage(targetLabel)))) return;
         showStorageError(null);
         statusEl.textContent = "Switching…";
         statusEl.removeAttribute("data-state");
@@ -958,13 +1043,33 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           statusEl.textContent = "";
           return;
         }
+        // A slow activation can outlive the request timeout while still
+        // committing server-side (#788's "couldn't switch" ghost) — before
+        // reporting failure, re-check: `lanes` only lists non-active lanes,
+        // so if the target id is gone from it, it was promoted and the
+        // switch actually worked.
+        const recheck = await getWorkspaceStorageStatus(apiOrigin, workspaceName);
+        if (!stillHere()) return;
+        if (recheck.kind === "ok" && !recheck.status.lanes.some((lane) => lane.laneId === laneId)) {
+          applyStatus(recheck.status);
+          const confirmEl =
+            recheck.status.mode === "byo" ? storageActionStatus : storageSavedActionStatus;
+          confirmEl.textContent = "Switched.";
+          confirmEl.dataset.state = "ok";
+          return;
+        }
         statusEl.textContent = "Couldn’t switch. Try again.";
         statusEl.dataset.state = "error";
       }
 
       storageUseBtn.addEventListener("click", () => {
         if (!savedLaneId) return;
-        void activateLane(savedLaneId, "your bucket", storageSavedActionStatus);
+        void activateLane(
+          savedLaneId,
+          "your bucket",
+          storageSavedActionStatus,
+          storageSavedConfirm,
+        );
       });
 
       storageDisconnectBtn.addEventListener("click", () => {
@@ -974,7 +1079,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             // switch — the common case once this workspace has ever used
             // the new activate primitive. Same decoupled switch as
             // "Use this bucket", pointed the other direction.
-            await activateLane(sharedFallbackLaneId, "storage.uploads.sh", storageActionStatus);
+            await activateLane(
+              sharedFallbackLaneId,
+              "storage.uploads.sh",
+              storageActionStatus,
+              storageByoConfirm,
+            );
             return;
           }
           // No recorded shared lane yet (this workspace has never switched
@@ -982,9 +1092,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           // Fall back to the legacy detach path, which restores shared
           // defaults directly.
           if (
-            !confirm(
+            !(await inlineConfirm(
+              storageByoConfirm,
               "Switch back to uploads.sh storage? Nothing on your own bucket is touched or deleted.",
-            )
+            ))
           ) {
             return;
           }
@@ -1011,11 +1122,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             showStorageError(result.message);
             storageActionStatus.textContent = "";
             if (
-              !confirm(
+              !(await inlineConfirm(
+                storageByoConfirm,
                 "This workspace still has files on your bucket. Switch back anyway? " +
                   "Your files stay on your bucket untouched and keep resolving from it, " +
                   "but new uploads move to storage.uploads.sh.",
-              )
+              ))
             ) {
               return;
             }
@@ -1040,6 +1152,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         closeWizard();
         storageActionStatus.textContent = "";
         storageActionStatus.removeAttribute("data-state");
+        storageSavedConfirm.hidden = true;
+        storageByoConfirm.hidden = true;
         renderPreviousLine(status);
 
         // The shared (binding-mode) fallback lane is the "switch back"
@@ -1061,12 +1175,17 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           const standby = status.lanes.find((lane) => lane.role === "standby");
           if (standby) {
             savedLaneId = standby.laneId;
+            // One state at a time (#788): with a saved lane the lane card is
+            // the page — the connect pitch + walkthrough disappear instead
+            // of stacking above it ("Replace bucket" reopens the wizard).
+            storageIntro.hidden = true;
             storageSaved.hidden = false;
             renderSavedDetails(standby);
             storageSavedActionStatus.textContent = "";
             storageSavedActionStatus.removeAttribute("data-state");
           } else {
             savedLaneId = null;
+            storageIntro.hidden = false;
             storageSaved.hidden = true;
           }
         }

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -577,6 +577,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 
       let wizardMode: "connect" | "rotate" = "connect";
       let lastVerify: StorageVerifyResult | null = null;
+      /** Last status rendered — what a cancelled wizard restores the page to. */
+      let lastStatus: WorkspaceStorageStatus | null = null;
       /** The standby lane currently offered by the "Use this bucket" card, if any. */
       let savedLaneId: string | null = null;
       /** The demoted shared (binding-mode) fallback lane "Switch back" targets, if one has been recorded yet. */
@@ -785,6 +787,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         resetWizardForm();
         showStorageError(null);
         storageWizard.hidden = false;
+        // One state at a time (#788): while the wizard is open it IS the
+        // page — the lane cards hide so their buttons (Use this bucket,
+        // Switch back…) can't fire mid-edit. `closeWizard` restores whichever
+        // card the last-loaded status calls for.
+        storageSharedEl.hidden = true;
+        storageByoEl.hidden = true;
         // The summary card is the collapsed stand-in for these same three
         // steps — once the wizard is open it would just say them twice.
         storageSummary.hidden = true;
@@ -803,10 +811,17 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         }
       }
 
-      function closeWizard(): void {
+      /** Hides the wizard chrome without re-rendering the cards — `applyStatus` calls this before it repaints from a fresh status. */
+      function hideWizard(): void {
         storageWizard.hidden = true;
         storageSummary.hidden = false;
         resetWizardForm();
+      }
+
+      /** The user-cancel path: close the wizard and restore the view the last-loaded status calls for (the wizard hid the lane cards on open). */
+      function closeWizard(): void {
+        hideWizard();
+        if (lastStatus) applyStatus(lastStatus);
       }
 
       function collectCandidate(): StorageCandidate {
@@ -929,7 +944,6 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             // becomes available to switch to (spec: "Configure, then
             // switch"). The lane card appearing IS the confirmation — no
             // extra "Saved." status line lingering as page furniture (#788).
-            closeWizard();
             applyStatus(result.status);
             return;
           }
@@ -1045,12 +1059,13 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         }
         // A slow activation can outlive the request timeout while still
         // committing server-side (#788's "couldn't switch" ghost) — before
-        // reporting failure, re-check: `lanes` only lists non-active lanes,
-        // so if the target id is gone from it, it was promoted and the
-        // switch actually worked.
+        // reporting failure, re-check whether the target lane is now the
+        // ACTIVE lane. (Mere absence from `lanes` isn't proof: a stale id —
+        // already promoted, or removed by another tab — 404s into this same
+        // branch and would also be absent.)
         const recheck = await getWorkspaceStorageStatus(apiOrigin, workspaceName);
         if (!stillHere()) return;
-        if (recheck.kind === "ok" && !recheck.status.lanes.some((lane) => lane.laneId === laneId)) {
+        if (recheck.kind === "ok" && recheck.status.activeLaneId === laneId) {
           applyStatus(recheck.status);
           const confirmEl =
             recheck.status.mode === "byo" ? storageActionStatus : storageSavedActionStatus;
@@ -1149,7 +1164,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       });
 
       function applyStatus(status: WorkspaceStorageStatus): void {
-        closeWizard();
+        lastStatus = status;
+        hideWizard();
         storageActionStatus.textContent = "";
         storageActionStatus.removeAttribute("data-state");
         storageSavedConfirm.hidden = true;

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -23,6 +23,11 @@
     // the Flagship `console-mode` flag (FLAGS binding below) is unavailable;
     // see src/lib/console-mode.ts for the resolution order.
     "CONSOLE_MODE": "linked-only",
+    // Gates the dev-only /dev/ui-kit kitchen sink (404s when "production").
+    // Mirrors apps/api's/apps/auth's ENVIRONMENT convention: set here, unset
+    // in local dev. #785 shipped the page reading this var without declaring
+    // it, so the production gate never tripped (undefined !== "production").
+    "ENVIRONMENT": "production",
   },
   // Same-origin auth proxy (#731 phase A): lets server code call the auth
   // and api workers directly instead of over the public internet. Astro dev


### PR DESCRIPTION
Closes #788.

## Two-state storage page
The post-save screen stacked the connect pitch, the 3-step walkthrough, the CTA, and three separate status strings on top of the saved-bucket card. Now the page renders one state at a time:

- **No saved lane** — intro, "Connect your own bucket", and the walkthrough, as before.
- **Saved lane** — the lane card is the page: a "Not in use yet" badge, a context line saying uploads currently go to shared storage, details, and "Use this bucket" as the primary action ("Rotate credentials" / "Replace bucket" secondary). The intro/walkthrough/CTA are hidden; the lingering "Saved." status line is gone (the card appearing is the confirmation).
- **Active BYO** — the existing view gains a "Your bucket · Active" heading and a "New uploads go to this bucket" line.

## In-page switch confirmation
`window.confirm` (a native "uploads.sh says…" browser alert) replaced with an in-page confirm box in both views, covering all three confirmation sites (use bucket, switch back, forced switch back).

## "Couldn't switch. Try again." for a switch that succeeded
A lane activated >10 min after verification triggers a server-side re-verify (which legitimately includes a 5s public-URL probe and jurisdiction probing) plus an awaited usage reconcile — together they could outlive the browser's default 8s request timeout. The worker kept going and committed the switch; the client reported failure. Fixed three ways:

1. Storage verify/save/buckets/activate/detach client calls get a 30s timeout.
2. The activate/detach usage reconcile moves off the response path via `waitUntil` (unit-test runtimes without an execution context fall back to awaiting).
3. On a failed-looking activation the client re-checks status before reporting failure — if the target lane is no longer listed among non-active lanes it was promoted, so the UI shows the switch instead of a false error.

## Drive-by fix
#785's dev-only `/dev/ui-kit` page reads `env.ENVIRONMENT`, but apps/web never declared the var — `pnpm typecheck` failed on main, and the production 404 gate never tripped (undefined ≠ "production"), leaving the dev page live on prod. Declared `ENVIRONMENT: "production"` in apps/web's wrangler vars, matching the apps/api / apps/auth convention.

## Testing
- `pnpm test` (4907 tests) green; `pnpm typecheck` (Node 24) clean including the previously-failing apps/web; lint + format clean.
- Every `requireElement` selector cross-checked against the markup (1:1); no native `confirm(` remains.