### PR TITLE
fix(web): dev-server console noise — public/ assets 404 and blocked blob worker

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -1,7 +1,74 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "astro/config";
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
+
+/**
+ * Serve `public/` during `astro dev`.
+ *
+ * The Cloudflare Vite plugin routes dev requests through workerd and serves
+ * static assets from wrangler's `assets.directory` (`./dist` — the production
+ * build output), not from `public/`. With `run_worker_first: ["/*"]` every
+ * public asset (favicon, /preview/* hero images, robots.txt) therefore hits
+ * the Astro worker, matches no route, and renders 404.astro in dev — prod is
+ * unaffected because the build copies `public/` into `dist/`. This tiny
+ * middleware answers from `public/` before the worker sees the request,
+ * restoring parity. Dev-only: Vite ignores `configureServer` in builds.
+ */
+const PUBLIC_DIR = fileURLToPath(new URL("./public/", import.meta.url));
+const PUBLIC_MIME = {
+  ".avif": "image/avif",
+  ".css": "text/css",
+  ".gif": "image/gif",
+  ".ico": "image/x-icon",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".js": "text/javascript",
+  ".json": "application/json",
+  ".md": "text/markdown; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".txt": "text/plain; charset=utf-8",
+  ".webmanifest": "application/manifest+json",
+  ".webp": "image/webp",
+  ".woff2": "font/woff2",
+  ".xml": "application/xml",
+};
+function servePublicInDev() {
+  return {
+    name: "uploads:serve-public-in-dev",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.method !== "GET" && req.method !== "HEAD") return next();
+        let pathname;
+        try {
+          pathname = decodeURIComponent((req.url ?? "").split("?")[0]);
+        } catch {
+          return next();
+        }
+        const file = path.normalize(path.join(PUBLIC_DIR, pathname));
+        if (!file.startsWith(PUBLIC_DIR)) return next();
+        stat(file).then(
+          (st) => {
+            if (!st.isFile()) return next();
+            res.setHeader(
+              "Content-Type",
+              PUBLIC_MIME[path.extname(file)] ?? "application/octet-stream",
+            );
+            res.setHeader("Content-Length", String(st.size));
+            if (req.method === "HEAD") return res.end();
+            createReadStream(file).pipe(res);
+          },
+          () => next(),
+        );
+      });
+    },
+  };
+}
 
 /**
  * Vite 8 / Rolldown + @vitejs/plugin-react injects Fast Refresh helpers
@@ -29,7 +96,7 @@ export default defineConfig({
     format: "file",
   },
   vite: {
-    plugins: [tailwindcss()],
+    plugins: [tailwindcss(), servePublicInDev()],
     server: {
       hmr: false,
     },

--- a/apps/web/src/lib/signed-in-page.ts
+++ b/apps/web/src/lib/signed-in-page.ts
@@ -126,6 +126,11 @@ export function signedInCsp(authOrigin: string, apiOrigin: string): string {
     import.meta.env.DEV
       ? "img-src data: https: http://127.0.0.1:* http://localhost:*"
       : "img-src data: https:",
+    // Dev tooling (in-app-browser/devtools instrumentation) occasionally
+    // spawns a blob: worker in page context; with no worker-src the strict
+    // script-src blocks it and logs a scary console error on signed-in
+    // pages. App code never creates workers, so prod stays locked down.
+    ...(import.meta.env.DEV ? ["worker-src 'self' blob:"] : []),
     "base-uri 'none'",
     "form-action 'none'",
     "frame-ancestors 'none'",


### PR DESCRIPTION
## Summary

Two dev-only fixes for console noise on every `astro dev` page load.

### public/ assets 404 in dev

The Cloudflare Vite plugin routes dev requests through workerd and serves static assets from wrangler's `assets.directory` (`./dist` — the production build output), not `public/`. With `run_worker_first: ["/*"]`, every public asset — `/favicon.svg`, the homepage's `/preview/hero-*.webp`, `/robots.txt`, all of it — hit the Astro worker in dev, matched no route, and rendered 404.astro. Prod is unaffected (the build copies `public/` into `dist/`).

Fix: a small dev-only Vite middleware (`servePublicInDev` in `astro.config.mjs`) that answers `GET`/`HEAD` from `public/` (with path-traversal guard and a minimal MIME map) before the worker sees the request. `configureServer` is ignored in builds, so prod behavior is untouched.

### CSP-blocked blob worker on signed-in pages

Dev sessions intermittently log `Creating a worker from 'blob:…' violates … script-src` on `/account/*`. No app or dependency code creates workers (verified by grepping the entire loaded module graph); the spawner is dev tooling instrumentation running in page context. `signedInCsp` now emits `worker-src 'self' blob:` under `import.meta.env.DEV` only — same pattern as the existing dev `img-src` loopback allowance. Prod CSP is unchanged.

## Verification

On the local stack (`PORTLESS=0 node scripts/dev-stack.mjs`):
- `/favicon.svg`, `/preview/hero-before.webp`, `/robots.txt` now 200 with correct Content-Type (all previously 404)
- `/account/workspaces` response header carries `worker-src 'self' blob:` in dev
- Signed-in people page reloads with a clean console (no 404s, no CSP error)
- Web vitest suite 57 files / 868 tests pass; `tsc --noEmit` clean