### PR TITLE
feat(web): migrate admin surface off bespoke CSS (migration phase 3, surface 3)

### DIFF
--- a/apps/web/src/lib/admin-ui.ts
+++ b/apps/web/src/lib/admin-ui.ts
@@ -4,6 +4,44 @@
  */
 import { skeletonBarHtml } from "./workspace-ui";
 
+/**
+ * Shared Tailwind utility strings for the hand-built `.admin-table` markup
+ * (both the static Astro `<thead>`s and the JS-rendered `<tbody>` rows).
+ * Centralized here rather than repeated per page so every table stays
+ * visually identical without duplicating long class lists — the CSS
+ * equivalents these replace lived in admin.css's `.admin-table` block.
+ */
+export const ADMIN_TH =
+  "text-left font-medium text-(length:--text-micro) uppercase tracking-[0.06em] text-muted-foreground pr-3 pb-[10px] border-b border-border whitespace-nowrap last:pr-0";
+export const ADMIN_TH_NUM = `${ADMIN_TH} text-right tabular-nums pl-4`;
+export const ADMIN_TH_ACTIONS = `${ADMIN_TH} text-right`;
+
+export const ADMIN_TD = "py-3 pr-3 border-b border-border text-body align-middle last:pr-0";
+export const ADMIN_TD_NUM = `${ADMIN_TD} text-right tabular-nums pl-4`;
+export const ADMIN_TD_ACTIONS = `${ADMIN_TD} text-right w-px whitespace-nowrap pl-4`;
+
+export const ADMIN_CELL_PRIMARY = "text-foreground font-semibold";
+export const ADMIN_CELL_MONO = "font-mono font-medium";
+export const ADMIN_CELL_MUTED = "text-muted-foreground text-(length:--text-micro)";
+
+/** Chevron cell for an expandable `tbody.admin-row-group` summary row. */
+export const ADMIN_EXPAND_TD =
+  "w-[18px] text-muted-foreground text-(length:--text-micro) leading-none transition-transform duration-150 ease-linear select-none [.is-open_&]:rotate-90 [.is-open_&]:text-foreground";
+
+/** Small uppercase heading inside an expanded `.admin-detail-inner` block. */
+export const ADMIN_DETAIL_HEADING =
+  "m-0 mb-2 text-(length:--text-micro) font-semibold tracking-[0.04em] uppercase text-foreground";
+
+/** Outline button — the shared `.admin-btn` look. */
+export const ADMIN_BTN =
+  "text-(length:--text-micro) text-primary bg-transparent border border-border rounded-sm px-3 py-[7px] cursor-pointer whitespace-nowrap w-fit hover:border-primary focus-visible:border-primary focus-visible:outline-none disabled:opacity-55 disabled:cursor-default";
+export const ADMIN_MINI_LIST = "list-none m-0 p-0 grid gap-1.5";
+export const ADMIN_MINI_LIST_ITEM =
+  "flex justify-between gap-2 text-(length:--text-micro) text-body";
+
+export const ADMIN_BTN_DANGER =
+  "text-destructive border-destructive/40 hover:not-disabled:border-destructive focus-visible:not-disabled:border-destructive disabled:text-muted-foreground disabled:opacity-60 disabled:cursor-not-allowed";
+
 /** Escape text for insertion into HTML attribute/text nodes. */
 export function escapeHtml(value: string): string {
   return value.replace(
@@ -15,7 +53,7 @@ export function escapeHtml(value: string): string {
 export interface AdminSkeletonColumn {
   /** CSS length passed to `skeletonBarHtml` (e.g. "88px"). */
   width: string;
-  /** Adds `class="num"`, matching `.admin-table td.num`'s right alignment. */
+  /** Uses `ADMIN_TD_NUM` instead of `ADMIN_TD` for right-aligned numeric columns. */
   num?: boolean;
 }
 
@@ -31,7 +69,9 @@ export function renderAdminTableSkeletonRowsHtml(columns: AdminSkeletonColumn[],
     { length: rows },
     () =>
       `<tr class="admin-row">${columns
-        .map((c) => `<td${c.num ? ' class="num"' : ""}>${skeletonBarHtml(c.width)}</td>`)
+        .map(
+          (c) => `<td class="${c.num ? ADMIN_TD_NUM : ADMIN_TD}">${skeletonBarHtml(c.width)}</td>`,
+        )
         .join("")}</tr>`,
   ).join("");
 }

--- a/apps/web/src/pages/admin/email.astro
+++ b/apps/web/src/pages/admin/email.astro
@@ -4,6 +4,15 @@
  * Type list mirrors EMAIL_PREVIEW_TYPES in apps/api/src/admin-email-preview.ts.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import {
+  ADMIN_BTN,
+  ADMIN_CELL_MUTED,
+  ADMIN_CELL_PRIMARY,
+  ADMIN_TD,
+  ADMIN_TD_ACTIONS,
+  ADMIN_TH,
+  ADMIN_TH_ACTIONS,
+} from "../../lib/admin-ui";
 
 export const prerender = false;
 
@@ -18,42 +27,65 @@ const PREVIEW_TYPES = [
 ---
 
 <AdminLayout section="email">
-  <section class="admin-page">
-    <header class="admin-page-header">
-      <h2>Email previews</h2>
-      <p>
+  <section class="admin-page grid gap-4 min-w-0">
+    <header class="admin-page-header grid gap-1.5 max-w-2xl">
+      <h2 class="m-0 text-(length:--text-body) font-semibold text-foreground">Email previews</h2>
+      <p class="m-0 text-body text-(length:--text-meta) leading-[1.55] text-pretty">
         Send a sample of each product email through Cloudflare Email Sending. Links use placeholder
         tokens and will not complete a real sign-in or invite. Defaults to your signed-in address;
         override for another inbox (e.g. Gmail markup tests).
       </p>
     </header>
 
-    <div class="admin-field">
-      <label for="email-to">Send to</label>
-      <input type="email" id="email-to" maxlength="320" placeholder="you@example.com" />
+    <div class="admin-field flex flex-wrap items-center gap-y-2 gap-x-3 max-w-[480px]">
+      <label
+        for="email-to"
+        class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+        >Send to</label
+      >
+      <input
+        type="email"
+        id="email-to"
+        maxlength="320"
+        placeholder="you@example.com"
+        class="flex-1 min-w-[200px] bg-panel border border-border rounded-sm text-foreground px-[9px] py-[7px] text-(length:--text-micro) focus-visible:outline-none focus-visible:border-primary"
+      />
     </div>
 
-    <div id="email-action-status" class="admin-status" role="status" hidden></div>
+    <div
+      id="email-action-status"
+      class="admin-status text-(length:--text-meta) text-muted-foreground"
+      role="status"
+      hidden
+    >
+    </div>
 
-    <div class="admin-table-wrap">
-      <table class="admin-table" aria-label="Email previews">
+    <div class="admin-table-wrap w-full overflow-x-auto">
+      <table
+        class="admin-table w-full border-collapse text-(length:--text-meta) leading-[1.4]"
+        aria-label="Email previews"
+      >
         <thead>
           <tr>
-            <th class="keep" scope="col">Template</th>
-            <th scope="col">Category</th>
-            <th class="actions" scope="col"></th>
+            <th class={`keep ${ADMIN_TH}`} scope="col">Template</th>
+            <th class={ADMIN_TH} scope="col">Category</th>
+            <th class={`actions ${ADMIN_TH_ACTIONS}`} scope="col"></th>
           </tr>
         </thead>
         <tbody>
           {
             PREVIEW_TYPES.map((t) => (
               <tr class="admin-row">
-                <td class="keep">
-                  <span class="primary">{t.label}</span>
+                <td class={`keep ${ADMIN_TD}`}>
+                  <span class={`primary ${ADMIN_CELL_PRIMARY}`}>{t.label}</span>
                 </td>
-                <td class="optional muted">{t.category}</td>
-                <td class="actions">
-                  <button type="button" class="admin-btn email-send" data-type={t.id}>
+                <td class={`optional ${ADMIN_TD} ${ADMIN_CELL_MUTED}`}>{t.category}</td>
+                <td class={`actions ${ADMIN_TD_ACTIONS}`}>
+                  <button
+                    type="button"
+                    class={`admin-btn email-send ${ADMIN_BTN}`}
+                    data-type={t.id}
+                  >
                     Send preview
                   </button>
                 </td>

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -1,29 +1,39 @@
 ---
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-workspaces.css";
+import { ADMIN_TH, ADMIN_TH_NUM } from "../../lib/admin-ui";
 
 export const prerender = false;
 ---
 
 <AdminLayout section="workspaces">
-  <section class="admin-page">
-    <header class="admin-page-header">
-      <h2>Workspaces</h2>
-      <p>
+  <section class="admin-page grid gap-4 min-w-0">
+    <header class="admin-page-header grid gap-1.5 max-w-2xl">
+      <h2 class="m-0 text-(length:--text-body) font-semibold text-foreground">Workspaces</h2>
+      <p class="m-0 text-body text-(length:--text-meta) leading-[1.55] text-pretty">
         Every registered workspace, with its members and pending invites. Expand a row to load
         people, plan, limits, and invites.
       </p>
     </header>
-    <div id="workspaces-status" class="admin-status">Loading…</div>
-    <div class="admin-table-wrap" id="workspaces-table-wrap" hidden>
-      <table class="admin-table" id="workspaces-list" aria-label="Workspaces">
+    <div
+      id="workspaces-status"
+      class="admin-status text-(length:--text-meta) text-muted-foreground"
+    >
+      Loading…
+    </div>
+    <div class="admin-table-wrap w-full overflow-x-auto" id="workspaces-table-wrap" hidden>
+      <table
+        class="admin-table w-full border-collapse text-(length:--text-meta) leading-[1.4]"
+        id="workspaces-list"
+        aria-label="Workspaces"
+      >
         <thead>
           <tr>
-            <th class="keep" scope="col" style="width:18px"></th>
-            <th class="keep" scope="col">Workspace</th>
-            <th scope="col">Organization</th>
-            <th class="num" scope="col">Members</th>
-            <th class="num" scope="col">Pending</th>
+            <th class={`keep ${ADMIN_TH}`} scope="col" style="width:18px"></th>
+            <th class={`keep ${ADMIN_TH}`} scope="col">Workspace</th>
+            <th class={ADMIN_TH} scope="col">Organization</th>
+            <th class={`num ${ADMIN_TH_NUM}`} scope="col">Members</th>
+            <th class={`num ${ADMIN_TH_NUM}`} scope="col">Pending</th>
           </tr>
         </thead>
       </table>
@@ -33,7 +43,22 @@ export const prerender = false;
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
     import { formatDate } from "../../lib/subscription-copy";
-    import { clearExpandGroups, escapeHtml, loadOnce, wireExpandGroup } from "../../lib/admin-ui";
+    import {
+      ADMIN_BTN,
+      ADMIN_CELL_MONO,
+      ADMIN_CELL_MUTED,
+      ADMIN_CELL_PRIMARY,
+      ADMIN_DETAIL_HEADING,
+      ADMIN_EXPAND_TD,
+      ADMIN_MINI_LIST,
+      ADMIN_MINI_LIST_ITEM,
+      ADMIN_TD,
+      ADMIN_TD_NUM,
+      clearExpandGroups,
+      escapeHtml,
+      loadOnce,
+      wireExpandGroup,
+    } from "../../lib/admin-ui";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("workspaces-list")) return;
@@ -141,15 +166,15 @@ export const prerender = false;
           : "";
 
         host.innerHTML = `
-        <h4 class="plan-heading">Plan</h4>
+        <h4 class="plan-heading ${ADMIN_DETAIL_HEADING}">Plan</h4>
         <p class="muted plan-availability">${data.available ? "Available" : "Not available for self-serve upgrade"}</p>
         <p class="muted plan-source">Source: ${escapeHtml(PLAN_SOURCE_LABEL[data.planSource])}</p>
         ${subscriptionLine}
         ${appliedNote}
-        <form class="plan-form">
-          <select class="plan-select ul-select ul-select--sm" aria-label="Plan">${options}</select>
-          <button type="submit">Save plan</button>
-          <div class="plan-status" role="status" aria-live="polite" hidden></div>
+        <form class="plan-form flex flex-wrap gap-2 items-center">
+          <select class="plan-select ul-select ul-select--sm" style="width:auto" aria-label="Plan">${options}</select>
+          <button type="submit" class="${ADMIN_BTN}">Save plan</button>
+          <div class="plan-status w-full text-(length:--text-micro)" role="status" aria-live="polite" hidden></div>
         </form>`;
 
         const form = host.querySelector<HTMLFormElement>(".plan-form");
@@ -240,19 +265,19 @@ export const prerender = false;
                 `<option value="${u.label}"${u.label === split.unit ? " selected" : ""}>${u.label}</option>`,
             ).join("");
             return `
-            <div class="limit-row" data-field="${f.key}" data-byte="1">
-              <label>${f.label}</label>
-              <input type="number" min="1" step="1" class="limit-value" value="${split.value}" ${unlimited ? "disabled" : ""} />
-              <select class="limit-unit ul-select ul-select--sm" ${unlimited ? "disabled" : ""}>${options}</select>
-              <label class="limit-unlimited"><input type="checkbox" class="limit-unlim" ${unlimited ? "checked" : ""} /> Unlimited</label>
+            <div class="limit-row grid grid-cols-[130px_1fr_70px_auto] max-[560px]:grid-cols-1 items-center gap-2 max-[560px]:gap-1" data-field="${f.key}" data-byte="1">
+              <label class="text-(length:--text-meta) text-body">${f.label}</label>
+              <input type="number" min="1" step="1" class="limit-value bg-background border border-border rounded-sm text-foreground px-1.5 py-1 font-mono text-(length:--text-micro) disabled:opacity-50" value="${split.value}" ${unlimited ? "disabled" : ""} />
+              <select class="limit-unit ul-select ul-select--sm" style="width:auto" ${unlimited ? "disabled" : ""}>${options}</select>
+              <label class="limit-unlimited inline-flex items-center gap-1 text-(length:--text-micro) whitespace-nowrap text-muted-foreground"><input type="checkbox" class="limit-unlim" ${unlimited ? "checked" : ""} /> Unlimited</label>
             </div>`;
           }
           return (
             `
-          <div class="limit-row" data-field="${f.key}">
-            <label>${f.label}</label>
-            <input type="number" min="1" step="1" class="limit-value" value="${raw === null ? "" : raw}" ${unlimited ? "disabled" : ""} />
-            <label class="limit-unlimited"><input type="checkbox" class="limit-unlim" ${unlimited ? "checked" : ""} /> Unlimited</label>` +
+          <div class="limit-row grid grid-cols-[130px_1fr_auto_auto] max-[560px]:grid-cols-1 items-center gap-2 max-[560px]:gap-1" data-field="${f.key}">
+            <label class="text-(length:--text-meta) text-body">${f.label}</label>
+            <input type="number" min="1" step="1" class="limit-value bg-background border border-border rounded-sm text-foreground px-1.5 py-1 font-mono text-(length:--text-micro) disabled:opacity-50" value="${raw === null ? "" : raw}" ${unlimited ? "disabled" : ""} />
+            <label class="limit-unlimited inline-flex items-center gap-1 text-(length:--text-micro) whitespace-nowrap text-muted-foreground"><input type="checkbox" class="limit-unlim" ${unlimited ? "checked" : ""} /> Unlimited</label>` +
             `</div>`
           );
         }).join("");
@@ -265,12 +290,12 @@ export const prerender = false;
               : "";
 
         host.innerHTML = `
-        <h4 class="limits-heading">Limits</h4>
+        <h4 class="limits-heading ${ADMIN_DETAIL_HEADING}">Limits</h4>
         ${usageLine}
-        <form class="limits-form">
+        <form class="limits-form flex flex-col gap-2">
           ${rows}
-          <button type="submit">Save limits</button>
-          <div class="limit-status" role="status" aria-live="polite" hidden></div>
+          <button type="submit" class="${ADMIN_BTN} self-start mt-1">Save limits</button>
+          <div class="limit-status w-full text-(length:--text-micro)" role="status" aria-live="polite" hidden></div>
         </form>`;
 
         // Unlimited checkbox toggles its row's inputs.
@@ -417,17 +442,17 @@ export const prerender = false;
       ): void {
         const provenance =
           data.mode === "byo"
-            ? `<ul class="admin-mini-list storage-provenance">
-              ${data.bucket ? `<li><span>Bucket</span><span class="mono">${escapeHtml(data.bucket)}</span></li>` : ""}
-              ${data.accountIdMasked ? `<li><span>Account</span><span class="mono">${escapeHtml(data.accountIdMasked)}</span></li>` : ""}
-              ${data.accessKeyIdLast4 ? `<li><span>Access key</span><span class="mono">${escapeHtml(data.accessKeyIdLast4)}</span></li>` : ""}
-              ${data.publicBaseUrl ? `<li><span>Public URL</span><span class="mono">${escapeHtml(data.publicBaseUrl)}</span></li>` : ""}
-              <li><span>Configured</span><span>${
+            ? `<ul class="admin-mini-list storage-provenance ${ADMIN_MINI_LIST}">
+              ${data.bucket ? `<li class="${ADMIN_MINI_LIST_ITEM}"><span>Bucket</span><span class="mono font-mono font-medium">${escapeHtml(data.bucket)}</span></li>` : ""}
+              ${data.accountIdMasked ? `<li class="${ADMIN_MINI_LIST_ITEM}"><span>Account</span><span class="mono font-mono font-medium">${escapeHtml(data.accountIdMasked)}</span></li>` : ""}
+              ${data.accessKeyIdLast4 ? `<li class="${ADMIN_MINI_LIST_ITEM}"><span>Access key</span><span class="mono font-mono font-medium">${escapeHtml(data.accessKeyIdLast4)}</span></li>` : ""}
+              ${data.publicBaseUrl ? `<li class="${ADMIN_MINI_LIST_ITEM}"><span>Public URL</span><span class="mono font-mono font-medium">${escapeHtml(data.publicBaseUrl)}</span></li>` : ""}
+              <li class="${ADMIN_MINI_LIST_ITEM}"><span>Configured</span><span>${
                 data.configuredAt
                   ? `${escapeHtml(formatDate(data.configuredAt) ?? data.configuredAt)}${data.configuredBy ? ` by ${escapeHtml(data.configuredBy)}` : ""}`
                   : `<span class="muted">Not configured</span>`
               }</span></li>
-              <li><span>Verified</span><span>${data.verifiedAt ? escapeHtml(formatDate(data.verifiedAt) ?? data.verifiedAt) : `<span class="muted">Not verified</span>`}</span></li>
+              <li class="${ADMIN_MINI_LIST_ITEM}"><span>Verified</span><span>${data.verifiedAt ? escapeHtml(formatDate(data.verifiedAt) ?? data.verifiedAt) : `<span class="muted">Not verified</span>`}</span></li>
             </ul>`
             : `<p class="muted storage-shared-note">Using the shared platform bucket.</p>`;
 
@@ -438,12 +463,12 @@ export const prerender = false;
         const lanes = data.lanes ?? [];
         const laneList =
           lanes.length > 0
-            ? `<ul class="admin-mini-list storage-lanes">
+            ? `<ul class="admin-mini-list storage-lanes ${ADMIN_MINI_LIST}">
               ${lanes
                 .map(
-                  (lane) => `<li>
-                    <span>${lane.role === "fallback" ? "Previous" : "Saved"}</span>
-                    <span class="mono">${escapeHtml(lane.bucket)}${lane.lastActiveAt ? ` — until ${escapeHtml(formatDate(lane.lastActiveAt) ?? lane.lastActiveAt)}` : ""}</span>
+                  (lane) => `<li class="${ADMIN_MINI_LIST_ITEM}">
+                    <span class="text-muted-foreground">${lane.role === "fallback" ? "Previous" : "Saved"}</span>
+                    <span class="mono font-mono font-medium">${escapeHtml(lane.bucket)}${lane.lastActiveAt ? ` — until ${escapeHtml(formatDate(lane.lastActiveAt) ?? lane.lastActiveAt)}` : ""}</span>
                   </li>`,
                 )
                 .join("")}
@@ -451,14 +476,14 @@ export const prerender = false;
             : "";
 
         host.innerHTML = `
-        <h4 class="storage-heading">Storage</h4>
+        <h4 class="storage-heading ${ADMIN_DETAIL_HEADING}">Storage</h4>
         <p class="muted storage-mode">Mode: ${data.mode === "byo" ? "Bring your own bucket" : "Shared"}</p>
         ${provenance}
         ${laneList}
-        <form class="storage-form">
-          <label class="storage-enabled"><input type="checkbox" class="storage-enabled-check" ${data.byoBucketEnabled ? "checked" : ""} /> Allow bring-your-own bucket</label>
-          <button type="submit">Save</button>
-          <div class="storage-status" role="status" aria-live="polite" hidden></div>
+        <form class="storage-form flex flex-wrap gap-2 items-center">
+          <label class="storage-enabled inline-flex items-center gap-1.5 text-(length:--text-meta) text-body"><input type="checkbox" class="storage-enabled-check" ${data.byoBucketEnabled ? "checked" : ""} /> Allow bring-your-own bucket</label>
+          <button type="submit" class="${ADMIN_BTN}">Save</button>
+          <div class="storage-status w-full text-(length:--text-micro)" role="status" aria-live="polite" hidden></div>
         </form>`;
 
         const form = host.querySelector<HTMLFormElement>(".storage-form");
@@ -525,12 +550,12 @@ export const prerender = false;
 
       function renderGithubLinks(host: HTMLElement, links: GithubLink[]): void {
         host.innerHTML = links.length
-          ? `<h4 class="github-links-heading">GitHub repos claimed</h4>
-           <ul class="github-links-list">
+          ? `<h4 class="github-links-heading ${ADMIN_DETAIL_HEADING}">GitHub repos claimed</h4>
+           <ul class="github-links-list list-none m-0 p-0 grid gap-1">
              ${links
                .map(
                  (l) =>
-                   `<li><span class="repo">${escapeHtml(l.repo)}</span><span class="muted">${escapeHtml(l.source)}</span></li>`,
+                   `<li class="flex justify-between gap-2 text-(length:--text-meta)"><span class="repo font-mono text-(length:--text-micro) text-foreground">${escapeHtml(l.repo)}</span><span class="muted">${escapeHtml(l.source)}</span></li>`,
                )
                .join("")}
            </ul>`
@@ -541,19 +566,19 @@ export const prerender = false;
         const group = document.createElement("tbody");
         group.className = "admin-row-group workspace";
         const org = ws.organization ? ws.organization.name : "no organization yet";
-        const orgClass = ws.organization ? "" : " muted";
+        const orgClass = ws.organization ? "" : ` ${ADMIN_CELL_MUTED}`;
 
         group.innerHTML = `
-      <tr class="admin-row" tabindex="0" aria-expanded="false">
-        <td class="admin-expand" aria-hidden="true">›</td>
-        <td class="keep"><span class="primary mono">${escapeHtml(ws.workspace)}</span></td>
-        <td class="optional${orgClass}">${escapeHtml(org)}</td>
-        <td class="num optional">${ws.memberCount}</td>
-        <td class="num optional">${ws.pendingInviteCount}</td>
+      <tr class="admin-row group cursor-pointer" tabindex="0" aria-expanded="false">
+        <td class="admin-expand ${ADMIN_EXPAND_TD} group-hover:bg-panel/55 group-focus-within:bg-panel/55" aria-hidden="true">›</td>
+        <td class="keep ${ADMIN_TD} group-hover:bg-panel/55 group-focus-within:bg-panel/55"><span class="primary mono ${ADMIN_CELL_PRIMARY} ${ADMIN_CELL_MONO}">${escapeHtml(ws.workspace)}</span></td>
+        <td class="optional${orgClass} ${ADMIN_TD} group-hover:bg-panel/55 group-focus-within:bg-panel/55">${escapeHtml(org)}</td>
+        <td class="num optional ${ADMIN_TD_NUM} group-hover:bg-panel/55 group-focus-within:bg-panel/55">${ws.memberCount}</td>
+        <td class="num optional ${ADMIN_TD_NUM} group-hover:bg-panel/55 group-focus-within:bg-panel/55">${ws.pendingInviteCount}</td>
       </tr>
       <tr class="admin-detail" hidden>
-        <td colspan="5">
-          <div class="admin-detail-inner">
+        <td colspan="5" class="p-0 pb-[18px] border-b border-border bg-panel/35">
+          <div class="admin-detail-inner grid gap-3.5 pt-1 pb-0.5 max-w-[560px]">
             <div class="members admin-detail-block" data-state="unloaded">Members load when expanded.</div>
             <div class="invites admin-detail-block"></div>
             <div class="plan admin-detail-block" data-state="unloaded"></div>
@@ -562,25 +587,25 @@ export const prerender = false;
             <div class="github-links admin-detail-block" data-state="unloaded"></div>
             ${
               ws.organization
-                ? `<form class="invite-form admin-inline-form admin-detail-block" data-workspace="${escapeHtml(ws.workspace)}">
-                    <label>Email<input type="email" required class="invite-email" placeholder="you@example.com" /></label>
-                    <label>Role
-                      <select class="invite-role ul-select ul-select--sm">
+                ? `<form class="invite-form admin-inline-form admin-detail-block flex flex-wrap gap-2 items-end max-w-[480px]" data-workspace="${escapeHtml(ws.workspace)}">
+                    <label class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">Email<input type="email" required class="invite-email bg-background border border-border rounded-sm text-foreground normal-case tracking-normal px-[9px] py-[7px] font-sans text-(length:--text-micro) flex-1 min-w-[200px]" placeholder="you@example.com" /></label>
+                    <label class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">Role
+                      <select class="invite-role ul-select ul-select--sm" style="width:auto">
                         <option value="member">member</option>
                         <option value="admin">admin</option>
                       </select>
                     </label>
-                    <button type="submit">Invite</button>
+                    <button type="submit" class="${ADMIN_BTN}">Invite</button>
                   </form>
-                  <div class="invite-status" hidden></div>`
+                  <div class="invite-status text-(length:--text-micro)" hidden></div>`
                 : `<p class="muted admin-detail-block">No organization provisioned for this workspace yet - run the org backfill.</p>`
             }
-            <div class="invite-link-row admin-detail-block">
-              <button type="button" class="invite-link-generate">Generate invite link</button>
-              <input type="text" class="invite-link-url" readonly hidden aria-label="Invite link" />
-              <button type="button" class="invite-link-copy" hidden>Copy</button>
+            <div class="invite-link-row admin-detail-block flex gap-2 items-center flex-wrap">
+              <button type="button" class="invite-link-generate ${ADMIN_BTN}">Generate invite link</button>
+              <input type="text" class="invite-link-url flex-1 min-w-[200px] bg-background border border-border rounded-sm text-foreground px-[9px] py-[7px] font-mono text-(length:--text-micro)" readonly hidden aria-label="Invite link" />
+              <button type="button" class="invite-link-copy ${ADMIN_BTN}" hidden>Copy</button>
             </div>
-            <div class="invite-status invite-link-status" role="status" aria-live="polite" hidden></div>
+            <div class="invite-status invite-link-status text-(length:--text-micro)" role="status" aria-live="polite" hidden></div>
           </div>
         </td>
       </tr>`;
@@ -610,12 +635,12 @@ export const prerender = false;
                 ]);
                 if (membersEl) {
                   membersEl.innerHTML = members.length
-                    ? `<h4>Members</h4><ul class="admin-mini-list">${members.map((m) => `<li><span>${escapeHtml(m.email)}</span><span class="role">${escapeHtml(m.role)}</span></li>`).join("")}</ul>`
+                    ? `<h4 class="${ADMIN_DETAIL_HEADING}">Members</h4><ul class="admin-mini-list ${ADMIN_MINI_LIST}">${members.map((m) => `<li class="${ADMIN_MINI_LIST_ITEM}"><span>${escapeHtml(m.email)}</span><span class="role text-muted-foreground">${escapeHtml(m.role)}</span></li>`).join("")}</ul>`
                     : `<p class="muted">No members yet.</p>`;
                 }
                 if (invitesEl) {
                   invitesEl.innerHTML = invites.length
-                    ? `<h4>Pending invites</h4><ul class="admin-mini-list">${invites.map((i) => `<li><span>${escapeHtml(i.email)}</span><span class="role">pending</span></li>`).join("")}</ul>`
+                    ? `<h4 class="${ADMIN_DETAIL_HEADING}">Pending invites</h4><ul class="admin-mini-list ${ADMIN_MINI_LIST}">${invites.map((i) => `<li class="${ADMIN_MINI_LIST_ITEM}"><span>${escapeHtml(i.email)}</span><span class="role text-muted-foreground">pending</span></li>`).join("")}</ul>`
                     : "";
                 }
               } catch {

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -7,7 +7,12 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-metrics.css";
-import { renderAdminTableSkeletonRowsHtml } from "../../lib/admin-ui";
+import {
+  ADMIN_BTN,
+  ADMIN_TH,
+  ADMIN_TH_NUM,
+  renderAdminTableSkeletonRowsHtml,
+} from "../../lib/admin-ui";
 
 export const prerender = false;
 
@@ -36,81 +41,201 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
 ---
 
 <AdminLayout section="metrics">
-  <section class="admin-page">
-    <header class="admin-page-header">
-      <h2>Adoption</h2>
-      <p>Signup, upload, and workspace activity across the platform over a rolling window.</p>
+  <section class="admin-page grid gap-4 min-w-0">
+    <header class="admin-page-header grid gap-1.5 max-w-2xl">
+      <h2 class="m-0 text-(length:--text-body) font-semibold text-foreground">Adoption</h2>
+      <p class="m-0 text-body text-(length:--text-meta) leading-[1.55] text-pretty">
+        Signup, upload, and workspace activity across the platform over a rolling window.
+      </p>
     </header>
 
-    <div class="metrics-range" role="group" aria-label="Time window">
-      <button type="button" class="admin-btn" data-days="7" aria-pressed="false">7 days</button>
-      <button type="button" class="admin-btn" data-days="30" aria-pressed="true">30 days</button>
-      <button type="button" class="admin-btn" data-days="90" aria-pressed="false">90 days</button>
+    <div class="metrics-range flex flex-wrap gap-2" role="group" aria-label="Time window">
+      <button
+        type="button"
+        class={`admin-btn ${ADMIN_BTN} aria-pressed:bg-primary aria-pressed:text-background aria-pressed:border-primary`}
+        data-days="7"
+        aria-pressed="false">7 days</button
+      >
+      <button
+        type="button"
+        class={`admin-btn ${ADMIN_BTN} aria-pressed:bg-primary aria-pressed:text-background aria-pressed:border-primary`}
+        data-days="30"
+        aria-pressed="true">30 days</button
+      >
+      <button
+        type="button"
+        class={`admin-btn ${ADMIN_BTN} aria-pressed:bg-primary aria-pressed:text-background aria-pressed:border-primary`}
+        data-days="90"
+        aria-pressed="false">90 days</button
+      >
     </div>
 
-    <div id="metrics-status" class="admin-status" role="status">Loading…</div>
+    <div
+      id="metrics-status"
+      class="admin-status text-(length:--text-meta) text-muted-foreground"
+      role="status"
+    >
+      Loading…
+    </div>
 
-    <div id="metrics-content">
-      <dl class="metrics-tiles" id="metrics-tiles">
-        <div class="metrics-tile">
-          <dt>Users</dt>
-          <dd id="tile-users">—</dd>
+    <div
+      id="metrics-content"
+      class="transition-opacity duration-150 ease data-[loading=true]:opacity-60"
+    >
+      <dl
+        class="metrics-tiles grid gap-3.5 m-0 p-0 mb-8 [grid-template-columns:repeat(auto-fit,minmax(11rem,1fr))]"
+        id="metrics-tiles"
+      >
+        <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+          <dt
+            class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+          >
+            Users
+          </dt>
+          <dd
+            id="tile-users"
+            class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+          >
+            —
+          </dd>
         </div>
-        <div class="metrics-tile">
-          <dt>Organizations</dt>
-          <dd id="tile-orgs">—</dd>
+        <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+          <dt
+            class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+          >
+            Organizations
+          </dt>
+          <dd
+            id="tile-orgs"
+            class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+          >
+            —
+          </dd>
         </div>
-        <div class="metrics-tile">
-          <dt>Workspaces with uploads</dt>
-          <dd id="tile-workspaces">—</dd>
+        <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+          <dt
+            class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+          >
+            Workspaces with uploads
+          </dt>
+          <dd
+            id="tile-workspaces"
+            class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+          >
+            —
+          </dd>
         </div>
-        <div class="metrics-tile">
-          <dt>Stored bytes</dt>
-          <dd id="tile-stored">—</dd>
+        <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+          <dt
+            class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+          >
+            Stored bytes
+          </dt>
+          <dd
+            id="tile-stored"
+            class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+          >
+            —
+          </dd>
         </div>
-        <div class="metrics-tile">
-          <dt>Active, 7d</dt>
-          <dd id="tile-active-7">—</dd>
+        <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+          <dt
+            class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+          >
+            Active, 7d
+          </dt>
+          <dd
+            id="tile-active-7"
+            class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+          >
+            —
+          </dd>
         </div>
-        <div class="metrics-tile">
-          <dt>Active, 30d</dt>
-          <dd id="tile-active-30">—</dd>
+        <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+          <dt
+            class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+          >
+            Active, 30d
+          </dt>
+          <dd
+            id="tile-active-30"
+            class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+          >
+            —
+          </dd>
         </div>
-        <div class="metrics-tile">
-          <dt>Uploads in window</dt>
-          <dd id="tile-uploads">—</dd>
+        <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+          <dt
+            class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+          >
+            Uploads in window
+          </dt>
+          <dd
+            id="tile-uploads"
+            class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+          >
+            —
+          </dd>
         </div>
       </dl>
 
       <section class="metrics-section">
-        <h3>Uploads per day</h3>
-        <div id="chart-uploads" aria-busy="true">
-          <div class="metrics-chart-skeleton" aria-hidden="true"></div>
+        <h3
+          class="m-0 mb-3.5 text-(length:--text-micro) font-semibold tracking-[0.04em] uppercase text-foreground"
+        >
+          Uploads per day
+        </h3>
+        <div
+          id="chart-uploads"
+          class="relative [aspect-ratio:480/200] has-[>p.muted]:flex has-[>p.muted]:items-center has-[>p.muted]:justify-center"
+          aria-busy="true"
+        >
+          <div
+            class="metrics-chart-skeleton block size-full rounded-sm bg-panel"
+            aria-hidden="true"
+          >
+          </div>
         </div>
       </section>
 
-      <section class="metrics-section">
-        <h3>Signups per day</h3>
-        <div id="chart-signups" aria-busy="true">
-          <div class="metrics-chart-skeleton" aria-hidden="true"></div>
+      <section class="metrics-section mt-2 pt-8 border-t border-border">
+        <h3
+          class="m-0 mb-3.5 text-(length:--text-micro) font-semibold tracking-[0.04em] uppercase text-foreground"
+        >
+          Signups per day
+        </h3>
+        <div
+          id="chart-signups"
+          class="relative [aspect-ratio:480/200] has-[>p.muted]:flex has-[>p.muted]:items-center has-[>p.muted]:justify-center"
+          aria-busy="true"
+        >
+          <div
+            class="metrics-chart-skeleton block size-full rounded-sm bg-panel"
+            aria-hidden="true"
+          >
+          </div>
         </div>
       </section>
 
-      <section class="metrics-section">
-        <h3>Workspace activity</h3>
-        <div class="metrics-table-wrap">
+      <section class="metrics-section mt-2 pt-8 border-t border-border">
+        <h3
+          class="m-0 mb-3.5 text-(length:--text-micro) font-semibold tracking-[0.04em] uppercase text-foreground"
+        >
+          Workspace activity
+        </h3>
+        <div class="metrics-table-wrap mt-3 overflow-x-auto">
           <table
-            class="admin-table"
+            class="admin-table w-full border-collapse text-(length:--text-meta) leading-[1.4]"
             id="workspace-activity"
             aria-label="Workspace activity"
             aria-busy="true"
           >
             <thead>
               <tr>
-                <th class="keep" scope="col">Workspace</th>
-                <th class="keep num" scope="col">Uploads</th>
-                <th class="keep num" scope="col">Bytes</th>
-                <th class="keep" scope="col">Last active</th>
+                <th class={`keep ${ADMIN_TH}`} scope="col">Workspace</th>
+                <th class={`keep num ${ADMIN_TH_NUM}`} scope="col">Uploads</th>
+                <th class={`keep num ${ADMIN_TH_NUM}`} scope="col">Bytes</th>
+                <th class={`keep ${ADMIN_TH}`} scope="col">Last active</th>
               </tr>
             </thead>
             <tbody set:html={workspaceActivitySkeleton} />
@@ -118,46 +243,99 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
         </div>
       </section>
 
-      <section class="metrics-section" id="features-panel">
-        <h3>Feature adoption</h3>
-        <p class="admin-hint">Counts within the selected window, not all-time totals.</p>
-        <dl class="metrics-tiles" id="feature-tiles">
-          <div class="metrics-tile">
-            <dt>Workspaces created</dt>
-            <dd id="tile-feature-workspace_created">—</dd>
+      <section class="metrics-section mt-2 pt-8 border-t border-border" id="features-panel">
+        <h3
+          class="m-0 mb-3.5 text-(length:--text-micro) font-semibold tracking-[0.04em] uppercase text-foreground"
+        >
+          Feature adoption
+        </h3>
+        <p
+          class="admin-hint m-0 mb-3 text-muted-foreground text-(length:--text-meta) leading-[1.5]"
+        >
+          Counts within the selected window, not all-time totals.
+        </p>
+        <dl
+          class="metrics-tiles grid gap-3.5 m-0 p-0 mb-8 [grid-template-columns:repeat(auto-fit,minmax(11rem,1fr))]"
+          id="feature-tiles"
+        >
+          <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+            <dt
+              class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+            >
+              Workspaces created
+            </dt>
+            <dd
+              id="tile-feature-workspace_created"
+              class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+            >
+              —
+            </dd>
           </div>
-          <div class="metrics-tile">
-            <dt>Galleries created</dt>
-            <dd id="tile-feature-gallery_created">—</dd>
+          <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+            <dt
+              class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+            >
+              Galleries created
+            </dt>
+            <dd
+              id="tile-feature-gallery_created"
+              class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+            >
+              —
+            </dd>
           </div>
-          <div class="metrics-tile">
-            <dt>PR comments posted</dt>
-            <dd id="tile-feature-comment_posted">—</dd>
+          <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+            <dt
+              class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+            >
+              PR comments posted
+            </dt>
+            <dd
+              id="tile-feature-comment_posted"
+              class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+            >
+              —
+            </dd>
           </div>
-          <div class="metrics-tile">
-            <dt>Repos linked</dt>
-            <dd id="tile-feature-repo_linked">—</dd>
+          <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+            <dt
+              class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+            >
+              Repos linked
+            </dt>
+            <dd
+              id="tile-feature-repo_linked"
+              class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+            >
+              —
+            </dd>
           </div>
         </dl>
       </section>
 
-      <section class="metrics-section" id="multi-identity-panel">
-        <h3>Multi-identity workspaces</h3>
-        <p class="admin-hint">
+      <section class="metrics-section mt-2 pt-8 border-t border-border" id="multi-identity-panel">
+        <h3
+          class="m-0 mb-3.5 text-(length:--text-micro) font-semibold tracking-[0.04em] uppercase text-foreground"
+        >
+          Multi-identity workspaces
+        </h3>
+        <p
+          class="admin-hint m-0 mb-3 text-muted-foreground text-(length:--text-meta) leading-[1.5]"
+        >
           Workspaces with two or more people minting tokens — a revisit trigger for the actor-on-PR
           gate (issue #579). All-time, not scoped to the selected window.
         </p>
-        <div class="metrics-table-wrap">
+        <div class="metrics-table-wrap mt-3 overflow-x-auto">
           <table
-            class="admin-table"
+            class="admin-table w-full border-collapse text-(length:--text-meta) leading-[1.4]"
             id="multi-identity-table"
             aria-label="Multi-identity workspaces"
             aria-busy="true"
           >
             <thead>
               <tr>
-                <th class="keep" scope="col">Workspace</th>
-                <th class="keep num" scope="col">Distinct minters</th>
+                <th class={`keep ${ADMIN_TH}`} scope="col">Workspace</th>
+                <th class={`keep num ${ADMIN_TH_NUM}`} scope="col">Distinct minters</th>
               </tr>
             </thead>
             <tbody set:html={multiIdentitySkeleton} />
@@ -165,29 +343,46 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
         </div>
       </section>
 
-      <section class="metrics-section" id="breakdown-panel">
-        <h3>Upload breakdown</h3>
-        <p class="admin-hint">Last 90 days, from Analytics Engine. Sampled and approximate.</p>
-        <label for="breakdown-dimension">Group by</label>
+      <section class="metrics-section mt-2 pt-8 border-t border-border" id="breakdown-panel">
+        <h3
+          class="m-0 mb-3.5 text-(length:--text-micro) font-semibold tracking-[0.04em] uppercase text-foreground"
+        >
+          Upload breakdown
+        </h3>
+        <p
+          class="admin-hint m-0 mb-3 text-muted-foreground text-(length:--text-meta) leading-[1.5]"
+        >
+          Last 90 days, from Analytics Engine. Sampled and approximate.
+        </p>
+        <label
+          for="breakdown-dimension"
+          class="inline-block mr-2 mb-3 text-(length:--text-meta) text-body">Group by</label
+        >
         <select id="breakdown-dimension" class="ul-select">
           <option value="surface">Surface</option>
           <option value="contentType">Content type</option>
           <option value="client">Client</option>
           <option value="repo">Repository</option>
         </select>
-        <div id="breakdown-status" class="admin-status" role="status" hidden></div>
-        <div class="metrics-table-wrap">
+        <div
+          id="breakdown-status"
+          class="admin-status my-2 text-(length:--text-meta) text-muted-foreground"
+          role="status"
+          hidden
+        >
+        </div>
+        <div class="metrics-table-wrap mt-4 overflow-x-auto">
           <table
-            class="admin-table"
+            class="admin-table w-full border-collapse text-(length:--text-meta) leading-[1.4]"
             id="breakdown-table"
             aria-label="Upload breakdown"
             aria-busy="true"
           >
             <thead>
               <tr>
-                <th class="keep" scope="col">Value</th>
-                <th class="keep num" scope="col">Uploads</th>
-                <th class="keep num" scope="col">Bytes</th>
+                <th class={`keep ${ADMIN_TH}`} scope="col">Value</th>
+                <th class={`keep num ${ADMIN_TH_NUM}`} scope="col">Uploads</th>
+                <th class={`keep num ${ADMIN_TH_NUM}`} scope="col">Bytes</th>
               </tr>
             </thead>
             <tbody set:html={breakdownSkeleton} />
@@ -199,7 +394,7 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
 
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
-    import { escapeHtml } from "../../lib/admin-ui";
+    import { ADMIN_TD, ADMIN_TD_NUM, escapeHtml } from "../../lib/admin-ui";
     import { formatBytes } from "../../lib/workspace-ui";
 
     onAstroPageLoad(() => {
@@ -455,7 +650,7 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
           .join("");
 
         container.innerHTML = `
-          <div class="metrics-chart-wrap">
+          <div class="metrics-chart-wrap relative">
             ${svg}
             <div class="metrics-chart-tooltip" data-visible="false" role="presentation"></div>
           </div>
@@ -591,10 +786,10 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
           ? overview.workspaces
               .map(
                 (row) =>
-                  `<tr class="admin-row"><td>${escapeHtml(row.workspace)}</td><td class="num">${num(row.uploads)}</td><td class="num">${bytes(row.bytes)}</td><td>${escapeHtml(row.lastActive)}</td></tr>`,
+                  `<tr class="admin-row"><td class="${ADMIN_TD}">${escapeHtml(row.workspace)}</td><td class="num ${ADMIN_TD_NUM}">${num(row.uploads)}</td><td class="num ${ADMIN_TD_NUM}">${bytes(row.bytes)}</td><td class="${ADMIN_TD}">${escapeHtml(row.lastActive)}</td></tr>`,
               )
               .join("")
-          : `<tr class="admin-row"><td colspan="4" class="muted">No workspace activity in this window.</td></tr>`;
+          : `<tr class="admin-row"><td colspan="4" class="muted ${ADMIN_TD}">No workspace activity in this window.</td></tr>`;
         const tableBody = table.querySelector<HTMLElement>("tbody");
         if (tableBody) tableBody.innerHTML = rows;
         table.removeAttribute("aria-busy");
@@ -607,10 +802,10 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
           ? overview.multiIdentityWorkspaces
               .map(
                 (row) =>
-                  `<tr class="admin-row"><td>${escapeHtml(row.workspace)}</td><td class="num">${num(row.users)}</td></tr>`,
+                  `<tr class="admin-row"><td class="${ADMIN_TD}">${escapeHtml(row.workspace)}</td><td class="num ${ADMIN_TD_NUM}">${num(row.users)}</td></tr>`,
               )
               .join("")
-          : `<tr class="admin-row"><td colspan="2" class="muted">No multi-identity workspaces yet.</td></tr>`;
+          : `<tr class="admin-row"><td colspan="2" class="muted ${ADMIN_TD}">No multi-identity workspaces yet.</td></tr>`;
         const multiIdentityBody = multiIdentityTable.querySelector<HTMLElement>("tbody");
         if (multiIdentityBody) multiIdentityBody.innerHTML = multiIdentityRows;
         multiIdentityTable.removeAttribute("aria-busy");
@@ -684,7 +879,7 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
             tableBody.innerHTML = body.rows
               .map(
                 (row) =>
-                  `<tr class="admin-row"><td>${escapeHtml(row.value || "(none)")}</td><td class="num">${num(row.events)}</td><td class="num">${bytes(row.bytes)}</td></tr>`,
+                  `<tr class="admin-row"><td class="${ADMIN_TD}">${escapeHtml(row.value || "(none)")}</td><td class="num ${ADMIN_TD_NUM}">${num(row.events)}</td><td class="num ${ADMIN_TD_NUM}">${bytes(row.bytes)}</td></tr>`,
               )
               .join("");
           }

--- a/apps/web/src/pages/admin/oauth.astro
+++ b/apps/web/src/pages/admin/oauth.astro
@@ -1,30 +1,37 @@
 ---
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-oauth.css";
+import { ADMIN_BTN, ADMIN_TH, ADMIN_TH_ACTIONS, ADMIN_TH_NUM } from "../../lib/admin-ui";
 
 export const prerender = false;
 ---
 
 <AdminLayout section="oauth">
-  <section class="admin-page">
-    <header class="admin-page-header">
-      <h2>OAuth apps</h2>
-      <p>
+  <section class="admin-page grid gap-4 min-w-0">
+    <header class="admin-page-header grid gap-1.5 max-w-2xl">
+      <h2 class="m-0 text-(length:--text-body) font-semibold text-foreground">OAuth apps</h2>
+      <p class="m-0 text-body text-(length:--text-meta) leading-[1.55] text-pretty">
         Registered OAuth client applications. All clients are public PKCE clients - there is no
         client secret to manage.
       </p>
     </header>
-    <div id="oauth-status" class="admin-status">Loading…</div>
-    <div class="admin-table-wrap" id="oauth-table-wrap" hidden>
-      <table class="admin-table" id="oauth-list" aria-label="OAuth apps">
+    <div id="oauth-status" class="admin-status text-(length:--text-meta) text-muted-foreground">
+      Loading…
+    </div>
+    <div class="admin-table-wrap w-full overflow-x-auto" id="oauth-table-wrap" hidden>
+      <table
+        class="admin-table w-full border-collapse text-(length:--text-meta) leading-[1.4]"
+        id="oauth-list"
+        aria-label="OAuth apps"
+      >
         <thead>
           <tr>
-            <th class="keep" scope="col">Name</th>
-            <th scope="col">Client ID</th>
-            <th scope="col">Scopes</th>
-            <th scope="col">Created</th>
-            <th class="num" scope="col">Consents</th>
-            <th class="actions" scope="col">Status</th>
+            <th class={`keep ${ADMIN_TH}`} scope="col">Name</th>
+            <th class={ADMIN_TH} scope="col">Client ID</th>
+            <th class={ADMIN_TH} scope="col">Scopes</th>
+            <th class={ADMIN_TH} scope="col">Created</th>
+            <th class={`num ${ADMIN_TH_NUM}`} scope="col">Consents</th>
+            <th class={`actions ${ADMIN_TH_ACTIONS}`} scope="col">Status</th>
           </tr>
         </thead>
         <tbody id="oauth-list-body"></tbody>
@@ -32,23 +39,38 @@ export const prerender = false;
     </div>
   </section>
 
-  <section class="admin-page">
-    <header class="admin-page-header">
-      <h2>New OAuth app</h2>
-      <p>Create a public PKCE client for an integration or agent.</p>
+  <section class="admin-page grid gap-4 min-w-0 mt-2 pt-7 border-t border-border">
+    <header class="admin-page-header grid gap-1.5 max-w-2xl">
+      <h2 class="m-0 text-(length:--text-body) font-semibold text-foreground">New OAuth app</h2>
+      <p class="m-0 text-body text-(length:--text-meta) leading-[1.55] text-pretty">
+        Create a public PKCE client for an integration or agent.
+      </p>
     </header>
-    <form id="oauth-create-form" class="admin-stack-form">
-      <label>
+    <form id="oauth-create-form" class="admin-stack-form grid gap-3 max-w-[480px]">
+      <label
+        class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+      >
         Name
-        <input type="text" id="oauth-create-name" required maxlength="200" placeholder="My app" />
+        <input
+          type="text"
+          id="oauth-create-name"
+          required
+          maxlength="200"
+          placeholder="My app"
+          class="bg-panel border border-border rounded-sm text-foreground normal-case tracking-normal px-[9px] py-[7px] font-sans text-(length:--text-micro) focus-visible:outline-none focus-visible:border-primary"
+        />
       </label>
-      <label>
+      <label
+        class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+      >
         Redirect URIs (one per line)
         <textarea
           id="oauth-create-redirects"
           required
           rows="3"
-          placeholder="https://example.com/callback"></textarea>
+          placeholder="https://example.com/callback"
+          class="bg-panel border border-border rounded-sm text-foreground normal-case tracking-normal px-[9px] py-[7px] font-sans text-(length:--text-micro) resize-y focus-visible:outline-none focus-visible:border-primary"
+        ></textarea>
       </label>
       <fieldset class="oauth-scopes">
         <legend>Scopes</legend>
@@ -65,29 +87,50 @@ export const prerender = false;
           files:delete
         </label>
       </fieldset>
-      <label>
+      <label
+        class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+      >
         Homepage URL (optional)
-        <input type="url" id="oauth-create-uri" placeholder="https://example.com" />
+        <input
+          type="url"
+          id="oauth-create-uri"
+          placeholder="https://example.com"
+          class="bg-panel border border-border rounded-sm text-foreground normal-case tracking-normal px-[9px] py-[7px] font-sans text-(length:--text-micro) focus-visible:outline-none focus-visible:border-primary"
+        />
       </label>
       <label class="oauth-scope-check">
         <input type="checkbox" id="oauth-create-official" />
         Official app
       </label>
-      <button type="submit">Create app</button>
+      <button type="submit" class={ADMIN_BTN}>Create app</button>
     </form>
-    <div id="oauth-create-status" class="admin-status" role="status" hidden></div>
+    <div
+      id="oauth-create-status"
+      class="admin-status text-(length:--text-meta) text-muted-foreground"
+      role="status"
+      hidden
+    >
+    </div>
     <div id="oauth-create-result" hidden>
-      <p class="muted" style="margin:0;font-size:var(--text-meta)">New client ID (copy it now):</p>
+      <p class="muted m-0 text-(length:--text-meta)">New client ID (copy it now):</p>
       <div class="oauth-copy-row">
         <input type="text" id="oauth-create-client-id" readonly aria-label="New client ID" />
-        <button type="button" class="admin-btn" id="oauth-create-copy">Copy</button>
+        <button type="button" class={`admin-btn ${ADMIN_BTN}`} id="oauth-create-copy">Copy</button>
       </div>
     </div>
   </section>
 
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
-    import { escapeHtml } from "../../lib/admin-ui";
+    import {
+      ADMIN_CELL_MONO,
+      ADMIN_CELL_MUTED,
+      ADMIN_CELL_PRIMARY,
+      ADMIN_TD,
+      ADMIN_TD_ACTIONS,
+      ADMIN_TD_NUM,
+      escapeHtml,
+    } from "../../lib/admin-ui";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("oauth-list-body")) return;
@@ -130,8 +173,12 @@ export const prerender = false;
 
       function badges(client: OAuthClient): string {
         const parts: string[] = [];
-        if (client.official) parts.push(`<span class="pill is-admin">Official</span>`);
-        if (client.disabled) parts.push(`<span class="pill is-disabled">Disabled</span>`);
+        if (client.official)
+          parts.push(`<span class="pill is-admin text-primary border-primary">Official</span>`);
+        if (client.disabled)
+          parts.push(
+            `<span class="pill is-disabled text-destructive border-destructive">Disabled</span>`,
+          );
         return parts.join(" ") || `<span class="muted">-</span>`;
       }
 
@@ -140,16 +187,16 @@ export const prerender = false;
         row.className = "admin-row";
         const href = `/admin/oauth/${encodeURIComponent(client.clientId)}`;
         row.innerHTML = `
-          <td class="keep">
-            <a class="admin-row-link" href="${href}">
-              <span class="primary">${escapeHtml(client.name)}</span>
+          <td class="keep ${ADMIN_TD}">
+            <a class="admin-row-link group text-inherit no-underline" href="${href}">
+              <span class="primary ${ADMIN_CELL_PRIMARY} group-hover:text-primary group-focus-visible:text-primary">${escapeHtml(client.name)}</span>
             </a>
           </td>
-          <td class="optional mono muted">${escapeHtml(client.clientId)}</td>
-          <td class="optional muted">${client.scopes.map(escapeHtml).join(", ") || "-"}</td>
-          <td class="optional muted">${new Date(client.createdAt).toLocaleDateString()}</td>
-          <td class="num optional">${client.consentCount}</td>
-          <td class="actions">${badges(client)}</td>
+          <td class="optional mono muted ${ADMIN_TD} ${ADMIN_CELL_MONO} ${ADMIN_CELL_MUTED}">${escapeHtml(client.clientId)}</td>
+          <td class="optional muted ${ADMIN_TD} ${ADMIN_CELL_MUTED}">${client.scopes.map(escapeHtml).join(", ") || "-"}</td>
+          <td class="optional muted ${ADMIN_TD} ${ADMIN_CELL_MUTED}">${new Date(client.createdAt).toLocaleDateString()}</td>
+          <td class="num optional ${ADMIN_TD_NUM}">${client.consentCount}</td>
+          <td class="actions ${ADMIN_TD_ACTIONS}">${badges(client)}</td>
         `;
         return row;
       }

--- a/apps/web/src/pages/admin/oauth/[clientId].astro
+++ b/apps/web/src/pages/admin/oauth/[clientId].astro
@@ -1,6 +1,7 @@
 ---
 import AdminLayout from "../../../layouts/AdminLayout.astro";
 import "../../../styles/admin-oauth.css";
+import { ADMIN_BTN, ADMIN_BTN_DANGER } from "../../../lib/admin-ui";
 
 export const prerender = false;
 
@@ -9,69 +10,151 @@ if (!clientId) return Astro.redirect("/admin/oauth");
 ---
 
 <AdminLayout section="oauth">
-  <section class="admin-page">
-    <a href="/admin/oauth" class="admin-back">&larr; OAuth apps</a>
-    <div id="oauth-detail-status" class="admin-status">Loading…</div>
+  <section class="admin-page grid gap-4 min-w-0">
+    <a
+      href="/admin/oauth"
+      class="admin-back text-(length:--text-micro) text-muted-foreground no-underline w-fit hover:text-primary focus-visible:text-primary focus-visible:outline-none"
+      >&larr; OAuth apps</a
+    >
+    <div
+      id="oauth-detail-status"
+      class="admin-status text-(length:--text-meta) text-muted-foreground"
+    >
+      Loading…
+    </div>
 
-    <div id="oauth-detail" hidden>
-      <div class="oauth-detail-header">
-        <h2 id="oauth-detail-name"></h2>
-        <div id="oauth-detail-badges" class="oauth-detail-badges"></div>
+    <div id="oauth-detail" class="grid gap-4" hidden>
+      <div class="oauth-detail-header flex items-center gap-2.5 flex-wrap">
+        <h2 id="oauth-detail-name" class="m-0 text-(length:--text-body) font-semibold"></h2>
+        <div id="oauth-detail-badges" class="oauth-detail-badges flex gap-1.5 flex-wrap"></div>
       </div>
 
-      <dl class="admin-dl">
+      <dl
+        class="admin-dl m-0 grid gap-3.5 gap-x-5 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]"
+      >
         <div>
-          <dt>Client ID</dt>
-          <dd><code id="oauth-detail-client-id"></code></dd>
+          <dt class="text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">
+            Client ID
+          </dt>
+          <dd class="mt-1 mb-0 text-body text-(length:--text-meta) break-words">
+            <code id="oauth-detail-client-id" class="font-mono text-(length:--text-micro)"></code>
+          </dd>
         </div>
         <div>
-          <dt>Homepage</dt>
-          <dd id="oauth-detail-uri"></dd>
+          <dt class="text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">
+            Homepage
+          </dt>
+          <dd
+            id="oauth-detail-uri"
+            class="mt-1 mb-0 text-body text-(length:--text-meta) break-words"
+          >
+          </dd>
         </div>
         <div>
-          <dt>Redirect URIs</dt>
-          <dd id="oauth-detail-redirects"></dd>
+          <dt class="text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">
+            Redirect URIs
+          </dt>
+          <dd
+            id="oauth-detail-redirects"
+            class="mt-1 mb-0 text-body text-(length:--text-meta) break-words"
+          >
+          </dd>
         </div>
         <div>
-          <dt>Scopes</dt>
-          <dd id="oauth-detail-scopes"></dd>
+          <dt class="text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">
+            Scopes
+          </dt>
+          <dd
+            id="oauth-detail-scopes"
+            class="mt-1 mb-0 text-body text-(length:--text-meta) break-words"
+          >
+          </dd>
         </div>
         <div>
-          <dt>Consents</dt>
-          <dd id="oauth-detail-consent-count"></dd>
+          <dt class="text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">
+            Consents
+          </dt>
+          <dd
+            id="oauth-detail-consent-count"
+            class="mt-1 mb-0 text-body text-(length:--text-meta) break-words"
+          >
+          </dd>
         </div>
         <div>
-          <dt>Active tokens</dt>
-          <dd id="oauth-detail-active-tokens"></dd>
+          <dt class="text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">
+            Active tokens
+          </dt>
+          <dd
+            id="oauth-detail-active-tokens"
+            class="mt-1 mb-0 text-body text-(length:--text-meta) break-words"
+          >
+          </dd>
         </div>
         <div>
-          <dt>Last consent</dt>
-          <dd id="oauth-detail-last-consent"></dd>
+          <dt class="text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">
+            Last consent
+          </dt>
+          <dd
+            id="oauth-detail-last-consent"
+            class="mt-1 mb-0 text-body text-(length:--text-meta) break-words"
+          >
+          </dd>
         </div>
         <div>
-          <dt>Created</dt>
-          <dd id="oauth-detail-created"></dd>
+          <dt class="text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">
+            Created
+          </dt>
+          <dd
+            id="oauth-detail-created"
+            class="mt-1 mb-0 text-body text-(length:--text-meta) break-words"
+          >
+          </dd>
         </div>
       </dl>
 
-      <div class="admin-actions">
-        <button type="button" class="admin-btn" id="oauth-edit-toggle">Edit</button>
-        <button type="button" class="admin-btn" id="oauth-disable-toggle"></button>
-        <button type="button" class="admin-btn admin-btn--danger" id="oauth-delete">Delete</button>
+      <div class="admin-actions flex flex-wrap gap-2 items-center">
+        <button type="button" class={`admin-btn ${ADMIN_BTN}`} id="oauth-edit-toggle">Edit</button>
+        <button type="button" class={`admin-btn ${ADMIN_BTN}`} id="oauth-disable-toggle"></button>
+        <button
+          type="button"
+          class={`admin-btn admin-btn--danger ${ADMIN_BTN} ${ADMIN_BTN_DANGER}`}
+          id="oauth-delete">Delete</button
+        >
       </div>
-      <p id="oauth-delete-hint" class="muted" style="font-size:var(--text-micro);margin:0" hidden>
+      <p id="oauth-delete-hint" class="muted m-0 text-(length:--text-micro)" hidden>
         Remove the official flag to enable deletion.
       </p>
-      <div id="oauth-action-status" class="admin-status" role="status" hidden></div>
+      <div
+        id="oauth-action-status"
+        class="admin-status text-(length:--text-meta) text-muted-foreground"
+        role="status"
+        hidden
+      >
+      </div>
 
-      <form id="oauth-edit-form" class="admin-stack-form" hidden style="margin-top:8px">
-        <label>
+      <form id="oauth-edit-form" class="admin-stack-form grid gap-3 max-w-[480px] mt-2" hidden>
+        <label
+          class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+        >
           Name
-          <input type="text" id="oauth-edit-name" required maxlength="200" />
+          <input
+            type="text"
+            id="oauth-edit-name"
+            required
+            maxlength="200"
+            class="bg-panel border border-border rounded-sm text-foreground normal-case tracking-normal px-[9px] py-[7px] font-sans text-(length:--text-micro) focus-visible:outline-none focus-visible:border-primary"
+          />
         </label>
-        <label>
+        <label
+          class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+        >
           Redirect URIs (one per line)
-          <textarea id="oauth-edit-redirects" required rows="3"></textarea>
+          <textarea
+            id="oauth-edit-redirects"
+            required
+            rows="3"
+            class="bg-panel border border-border rounded-sm text-foreground normal-case tracking-normal px-[9px] py-[7px] font-sans text-(length:--text-micro) resize-y focus-visible:outline-none focus-visible:border-primary"
+          ></textarea>
         </label>
         <fieldset class="oauth-scopes">
           <legend>Scopes</legend>
@@ -88,17 +171,23 @@ if (!clientId) return Astro.redirect("/admin/oauth");
             files:delete
           </label>
         </fieldset>
-        <label>
+        <label
+          class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+        >
           Homepage URL (optional)
-          <input type="url" id="oauth-edit-uri" />
+          <input
+            type="url"
+            id="oauth-edit-uri"
+            class="bg-panel border border-border rounded-sm text-foreground normal-case tracking-normal px-[9px] py-[7px] font-sans text-(length:--text-micro) focus-visible:outline-none focus-visible:border-primary"
+          />
         </label>
         <label class="oauth-scope-check">
           <input type="checkbox" id="oauth-edit-official" />
           Official app
         </label>
-        <div class="oauth-form-actions">
-          <button type="submit">Save changes</button>
-          <button type="button" id="oauth-edit-cancel">Cancel</button>
+        <div class="oauth-form-actions flex gap-2 flex-wrap">
+          <button type="submit" class={ADMIN_BTN}>Save changes</button>
+          <button type="button" class={ADMIN_BTN} id="oauth-edit-cancel">Cancel</button>
         </div>
       </form>
     </div>
@@ -196,8 +285,12 @@ if (!clientId) return Astro.redirect("/admin/oauth");
 
       function badges(client: OAuthClient): string {
         const parts: string[] = [];
-        if (client.official) parts.push(`<span class="pill is-admin">Official</span>`);
-        if (client.disabled) parts.push(`<span class="pill is-disabled">Disabled</span>`);
+        if (client.official)
+          parts.push(`<span class="pill is-admin text-primary border-primary">Official</span>`);
+        if (client.disabled)
+          parts.push(
+            `<span class="pill is-disabled text-destructive border-destructive">Disabled</span>`,
+          );
         return parts.join(" ");
       }
 
@@ -209,7 +302,7 @@ if (!clientId) return Astro.redirect("/admin/oauth");
         clientIdEl.textContent = client.clientId;
         uriEl.textContent = client.uri || "-";
         redirectsEl.innerHTML = client.redirectUris.length
-          ? `<ul class="oauth-uri-list">${client.redirectUris.map((u) => `<li>${escapeHtml(u)}</li>`).join("")}</ul>`
+          ? `<ul class="oauth-uri-list list-none m-0 p-0 grid gap-1 font-mono text-(length:--text-micro)">${client.redirectUris.map((u) => `<li>${escapeHtml(u)}</li>`).join("")}</ul>`
           : "-";
         scopesEl.textContent = client.scopes.join(", ") || "-";
         consentCountEl.textContent = String(client.consentCount);

--- a/apps/web/src/pages/admin/users.astro
+++ b/apps/web/src/pages/admin/users.astro
@@ -4,20 +4,25 @@
  * List: Better Auth admin list-users. Ban/unban: /admin-ui/users/:id/{ban,unban}.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import { ADMIN_TH, ADMIN_TH_ACTIONS } from "../../lib/admin-ui";
 
 export const prerender = false;
 ---
 
 <AdminLayout section="users">
-  <section class="admin-page">
-    <header class="admin-page-header">
-      <h2>Users</h2>
-      <p>
+  <section class="admin-page grid gap-4 min-w-0">
+    <header class="admin-page-header grid gap-1.5 max-w-2xl">
+      <h2 class="m-0 text-(length:--text-body) font-semibold text-foreground">Users</h2>
+      <p class="m-0 text-body text-(length:--text-meta) leading-[1.55] text-pretty">
         Deactivate an account for abuse - ends their sessions and revokes workspace API tokens they
         minted. Reactivate restores sign-in only (tokens stay revoked).
       </p>
     </header>
-    <form id="users-search" class="admin-toolbar" role="search">
+    <form
+      id="users-search"
+      class="admin-toolbar flex flex-wrap items-center gap-y-2 gap-x-3 max-w-[480px]"
+      role="search"
+    >
       <label class="sr-only" for="users-search-input">Search by email</label>
       <input
         type="search"
@@ -26,20 +31,38 @@ export const prerender = false;
         placeholder="Search email…"
         autocomplete="off"
         maxlength="200"
+        class="flex-1 min-w-[200px] bg-panel border border-border rounded-sm text-foreground px-[9px] py-[7px] text-(length:--text-micro) focus-visible:outline-none focus-visible:border-primary"
       />
-      <button type="submit">Search</button>
+      <button
+        type="submit"
+        class="text-(length:--text-micro) text-primary bg-transparent border border-border rounded-sm px-3 py-[7px] cursor-pointer whitespace-nowrap w-fit hover:border-primary focus-visible:border-primary focus-visible:outline-none"
+      >
+        Search
+      </button>
     </form>
-    <div id="users-status" class="admin-status">Loading…</div>
-    <div id="users-action-status" class="admin-status" role="status" hidden></div>
-    <div class="admin-table-wrap" id="users-table-wrap" hidden>
-      <table class="admin-table" id="users-list" aria-label="Users">
+    <div id="users-status" class="admin-status text-(length:--text-meta) text-muted-foreground">
+      Loading…
+    </div>
+    <div
+      id="users-action-status"
+      class="admin-status text-(length:--text-meta) text-muted-foreground"
+      role="status"
+      hidden
+    >
+    </div>
+    <div class="admin-table-wrap w-full overflow-x-auto" id="users-table-wrap" hidden>
+      <table
+        class="admin-table w-full border-collapse text-(length:--text-meta) leading-[1.4]"
+        id="users-list"
+        aria-label="Users"
+      >
         <thead>
           <tr>
-            <th class="keep" scope="col" style="width:18px"></th>
-            <th class="keep" scope="col">Email</th>
-            <th scope="col">Name</th>
-            <th scope="col">Joined</th>
-            <th class="actions" scope="col">Status</th>
+            <th class={`keep ${ADMIN_TH}`} scope="col" style="width:18px"></th>
+            <th class={`keep ${ADMIN_TH}`} scope="col">Email</th>
+            <th class={ADMIN_TH} scope="col">Name</th>
+            <th class={ADMIN_TH} scope="col">Joined</th>
+            <th class={`actions ${ADMIN_TH_ACTIONS}`} scope="col">Status</th>
           </tr>
         </thead>
       </table>
@@ -49,7 +72,17 @@ export const prerender = false;
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
     import { banUser, listAdminUsers, unbanUser, type AdminUser } from "../../lib/auth-client";
-    import { clearExpandGroups, escapeHtml, wireExpandGroup } from "../../lib/admin-ui";
+    import {
+      ADMIN_BTN,
+      ADMIN_BTN_DANGER,
+      ADMIN_CELL_MUTED,
+      ADMIN_CELL_PRIMARY,
+      ADMIN_EXPAND_TD,
+      ADMIN_TD,
+      clearExpandGroups,
+      escapeHtml,
+      wireExpandGroup,
+    } from "../../lib/admin-ui";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("users-list")) return;
@@ -101,28 +134,34 @@ export const prerender = false;
 
       function actionsHtml(user: AdminUser): string {
         if (sessionUserId && user.id === sessionUserId) {
-          return `<p class="users-self-note">That's you - ban is unavailable.</p>`;
+          return `<p class="users-self-note m-0 text-(length:--text-micro) text-muted-foreground">That's you - ban is unavailable.</p>`;
         }
         if (user.banned) {
-          return `<button type="button" class="admin-btn users-unban-btn" data-user-id="${escapeHtml(user.id)}">
+          return `<button type="button" class="admin-btn users-unban-btn ${ADMIN_BTN}" data-user-id="${escapeHtml(user.id)}">
             Reactivate account
           </button>`;
         }
-        return `<form class="users-ban-form" data-user-id="${escapeHtml(user.id)}">
-          <label>
+        return `<form class="users-ban-form grid gap-2 max-w-[360px]" data-user-id="${escapeHtml(user.id)}">
+          <label class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">
             Reason (optional)
-            <input type="text" class="users-ban-reason" maxlength="500"
+            <input type="text" class="users-ban-reason bg-background border border-border rounded-sm text-foreground normal-case tracking-normal px-[9px] py-[7px] font-sans text-(length:--text-micro) focus-visible:outline-none focus-visible:border-primary" maxlength="500"
               placeholder="Abuse, spam, …" autocomplete="off" />
           </label>
-          <button type="submit" class="admin-btn admin-btn--danger users-ban-btn">Deactivate account</button>
+          <button type="submit" class="admin-btn admin-btn--danger users-ban-btn ${ADMIN_BTN} ${ADMIN_BTN_DANGER}">Deactivate account</button>
         </form>`;
       }
 
       function statusPills(user: AdminUser): string {
         return [
-          isAdmin(user.role) ? `<span class="pill is-admin">Admin</span>` : "",
-          user.banned ? `<span class="pill is-banned">Deactivated</span>` : "",
-          !user.emailVerified ? `<span class="pill is-unverified">Unverified</span>` : "",
+          isAdmin(user.role)
+            ? `<span class="pill is-admin text-primary border-primary">Admin</span>`
+            : "",
+          user.banned
+            ? `<span class="pill is-banned text-destructive border-destructive">Deactivated</span>`
+            : "",
+          !user.emailVerified
+            ? `<span class="pill is-unverified text-muted-foreground">Unverified</span>`
+            : "",
         ]
           .filter(Boolean)
           .join(" ");
@@ -140,25 +179,26 @@ export const prerender = false;
           user.cliOnboardedAt != null && String(user.cliOnboardedAt)
             ? formatDate(user.cliOnboardedAt)
             : "never";
+        const emailCls = user.banned ? "text-[color-mix(in_srgb,var(--red)_70%,var(--fg))]" : "";
 
         group.innerHTML = `
-          <tr class="admin-row" tabindex="0" aria-expanded="false">
-            <td class="admin-expand" aria-hidden="true">›</td>
-            <td class="keep"><span class="email primary">${escapeHtml(user.email)}</span></td>
-            <td class="optional">${displayName || `<span class="muted">-</span>`}</td>
-            <td class="optional muted">${escapeHtml(formatDate(user.createdAt))}</td>
-            <td class="actions">${pills || `<span class="muted">-</span>`}</td>
+          <tr class="admin-row group cursor-pointer" tabindex="0" aria-expanded="false">
+            <td class="admin-expand ${ADMIN_EXPAND_TD} group-hover:bg-panel/55 group-focus-within:bg-panel/55" aria-hidden="true">›</td>
+            <td class="keep ${ADMIN_TD} group-hover:bg-panel/55 group-focus-within:bg-panel/55"><span class="email primary ${ADMIN_CELL_PRIMARY} font-mono font-medium ${emailCls}">${escapeHtml(user.email)}</span></td>
+            <td class="optional ${ADMIN_TD} group-hover:bg-panel/55 group-focus-within:bg-panel/55">${displayName || `<span class="muted">-</span>`}</td>
+            <td class="optional ${ADMIN_TD} ${ADMIN_CELL_MUTED} group-hover:bg-panel/55 group-focus-within:bg-panel/55">${escapeHtml(formatDate(user.createdAt))}</td>
+            <td class="actions text-right w-px whitespace-nowrap pl-4 ${ADMIN_TD} group-hover:bg-panel/55 group-focus-within:bg-panel/55">${pills || `<span class="muted">-</span>`}</td>
           </tr>
           <tr class="admin-detail" hidden>
-            <td colspan="5">
-              <div class="admin-detail-inner">
-                <div class="admin-detail-kv">
-                  <div><span class="label">id</span> <code>${escapeHtml(user.id)}</code></div>
-                  <div><span class="label">role</span> ${escapeHtml(user.role?.trim() || "user")}</div>
-                  <div><span class="label">CLI onboarded</span> ${escapeHtml(cli)}</div>
+            <td colspan="5" class="p-0 pb-[18px] border-b border-border bg-panel/35">
+              <div class="admin-detail-inner grid gap-3.5 pt-1 pb-0.5 max-w-[560px]">
+                <div class="admin-detail-kv grid gap-1.5 text-(length:--text-micro) text-body">
+                  <div class="flex flex-wrap gap-x-2.5 gap-y-1.5"><span class="label text-muted-foreground min-w-[7rem]">id</span> <code class="font-mono text-(length:--text-micro) text-foreground break-all">${escapeHtml(user.id)}</code></div>
+                  <div class="flex flex-wrap gap-x-2.5 gap-y-1.5"><span class="label text-muted-foreground min-w-[7rem]">role</span> ${escapeHtml(user.role?.trim() || "user")}</div>
+                  <div class="flex flex-wrap gap-x-2.5 gap-y-1.5"><span class="label text-muted-foreground min-w-[7rem]">CLI onboarded</span> ${escapeHtml(cli)}</div>
                   ${
                     user.banned && user.banReason
-                      ? `<div><span class="label">reason</span> ${escapeHtml(user.banReason)}</div>`
+                      ? `<div class="flex flex-wrap gap-x-2.5 gap-y-1.5"><span class="label text-muted-foreground min-w-[7rem]">reason</span> ${escapeHtml(user.banReason)}</div>`
                       : ""
                   }
                 </div>

--- a/apps/web/src/styles/admin-metrics.css
+++ b/apps/web/src/styles/admin-metrics.css
@@ -1,124 +1,12 @@
 /*
- * Operator metrics surface (/admin/metrics). Follows the per-page CSS
- * convention used by admin-workspaces.css / admin-oauth.css — design-system
- * tokens only, no hard-coded colors, so light and dark both work.
- *
- * Token names verified against packages/ui/src/tokens.css and
- * apps/web/src/styles/admin.css: this repo has no "--space-", "--font-size-"
- * or "--color-" prefixed custom properties in active use anywhere under
- * apps/web/src, so spacing here matches admin.css's raw-px convention (its
- * numbers are all literal px, not a token scale) and colors read the real
- * tokens — var(--line), var(--fg), var(--body), var(--muted), var(--accent),
- * var(--panel), var(--bg), var(--sans), var(--radius-sm), var(--radius-md).
+ * Operator metrics surface (/admin/metrics). Tiles, section rhythm, table
+ * wraps, and the skeleton/loading-opacity states moved to Tailwind utility
+ * classes directly in metrics.astro. What's left is the inline SVG bar
+ * chart (`drawChart` in metrics.astro's script) — hover/focus interaction,
+ * a JS-positioned tooltip, and SVG fill/stroke that read more naturally as
+ * CSS than as long per-element `class` strings on hand-built SVG markup —
+ * plus `.ws-skel`, a duplicated-on-purpose primitive (see its own comment).
  */
-
-.metrics-tiles {
-  display: grid;
-  gap: 14px;
-  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
-  margin: 0;
-  padding: 0;
-}
-
-#metrics-tiles {
-  margin-bottom: 32px;
-}
-
-.metrics-tile {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  padding: 12px 14px;
-}
-
-.metrics-tile dt {
-  margin: 0;
-  color: var(--muted);
-  font: var(--text-micro) var(--sans);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.metrics-tile dd {
-  margin: 6px 0 0;
-  color: var(--fg);
-  font-size: var(--text-h3);
-  font-weight: var(--weight-semibold);
-  /* Tabular figures so the numbers don't jitter on refresh. */
-  font-variant-numeric: tabular-nums;
-}
-
-.metrics-range {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-/* .admin-btn is the shared admin button look; the pressed state here is
-   the same pattern as .wft-view__btn[aria-pressed="true"] in
-   account-content.css — a filled accent chip instead of an outline. */
-.metrics-range .admin-btn[aria-pressed="true"] {
-  color: var(--bg);
-  background: var(--accent);
-  border-color: var(--accent);
-}
-
-/* Vertical rhythm between sections: a hairline + generous top padding on
-   every section after the first, matching the .admin-subsection separator
-   idiom in admin.css (border-top + padding-top, not just a margin) so
-   headings read as clearly starting a new region rather than trailing off
-   the previous one. */
-.metrics-section + .metrics-section {
-  margin-top: 8px;
-  padding-top: 32px;
-  border-top: 1px solid var(--line);
-}
-
-.metrics-section h3 {
-  margin: 0 0 14px;
-  font-size: var(--text-micro);
-  font-weight: var(--weight-semibold);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--fg);
-}
-
-/*
- * Progressive loading (issue #586), following the three-tier pattern PR #526
- * shipped for /account: static chrome up front (the section heading and, for
- * tables, the `<thead>`, both now server-rendered), then a skeleton reserving
- * the real content's footprint until data lands.
- *
- * The chart containers (#chart-uploads / #chart-signups) fix `aspect-ratio`
- * to the SVG's own `viewBox` ratio (480 / 200, see the `drawChart` script)
- * so the box is the same size whether it holds the skeleton, the rendered
- * chart, or the "No data yet." empty state — swapping `innerHTML` never
- * changes the container's own size, so there is nothing to shift.
- */
-.metrics-chart-wrap {
-  position: relative;
-}
-
-#chart-uploads,
-#chart-signups {
-  aspect-ratio: 480 / 200;
-}
-
-/* Centers the "No data yet." message in the same reserved box, rather than
-   letting a lone <p> collapse to its line height. */
-#chart-uploads:has(> p.muted),
-#chart-signups:has(> p.muted) {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.metrics-chart-skeleton {
-  display: block;
-  inline-size: 100%;
-  block-size: 100%;
-  border-radius: var(--radius-sm);
-  background: var(--panel);
-}
 
 .metrics-chart {
   display: block;
@@ -185,48 +73,6 @@
 .metrics-chart-tooltip .day {
   color: var(--muted);
   margin-right: 4px;
-}
-
-/* Wide content scrolls inside its own container; the page body never
-   scrolls horizontally. */
-.metrics-table-wrap {
-  margin-top: 12px;
-  overflow-x: auto;
-}
-
-/* Reduced opacity while a range change is refetching, so the previous
-   render holds instead of flashing to empty. */
-#metrics-content {
-  transition: opacity 0.15s ease;
-}
-
-#metrics-content[data-loading="true"] {
-  opacity: 0.6;
-}
-
-/* Small explanatory line under a section heading — same treatment as
-   .admin-page-header p, scoped to this page since no other /admin/* section
-   currently needs one. */
-.admin-hint {
-  margin: 0 0 12px;
-  color: var(--muted);
-  font-size: var(--text-meta);
-  line-height: 1.5;
-}
-
-#breakdown-panel label {
-  display: inline-block;
-  margin: 0 8px 12px 0;
-  font-size: var(--text-meta);
-  color: var(--body);
-}
-
-#breakdown-panel #breakdown-status {
-  margin: 8px 0;
-}
-
-#breakdown-panel .metrics-table-wrap {
-  margin-top: 16px;
 }
 
 /* Loading placeholder emitted by workspace-ui.ts's skeletonBarHtml (reused by

--- a/apps/web/src/styles/admin-oauth.css
+++ b/apps/web/src/styles/admin-oauth.css
@@ -1,4 +1,13 @@
-/* OAuth create form + detail extras. */
+/*
+ * OAuth create/edit form extras (admin/oauth.astro, admin/oauth/[clientId].astro).
+ * Only `.oauth-scopes`/`.oauth-scope-check` remain: the fieldset/legend look
+ * has no Tailwind-utility equivalent on a bare <fieldset>/<legend>, and the
+ * scope checkboxes need `!important` to win over the shared
+ * `.admin-stack-form label` uppercase/vertical-stack rule that would
+ * otherwise apply (that rule itself now lives inline as a utility string on
+ * every other label in these forms — see admin-ui.ts — so this is the one
+ * spot still fighting a same-name legacy selector).
+ */
 
 .oauth-scopes {
   border: 1px solid var(--line);
@@ -23,50 +32,4 @@
   letter-spacing: normal !important;
   color: var(--body) !important;
   font-size: var(--text-micro) !important;
-}
-.oauth-copy-row {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  flex-wrap: wrap;
-  margin-top: 8px;
-}
-.oauth-copy-row input {
-  flex: 1;
-  min-width: 200px;
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  color: var(--fg);
-  padding: 7px 9px;
-  font: var(--text-micro) var(--mono);
-}
-.oauth-uri-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 4px;
-  font: var(--text-micro) var(--mono);
-}
-.oauth-detail-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-.oauth-detail-header h2 {
-  margin: 0;
-  font-size: var(--text-body);
-  font-weight: var(--weight-semibold);
-}
-.oauth-detail-badges {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-.oauth-form-actions {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
 }

--- a/apps/web/src/styles/admin-workspaces.css
+++ b/apps/web/src/styles/admin-workspaces.css
@@ -1,45 +1,10 @@
-/* Workspace expand-detail: plan, limits, GitHub, invite link. */
+/*
+ * Workspace expand-detail (admin/index.astro): only the bits that don't map
+ * to a static Tailwind utility survive here — colors driven by a JS-set
+ * `data-state` attribute. Layout (grids, flex rows, form field boxes) moved
+ * to Tailwind utility classes directly on the generated markup.
+ */
 
-.workspace .plan-availability,
-.workspace .plan-unapplied,
-.workspace .limit-usage {
-  margin: 0 0 10px;
-  font-size: var(--text-micro);
-  color: var(--muted);
-}
-.workspace .plan-form {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
-}
-.workspace .limit-value {
-  background: var(--bg);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  color: var(--fg);
-  padding: 4px 6px;
-  font: var(--text-micro) var(--mono);
-}
-/* .plan-select, .limit-unit, and .invite-role are styled by .ul-select
-   .ul-select--sm (markup in admin/index.astro) instead of bespoke box CSS.
-   All three need width: auto — .ul-select defaults to 100% for a stacked
-   field, but each of these sits in a flex row (.plan-form next to "Save
-   plan"; the invite-role <label> inside the flex-wrap .admin-inline-form)
-   or, for .limit-unit, reads clearer pinned to content width like the
-   sibling .limit-value input even though its 70px grid column would also
-   work with the 100% default. */
-.workspace .plan-select,
-.workspace .limit-unit,
-.workspace .invite-role {
-  width: auto;
-}
-.workspace .plan-status,
-.workspace .limit-status,
-.workspace .invite-status {
-  font-size: var(--text-micro);
-  width: 100%;
-}
 .workspace .plan-status[data-state="error"],
 .workspace .limit-status[data-state="error"],
 .workspace .invite-status[data-state="error"] {
@@ -51,79 +16,4 @@
 }
 .workspace .invite-status[data-state="ready"] {
   color: var(--accent);
-}
-.workspace .limits-form {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-.workspace .limit-row {
-  display: grid;
-  grid-template-columns: 130px 1fr auto auto;
-  align-items: center;
-  gap: 8px;
-}
-.workspace .limit-row[data-byte] {
-  grid-template-columns: 130px 1fr 70px auto;
-}
-.workspace .limit-row > label:first-child {
-  font-size: var(--text-meta);
-  color: var(--body);
-}
-/* .limit-unit's disabled treatment now comes from .ul-select:disabled. */
-.workspace .limit-value:disabled {
-  opacity: 0.5;
-}
-.workspace .limit-unlimited {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: var(--text-micro);
-  white-space: nowrap;
-  color: var(--muted);
-}
-.workspace .limits-form button {
-  align-self: flex-start;
-  margin-top: 4px;
-}
-.workspace .github-links-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 4px;
-}
-.workspace .github-links-list li {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  font-size: var(--text-meta);
-}
-.workspace .github-links-list .repo {
-  font: var(--text-micro) var(--mono);
-  color: var(--fg);
-}
-.workspace .invite-link-row {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  flex-wrap: wrap;
-}
-.workspace .invite-link-url {
-  flex: 1;
-  min-width: 200px;
-  background: var(--bg);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  color: var(--fg);
-  padding: 7px 9px;
-  font: var(--text-micro) var(--mono);
-}
-
-@media (max-width: 560px) {
-  .workspace .limit-row,
-  .workspace .limit-row[data-byte] {
-    grid-template-columns: 1fr;
-    gap: 4px;
-  }
 }

--- a/apps/web/src/styles/admin.css
+++ b/apps/web/src/styles/admin.css
@@ -1,205 +1,24 @@
 /*
- * Operator admin surface (/admin/*).
- * Flat sections + tables. Spacing and hairlines, not nested cards.
+ * Operator admin surface (/admin/*): only structural + state-driven rules
+ * that don't map to a static Tailwind utility survive here (phase 3 of the
+ * Tailwind + shadcn migration, .context/2026-08-22-tailwind-shadcn-migration-plan.md).
+ * Everything else moved onto Tailwind utility classes directly in the
+ * markup — see the shared class strings in lib/admin-ui.ts and the
+ * per-page .astro files/scripts.
  */
 
-/* ── Page ──────────────────────────────────────────────────────────────── */
-.admin-page {
-  display: grid;
-  gap: 16px;
-  min-width: 0;
-}
-.admin-page + .admin-page {
-  margin-top: 8px;
-  padding-top: 28px;
-  border-top: 1px solid var(--line);
-}
-.admin-page-header {
-  display: grid;
-  gap: 6px;
-  max-width: 42rem;
-}
-.admin-page-header h2 {
-  margin: 0;
-  font-size: var(--text-body);
-  font-weight: var(--weight-semibold);
-  color: var(--fg);
-}
-.admin-page-header p {
-  margin: 0;
-  color: var(--body);
-  font-size: var(--text-meta);
-  line-height: 1.55;
-  text-wrap: pretty;
-}
-.admin-subsection + .admin-subsection {
-  margin-top: 8px;
-  padding-top: 20px;
-  border-top: 1px solid var(--line);
-}
-.admin-subsection-label {
-  margin: 0 0 10px;
-  font: var(--weight-medium) var(--text-micro) / 1 var(--sans);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-/* ── Status / controls ─────────────────────────────────────────────────── */
-.admin-status {
-  font-size: var(--text-meta);
-  color: var(--muted);
-}
+/* `data-state`-driven status colors — set by JS (statusEl.dataset.state),
+   kept as CSS per the migration's own carve-out for state-driven rules. */
 .admin-status[data-state="error"] {
   color: var(--red);
 }
 .admin-status[data-state="ready"] {
   color: var(--accent);
 }
-.admin-toolbar,
-.admin-field {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px 12px;
-  max-width: 480px;
-}
-.admin-field label {
-  font: var(--text-micro) var(--sans);
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-.admin-toolbar input,
-.admin-field input {
-  flex: 1 1 200px;
-  min-width: 0;
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  color: var(--fg);
-  padding: 7px 9px;
-  font: var(--text-micro) var(--sans);
-}
-.admin-toolbar input:focus-visible,
-.admin-field input:focus-visible {
-  outline: none;
-  border-color: var(--accent);
-}
-.admin-btn,
-.admin-toolbar button,
-.admin-inline-form button,
-.admin-stack-form button[type="submit"],
-.workspace .plan-form button,
-.workspace .limits-form button,
-.workspace .invite-link-row button {
-  font: var(--text-micro) var(--sans);
-  color: var(--accent);
-  background: transparent;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  padding: 7px 12px;
-  cursor: pointer;
-  white-space: nowrap;
-  width: fit-content;
-}
-.admin-btn:hover,
-.admin-btn:focus-visible,
-.admin-toolbar button:hover,
-.admin-toolbar button:focus-visible,
-.admin-inline-form button:hover,
-.admin-inline-form button:focus-visible,
-.admin-stack-form button[type="submit"]:hover,
-.admin-stack-form button[type="submit"]:focus-visible,
-.workspace .plan-form button:hover,
-.workspace .plan-form button:focus-visible,
-.workspace .limits-form button:hover,
-.workspace .limits-form button:focus-visible,
-.workspace .invite-link-row button:hover,
-.workspace .invite-link-row button:focus-visible {
-  border-color: var(--accent);
-  outline: none;
-}
-.admin-btn:disabled {
-  opacity: 0.55;
-  cursor: default;
-}
-.admin-btn--danger {
-  color: var(--red);
-  border-color: color-mix(in srgb, var(--red) 40%, var(--line));
-}
-.admin-btn--danger:hover:not(:disabled),
-.admin-btn--danger:focus-visible:not(:disabled) {
-  border-color: var(--red);
-}
-.admin-btn--danger:disabled {
-  color: var(--muted);
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-.admin-back {
-  font-size: var(--text-micro);
-  color: var(--muted);
-  text-decoration: none;
-  width: fit-content;
-}
-.admin-back:hover,
-.admin-back:focus-visible {
-  color: var(--accent);
-  outline: none;
-}
-.admin-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
-}
 
-/* ── Table ─────────────────────────────────────────────────────────────── */
-.admin-table-wrap {
-  width: 100%;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-.admin-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--text-meta);
-  line-height: 1.4;
-}
-.admin-table th {
-  text-align: left;
-  font: var(--weight-medium) var(--text-micro) / 1 var(--sans);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--muted);
-  padding: 0 12px 10px 0;
-  border-bottom: 1px solid var(--line);
-  white-space: nowrap;
-}
-.admin-table th:last-child,
-.admin-table td:last-child {
-  padding-right: 0;
-}
-.admin-table th.num,
-.admin-table td.num {
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-  padding-left: 16px;
-}
-.admin-table th.actions,
-.admin-table td.actions {
-  text-align: right;
-  width: 1%;
-  white-space: nowrap;
-  padding-left: 16px;
-}
-.admin-table tbody > tr.admin-row > td {
-  padding: 12px 12px 12px 0;
-  border-bottom: 1px solid var(--line);
-  color: var(--body);
-  vertical-align: middle;
-}
+/* Table rows are dynamically inserted `tbody`s, so "last visible row has no
+   bottom border" and "the JS-toggled `.is-open` expand state" can't be
+   expressed as static utility classes. */
 .admin-table tbody:not(.admin-row-group) > tr.admin-row:last-child > td,
 .admin-table tbody.admin-row-group:last-child:not(.is-open) > tr.admin-row > td {
   border-bottom: 0;
@@ -207,74 +26,14 @@
 .admin-table tbody.admin-row-group.is-open > tr.admin-row > td {
   border-bottom-color: transparent;
 }
-.admin-table .primary {
-  color: var(--fg);
-  font-weight: var(--weight-semibold);
-}
-.admin-table .email,
-.admin-table .mono {
-  font-family: var(--mono);
-  font-weight: var(--weight-medium);
-}
-.admin-table .muted {
-  color: var(--muted);
-  font-size: var(--text-micro);
-}
-.admin-table a.admin-row-link {
-  color: inherit;
-  text-decoration: none;
-}
-.admin-table a.admin-row-link:hover .primary,
-.admin-table a.admin-row-link:focus-visible .primary {
-  color: var(--accent);
-  outline: none;
-}
-
-/* Expandable groups */
-.admin-table tbody.admin-row-group > tr.admin-row {
-  cursor: pointer;
-}
-.admin-table tbody.admin-row-group > tr.admin-row:hover > td,
-.admin-table tbody.admin-row-group > tr.admin-row:focus-within > td {
-  background: color-mix(in srgb, var(--panel) 55%, transparent);
-}
-.admin-table .admin-expand {
-  width: 18px;
-  color: var(--muted);
-  font-size: var(--text-micro);
-  line-height: 1;
-  transition: transform 0.15s ease;
-  user-select: none;
-}
-.admin-table tbody.admin-row-group.is-open .admin-expand {
-  transform: rotate(90deg);
-  color: var(--fg);
-}
-.admin-table tbody.admin-row-group > tr.admin-detail > td {
-  padding: 0 0 18px;
-  border-bottom: 1px solid var(--line);
-  background: color-mix(in srgb, var(--panel) 35%, transparent);
-}
 .admin-table tbody.admin-row-group:last-child > tr.admin-detail > td {
   border-bottom: 0;
 }
-.admin-detail-inner {
-  display: grid;
-  gap: 14px;
-  padding: 4px 0 2px;
-  max-width: 560px;
-}
-.admin-detail-inner h4,
-.workspace .plan-heading,
-.workspace .limits-heading,
-.workspace .github-links-heading {
-  margin: 0 0 8px;
-  font-size: var(--text-micro);
-  font-weight: var(--weight-semibold);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--fg);
-}
+
+/* Detail blocks fill in asynchronously (plan/limits/storage/members load on
+   expand) — hiding an empty one, and only drawing a divider between two
+   non-empty neighbors, depends on runtime content and can't be a static
+   class. */
 .admin-detail-block:empty {
   display: none;
 }
@@ -282,161 +41,14 @@
   padding-top: 12px;
   border-top: 1px solid var(--line);
 }
-.admin-detail-kv {
-  display: grid;
-  gap: 6px;
-  font-size: var(--text-micro);
-  color: var(--body);
-}
-.admin-detail-kv div {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px 10px;
-}
-.admin-detail-kv .label {
-  color: var(--muted);
-  min-width: 7rem;
-}
-.admin-detail-kv code {
-  font: var(--text-micro) var(--mono);
-  color: var(--fg);
-  word-break: break-all;
-}
-.admin-mini-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 6px;
-}
-.admin-mini-list li {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  font-size: var(--text-micro);
-  color: var(--body);
-}
-.admin-mini-list .role {
-  color: var(--muted);
-}
 
-/* Forms */
-.admin-inline-form {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: flex-end;
-}
-.admin-stack-form {
-  display: grid;
-  gap: 12px;
-  max-width: 480px;
-}
-.admin-inline-form label,
-.admin-stack-form label,
-.users-ban-form label {
-  display: grid;
-  gap: 4px;
-  color: var(--muted);
-  font-size: var(--text-micro);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-/*
- * `select` deliberately dropped from these lists: .invite-role (the only
- * <select> in an .admin-inline-form) is now styled by .ul-select
- * .ul-select--sm, and a class+type rule here would out-specificity
- * .ul-select's own declarations (background/border/padding/font) and clobber
- * them. No .admin-stack-form <select> exists today either — leaving `select`
- * out of both lists keeps the box available for .ul-select if one shows up.
- */
-.admin-inline-form input,
-.admin-stack-form input[type="text"],
-.admin-stack-form input[type="url"],
-.admin-stack-form textarea,
-.users-ban-form input {
-  background: var(--bg);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  color: var(--fg);
-  padding: 7px 9px;
-  font: var(--text-micro) var(--sans);
-  text-transform: none;
-  letter-spacing: normal;
-}
-.admin-stack-form input[type="text"],
-.admin-stack-form input[type="url"],
-.admin-stack-form textarea {
-  background: var(--panel);
-}
-.admin-inline-form input:focus-visible,
-.admin-stack-form input:focus-visible,
-.admin-stack-form textarea:focus-visible,
-.users-ban-form input:focus-visible {
-  outline: none;
-  border-color: var(--accent);
-}
-.admin-stack-form textarea {
-  resize: vertical;
-}
-.users-ban-form {
-  display: grid;
-  gap: 8px;
-  max-width: 360px;
-}
-.users-self-note {
-  margin: 0;
-  font-size: var(--text-micro);
-  color: var(--muted);
-}
-.user-row.is-banned .email {
-  color: color-mix(in srgb, var(--red) 70%, var(--fg));
-}
-
-/* Pills */
-.pill.is-admin {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-.pill.is-banned,
-.pill.is-disabled {
-  color: var(--red);
-  border-color: var(--red);
-}
-.pill.is-unverified {
-  color: var(--muted);
-}
-
-/* Definition list (oauth detail) */
-.admin-dl {
-  margin: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 14px 20px;
-}
-.admin-dl dt {
-  color: var(--muted);
-  font-size: var(--text-micro);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-.admin-dl dd {
-  margin: 4px 0 0;
-  color: var(--body);
-  font-size: var(--text-meta);
-  overflow-wrap: anywhere;
-}
-.admin-dl code {
-  font: var(--text-micro) var(--mono);
-}
-
+/* Narrow viewports drop secondary columns; which `<td>`s are "optional" is
+   set per-table in markup (`class="optional"`), so the collapse itself
+   stays a media query rather than a `max-*:hidden` utility repeated on
+   every generated cell. */
 @media (max-width: 680px) {
   .admin-table th:not(.keep),
   .admin-table td.optional {
     display: none;
-  }
-  .admin-table th,
-  .admin-table tbody > tr.admin-row > td {
-    padding-right: 8px;
   }
 }


### PR DESCRIPTION
Third phase-3 surface of the Tailwind + shadcn migration (follows #787/#789; plan in `.context/2026-08-22-tailwind-shadcn-migration-plan.md`, local doc).

## What

- All six admin pages (workspaces, users, email, metrics, oauth, oauth/[clientId]) — static templates and script-generated HTML — moved to Tailwind utilities; legacy class names stay as DOM hooks.
- New shared class-string constants in `admin-ui.ts` (table cells, buttons, mini-lists) keep the repeated chrome DRY across pages.
- **Admin CSS cut 889 → 200 lines (78%).** What remains is deliberately state-driven or non-static: `[data-state]` status colors, JS-toggled `.is-open` rules, the 680px column collapse, the inline-SVG metrics chart styling, and the `oauth-scopes` fieldset.
- Cascade rule from #789 applied: the narrow selects governed by kept `ul-select` (`width:100%`, unlayered) use inline `style="width:auto"` rather than a utility that would silently lose.

## Verification

- `astro build`, lint, `admin-ui` vitest 3/3 green.
- Visual audit against the local stack with an admin session: workspaces table + full expand panel (members/plan/limits/storage forms), metrics tiles + range chips (pressed state still violet-filled) + bar chart, users table with search, oauth table + new-app form + scopes fieldset, email previews table — all at parity with pre-migration baselines.
- Flagged for a prod glance: row-hover tint is `bg-panel/55` replacing a `color-mix()` (visually close, not bit-identical), and the expand panel's nested list spacing is authored per-list now.

Screenshots attach via the managed comment.
