### PR TITLE
fix(scripts): bootstrap aborts on fresh checkouts missing the legacy auth secret

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -141,7 +141,9 @@ if have openssl; then
     "local encryption for BYO workspace secrets in REGISTRY KV"
   # #754 renamed the auth signing secret BETTER_AUTH_SECRET_DEV → BETTER_AUTH_SECRET;
   # carry over an existing legacy value so local sessions stay valid.
-  AUTH_SECRET_VALUE="$(grep -E '^BETTER_AUTH_SECRET_DEV=.+$' "$AUTH_DEV_VARS" 2>/dev/null | head -n1 | cut -d= -f2-)"
+  # `|| true`: with pipefail, grep's no-match exit 1 would abort the whole
+  # script on any checkout without the legacy line — i.e. every fresh one.
+  AUTH_SECRET_VALUE="$(grep -E '^BETTER_AUTH_SECRET_DEV=.+$' "$AUTH_DEV_VARS" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
   [ -n "$AUTH_SECRET_VALUE" ] || AUTH_SECRET_VALUE="$(openssl rand -base64 32)"
   ensure_secret "$AUTH_DEV_VARS" "BETTER_AUTH_SECRET" "$AUTH_SECRET_VALUE" \
     "local Better Auth signing secret (never used in production)"


### PR DESCRIPTION
## Summary

`scripts/bootstrap.sh` runs under `set -euo pipefail`. The #754 carry-over line

```bash
AUTH_SECRET_VALUE="$(grep -E '^BETTER_AUTH_SECRET_DEV=.+$' "$AUTH_DEV_VARS" 2>/dev/null | head -n1 | cut -d= -f2-)"
```

exits 1 via pipefail when `apps/auth/.dev.vars` has no legacy `BETTER_AUTH_SECRET_DEV` line — true for every fresh checkout/worktree since the rename — so `set -e` aborts the whole bootstrap during "Scaffolding env files" and `node scripts/dev-stack.mjs` dies before starting anything. Append `|| true` inside the substitution; the existing empty-value fallback on the next line already mints a fresh secret.

## Verification

In a worktree whose `apps/auth/.dev.vars` contains only `BETTER_AUTH_SECRET` (no legacy line): `bash scripts/bootstrap.sh --skip-db --skip-workspace` previously died after the WORKSPACE_SECRETS_KEY step with exit 1; with this change it runs to completion (exit 0).