### PR TITLE
feat(web): migrate screenshots-by-path surface off bespoke CSS (migration phase 3, surface 4)

### DIFF
--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -1292,7 +1292,7 @@ function ScreenshotsByPathInner({
   }
 
   return (
-    <div className="wsp" aria-busy={overviewRefreshing || undefined}>
+    <div className="wsp grid gap-8" aria-busy={overviewRefreshing || undefined}>
       {filterBar}
       {isEmptyWorkspace ? (
         <EmptyShotsCta title="No screenshots yet" />

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -303,10 +303,18 @@ function ShotThumb({
           {showLock ? "🔒" : extLabel(item.key)}
         </span>
       )}
-      {contextLabel && <span className="wsp-state">{contextLabel}</span>}
+      {contextLabel && (
+        <span className="wsp-state absolute top-1 left-1 rounded-full border border-line bg-panel px-[5px] py-px text-[12px] leading-[1.4] tracking-[0.04em] text-muted-foreground uppercase">
+          {contextLabel}
+        </span>
+      )}
       {paired && (
-        <span className="wsp-pair" aria-hidden="true" title="Has a before/after pair">
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+        <span
+          className="wsp-pair absolute top-1 right-1 grid h-[18px] w-[18px] place-items-center rounded-[4px] border border-line bg-panel text-muted-foreground"
+          aria-hidden="true"
+          title="Has a before/after pair"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="block">
             <rect x="1" y="1" width="4.5" height="10" rx="1" fill="currentColor" opacity="0.45" />
             <rect
               x="6.5"
@@ -357,18 +365,18 @@ function SkelBar({ width }: { width: string }) {
 
 function OverviewLoadingSkeleton() {
   return (
-    <div className="wsp" aria-busy="true">
-      <div className="wsp-filter">
-        <span className="wsp-filter__project wsp-filter__skel">
+    <div className="wsp grid gap-8" aria-busy="true">
+      <div className="wsp-filter flex flex-wrap items-stretch gap-2">
+        <span className="wsp-filter__project wsp-filter__skel flex min-h-9 items-center rounded-[6px] border border-line bg-bg px-3 box-border">
           <SkelBar width="120px" />
         </span>
-        <span className="wsp-filter__q wsp-filter__skel">
+        <span className="wsp-filter__q wsp-filter__skel flex min-h-9 items-center rounded-[6px] border border-line bg-bg px-3 box-border">
           <SkelBar width="60%" />
         </span>
       </div>
       {[0, 1, 2].map((row) => (
-        <div className="wsp-group" key={row}>
-          <div className="wsp-group__head">
+        <div className="wsp-group grid gap-2.5" key={row}>
+          <div className="wsp-group__head flex w-full items-baseline gap-2.5">
             <SkelBar width="140px" />
           </div>
           <div className="wsp-strip">
@@ -452,9 +460,9 @@ function FilterBar({
   };
 
   return (
-    <div className="wsp-filter">
+    <div className="wsp-filter flex flex-wrap items-stretch gap-2">
       <Select
-        className="ul-select--sm wsp-filter__project"
+        className="ul-select--sm wsp-filter__project flex-[0_1_16rem] min-w-[12rem] max-w-full min-h-9 text-base sm:text-[13px] box-border"
         aria-label="Filter by project"
         value={project}
         onChange={(event) => onProject(event.target.value)}
@@ -466,11 +474,11 @@ function FilterBar({
           </option>
         ))}
       </Select>
-      <div className="wsp-filter__qwrap">
+      <div className="wsp-filter__qwrap relative flex flex-[1_1_16rem] min-w-0">
         <Input
           id="wsp-path-filter"
           type="search"
-          className="wsp-filter__q"
+          className="wsp-filter__q flex-1 min-w-0 min-h-9 px-3 py-1.5 text-base sm:text-[13px] rounded-[6px] box-border"
           aria-label="Filter by path"
           aria-keyshortcuts="Meta+K Control+K Slash"
           aria-expanded={open}
@@ -496,7 +504,12 @@ function FilterBar({
           onKeyDown={onKeyDown}
         />
         {open && (
-          <ul className="wsp-suggest" id="wsp-path-suggest" role="listbox" aria-label="Paths">
+          <ul
+            className="wsp-suggest absolute top-[calc(100%+4px)] left-0 right-0 z-30 m-0 max-h-[280px] list-none overflow-y-auto rounded-[6px] border border-line bg-panel p-1 shadow-[0_8px_24px_rgb(0_0_0_/_0.25)]"
+            id="wsp-path-suggest"
+            role="listbox"
+            aria-label="Paths"
+          >
             {suggestions.map((entry, index) => (
               <li key={entry.path} role="presentation">
                 <button
@@ -504,15 +517,17 @@ function FilterBar({
                   role="option"
                   id={`wsp-path-suggest-${index}`}
                   aria-selected={index === active}
-                  className={index === active ? "wsp-suggest__opt is-active" : "wsp-suggest__opt"}
+                  className={`wsp-suggest__opt flex w-full items-baseline gap-3 rounded-sm border-0 bg-none px-2 py-1.5 text-left font-[inherit] text-inherit cursor-pointer ${index === active ? "is-active bg-bg" : ""}`}
                   onMouseDown={(event) => {
                     event.preventDefault();
                     pick(entry.path);
                   }}
                   onMouseEnter={() => setActive(index)}
                 >
-                  <span className="wsp-suggest__path">{entry.path}</span>
-                  <span className="wsp-suggest__count">
+                  <span className="wsp-suggest__path text-[13px] font-semibold [overflow-wrap:anywhere]">
+                    {entry.path}
+                  </span>
+                  <span className="wsp-suggest__count ml-auto text-[12px] whitespace-nowrap text-muted-foreground">
                     {entry.count} {entry.count === 1 ? "file" : "files"}
                   </span>
                 </button>
@@ -524,11 +539,15 @@ function FilterBar({
       {/* One flex item so the two toggle groups wrap together as a cluster —
           separately they wrap independently and "Merged only" ends up
           orphaned on its own row. */}
-      <div className="wsp-filter__toggles">
-        <div className="wsp-toggle" role="group" aria-label="Layout">
+      <div className="wsp-filter__toggles flex flex-none items-stretch gap-2">
+        <div
+          className="wsp-toggle flex items-stretch overflow-hidden rounded-[6px] border border-line box-border"
+          role="group"
+          aria-label="Layout"
+        >
           <button
             type="button"
-            className="wsp-toggle__opt"
+            className="wsp-toggle__opt min-h-[34px] whitespace-nowrap border-0 bg-none px-3 text-[13px] text-muted-foreground cursor-pointer first:border-l-0 [&+&]:border-l [&+&]:border-line aria-pressed:bg-panel aria-pressed:text-fg hover:text-fg focus-visible:text-fg"
             aria-pressed={feed === "grouped"}
             onClick={() => onFeed("grouped")}
           >
@@ -536,7 +555,7 @@ function FilterBar({
           </button>
           <button
             type="button"
-            className="wsp-toggle__opt"
+            className="wsp-toggle__opt min-h-[34px] whitespace-nowrap border-0 bg-none px-3 text-[13px] text-muted-foreground cursor-pointer [&+&]:border-l [&+&]:border-line aria-pressed:bg-panel aria-pressed:text-fg hover:text-fg focus-visible:text-fg"
             aria-pressed={feed === "recent"}
             onClick={() => onFeed("recent")}
           >
@@ -545,10 +564,14 @@ function FilterBar({
         </div>
         {/* Persisted PR merge-state tagging: filters both the drill-in
             (meta.gh.merged=true) and the grouped overview (?merged=1). */}
-        <div className="wsp-toggle" role="group" aria-label="Merge filter">
+        <div
+          className="wsp-toggle flex items-stretch overflow-hidden rounded-[6px] border border-line box-border"
+          role="group"
+          aria-label="Merge filter"
+        >
           <button
             type="button"
-            className="wsp-toggle__opt"
+            className="wsp-toggle__opt min-h-[34px] whitespace-nowrap border-0 bg-none px-3 text-[13px] text-muted-foreground cursor-pointer aria-pressed:bg-panel aria-pressed:text-fg hover:text-fg focus-visible:text-fg"
             aria-pressed={merged}
             onClick={() => onMerged(!merged)}
           >
@@ -1105,16 +1128,21 @@ function ScreenshotsByPathInner({
     }
 
     return (
-      <div className="wsp" aria-busy={overviewRefreshing || undefined}>
+      <div className="wsp grid gap-8" aria-busy={overviewRefreshing || undefined}>
         {filterBar}
-        <div className="wsp-drill__head">
+        <div className="wsp-drill__head grid gap-2 justify-items-start">
           <button type="button" className="text-btn" onClick={() => setView({ ...view, path: "" })}>
             {view.project ? `← ${view.project}` : "← all projects"}
           </button>
-          <h2 className="wsp-drill__heading">{view.path}</h2>
+          <h2 className="wsp-drill__heading m-0 text-base font-semibold [overflow-wrap:anywhere]">
+            {view.path}
+          </h2>
         </div>
         {drill.status === "loading" && (
-          <div className="wsp-grid" aria-busy="true">
+          <div
+            className="wsp-grid grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]"
+            aria-busy="true"
+          >
             {Array.from({ length: 8 }, (_, i) => (
               <span className="wsp-thumb wsp-thumb--skel" key={i} aria-hidden="true" />
             ))}
@@ -1134,7 +1162,7 @@ function ScreenshotsByPathInner({
         )}
         {drill.status === "ready" && (
           <>
-            <div className="wsp-grid">
+            <div className="wsp-grid grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]">
               {drillItems.map((item) => (
                 <ShotThumb
                   key={item.key}
@@ -1175,7 +1203,7 @@ function ScreenshotsByPathInner({
     });
     const latestPaired = pairedShotKeys(latestItems);
     return (
-      <div className="wsp" aria-busy={overviewRefreshing || undefined}>
+      <div className="wsp grid gap-8" aria-busy={overviewRefreshing || undefined}>
         {filterBar}
         {latestItems.length === 0 ? (
           !view.merged && overview.latest.length === 0 && overview.catalog.length === 0 ? (
@@ -1191,7 +1219,7 @@ function ScreenshotsByPathInner({
           )
         ) : (
           <>
-            <div className="wsp-grid">
+            <div className="wsp-grid grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]">
               {latestItems.map((item) => (
                 <ShotThumb
                   key={item.key}
@@ -1272,7 +1300,7 @@ function ScreenshotsByPathInner({
         <p className="wft-end">{emptyFilterMessage}</p>
       ) : (
         <>
-          {sectionLabels.map((label) => {
+          {sectionLabels.map((label, index) => {
             const projectSummary = overview.projects.find((p) => p.label === label);
             const groups = matchingGroups.filter((group) => group.project === label);
             const previewGroups = filtering ? groups : groups.slice(0, PREVIEW_PATHS_PER_PROJECT);
@@ -1285,6 +1313,10 @@ function ScreenshotsByPathInner({
                 groups={previewGroups}
                 ghItems={ghItems}
                 showViewProject={!view.project}
+                // Each subsequent project opens with a full-width hairline —
+                // the section boundary is structural, not just whitespace —
+                // so a project head can't be misread as one more path row.
+                bordered={index > 0}
                 onViewProject={() => setView({ ...view, project: label, path: "" })}
                 onDrill={onDrill}
                 opener={opener}
@@ -1329,6 +1361,7 @@ function ProjectSection({
   groups,
   ghItems,
   showViewProject,
+  bordered,
   onViewProject,
   onDrill,
   opener,
@@ -1339,6 +1372,8 @@ function ProjectSection({
   groups: FilesPathGroup[];
   ghItems: SearchFileItem[] | undefined;
   showViewProject: boolean;
+  /** True for every project section after the first — see call site. */
+  bordered: boolean;
   onViewProject: () => void;
   onDrill: (group: { project: string; path: string }) => void;
   opener: FileOpener;
@@ -1359,23 +1394,32 @@ function ProjectSection({
   );
 
   return (
-    <div className="wsp-project">
-      <div className="wsp-project__head">
+    <div className={`wsp-project grid gap-4${bordered ? " border-t border-line pt-7" : ""}`}>
+      <div className="wsp-project__head flex flex-wrap items-baseline gap-x-2.5 gap-y-0.5 w-full sm:flex-nowrap">
         {/* The project name IS the "view project" control — a standing
             "view project →" beside every section repeated the same text
             down the page. The arrow affordance discloses on hover/focus
             (always visible on hover-less devices). */}
         {showViewProject ? (
-          <button type="button" className="wsp-project__label" onClick={onViewProject}>
+          <button
+            type="button"
+            className="wsp-project__label flex-[1_0_100%] sm:flex-none bg-none border-0 p-0 text-left cursor-pointer text-fg font-semibold text-[19px] leading-[1.3] [overflow-wrap:anywhere] hover:underline focus-visible:underline [text-underline-offset:4px] hover:decoration-muted-foreground focus-visible:decoration-muted-foreground [text-decoration-thickness:1px]"
+            onClick={onViewProject}
+          >
             {labelBody}
-            <span className="wsp-project__go" aria-hidden="true">
+            <span
+              className="wsp-project__go hidden ml-2 text-muted-foreground [@media(hover:none)]:inline"
+              aria-hidden="true"
+            >
               →
             </span>
           </button>
         ) : (
-          <span className="wsp-project__label">{labelBody}</span>
+          <span className="wsp-project__label flex-[1_0_100%] sm:flex-none text-fg font-semibold text-[19px] leading-[1.3] [overflow-wrap:anywhere]">
+            {labelBody}
+          </span>
         )}
-        <span className="wsp-group__meta">
+        <span className="wsp-group__meta text-muted-foreground text-[12px] whitespace-nowrap">
           {count} {count === 1 ? "file" : "files"}
           {lastUpdated ? ` · ${lastUpdatedLabel(lastUpdated, new Date())}` : ""}
         </span>
@@ -1404,10 +1448,12 @@ function GitHubSection({
   preview: PreviewHandlers;
 }) {
   return (
-    <div className="wsp-group">
-      <div className="wsp-group__head">
-        <span className="wsp-group__path">From GitHub</span>
-        <span className="wsp-group__meta">
+    <div className="wsp-group grid gap-2.5">
+      <div className="wsp-group__head flex items-baseline gap-2.5 w-full">
+        <span className="wsp-group__path font-semibold text-[13px] [overflow-wrap:anywhere]">
+          From GitHub
+        </span>
+        <span className="wsp-group__meta text-muted-foreground text-[12px] whitespace-nowrap">
           {items.length} {items.length === 1 ? "file" : "files"}
         </span>
       </div>
@@ -1444,15 +1490,25 @@ function PathGroupSection({
 }) {
   const paired = pairedShotKeys(group.recent);
   return (
-    <div className="wsp-group">
-      <button type="button" className="wsp-group__head" onClick={() => onDrill(group)}>
-        <span className="wsp-group__path">{group.path}</span>
-        <span className="wsp-group__meta">
+    <div className="wsp-group grid gap-2.5">
+      <button
+        type="button"
+        className="wsp-group__head group flex items-baseline gap-2.5 w-full bg-none border-0 p-0 text-left cursor-pointer text-inherit font-[inherit]"
+        onClick={() => onDrill(group)}
+      >
+        <span className="wsp-group__path font-semibold text-[13px] [overflow-wrap:anywhere]">
+          {group.path}
+        </span>
+        <span className="wsp-group__meta text-muted-foreground text-[12px] whitespace-nowrap">
           {group.count} {group.count === 1 ? "file" : "files"} ·{" "}
           {lastUpdatedLabel(group.lastUpdated, new Date())}
         </span>
-        <span className="wsp-group__viewall">
-          <span className="wsp-group__viewall-text">view all </span>→
+        {/* Hint, not a control (the whole head is the drill-in button) — disclosed
+            on hover/focus; opacity (not display) keeps it in the accessible name
+            and keeps the row's layout stable. Hover-less devices keep a compact
+            trailing chevron always visible instead (no hover reveal moment). */}
+        <span className="wsp-group__viewall ml-auto text-muted-foreground text-[12px] whitespace-nowrap opacity-0 transition-opacity duration-[120ms] ease-linear group-hover:opacity-100 group-hover:text-fg group-focus-visible:opacity-100 group-focus-visible:text-fg [@media(hover:none)]:opacity-100">
+          <span className="wsp-group__viewall-text [@media(hover:none)]:hidden">view all </span>→
         </span>
       </button>
       {group.recent.length > 0 && (

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1741,149 +1741,14 @@ button.wft-card__name:focus-visible {
   outline: none;
 }
 
-/* Screenshots-by-path tab (Task 6) — sits beside the `wft-` file table;
-   reuses its custom properties (--line/--muted/--fg/--panel/--mono) so the
-   two tabs read as one system. */
-/* Spacing thesis: bond a group head to its strip (10px), stack a project's
-   groups (16px), zone the toolbar away from content (32px), and separate
-   projects decisively (32px gap + 8px margin = 40px, --space-6). The
-   between-projects interval must read a clear step above within-project. */
-.wsp {
-  display: grid;
-  gap: 32px;
-}
-/* Overview project section — one level up from .wsp-group, so its head
-   reads slightly larger and its children (.wsp-group rows) sit stacked
-   underneath with the same rhythm as the rest of the page. */
-.wsp-project {
-  display: grid;
-  gap: 16px;
-}
-/* Each subsequent project opens with a full-width hairline: the section
-   boundary is structural, not just whitespace, so a project head can't be
-   misread as one more path row. */
-.wsp-project + .wsp-project {
-  border-top: 1px solid var(--line);
-  padding-top: 28px;
-}
-.wsp-project__head {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  width: 100%;
-}
-/* Rendered as a <button> on the overview (the name is the "view project"
-   control) and a plain <span> once that project is the active filter — the
-   reset below has to erase the button chrome for the first case. */
-.wsp-project__label {
-  background: none;
-  border: 0;
-  padding: 0;
-  color: inherit;
-  text-align: left;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: var(--weight-semibold);
-  /* A full scale step above the 13px path rows — at --text-body the two
-     levels blurred together and project names were easy to scan past. */
-  font-size: var(--text-h3);
-  line-height: 1.3;
-  overflow-wrap: anywhere;
-}
-span.wsp-project__label {
-  cursor: auto;
-}
-/* Pointer devices signal "the name is a link" with an underline on
-   hover/focus — an in-flow arrow reserved a dead gap between the name and
-   its meta at rest. The inline arrow exists only on hover-less devices
-   (below), where it is always visible and so never leaves a phantom gap. */
-.wsp-project__go {
-  display: none;
-  margin-left: 8px;
-  color: var(--muted);
-}
-button.wsp-project__label:hover,
-button.wsp-project__label:focus-visible {
-  text-decoration: underline;
-  text-underline-offset: 4px;
-  text-decoration-color: var(--muted);
-  text-decoration-thickness: 1px;
-}
-
-.wsp-group {
-  display: grid;
-  gap: 10px;
-}
-.wsp-group__head {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  width: 100%;
-  background: none;
-  border: 0;
-  padding: 0;
-  color: inherit;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-.wsp-group__path {
-  font-weight: var(--weight-semibold);
-  font-size: var(--text-meta);
-  overflow-wrap: anywhere;
-}
-.wsp-group__meta {
-  color: var(--muted);
-  font-size: var(--text-micro);
-  white-space: nowrap;
-}
-/* The whole group head is the drill-in button, so "view all →" is a hint,
-   not a control — disclose it on hover/focus instead of repeating the same
-   words on every row. Opacity (not display) keeps it in the accessible name
-   and keeps the row's layout stable. */
-.wsp-group__viewall {
-  margin-left: auto;
-  color: var(--muted);
-  font-size: var(--text-micro);
-  white-space: nowrap;
-  opacity: 0;
-  transition: opacity 120ms ease;
-}
-.wsp-group__head:hover .wsp-group__viewall,
-.wsp-group__head:focus-visible .wsp-group__viewall {
-  color: var(--fg);
-  opacity: 1;
-}
-/* Hover-less (touch) devices: no reveal moment exists, so keep a compact
-   trailing chevron per row — the standard tappable-row disclosure — and
-   drop the repeated words. */
-@media (hover: none) {
-  .wsp-group__viewall {
-    opacity: 1;
-  }
-  .wsp-group__viewall-text {
-    display: none;
-  }
-  .wsp-project__go {
-    display: inline;
-  }
-}
-
-/* Drill-in header: breadcrumb back-link bonded tight above the path title.
-   `justify-items: start` keeps the back button shrink-wrapped — as a bare
-   grid child it stretched full-width and its centered label floated
-   mid-page. */
-.wsp-drill__head {
-  display: grid;
-  gap: 8px;
-  justify-items: start;
-}
-.wsp-drill__heading {
-  margin: 0;
-  font-size: var(--text-body);
-  font-weight: var(--weight-semibold);
-  overflow-wrap: anywhere;
-}
+/* Screenshots-by-path tab (migration phase 3, surface 4). Most layout and
+   typography moved to Tailwind utilities directly on the markup in
+   ScreenshotsByPath.tsx — legacy `wsp-*` class names stay only as DOM/test
+   hooks there. What remains here is the custom-property-driven thumb/strip
+   sizing (aspect-ratio tracks each image's real proportions via a JS-set
+   `--wsp-ar`, and strip width is derived from `--wsp-strip-h`) and the
+   flip-aware hover-preview popover (#776) — both are subtle, JS-coupled
+   layout that stayed CSS deliberately rather than risk a utility rewrite. */
 
 /* Horizontal strip of a group's recent thumbs (overview). Shared height,
    width follows each shot's aspect ratio (set as --wsp-ar on load; 4/3
@@ -1904,13 +1769,6 @@ button.wsp-project__label:focus-visible {
   height: var(--wsp-strip-h);
   min-width: 56px;
   max-width: min(280px, 72vw);
-}
-
-/* Responsive grid of a full path's items (drill-in). */
-.wsp-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 12px;
 }
 
 /* Renders as an <a> when the destination is known at render time, and as a
@@ -1972,204 +1830,10 @@ button.wsp-project__label:focus-visible {
   aspect-ratio: 4 / 3;
 }
 
-.wsp-state {
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  padding: 1px 5px;
-  border-radius: 999px;
-  background: var(--panel);
-  border: 1px solid var(--line);
-  color: var(--muted);
-  font-size: var(--text-micro);
-  line-height: 1.4;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-/* Compact before/after pair indicator — shown only when the counterpart
-   actually sits in the same strip/grid (pairedShotKeys), replacing the old
-   full-width BEFORE/AFTER text pills that dominated 96px tiles. */
-.wsp-pair {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  display: grid;
-  place-items: center;
-  width: 18px;
-  height: 18px;
-  border-radius: 4px;
-  background: var(--panel);
-  border: 1px solid var(--line);
-  color: var(--muted);
-}
-.wsp-pair svg {
-  display: block;
-}
-
-/* Path/project filter — compact row above the grouped feed. Native select
-   + search input, same 36px box as the files tab filter so the two tabs
-   sit in one system. 16px type on small viewports so iOS doesn't zoom. */
-.wsp-filter {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: stretch;
-}
-.wsp-filter .wsp-filter__project {
-  width: auto;
-  flex: 0 1 16rem;
-  min-width: 12rem;
-  max-width: 100%;
-  min-height: 36px;
-  font-size: var(--text-body);
-  box-sizing: border-box;
-}
-.wsp-filter .wsp-filter__qwrap {
-  position: relative;
-  display: flex;
-  flex: 1 1 16rem;
-  min-width: 0;
-}
-.wsp-filter .wsp-filter__q {
-  flex: 1 1 auto;
-  min-width: 0;
-  min-height: 36px;
-  padding: 6px 12px;
-  font-size: var(--text-body);
-  border-radius: 6px;
-  box-sizing: border-box;
-}
-
-/* Path autocomplete under the filter input — same panel treatment as the
-   files tab's facet typeahead. */
-.wsp-suggest {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  right: 0;
-  z-index: 30;
-  margin: 0;
-  padding: 4px;
-  list-style: none;
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  box-shadow: 0 8px 24px rgb(0 0 0 / 0.25);
-  max-height: 280px;
-  overflow-y: auto;
-}
-.wsp-suggest__opt {
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
-  width: 100%;
-  padding: 6px 8px;
-  background: none;
-  border: 0;
-  border-radius: 4px;
-  color: inherit;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-.wsp-suggest__opt.is-active {
-  background: var(--bg);
-}
-.wsp-suggest__path {
-  font-size: var(--text-meta);
-  font-weight: var(--weight-semibold);
-  overflow-wrap: anywhere;
-}
-.wsp-suggest__count {
-  margin-left: auto;
-  color: var(--muted);
-  font-size: var(--text-micro);
-  white-space: nowrap;
-}
-
-/* Grouped / Recent segmented toggle at the filter row's end. */
-.wsp-toggle {
-  display: flex;
-  align-items: stretch;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  overflow: hidden;
-  box-sizing: border-box;
-}
-.wsp-toggle__opt {
-  min-height: 34px;
-  padding: 0 12px;
-  background: none;
-  border: 0;
-  color: var(--muted);
-  font: inherit;
-  font-size: var(--text-meta);
-  cursor: pointer;
-  white-space: nowrap;
-}
-.wsp-toggle__opt + .wsp-toggle__opt {
-  border-left: 1px solid var(--line);
-}
-.wsp-toggle__opt[aria-pressed="true"] {
-  background: var(--panel);
-  color: var(--fg);
-}
-.wsp-toggle__opt:hover,
-.wsp-toggle__opt:focus-visible {
-  color: var(--fg);
-}
-
-/* Inline GitHub glyphs beside repo labels and PR/issue text. */
-.wsp-ghicon {
-  display: inline-block;
-  vertical-align: -1px;
-  margin-right: 5px;
-  flex: none;
-}
-.wsp-state .wsp-ghicon,
-.wsp-preview__pr .wsp-ghicon {
-  margin-right: 2px;
-}
-/* Both toggle groups wrap as one cluster — independently they orphan
-   "Merged only" onto its own row at intermediate widths. */
-.wsp-filter__toggles {
-  display: flex;
-  flex: none;
-  gap: 8px;
-  align-items: stretch;
-}
-.wsp-filter__skel {
-  display: flex;
-  align-items: center;
-  padding: 0 12px;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  background: var(--bg);
-  box-sizing: border-box;
-}
-@media (min-width: 640px) {
-  .wsp-filter .wsp-filter__project,
-  .wsp-filter .wsp-filter__q {
-    font-size: var(--text-meta);
-  }
-}
-/* Long project labels (owner/repo) can't share one line with the meta and
-   action at phone widths — give the label the full first line and let
-   meta + "view project" settle underneath instead of stranding the label
-   below its own icon. */
-@media (max-width: 639px) {
-  .wsp-project__head {
-    flex-wrap: wrap;
-    row-gap: 2px;
-  }
-  .wsp-project__label {
-    flex: 1 0 100%;
-  }
-}
-
 /* Hover preview — hover-capable pointers only. pointer-events none so
-   scanning the strip doesn't get stuck on the popover. */
+   scanning the strip doesn't get stuck on the popover. Position (left/top)
+   is computed in JS (shotPreviewPosition, flip-aware, #776) and applied as
+   an inline style — this block is only the popover's static chrome. */
 .wsp-preview {
   position: fixed;
   z-index: 40;
@@ -2267,4 +1931,18 @@ button.wsp-project__label:focus-visible {
   .wsp-preview {
     display: none;
   }
+}
+
+/* Inline GitHub glyphs beside repo labels and PR/issue text — kept as CSS
+   because the two contextual overrides key off surrounding component
+   classes that also stayed CSS above (.wsp-state, .wsp-preview__pr). */
+.wsp-ghicon {
+  display: inline-block;
+  vertical-align: -1px;
+  margin-right: 5px;
+  flex: none;
+}
+.wsp-state .wsp-ghicon,
+.wsp-preview__pr .wsp-ghicon {
+  margin-right: 2px;
 }


### PR DESCRIPTION
Fourth phase-3 surface (follows #787/#789/#791; plan in `.context/2026-08-22-tailwind-shadcn-migration-plan.md`, local doc).

## What

- `ScreenshotsByPath.tsx` + `screenshots.astro`: the `.wsp*` families (project/group/drill layout, grid, filter + suggestions, segmented toggle, empty states, skeletons) moved to Tailwind utilities; legacy class names stay as DOM hooks. The `.wsp-project + .wsp-project` hairline became an index-based `bordered` prop (React map output has no sibling selector); hover/focus disclosure uses `group-hover:`/`group-focus-visible:`; `@media (hover:none)` via arbitrary variant.
- **Deliberately kept as CSS**: tile/thumb aspect-ratio chrome (driven by JS-set `--wsp-ar`/`--wsp-strip-h` custom properties) and the entire flip-aware hover-preview block (#776) — placement logic and its CSS untouched.
- Shared rules (`ws-empty-state`, `ws-skel`, `wft-*`) untouched — they serve other surfaces.

## Verification

- `astro build`, lint green; screenshots vitest suites 49/49 (includes the #776 placement tests).
- Visual audit against the local stack with a signed-in session on the migrated DOM: layout, filter bar, mode pills, group rhythm all at parity — including one regression caught and fixed in audit (the root `.wsp` grid/32px-gap rule was deleted without its replacement utilities, collapsing between-project spacing).
- Hover-preview could not be exercised locally (fixture thumbnails are broken images without cdn-cgi transforms; the preview never mounts) — logic is untouched and unit-tested, but worth a prod hover after merge.

Screenshot attaches via the managed comment.
