### PR TITLE
perf: kill screenshots-page search fan-out, fix auth rate-limit handling

### DIFF
--- a/apps/api/src/file-metadata-facets.test.ts
+++ b/apps/api/src/file-metadata-facets.test.ts
@@ -10,6 +10,7 @@ import {
   groupObjectsByPath,
   projectLabelFromMeta,
   BY_PATH_CATALOG_LIMIT,
+  BY_PATH_CATALOG_RECENT_LIMIT,
   BY_PATH_GROUP_LIMIT,
   BY_PATH_LATEST_LIMIT,
   BY_PATH_RECENT_LIMIT,
@@ -197,8 +198,14 @@ describe("groupObjectsByPath", () => {
       { project: "Other", path: "/home", count: 1, lastUpdated: at(2), recent: ["b.png"] },
     ]);
     expect(result.catalog).toEqual([
-      { project: "Other", path: "/settings", count: 2, lastUpdated: at(3) },
-      { project: "Other", path: "/home", count: 1, lastUpdated: at(2) },
+      {
+        project: "Other",
+        path: "/settings",
+        count: 2,
+        lastUpdated: at(3),
+        recent: ["c.png", "a.png"],
+      },
+      { project: "Other", path: "/home", count: 1, lastUpdated: at(2), recent: ["b.png"] },
     ]);
     expect(result.projects).toEqual([{ label: "Other", count: 3, lastUpdated: at(3) }]);
   });
@@ -279,6 +286,38 @@ describe("groupObjectsByPath", () => {
     expect(result.catalog.some((e) => e.project === "acme/api" && e.path === "/admin")).toBe(true);
     expect(result.projects.map((p) => p.label).sort()).toEqual(["acme/api", "acme/web"]);
     expect(result.projects.find((p) => p.label === "acme/api")?.count).toBe(1);
+  });
+
+  it("gives every catalog entry a short thumb strip, including past the group cap", async () => {
+    const rows = [
+      ...Array.from({ length: BY_PATH_GROUP_LIMIT }, (_, i) => ({
+        workspace: "acme",
+        key: `web-${i}.png`,
+        meta: { path: `/web-${i}` },
+        at: at(i + 10),
+      })),
+      ...Array.from({ length: BY_PATH_CATALOG_RECENT_LIMIT + 1 }, (_, i) => ({
+        workspace: "acme",
+        key: `old-${i}.png`,
+        meta: { path: "/old" },
+        at: at(i),
+      })),
+    ];
+    const result = await groupObjectsByPath(timedDb(rows), "acme");
+    expect(result.truncated).toBe(true);
+    expect(result.groups.map((g) => g.path)).not.toContain("/old");
+    const entry = result.catalog.find((e) => e.path === "/old")!;
+    expect(entry.count).toBe(BY_PATH_CATALOG_RECENT_LIMIT + 1);
+    // Newest-first, capped at the shorter catalog strip.
+    expect(entry.recent).toEqual([
+      `old-${BY_PATH_CATALOG_RECENT_LIMIT}.png`,
+      ...Array.from(
+        { length: BY_PATH_CATALOG_RECENT_LIMIT - 1 },
+        (_, i) => `old-${BY_PATH_CATALOG_RECENT_LIMIT - 1 - i}.png`,
+      ),
+    ]);
+    // Thumbed groups keep their longer strip; the catalog twin is capped.
+    expect(result.catalog.find((e) => e.path === "/web-0")!.recent).toEqual(["web-0.png"]);
   });
 
   it("caps the catalog at BY_PATH_CATALOG_LIMIT", async () => {

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -705,6 +705,12 @@ export const BY_PATH_GROUP_LIMIT = 50;
 /** Recent object keys returned per path group. */
 export const BY_PATH_RECENT_LIMIT = 6;
 /**
+ * Recent object keys returned per catalog entry — a shorter strip than the
+ * groups', so every path can render thumbs without the page fetching one
+ * search per group.
+ */
+export const BY_PATH_CATALOG_RECENT_LIMIT = 3;
+/**
  * Max unique (project, path) pairs in the screenshots catalog. Larger than
  * the thumbed-group cap so the filter bar can still name older paths.
  */
@@ -720,8 +726,11 @@ export type PathGroup = {
   recent: string[];
 };
 
-/** Unique (project, path) without thumbs — same fields as a group minus `recent`. */
-export type PathCatalogEntry = Omit<PathGroup, "recent">;
+/**
+ * Unique (project, path) — same fields as a group, with a shorter thumb strip
+ * (BY_PATH_CATALOG_RECENT_LIMIT keys).
+ */
+export type PathCatalogEntry = PathGroup;
 
 /** One entry in the flat newest-first feed (the "Recent" view). */
 export type LatestPathObject = {
@@ -738,9 +747,11 @@ export type ProjectSummary = { label: string; count: number; lastUpdated: string
  * query (spec: docs/superpowers/specs/2026-08-11-screenshots-project-grouping-design.md).
  * Groups come back most-recently-active first, each carrying its newest
  * BY_PATH_RECENT_LIMIT keys and total count. `catalog` is the same unique
- * pairs without thumbs, up to BY_PATH_CATALOG_LIMIT, so the page can filter
- * by path without a second query. `projects` summarizes the catalog by
- * project label, most-recent first.
+ * pairs, up to BY_PATH_CATALOG_LIMIT, with a shorter
+ * BY_PATH_CATALOG_RECENT_LIMIT strip — so the page can filter by path AND
+ * render thumbs for every group off this one query, with no per-group
+ * follow-up search. `projects` summarizes the catalog by project label,
+ * most-recent first.
  *
  * One flat scan of the `path` rows (seeked via `file_metadata_lookup_idx
  * (workspace, meta_key, meta_value)`), with the three project-label keys
@@ -836,12 +847,15 @@ export async function groupObjectsByPath(
       if (catalog.length === BY_PATH_CATALOG_LIMIT) {
         catalogTruncated = true;
       } else {
-        entry = { project, path: row.path, count: 0, lastUpdated: row.updated_at };
+        entry = { project, path: row.path, count: 0, lastUpdated: row.updated_at, recent: [] };
         catalogByKey.set(groupKey, entry);
         catalog.push(entry);
       }
     }
-    if (entry) entry.count += 1;
+    if (entry) {
+      entry.count += 1;
+      if (entry.recent.length < BY_PATH_CATALOG_RECENT_LIMIT) entry.recent.push(row.object_key);
+    }
 
     let group = byKey.get(groupKey);
     if (!group) {

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -1515,6 +1515,31 @@ describe("POST /admin-ui/users/:userId/ban", () => {
     expect(getRevokedBinds()?.[1]).toBe("u-target");
   });
 
+  it("propagates an auth worker 429 on ban as 429 auth_rate_limited", async () => {
+    const auth = stubAuth((req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify({ session: {}, user: ADMIN_USER }), { status: 200 });
+      }
+      // Better Auth's rate limiter emits `X-Retry-After`.
+      return new Response(null, { status: 429, headers: { "x-retry-after": "30" } });
+    });
+    const env = { AUTH: auth } as unknown as Env;
+    const res = await app().request(
+      "/admin-ui/users/u-target/ban",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", cookie: "session=abc" },
+        body: JSON.stringify({}),
+      },
+      env,
+    );
+    expect(res.status).toBe(429);
+    expect((await res.json()) as { error?: { code?: string } }).toMatchObject({
+      error: { code: "auth_rate_limited", details: { retry_after: 30 } },
+    });
+  });
+
   it("rejects self-ban without calling the auth worker", async () => {
     const { env, banCalls } = banEnv(ADMIN_USER);
     const res = await app().request(

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -93,10 +93,12 @@ async function proxyAdminAuth(
   body: unknown,
 ): Promise<{ status: number; payload: unknown }> {
   const headers = new Headers({ "content-type": "application/json" });
-  const cookie = req.headers.get("cookie");
-  const authorization = req.headers.get("authorization");
-  if (cookie) headers.set("cookie", cookie);
-  if (authorization) headers.set("authorization", authorization);
+  // Client IP headers included so Better Auth rate-limits per caller (same
+  // convention as session-auth.ts).
+  for (const name of ["cookie", "authorization", "cf-connecting-ip", "x-forwarded-for"]) {
+    const value = req.headers.get(name);
+    if (value) headers.set(name, value);
+  }
 
   let response: Response;
   try {

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -47,6 +47,7 @@ import {
   subscriptionForOrg,
 } from "../org-workspaces";
 import {
+  authRateLimitError,
   requireAdminUser,
   requireSessionUser,
   sessionAuth,
@@ -113,6 +114,9 @@ async function proxyAdminAuth(
       cause: err,
     });
   }
+  // Rate limiting is the caller's problem, not an outage — surface it before
+  // the status → AppError mapping turns it into a 503.
+  if (response.status === 429) throw authRateLimitError(response);
   return { status: response.status, payload: await response.json().catch(() => null) };
 }
 

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1921,6 +1921,39 @@ describe("GET /me/workspaces/:name/files/by-path", () => {
     expect(body.projects.map((p) => p.label).sort()).toEqual(["acme/web", "x.dev"]);
   });
 
+  it("gives every catalog entry a thumb strip, unenriched past the thumbed-group cap", async () => {
+    const db = metadataDb([
+      ...Array.from({ length: 50 }, (_, i) => ({
+        workspace: "acme",
+        key: `new-${i}.png`,
+        meta: { path: `/new-${i}`, state: "after" },
+      })),
+      { workspace: "acme", key: "old.png", meta: { path: "/old", state: "after" } },
+    ]);
+    const env = memberEnv({ workspace: "acme", db, bucket: new FakeR2Bucket(), record: R2_RECORD });
+    const res = await app().request("/me/workspaces/acme/files/by-path", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      groups: { path: string }[];
+      catalog: {
+        path: string;
+        recent: { key: string; url: string | null; embedUrl: string | null; state?: string }[];
+      }[];
+      truncated: boolean;
+    };
+    expect(body.truncated).toBe(true);
+    // Rows land newest-last in the fake DB, so "/old" is the group that fell
+    // off the thumbed cap — it still gets a strip, from the catalog.
+    const dropped = body.catalog.find(
+      (entry) => !body.groups.some((group) => group.path === entry.path),
+    )!;
+    expect(dropped.recent).toHaveLength(1);
+    expect(dropped.recent[0]).toMatchObject({ url: expect.stringContaining("https://") });
+    // Enrichment stays scoped to the thumbed groups + `latest`: no extra D1.
+    expect(dropped.recent[0]).not.toHaveProperty("state");
+    expect(dropped.recent[0]).not.toHaveProperty("updatedAt");
+  });
+
   it("returns a flat latest feed with project, path, and upload time per shot", async () => {
     const db = metadataDb([
       {

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -197,11 +197,14 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // page's single overview query (spec: docs/superpowers/specs/
   // 2026-08-10-screenshots-by-path-design.md). Drill-in reuses the sibling
   // `files/search?meta.path=…` route; this one answers "which paths, how
-  // recent, first few keys" plus a thumbless `catalog` of every unique
-  // (project, path) so the page can filter without a second query. `state`
-  // and `gh.kind`/`gh.number` are the metadata keys enriched — the page
-  // badges before/after and names the PR in the hover preview, and nothing
-  // else leaks into the payload.
+  // recent, first few keys" plus a `catalog` of every unique (project, path)
+  // — each with a shorter thumb strip of its own — so the page can filter AND
+  // render every group's thumbs without a second query. `state` and
+  // `gh.kind`/`gh.number` are the metadata keys enriched — the page badges
+  // before/after and names the PR in the hover preview, and nothing else
+  // leaks into the payload. Enrichment stays scoped to the thumbed groups'
+  // keys plus `latest`, so the catalog's growth never widens the two D1
+  // enrichment queries; catalog-only strips carry key/url/embedUrl alone.
   .get("/:workspace/files/by-path", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
     const record = c.get("workspace");
     const name = c.get("workspaceName");
@@ -251,7 +254,17 @@ export const workspaceFiles = new Hono<DualAuthVars>()
         lastUpdated: group.lastUpdated,
         recent: group.recent.map(shotItem),
       })),
-      catalog,
+      // Every catalog entry carries its own (shorter) strip, so the page can
+      // render thumbs for groups past the thumbed cap without fetching one
+      // search per group. Those keys are NOT metadata-enriched (see above):
+      // `objectPublicUrls` is pure computation, so this costs no extra D1.
+      catalog: catalog.map((entry) => ({
+        project: entry.project,
+        path: entry.path,
+        count: entry.count,
+        lastUpdated: entry.lastUpdated,
+        recent: entry.recent.map(shotItem),
+      })),
       projects,
       // Flat newest-first feed (the "Recent" view) — same item shape as
       // `recent`, plus which (project, path) each shot belongs to.

--- a/apps/api/src/session-auth.test.ts
+++ b/apps/api/src/session-auth.test.ts
@@ -114,6 +114,43 @@ describe("sessionAuth", () => {
     expect(res.status).toBe(401);
   });
 
+  it("forwards the client IP headers to the auth worker", async () => {
+    let seen: Headers | undefined;
+    const auth = stubAuth((req) => {
+      seen = req.headers;
+      return new Response(JSON.stringify(null), { status: 200 });
+    });
+    await appWith(auth).request(
+      "/whoami",
+      {
+        headers: { "cf-connecting-ip": "203.0.113.7", "x-forwarded-for": "203.0.113.7, 10.0.0.1" },
+      },
+      env(auth),
+    );
+    expect(seen?.get("cf-connecting-ip")).toBe("203.0.113.7");
+    expect(seen?.get("x-forwarded-for")).toBe("203.0.113.7, 10.0.0.1");
+  });
+
+  it("propagates an auth worker 429 as 429 auth_rate_limited with retry_after", async () => {
+    const auth = stubAuth(
+      () => new Response(null, { status: 429, headers: { "retry-after": "42" } }),
+    );
+    const res = await appWith(auth).request("/whoami", {}, env(auth));
+    expect(res.status).toBe(429);
+    expect((await res.json()) as { error?: { code?: string } }).toMatchObject({
+      error: { code: "auth_rate_limited", details: { retry_after: 42 } },
+    });
+  });
+
+  it("propagates an auth worker 429 without Retry-After as a bare 429", async () => {
+    const auth = stubAuth(() => new Response(null, { status: 429 }));
+    const res = await appWith(auth).request("/whoami", {}, env(auth));
+    expect(res.status).toBe(429);
+    expect((await res.json()) as { error?: { code?: string } }).toMatchObject({
+      error: { code: "auth_rate_limited" },
+    });
+  });
+
   it("allows requireAdminUser for a multi-role user (comma-separated role)", async () => {
     const user = { id: "u3", email: "admin2@b.com", name: "Admin2", role: "admin,support" };
     const auth = stubAuth(

--- a/apps/api/src/session-auth.test.ts
+++ b/apps/api/src/session-auth.test.ts
@@ -132,13 +132,25 @@ describe("sessionAuth", () => {
   });
 
   it("propagates an auth worker 429 as 429 auth_rate_limited with retry_after", async () => {
+    // Better Auth's rate limiter emits `X-Retry-After` (not `Retry-After`).
     const auth = stubAuth(
-      () => new Response(null, { status: 429, headers: { "retry-after": "42" } }),
+      () => new Response(null, { status: 429, headers: { "x-retry-after": "42" } }),
     );
     const res = await appWith(auth).request("/whoami", {}, env(auth));
     expect(res.status).toBe(429);
     expect((await res.json()) as { error?: { code?: string } }).toMatchObject({
       error: { code: "auth_rate_limited", details: { retry_after: 42 } },
+    });
+  });
+
+  it("falls back to a standard Retry-After header on a 429", async () => {
+    const auth = stubAuth(
+      () => new Response(null, { status: 429, headers: { "retry-after": "7" } }),
+    );
+    const res = await appWith(auth).request("/whoami", {}, env(auth));
+    expect(res.status).toBe(429);
+    expect((await res.json()) as { error?: { code?: string } }).toMatchObject({
+      error: { code: "auth_rate_limited", details: { retry_after: 7 } },
     });
   });
 

--- a/apps/api/src/session-auth.ts
+++ b/apps/api/src/session-auth.ts
@@ -5,7 +5,12 @@
  * (bearer tokens); this is the seam for session-authenticated admin UI
  * endpoints later phases build on.
  */
-import { ForbiddenError, ServiceUnavailableError, UnauthorizedError } from "@uploads/errors";
+import {
+  ForbiddenError,
+  RateLimitedError,
+  ServiceUnavailableError,
+  UnauthorizedError,
+} from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
 
 /** Minimal shape of Better Auth's `get-session` response body. */
@@ -50,10 +55,12 @@ export const sessionAuth: MiddlewareHandler<SessionVars> = async (c, next) => {
 
 async function resolveSessionUser(env: Env, req: Request): Promise<SessionUser | null> {
   const headers = new Headers();
-  const cookie = req.headers.get("cookie");
-  const authorization = req.headers.get("authorization");
-  if (cookie) headers.set("cookie", cookie);
-  if (authorization) headers.set("authorization", authorization);
+  // Client IP headers ride along so Better Auth's rate limiter buckets per
+  // caller instead of lumping every API-originated get-session into one key.
+  for (const name of ["cookie", "authorization", "cf-connecting-ip", "x-forwarded-for"]) {
+    const value = req.headers.get(name);
+    if (value) headers.set(name, value);
+  }
 
   try {
     const response = await env.AUTH.fetch(`${AUTH_INTERNAL_ORIGIN}/api/auth/get-session`, {
@@ -62,6 +69,15 @@ async function resolveSessionUser(env: Env, req: Request): Promise<SessionUser |
     // Better Auth returns a normal no-session result as 200 + null. An
     // explicitly unauthorized response also remains a normal signed-out case.
     if (response.status === 401) return null;
+    // A rate-limited auth worker is not an outage: surface it as a 429 the
+    // client can back off from, carrying the upstream Retry-After when given.
+    if (response.status === 429) {
+      const retryAfter = Number(response.headers.get("retry-after"));
+      throw new RateLimitedError("auth service rate limited this client", {
+        code: "auth_rate_limited",
+        ...(Number.isFinite(retryAfter) && retryAfter > 0 ? { retryAfterSeconds: retryAfter } : {}),
+      });
+    }
     if (!response.ok) {
       throw new ServiceUnavailableError("auth service is unavailable", {
         code: "auth_session_unavailable",
@@ -84,7 +100,7 @@ async function resolveSessionUser(env: Env, req: Request): Promise<SessionUser |
     if (body.user.banned === true) return null;
     return body.user;
   } catch (err) {
-    if (err instanceof ServiceUnavailableError) throw err;
+    if (err instanceof ServiceUnavailableError || err instanceof RateLimitedError) throw err;
     throw new ServiceUnavailableError("auth service is unavailable", {
       code: "auth_session_unavailable",
     });

--- a/apps/api/src/session-auth.ts
+++ b/apps/api/src/session-auth.ts
@@ -42,6 +42,20 @@ export type SessionVars = {
 const AUTH_INTERNAL_ORIGIN = "https://auth.internal";
 
 /**
+ * Maps a 429 from the auth worker to a RateLimitedError. Better Auth's rate
+ * limiter emits `X-Retry-After` (seconds); the standard `Retry-After` is
+ * accepted as a fallback for any intermediary that rewrites it.
+ */
+export function authRateLimitError(response: Response): RateLimitedError {
+  const raw = response.headers.get("x-retry-after") ?? response.headers.get("retry-after");
+  const retryAfter = Number(raw);
+  return new RateLimitedError("auth service rate limited this client", {
+    code: "auth_rate_limited",
+    ...(Number.isFinite(retryAfter) && retryAfter > 0 ? { retryAfterSeconds: retryAfter } : {}),
+  });
+}
+
+/**
  * Resolves the caller's session via the AUTH binding and sets `sessionUser`
  * (null only when there is genuinely no valid session). Auth binding outages
  * and malformed successful responses stay distinct as 503s: treating either
@@ -70,14 +84,8 @@ async function resolveSessionUser(env: Env, req: Request): Promise<SessionUser |
     // explicitly unauthorized response also remains a normal signed-out case.
     if (response.status === 401) return null;
     // A rate-limited auth worker is not an outage: surface it as a 429 the
-    // client can back off from, carrying the upstream Retry-After when given.
-    if (response.status === 429) {
-      const retryAfter = Number(response.headers.get("retry-after"));
-      throw new RateLimitedError("auth service rate limited this client", {
-        code: "auth_rate_limited",
-        ...(Number.isFinite(retryAfter) && retryAfter > 0 ? { retryAfterSeconds: retryAfter } : {}),
-      });
-    }
+    // client can back off from, carrying the upstream retry hint when given.
+    if (response.status === 429) throw authRateLimitError(response);
     if (!response.ok) {
       throw new ServiceUnavailableError("auth service is unavailable", {
         code: "auth_session_unavailable",

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -778,6 +778,14 @@ function buildAuth(
     rateLimit: {
       enabled: isProduction && env.AUTH_RATE_LIMIT_DISABLED !== "true",
       storage: "database",
+      customRules: {
+        // get-session is a cheap read hit once per API request (the api
+        // worker's sessionAuth middleware calls it over the service binding
+        // per request), so its budget is sized to page-request volume, not
+        // the 100/min default meant for auth mutations. Keyed per client IP —
+        // the api worker forwards cf-connecting-ip/x-forwarded-for.
+        "/get-session": { window: 60, max: 600 },
+      },
     },
     trustedOrigins: (request) => {
       const origin = request?.headers.get("origin");

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -6,6 +6,10 @@
  * = the existing `files/search?meta.path=…` route. Files without `path`
  * metadata never appear here — the empty state says how to get them.
  *
+ * Every rendered group's thumb strip comes from that one overview response:
+ * its `catalog` carries a short strip per (project, path), so filtering past
+ * the thumbed-group cap no longer fans out into one search request per group.
+ *
  * SSR-first (plan 006, following plan 005's `WorkspaceFileTable` shape):
  * when the request carries a session, `screenshots.astro` server-fetches the
  * by-path overview + workspace summary and renders this component with no
@@ -35,7 +39,6 @@ import {
   type GithubTitleMap,
   type LatestShotItem,
   type PathCatalogEntry,
-  type PathGroupItem,
   type ProjectSummary,
   type SearchFileItem,
 } from "../lib/api-client";
@@ -45,7 +48,6 @@ import { thumbUrl } from "../lib/thumb-url";
 import { onSession } from "../lib/account-shell";
 import { makeFileOpener, newTabLinkProps, type FileOpener } from "../lib/file-opener";
 import {
-  backfillTargets,
   filterCatalog,
   focusIsKeyboardDriven,
   groupsFromCatalog,
@@ -61,7 +63,6 @@ import {
   shotKindFromKey,
   shotPreviewCaption,
   shotPreviewPosition,
-  shotsFromSearchItems,
   type ScreenshotsFeed,
   type ScreenshotsView,
   type ShotPreviewBox,
@@ -664,11 +665,6 @@ function ScreenshotsByPathInner({
   const [drill, setDrill] = useState<DrillState>({ status: "idle" });
   const [drillRetryNonce, setDrillRetryNonce] = useState(0);
   const [ghState, setGhState] = useState<DrillState>({ status: "loading" });
-  // Thumb strips fetched for groups past the overview's thumbed cap, keyed
-  // `project\0path`. In-flight keys live in the ref so a re-render mid-fetch
-  // doesn't fire a duplicate search.
-  const [backfill, setBackfill] = useState<Record<string, PathGroupItem[]>>({});
-  const backfillStarted = useRef(new Set<string>());
   // Scope of the last overview fetch that is allowed to replace the page with
   // the full-page skeleton. `view.merged` is deliberately excluded: toggling
   // Merged only refetches the same workspace, and dropping a ready overview
@@ -811,52 +807,6 @@ function ScreenshotsByPathInner({
     view.merged,
     drillRetryNonce,
   ]);
-
-  // Thumb backfill for groups past the overview's 50-group thumbed cap:
-  // filtering (especially by project) surfaces catalog paths whose group got
-  // no `recent` strip, which used to render as bare headings. Fetch those
-  // strips lazily through the same search route the drill-in uses, capped
-  // per pass and cached per (project, path) for the life of the mount. A
-  // failed search caches an empty strip — the heading-only fallback — rather
-  // than retrying on every keystroke.
-  useEffect(() => {
-    if (overview.status !== "ready" || view.feed !== "grouped" || view.path) return;
-    const matching = groupsFromCatalog(
-      filterCatalog(overview.catalog, { project: view.project, q: view.q }),
-      overview.groups,
-    );
-    const targets = backfillTargets(matching, backfillStarted.current);
-    if (targets.length === 0) return;
-    const projectsByPath = new Map<string, string[]>();
-    for (const target of targets) {
-      backfillStarted.current.add(`${target.project}\0${target.path}`);
-      const projects = projectsByPath.get(target.path);
-      if (projects) projects.push(target.project);
-      else projectsByPath.set(target.path, [target.project]);
-    }
-    onSession(() => {
-      for (const [path, projects] of projectsByPath) {
-        void searchWorkspaceFiles(apiOrigin, workspace, [{ key: "path", value: path }], {
-          collapsePromoted: true,
-        }).then((result) => {
-          // No cancellation guard: the cache is keyed by (project, path)
-          // independent of the current view, so a late response is never
-          // stale — dropping it would strand its group (started, no strip).
-          const items = result.kind === "ok" ? result.items : [];
-          setBackfill((prev) => {
-            const next = { ...prev };
-            for (const project of projects) {
-              next[`${project}\0${path}`] = shotsFromSearchItems(items, project);
-            }
-            return next;
-          });
-        });
-      }
-    });
-    // `backfill` in the deps chains passes: each resolved batch re-runs the
-    // effect for the next ≤12 targets until none remain (the started set
-    // keeps every pass strictly new, so the chain terminates).
-  }, [apiOrigin, workspace, overview, backfill, view.project, view.q, view.feed, view.path]);
 
   useEffect(() => {
     const dismiss = () => {
@@ -1254,11 +1204,7 @@ function ScreenshotsByPathInner({
     project: view.project,
     q: view.q,
   });
-  const matchingGroups = groupsFromCatalog(matchingCatalog, overview.groups).map((group) =>
-    group.recent.length > 0
-      ? group
-      : { ...group, recent: backfill[`${group.project}\0${group.path}`] ?? [] },
-  );
+  const matchingGroups = groupsFromCatalog(matchingCatalog, overview.groups);
   const qTrim = view.q.trim();
   const filtering = qTrim !== "" || view.project !== "";
   // Path query hides GitHub strips that aren't path-grouped; project-only

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -541,6 +541,7 @@ describe("getWorkspaceFilesByPath", () => {
     path: "/settings",
     count: 2,
     lastUpdated: "2026-08-09T21:14:03.000Z",
+    recent: [{ key: "shots/a.png", url: "https://s.example/a.png", embedUrl: null }],
   };
 
   it("returns groups, catalog, and projects on a well-formed response", async () => {
@@ -601,6 +602,25 @@ describe("getWorkspaceFilesByPath", () => {
     expect(result.kind === "ok" && result.latest).toEqual([]);
   });
 
+  it("defaults a catalog entry's strip to empty when an older API omits it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          groups: [GROUP],
+          catalog: [{ project: "acme/web", path: "/older", count: 1, lastUpdated: "1" }],
+          projects: [PROJECT],
+          truncated: false,
+          catalogTruncated: false,
+        }),
+      ),
+    );
+    const result = await getWorkspaceFilesByPath("https://api.uploads.sh", "acme");
+    expect(result.kind === "ok" && result.catalog).toEqual([
+      { project: "acme/web", path: "/older", count: 1, lastUpdated: "1", recent: [] },
+    ]);
+  });
+
   it("synthesizes a catalog from groups when an older API omits it", async () => {
     vi.stubGlobal(
       "fetch",
@@ -610,7 +630,8 @@ describe("getWorkspaceFilesByPath", () => {
     expect(result).toEqual({
       kind: "ok",
       groups: [GROUP],
-      catalog: [CATALOG],
+      // Synthesized entries carry the group's own (longer) strip.
+      catalog: [{ ...CATALOG, recent: GROUP.recent }],
       projects: [PROJECT],
       latest: [],
       truncated: true,
@@ -624,7 +645,7 @@ describe("getWorkspaceFilesByPath", () => {
       vi.fn(async () =>
         Response.json({
           groups: [GROUP],
-          catalog: [{ path: 1 }],
+          catalog: [{ ...CATALOG, recent: [{ key: 1 }] }],
           projects: [PROJECT],
           truncated: false,
         }),

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -902,12 +902,17 @@ export interface FilesPathGroup {
   recent: PathGroupItem[];
 }
 
-/** One unique (project, path) pair without thumbs — the filter-bar catalog. */
+/**
+ * One unique (project, path) pair — the filter-bar catalog. Carries a short
+ * thumb strip of its own (shorter than a thumbed group's), so groups past the
+ * overview's thumbed cap still render thumbs off this one response.
+ */
 export interface PathCatalogEntry {
   project: string;
   path: string;
   count: number;
   lastUpdated: string;
+  recent: PathGroupItem[];
 }
 
 /** One shot in the flat newest-first feed (the "Recent" view). */
@@ -981,8 +986,17 @@ function isPathCatalogEntry(value: unknown): value is PathCatalogEntry {
     typeof entry.project === "string" &&
     typeof entry.path === "string" &&
     typeof entry.count === "number" &&
-    typeof entry.lastUpdated === "string"
+    typeof entry.lastUpdated === "string" &&
+    // `recent` is additive (older API deploys omit it) — normalized to []
+    // below, so those entries just render as heading-only groups.
+    (entry.recent === undefined ||
+      (Array.isArray(entry.recent) && entry.recent.every(isPathGroupItem)))
   );
+}
+
+/** Normalize a parsed catalog entry, filling in a missing (older-API) strip. */
+function catalogEntry(entry: PathCatalogEntry): PathCatalogEntry {
+  return entry.recent ? entry : { ...entry, recent: [] };
 }
 
 function isLatestShotItem(value: unknown): value is LatestShotItem {
@@ -997,11 +1011,12 @@ function isLatestShotItem(value: unknown): value is LatestShotItem {
 
 /** Derive a catalog from thumbed groups when an older API omitted it. */
 function catalogFromGroups(groups: FilesPathGroup[]): PathCatalogEntry[] {
-  return groups.map(({ project, path, count, lastUpdated }) => ({
+  return groups.map(({ project, path, count, lastUpdated, recent }) => ({
     project,
     path,
     count,
     lastUpdated,
+    recent,
   }));
 }
 
@@ -1064,7 +1079,7 @@ export async function getWorkspaceFilesByPath(
   return {
     kind: "ok",
     groups: body.groups,
-    catalog: body.catalog,
+    catalog: body.catalog.map(catalogEntry),
     projects: body.projects,
     latest,
     truncated: body.truncated,

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  backfillTargets,
   filterCatalog,
   focusIsKeyboardDriven,
   groupsFromCatalog,
@@ -16,7 +15,6 @@ import {
   shotKindFromKey,
   shotPreviewCaption,
   shotPreviewPosition,
-  shotsFromSearchItems,
 } from "./workspace-screenshots";
 
 describe("pairedShotKeys", () => {
@@ -308,10 +306,22 @@ describe("filterCatalog", () => {
 });
 
 describe("groupsFromCatalog", () => {
-  it("keeps thumbed groups and fills catalog-only paths with empty recent", () => {
+  it("prefers a thumbed group's strip and keeps the catalog's own otherwise", () => {
     const catalog = [
-      { project: "acme/web", path: "/admin", count: 2, lastUpdated: "2" },
-      { project: "acme/web", path: "/older", count: 1, lastUpdated: "1" },
+      {
+        project: "acme/web",
+        path: "/admin",
+        count: 2,
+        lastUpdated: "2",
+        recent: [{ key: "short.png", url: null, embedUrl: null }],
+      },
+      {
+        project: "acme/web",
+        path: "/older",
+        count: 1,
+        lastUpdated: "1",
+        recent: [{ key: "o.png", url: null, embedUrl: null }],
+      },
     ];
     const groups = [
       {
@@ -322,10 +332,7 @@ describe("groupsFromCatalog", () => {
         recent: [{ key: "a.png", url: null, embedUrl: null }],
       },
     ];
-    expect(groupsFromCatalog(catalog, groups)).toEqual([
-      groups[0],
-      { project: "acme/web", path: "/older", count: 1, lastUpdated: "1", recent: [] },
-    ]);
+    expect(groupsFromCatalog(catalog, groups)).toEqual([groups[0], catalog[1]]);
   });
 });
 
@@ -390,76 +397,5 @@ describe("focusIsKeyboardDriven", () => {
         },
       }),
     ).toBe(false);
-  });
-});
-
-describe("shotsFromSearchItems", () => {
-  const item = (key: string, metadata: Record<string, string>) => ({
-    key,
-    url: `https://s/${key}`,
-    embedUrl: `https://e/${key}`,
-    metadata,
-  });
-  it("keeps only items whose metadata resolves to the group's project", () => {
-    const items = [
-      item("shots/a.png", { repo: "acme/api", path: "/billing" }),
-      item("shots/b.png", { repo: "acme/web", path: "/billing" }),
-      item("shots/c.png", { path: "/billing" }),
-    ];
-    expect(shotsFromSearchItems(items, "acme/api")).toEqual([
-      { key: "shots/a.png", url: "https://s/shots/a.png", embedUrl: "https://e/shots/a.png" },
-    ]);
-    expect(shotsFromSearchItems(items, "Other").map((shot) => shot.key)).toEqual(["shots/c.png"]);
-  });
-  it("carries state and gh metadata into the shot shape", () => {
-    const shots = shotsFromSearchItems(
-      [
-        item("shots/a.png", {
-          repo: "acme/api",
-          state: "after",
-          "gh.kind": "pull",
-          "gh.number": "12",
-        }),
-      ],
-      "acme/api",
-    );
-    expect(shots).toEqual([
-      {
-        key: "shots/a.png",
-        url: "https://s/shots/a.png",
-        embedUrl: "https://e/shots/a.png",
-        state: "after",
-        ghKind: "pull",
-        ghNumber: "12",
-      },
-    ]);
-  });
-  it("caps the result at the strip limit", () => {
-    const items = Array.from({ length: 9 }, (_, i) => item(`shots/${i}.png`, { repo: "a/b" }));
-    expect(shotsFromSearchItems(items, "a/b")).toHaveLength(6);
-    expect(shotsFromSearchItems(items, "a/b", 2)).toHaveLength(2);
-  });
-});
-
-describe("backfillTargets", () => {
-  const group = (project: string, path: string, recent: number) => ({
-    project,
-    path,
-    count: 1,
-    lastUpdated: "2026-08-01T00:00:00Z",
-    recent: Array.from({ length: recent }, (_, i) => ({
-      key: `${path}/${i}`,
-      url: null,
-      embedUrl: null,
-    })),
-  });
-  it("targets only thumbless groups that are not already cached", () => {
-    const groups = [group("a/b", "/x", 2), group("a/b", "/y", 0), group("a/b", "/z", 0)];
-    expect(backfillTargets(groups, new Set(["a/b\0/z"]))).toEqual([{ project: "a/b", path: "/y" }]);
-  });
-  it("caps how many groups are backfilled per pass", () => {
-    const groups = Array.from({ length: 20 }, (_, i) => group("a/b", `/p${i}`, 0));
-    expect(backfillTargets(groups, new Set())).toHaveLength(12);
-    expect(backfillTargets(groups, new Set(), 3)).toHaveLength(3);
   });
 });

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -279,83 +279,18 @@ type PathCatalogFields = {
 };
 
 /**
- * Join filtered catalog entries with thumbed groups. Catalog-only paths
- * (beyond the thumbed cap) render as empty `recent` strips.
+ * Join filtered catalog entries with thumbed groups. Both carry a `recent`
+ * strip now (the overview's first N groups get the longer one, every other
+ * catalog entry a shorter one), so a group is rendered from its thumbed
+ * strip when it has one and from the catalog's own otherwise — no follow-up
+ * search per group.
  */
 export function groupsFromCatalog<TRecent>(
-  catalog: PathCatalogFields[],
+  catalog: Array<PathCatalogFields & { recent: TRecent[] }>,
   groups: Array<PathCatalogFields & { recent: TRecent[] }>,
 ): Array<PathCatalogFields & { recent: TRecent[] }> {
   const byKey = new Map(groups.map((group) => [`${group.project}\0${group.path}`, group]));
-  return catalog.map((entry) => {
-    const group = byKey.get(`${entry.project}\0${entry.path}`);
-    if (group) return group;
-    return { ...entry, recent: [] };
-  });
-}
-
-type BackfillShot = {
-  key: string;
-  url: string | null;
-  embedUrl: string | null;
-  state?: string;
-  ghKind?: string;
-  ghNumber?: string;
-};
-
-/**
- * Thumb strip for a group past the overview's thumbed cap, built from the
- * drill-in search route's items: keep the group's own project (labels via
- * projectLabelFromItemMeta, same as the drill-in view) and reshape to the
- * by-path `recent` item, capped at the server's strip length.
- */
-export function shotsFromSearchItems(
-  items: Array<{
-    key: string;
-    url: string | null;
-    embedUrl: string | null;
-    metadata?: Record<string, string>;
-  }>,
-  project: string,
-  limit = 6,
-): BackfillShot[] {
-  const shots: BackfillShot[] = [];
-  for (const item of items) {
-    if (projectLabelFromItemMeta(item.metadata) !== project) continue;
-    const state = item.metadata?.state;
-    const ghKind = item.metadata?.["gh.kind"];
-    const ghNumber = item.metadata?.["gh.number"];
-    shots.push({
-      key: item.key,
-      url: item.url,
-      embedUrl: item.embedUrl,
-      ...(state !== undefined ? { state } : {}),
-      ...(ghKind !== undefined ? { ghKind } : {}),
-      ...(ghNumber !== undefined ? { ghNumber } : {}),
-    });
-    if (shots.length === limit) break;
-  }
-  return shots;
-}
-
-/**
- * Which rendered groups still need a thumb backfill: no `recent` strip and
- * not already fetched (`cached` keys are `project\0path`). Capped per pass so
- * a broad filter never fans out into dozens of search requests at once.
- */
-export function backfillTargets(
-  groups: Array<{ project: string; path: string; recent: unknown[] }>,
-  cached: Set<string>,
-  limit = 12,
-): Array<{ project: string; path: string }> {
-  const targets: Array<{ project: string; path: string }> = [];
-  for (const group of groups) {
-    if (group.recent.length > 0) continue;
-    if (cached.has(`${group.project}\0${group.path}`)) continue;
-    targets.push({ project: group.project, path: group.path });
-    if (targets.length === limit) break;
-  }
-  return targets;
+  return catalog.map((entry) => byKey.get(`${entry.project}\0${entry.path}`) ?? entry);
 }
 
 /** Viewport box used to place the thumbnail hover preview. */


### PR DESCRIPTION
## Summary

Navigating the signed-in app produced bursts of 503s and general slowdown. Root cause: the screenshots page's thumb backfill fired one `files/search?meta.path=…` fetch per group past the by-path overview's 50-group thumb cap (chained batches of 12). Each request's session check hit Better Auth's `get-session` rate limit — keyed to one shared bucket because the internal fetch didn't forward client IP headers — and the API mapped the resulting 429s to `503 auth_session_unavailable`.

## Changes

- **Thumbs for all groups, no client fan-out**: `files/by-path` catalog entries now carry a `recent` strip of up to 3 keys (`key`/`url`/`embedUrl` — pure computation, no extra D1 queries). Metadata enrichment stays limited to the first 50 groups + `latest`, so the enrichment queries don't grow. The client backfill effect and `backfillTargets` are deleted; the page renders every strip from the single overview response. Contract is backward-compatible both directions (missing `recent` parses to `[]`).
- **Per-client rate-limit keying**: `session-auth` and the admin-ui auth proxy forward `cf-connecting-ip`/`x-forwarded-for` on internal AUTH fetches.
- **get-session budget**: `customRules` entry (window 60, max 600) — sized to page-request volume rather than the 100/min mutation default. Limiter stays on for everything else.
- **Honest error codes**: an upstream 429 propagates as `429 auth_rate_limited` with `retry_after` from the upstream header; 503 remains reserved for genuine auth outages and malformed responses.

## Testing

- Full suite: 326 files / 4908 tests pass (`pnpm test`)
- New coverage: catalog strips incl. past the group cap, unenriched catalog-only items, client parser (strip / older-API default / malformed), IP-header forwarding, 429 propagation with and without `Retry-After`
- Typechecks pass for api, auth, and web (web under Node ≥24)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thumbnail previews to every project/path entry in workspace overviews.
  * Catalog entries now include up to three recent thumbnails for faster browsing without extra searches.
* **Bug Fixes**
  * Preserved thumbnail data when combining catalog and grouped results.
  * Improved handling of authentication rate limits, including retry guidance.
  * Forwarded client IP information for more accurate authentication processing.
* **Improvements**
  * Simplified screenshot loading by using overview data directly, reducing additional requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->