### PR TITLE
fix(web): match Astro's SSR useId prefix in manual island hydration

### DIFF
--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -230,6 +230,7 @@ const sidebarSeedJson = JSON.stringify(sidebarProps).replace(/</g, "\\u003c");
       import { onAstroPageLoad, requireElement, resolveSessionGate } from "../lib/account-shell";
       import { createElement } from "react";
       import { hydrateRoot, type Root } from "react-dom/client";
+      import { detectIdentifierPrefix } from "../lib/react-island";
       import type { ShellSidebarIslandProps } from "../components/shell/ShellSidebar";
 
       let sidebarRoot: Root | null = null;
@@ -264,7 +265,9 @@ const sidebarSeedJson = JSON.stringify(sidebarProps).replace(/</g, "\\u003c");
         const { ShellSidebar } = await import("../components/shell/ShellSidebar");
         if (!document.contains(mount)) return;
         teardownSidebar();
-        sidebarRoot = hydrateRoot(mount, createElement(ShellSidebar, seed));
+        sidebarRoot = hydrateRoot(mount, createElement(ShellSidebar, seed), {
+          identifierPrefix: detectIdentifierPrefix(mount.innerHTML),
+        });
       }
 
       onAstroPageLoad(() => {

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -148,6 +148,7 @@ const sidebarSeedJson = JSON.stringify(sidebarProps).replace(/</g, "\\u003c");
       } from "../lib/account-shell";
       import { createElement } from "react";
       import { hydrateRoot, type Root } from "react-dom/client";
+      import { detectIdentifierPrefix } from "../lib/react-island";
       import type { ShellSidebarIslandProps } from "../components/shell/ShellSidebar";
 
       let sidebarRoot: Root | null = null;
@@ -177,7 +178,9 @@ const sidebarSeedJson = JSON.stringify(sidebarProps).replace(/</g, "\\u003c");
         const { ShellSidebar } = await import("../components/shell/ShellSidebar");
         if (!document.contains(mount)) return;
         teardownSidebar();
-        sidebarRoot = hydrateRoot(mount, createElement(ShellSidebar, seed));
+        sidebarRoot = hydrateRoot(mount, createElement(ShellSidebar, seed), {
+          identifierPrefix: detectIdentifierPrefix(mount.innerHTML),
+        });
       }
 
       onAstroPageLoad(() => {

--- a/apps/web/src/lib/react-island.test.ts
+++ b/apps/web/src/lib/react-island.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { detectIdentifierPrefix } from "./react-island";
+
+describe("detectIdentifierPrefix", () => {
+  it("recovers the Astro-assigned prefix from a server-rendered useId", () => {
+    const html = '<button id="base-ui-_r1R_qq_" aria-controls="base-ui-_r1R_qr_">x</button>';
+    expect(detectIdentifierPrefix(html)).toBe("r1");
+  });
+
+  it("handles multi-digit prefixes and the H-suffixed useId variant", () => {
+    expect(detectIdentifierPrefix('<div id="_r12R_abH2_"></div>')).toBe("r12");
+  });
+
+  it("returns empty when the markup has no server-generated useId", () => {
+    expect(detectIdentifierPrefix("<div><span>plain</span></div>")).toBe("");
+    expect(detectIdentifierPrefix("")).toBe("");
+    // Client-format ids (`_r_0_`) are not server tree ids and must not match.
+    expect(detectIdentifierPrefix('<div id="_r_0_"></div>')).toBe("");
+  });
+});

--- a/apps/web/src/lib/react-island.ts
+++ b/apps/web/src/lib/react-island.ts
@@ -1,0 +1,28 @@
+/**
+ * Manual-island hydration helper (`client:*` is banned repo-wide; see
+ * astro.config.mjs, so React components are SSR'd plain and `hydrateRoot`-ed
+ * from page/layout scripts).
+ *
+ * Astro's React renderer gives every server-rendered component on a page an
+ * incrementing `identifierPrefix` (`r0`, `r1`, … — @astrojs/react server.js),
+ * which React folds into every `useId` value (`_r1R_qq_`). A `client:*`
+ * island carries that prefix to the client on its `<astro-island>` wrapper,
+ * but a manual mount has no wrapper to read it from — hydrating with the
+ * default empty prefix makes every useId-bearing node (base-ui dropdown and
+ * tooltip triggers, form field ids) mismatch and log hydration errors, and
+ * the ids are regenerated instead of adopted. The prefix is recoverable from
+ * the server markup itself: every SSR'd useId embeds it as `_<prefix>R_…_`.
+ */
+
+/** Matches the prefix inside a server-generated React useId (`_r1R_qq_` → `r1`). */
+const SSR_USE_ID_RE = /_(r\d+)R_[0-9a-v]/;
+
+/**
+ * The `identifierPrefix` the server render used inside `html`, or `""` when
+ * none is detectable (component renders no useId — empty prefix is then
+ * harmless). Pass the mount's `innerHTML` before calling `hydrateRoot`, and
+ * hand the result to its `identifierPrefix` option.
+ */
+export function detectIdentifierPrefix(html: string): string {
+  return SSR_USE_ID_RE.exec(html)?.[1] ?? "";
+}

--- a/apps/web/src/pages/account/workspaces/[name]/files.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/files.astro
@@ -118,6 +118,7 @@ const filesSeedJson = JSON.stringify({
     import { onAstroPageLoad } from "../../../../lib/account-shell";
     import { createElement } from "react";
     import { hydrateRoot, type Root } from "react-dom/client";
+    import { detectIdentifierPrefix } from "../../../../lib/react-island";
     import type { ListingState } from "../../../../components/WorkspaceFileTable";
     import type { WorkspaceInfoStatus } from "../../../../lib/workspace-file-row";
 
@@ -171,7 +172,9 @@ const filesSeedJson = JSON.stringify({
       // internally (plan 005 Phase A) — mounting it directly, with no extra
       // wrapper, matches the SSR'd tree exactly, so `hydrateRoot` reconciles
       // without warnings.
-      filesTableRoot = hydrateRoot(mount, createElement(WorkspaceFileTable, seed));
+      filesTableRoot = hydrateRoot(mount, createElement(WorkspaceFileTable, seed), {
+        identifierPrefix: detectIdentifierPrefix(mount.innerHTML),
+      });
     }
 
     // astro:page-load fires on the initial load too (same as every sibling

--- a/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
@@ -113,6 +113,7 @@ const screenshotsSeedJson = JSON.stringify({
     import { onAstroPageLoad } from "../../../../lib/account-shell";
     import { createElement } from "react";
     import { hydrateRoot, type Root } from "react-dom/client";
+    import { detectIdentifierPrefix } from "../../../../lib/react-island";
     import type { OverviewState } from "../../../../components/ScreenshotsByPath";
     import type { WorkspaceInfoStatus } from "../../../../lib/workspace-file-row";
 
@@ -165,7 +166,9 @@ const screenshotsSeedJson = JSON.stringify({
       // `ScreenshotsByPath` already composes `IslandErrorBoundary` internally
       // (plan 006) — mounting it directly, with no extra wrapper, matches the
       // SSR'd tree exactly, so `hydrateRoot` reconciles without warnings.
-      screenshotsRoot = hydrateRoot(mount, createElement(ScreenshotsByPath, seed));
+      screenshotsRoot = hydrateRoot(mount, createElement(ScreenshotsByPath, seed), {
+        identifierPrefix: detectIdentifierPrefix(mount.innerHTML),
+      });
     }
 
     // astro:page-load fires on the initial load too (same as every sibling


### PR DESCRIPTION
## Summary

Every signed-in page logged a React hydration mismatch from the `ShellSidebar` island (PR #800): server ids like `base-ui-_r1R_qq_` vs client `base-ui-_R_qq_` on base-ui dropdown/tooltip triggers.

**Root cause:** Astro's React renderer assigns each server-rendered component an incrementing `identifierPrefix` (`r0`, `r1`, … — see `@astrojs/react`'s `server.js` + `context.js`), which React folds into every `useId`. With a `client:*` island the same prefix reaches the client on the `<astro-island>` wrapper, but our manual `hydrateRoot` mounts (`client:*` is banned repo-wide) passed no prefix — client ids came out unprefixed and every useId-bearing node mismatched.

**Fix:** the prefix is recoverable from the server markup itself, since every SSR'd useId embeds it as `_<prefix>R_…_`. New `detectIdentifierPrefix` helper in `apps/web/src/lib/react-island.ts` extracts it from the mount's `innerHTML`, and all four manual `hydrateRoot` call sites now pass it as `identifierPrefix`: `AccountLayout`, `AdminLayout`, the files tab, and the screenshots tab (the latter two had the same latent bug for any useId-bearing content).

## Verification

- Unit tests for the helper (prefix extraction, H-suffixed variant, client-format ids don't match)
- `pnpm --filter @uploads/web exec tsc --noEmit` clean; web vitest suite 58 files / 871 tests pass
- Live on the local stack (signed-in dev-session, `/account/workspaces/dev-demo/people`): before the fix every load logged the hydration error; after, an instrumented load shows `identifierPrefix=r1` detected and the console is clean of hydration errors across repeated reloads