### PR TITLE
fix(auth,api,web): keep auth responsive through storage stalls

### DIFF
--- a/apps/api/src/org-workspaces.test.ts
+++ b/apps/api/src/org-workspaces.test.ts
@@ -4,6 +4,7 @@ import {
   deleteOrg,
   invitesForOrg,
   listOrgs,
+  membershipsForUser,
   orgForWorkspace,
   removeMember,
   revokeInvite,
@@ -57,6 +58,38 @@ describe("orgForWorkspace", () => {
       return new Response(null, { status: 404 });
     });
     await orgForWorkspace(envWith(auth), "has space");
+  });
+});
+
+describe("membershipsForUser", () => {
+  it("attaches a bounded AbortSignal to the AUTH memberships fetch", async () => {
+    let seenSignal: AbortSignal | undefined;
+    const auth: Pick<Fetcher, "fetch"> = {
+      fetch: (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        seenSignal = init?.signal ?? undefined;
+        return Response.json([]);
+      }) as Fetcher["fetch"],
+    };
+    await membershipsForUser(envWith(auth), "u1");
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("throws a 503 auth_lookup_failed (not a hang) when the AUTH fetch aborts on timeout", async () => {
+    // Simulates AbortSignal.timeout firing: a stalled AUTH binding rejects
+    // with an AbortError instead of ever resolving. Regression guard for the
+    // 2026-08-23 incident (D1 stalls propagating as unbounded hangs).
+    const auth: Pick<Fetcher, "fetch"> = {
+      fetch: (() =>
+        Promise.reject(
+          new DOMException("The operation was aborted.", "AbortError"),
+        )) as Fetcher["fetch"],
+    };
+    const start = Date.now();
+    await expect(membershipsForUser(envWith(auth), "u1")).rejects.toMatchObject({
+      status: 503,
+      code: "auth_lookup_failed",
+    });
+    expect(Date.now() - start).toBeLessThan(1000);
   });
 });
 

--- a/apps/api/src/org-workspaces.ts
+++ b/apps/api/src/org-workspaces.ts
@@ -40,6 +40,11 @@ export interface Membership {
 
 const INTERNAL_ORIGIN = "https://auth.internal";
 
+// Bounded so a stalled auth/D1 dependency degrades to a fast 503 instead of
+// hanging every request for as long as the auth worker does (2026-08-23
+// incident: D1 stalls of 5-25s propagated through this unbounded fetch).
+const AUTH_FETCH_TIMEOUT_MS = 4000;
+
 function internalHeaders(): Headers {
   return new Headers({ "x-uploads-internal": "1" });
 }
@@ -84,7 +89,17 @@ export async function membershipsForUser(
   url.searchParams.set("userId", userId);
   if (opts?.slug) url.searchParams.set("slug", opts.slug);
 
-  const response = await env.AUTH.fetch(url.toString(), { headers: internalHeaders() });
+  let response: Response;
+  try {
+    response = await env.AUTH.fetch(url.toString(), {
+      headers: internalHeaders(),
+      signal: AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
+    });
+  } catch {
+    throw new ServiceUnavailableError("auth service is unavailable", {
+      code: "auth_lookup_failed",
+    });
+  }
   if (!response.ok) {
     throw new ServiceUnavailableError("auth service returned an unexpected status", {
       code: "auth_lookup_failed",

--- a/apps/api/src/session-auth.test.ts
+++ b/apps/api/src/session-auth.test.ts
@@ -114,6 +114,37 @@ describe("sessionAuth", () => {
     expect(res.status).toBe(401);
   });
 
+  it("attaches a bounded AbortSignal to the AUTH get-session fetch", async () => {
+    let seenSignal: AbortSignal | undefined;
+    const auth: Pick<Fetcher, "fetch"> = {
+      fetch: (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        seenSignal = init?.signal ?? undefined;
+        return new Response(JSON.stringify(null), { status: 200 });
+      }) as Fetcher["fetch"],
+    };
+    await appWith(auth).request("/whoami", {}, env(auth));
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("returns 503 auth_session_unavailable (not a hang) when the AUTH fetch aborts on timeout", async () => {
+    // Simulates AbortSignal.timeout firing: a stalled AUTH binding rejects
+    // with an AbortError instead of ever resolving. Regression guard for the
+    // 2026-08-23 incident (D1 stalls propagating as unbounded hangs).
+    const auth: Pick<Fetcher, "fetch"> = {
+      fetch: (() =>
+        Promise.reject(
+          new DOMException("The operation was aborted.", "AbortError"),
+        )) as Fetcher["fetch"],
+    };
+    const start = Date.now();
+    const res = await appWith(auth).request("/whoami", {}, env(auth));
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(res.status).toBe(503);
+    expect((await res.json()) as { error?: { code?: string } }).toMatchObject({
+      error: { code: "auth_session_unavailable" },
+    });
+  });
+
   it("forwards the client IP headers to the auth worker", async () => {
     let seen: Headers | undefined;
     const auth = stubAuth((req) => {

--- a/apps/api/src/session-auth.ts
+++ b/apps/api/src/session-auth.ts
@@ -41,6 +41,11 @@ export type SessionVars = {
 // for auth.uploads.sh callers elsewhere in this repo's plan (D1).
 const AUTH_INTERNAL_ORIGIN = "https://auth.internal";
 
+// Bounded so a stalled auth/D1 dependency degrades to a fast 503 instead of
+// hanging every request for as long as the auth worker does (2026-08-23
+// incident: D1 stalls of 5-25s propagated through this unbounded fetch).
+const AUTH_FETCH_TIMEOUT_MS = 4000;
+
 /**
  * Maps a 429 from the auth worker to a RateLimitedError. Better Auth's rate
  * limiter emits `X-Retry-After` (seconds); the standard `Retry-After` is
@@ -79,6 +84,7 @@ async function resolveSessionUser(env: Env, req: Request): Promise<SessionUser |
   try {
     const response = await env.AUTH.fetch(`${AUTH_INTERNAL_ORIGIN}/api/auth/get-session`, {
       headers,
+      signal: AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
     });
     // Better Auth returns a normal no-session result as 200 + null. An
     // explicitly unauthorized response also remains a normal signed-out case.

--- a/apps/auth/src/auth.test.ts
+++ b/apps/auth/src/auth.test.ts
@@ -1,6 +1,12 @@
 import { drizzle } from "drizzle-orm/d1";
 import { describe, expect, it } from "vitest";
-import { deriveCookieDomain, isCliSessionUserAgent, upsertGithubLogin } from "./auth";
+import {
+  createAuth,
+  deriveCookieDomain,
+  isCliSessionUserAgent,
+  upsertGithubLogin,
+  type AuthEnv,
+} from "./auth";
 import * as schema from "./schema";
 import { createFakeD1 } from "./test/fake-d1";
 
@@ -127,5 +133,84 @@ describe("upsertGithubLogin", () => {
     await expect(upsertGithubLogin(db, "", "octocat")).resolves.toBeUndefined();
     await expect(upsertGithubLogin(db, "123", "")).resolves.toBeUndefined();
     expect(await db.select().from(schema.githubIdentity)).toHaveLength(0);
+  });
+});
+
+// Rate-limit storage selection (2026-08-23 incident follow-up). The point of
+// these two: production must get the Durable-Object customStorage, and every
+// binding-less caller (tests, bare local envs) must still build without one.
+describe("rateLimit storage selection", () => {
+  function env(overrides: Partial<AuthEnv> = {}): AuthEnv {
+    return {
+      DB: createFakeD1(),
+      BETTER_AUTH_SECRET: "x".repeat(32),
+      BETTER_AUTH_URL: "https://uploads.sh",
+      WEB_ORIGIN: "https://uploads.sh",
+      ENVIRONMENT: "production",
+      ...overrides,
+    };
+  }
+
+  it("uses the Durable-Object customStorage when RATE_LIMIT is bound", async () => {
+    const RATE_LIMIT = {
+      idFromName: (name: string) => name,
+      get: () => ({ consume: async () => ({ allowed: true, retryAfter: null }) }),
+    };
+    const auth = await createAuth(env({ RATE_LIMIT }));
+    const rateLimit = auth?.options.rateLimit;
+    expect(rateLimit?.enabled).toBe(true);
+    expect(typeof rateLimit?.customStorage?.consume).toBe("function");
+    expect(rateLimit?.storage).toBeUndefined();
+  });
+
+  it("falls back to Better Auth's memory storage when the binding is absent", async () => {
+    const auth = await createAuth(env({ AUTH_RATE_LIMIT_DISABLED: "true" }));
+    const rateLimit = auth?.options.rateLimit;
+    expect(rateLimit?.customStorage).toBeUndefined();
+    expect(rateLimit?.storage).toBe("memory");
+  });
+});
+
+// End-to-end through Better Auth's own limiter, using a customStorage that
+// denies EVERYTHING. Anything that still answers non-429 is genuinely exempt.
+describe("rate limiting exemptions (live handler)", () => {
+  function denyAllEnv(): AuthEnv {
+    return {
+      DB: createFakeD1(),
+      BETTER_AUTH_SECRET: "x".repeat(32),
+      BETTER_AUTH_URL: "https://uploads.sh",
+      WEB_ORIGIN: "https://uploads.sh",
+      ENVIRONMENT: "production",
+      RATE_LIMIT: {
+        idFromName: (name: string) => name,
+        get: () => ({ consume: async () => ({ allowed: false, retryAfter: 30 }) }),
+      },
+    };
+  }
+
+  it("never 429s a burst of /get-session — the path is exempt (customRules false)", async () => {
+    const auth = await createAuth(denyAllEnv());
+    expect(auth).toBeTruthy();
+    for (let i = 0; i < 10; i++) {
+      const res = await auth!.handler(
+        new Request("https://uploads.sh/api/auth/get-session", {
+          headers: { "cf-connecting-ip": "203.0.113.7" },
+        }),
+      );
+      expect(res.status).not.toBe(429);
+    }
+  });
+
+  it("still 429s a limited path, proving the deny-all storage is wired in", async () => {
+    const auth = await createAuth(denyAllEnv());
+    const res = await auth!.handler(
+      new Request("https://uploads.sh/api/auth/sign-in/magic-link", {
+        method: "POST",
+        headers: { "content-type": "application/json", "cf-connecting-ip": "203.0.113.7" },
+        body: JSON.stringify({ email: "someone@example.com" }),
+      }),
+    );
+    expect(res.status).toBe(429);
+    expect(res.headers.get("X-Retry-After")).toBe("30");
   });
 });

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -26,6 +26,7 @@ import { deviceWorkspacePlugin } from "./device-workspace";
 import { sendAuthEmail } from "./email";
 import { localDemoEnabled, localDemoPlugin } from "./local-demo";
 import { memberCapDenial } from "./member-cap";
+import { createDurableRateLimitStorage, type RateLimitNamespaceLike } from "./rate-limit";
 import * as schema from "./schema";
 import { stripePluginOrNone } from "./stripe-plugin";
 import { authTrustedOrigins, isTrustedOrigin } from "./trusted-origins";
@@ -299,6 +300,13 @@ export type AuthEnv = GitHubCredentialsEnv &
     ENVIRONMENT?: string;
     BETTER_AUTH_TRUSTED_ORIGINS?: string;
     AUTH_RATE_LIMIT_DISABLED?: string;
+    /**
+     * Durable Object namespace backing Better Auth's rate limiter (see the
+     * `rateLimit` block below and src/rate-limit-do.ts). Optional: tests and
+     * bare local envs construct auth without it and fall back to Better
+     * Auth's in-process memory storage.
+     */
+    RATE_LIMIT?: RateLimitNamespaceLike;
     /** Ephemeral flag passed only by `pnpm dev:stack`; never configure in prod. */
     LOCAL_STACK?: string;
     /** Stripe phase 2 (task 5): gates stripePluginOrNone (src/stripe-plugin.ts)
@@ -311,6 +319,24 @@ export type AuthEnv = GitHubCredentialsEnv &
   };
 
 export type BetterAuthInstance = ReturnType<typeof buildAuth>;
+
+/**
+ * Pick the Better Auth rate-limit storage for this env: the Durable-Object
+ * customStorage when RATE_LIMIT is bound, Better Auth's in-process memory Map
+ * otherwise (unit tests, bare local envs). See the long comment on the
+ * `rateLimit` block in buildAuth for why D1 is no longer an option.
+ *
+ * Both branches return the same (partially-optional) shape so the resulting
+ * `auth.options.rateLimit` isn't a discriminated union that callers — and
+ * tests — have to narrow.
+ */
+function rateLimitStorage(env: AuthEnv): {
+  customStorage?: ReturnType<typeof createDurableRateLimitStorage>;
+  storage?: "memory";
+} {
+  if (env.RATE_LIMIT) return { customStorage: createDurableRateLimitStorage(env.RATE_LIMIT) };
+  return { storage: "memory" };
+}
 
 /**
  * Issue #580: capture the GitHub login at OAuth-link time. Called from the
@@ -775,16 +801,58 @@ function buildAuth(
     // rate limiting is on whenever ENVIRONMENT === "production", regardless
     // of whether GitHub/signing secrets happen to be configured, unless the
     // explicit dev opt-out is set.
+    //
+    // Storage (2026-08-23, post-incident): Cloudflare D1 stalled 5-25s in
+    // production, and every /api/auth/* request — including get-session,
+    // which the api worker calls over the service binding on every signed-in
+    // request — paid a rate-limit read+write against D1 before the handler
+    // even ran, so the D1 stall hung the whole site. D1 is now out of the
+    // rate-limit path entirely (the `rate_limit` table is retained unused; see
+    // schema.ts).
+    //
+    // Two changes came out of that. First, /get-session is exempt from the
+    // limiter altogether (see customRules below), so the hottest path has no
+    // rate-limit storage dependency of any kind. Second, what remains — the
+    // mutation-ish, low-frequency endpoints (sign-in, sign-up, magic-link,
+    // change-password, …) — is backed by Durable Objects: one
+    // `RateLimitCounter` object per rate-limit key (src/rate-limit-do.ts,
+    // bound as RATE_LIMIT). `idFromName(key)` is deterministic, so the whole
+    // fleet shares ONE exact fixed-window counter per key instead of the
+    // per-isolate approximation a memory Map gives — which is precisely what
+    // you want on the endpoints where the limit is load-bearing. The DO is
+    // single-threaded, so its read-decide-write needs no locking; the decision
+    // itself mirrors Better Auth's own `decideConsume` (src/rate-limit.ts).
+    // With /get-session out of the picture, a DO round trip on a sign-in
+    // attempt is a rounding error against the password/OAuth work that
+    // follows it.
+    //
+    // Two properties keep this from ever repeating the incident anyway: the
+    // wrapper is FAIL-OPEN (any throw → allowed) and TIME-BOUNDED (the DO call
+    // is raced against a ~1.5s timer → allowed), so no storage dependency can
+    // stall a request. Rate limiting is abuse-shaping, not a security
+    // boundary; taking the site down to enforce it is the wrong trade.
+    //
+    // When the binding is absent (unit tests, bare local envs) we fall back to
+    // Better Auth's in-process memory Map. Alternatives rejected: KV (1
+    // write/sec/key is too coarse for a shared counter) and D1 (the incident).
     rateLimit: {
       enabled: isProduction && env.AUTH_RATE_LIMIT_DISABLED !== "true",
-      storage: "database",
+      ...rateLimitStorage(env),
       customRules: {
-        // get-session is a cheap read hit once per API request (the api
-        // worker's sessionAuth middleware calls it over the service binding
-        // per request), so its budget is sized to page-request volume, not
-        // the 100/min default meant for auth mutations. Keyed per client IP —
-        // the api worker forwards cf-connecting-ip/x-forwarded-for.
-        "/get-session": { window: 60, max: 600 },
+        // `false` disables the limiter for this path outright — Better Auth
+        // 1.7.1 honors it in resolveRateLimitConfig
+        // (better-auth/dist/api/rate-limiter/index.mjs:274, `if (resolved ===
+        // false) return null`), which makes onRequestRateLimit return before
+        // it ever touches storage.
+        //
+        // get-session is a cheap read the api worker's sessionAuth middleware
+        // calls over a TRUSTED service binding on every signed-in request. Its
+        // old 600/min budget was really defending us against our own client
+        // fan-out bugs (fixed in #797), and on the single hottest path in the
+        // product any shared-store dependency costs more than the limit is
+        // worth. Browser-originated abuse of /api/auth/* belongs to the WAF at
+        // the edge (a per-IP rate-limiting rule), not to the app.
+        "/get-session": false,
       },
     },
     trustedOrigins: (request) => {
@@ -837,6 +905,9 @@ function cacheKey(
     githubClientSecret: github?.clientSecret ?? null,
     dashApiKey,
     hasEmail: Boolean(env.EMAIL),
+    // Presence flips the limiter between DO-backed customStorage and Better
+    // Auth's memory fallback, so it has to be part of the key.
+    hasRateLimitDO: Boolean(env.RATE_LIMIT),
   });
 }
 

--- a/apps/auth/src/env.d.ts
+++ b/apps/auth/src/env.d.ts
@@ -30,6 +30,15 @@ interface Env {
   /** Dev opt-out for Better Auth's fail-closed production rate limiting. */
   AUTH_RATE_LIMIT_DISABLED?: string;
   /**
+   * Durable Object namespace backing Better Auth's rate limiter (2026-08-23
+   * incident follow-up — see src/rate-limit-do.ts and the `durable_objects`
+   * block in wrangler.jsonc). Declared optional here, overriding the required
+   * version `wrangler types` generates from the binding: unit tests and bare
+   * local envs build auth without it and fall back to Better Auth's
+   * in-process memory storage.
+   */
+  RATE_LIMIT?: DurableObjectNamespace<import("./rate-limit-do").RateLimitCounter>;
+  /**
    * Service binding to apps/api (see wrangler.jsonc), used by
    * src/billing-bridge.ts to POST /internal/billing/plan. Optional: absent
    * in tests/local dev without both `wrangler dev` sessions running — the

--- a/apps/auth/src/env.d.ts
+++ b/apps/auth/src/env.d.ts
@@ -30,15 +30,6 @@ interface Env {
   /** Dev opt-out for Better Auth's fail-closed production rate limiting. */
   AUTH_RATE_LIMIT_DISABLED?: string;
   /**
-   * Durable Object namespace backing Better Auth's rate limiter (2026-08-23
-   * incident follow-up — see src/rate-limit-do.ts and the `durable_objects`
-   * block in wrangler.jsonc). Declared optional here, overriding the required
-   * version `wrangler types` generates from the binding: unit tests and bare
-   * local envs build auth without it and fall back to Better Auth's
-   * in-process memory storage.
-   */
-  RATE_LIMIT?: DurableObjectNamespace<import("./rate-limit-do").RateLimitCounter>;
-  /**
    * Service binding to apps/api (see wrangler.jsonc), used by
    * src/billing-bridge.ts to POST /internal/billing/plan. Optional: absent
    * in tests/local dev without both `wrangler dev` sessions running — the

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -11,6 +11,12 @@ import { BILLING_OUTBOX_CRON, drainBillingOutbox } from "./billing-outbox";
 import { billingPricesResponseBody } from "./billing-prices";
 import { ROBOTS_TXT } from "./robots";
 
+// Durable Object backing Better Auth's rate limiter (see src/rate-limit-do.ts
+// and the `durable_objects` block in wrangler.jsonc). Wrangler resolves the
+// binding's class_name against the entrypoint's named exports, so this
+// re-export is load-bearing even though nothing in this file calls it.
+export { RateLimitCounter } from "./rate-limit-do";
+
 // Credentialed CORS for the web origin (+ dev origins), scoped to /api/auth/*
 // only — this worker has no other public surface (D1: "CORS becomes trivial").
 const authCors = cors({

--- a/apps/auth/src/rate-limit-do.ts
+++ b/apps/auth/src/rate-limit-do.ts
@@ -1,0 +1,66 @@
+/**
+ * `RateLimitCounter` — one Durable Object per Better Auth rate-limit key.
+ *
+ * The object holds a single fixed-window counter. Because a DO is
+ * single-threaded, the read → decide → write below is atomic without any
+ * locking or compare-and-set, which is what lets the fleet share one exact
+ * counter per key (the built-in memory backend can only approximate that,
+ * per isolate).
+ *
+ * All decision logic lives in src/rate-limit.ts (`decideWindow`) so it can be
+ * unit-tested under plain vitest — this file is the only one that imports
+ * `cloudflare:workers`. It is exported from src/index.ts because wrangler
+ * requires the class to be a named export of the worker entrypoint.
+ */
+import { DurableObject } from "cloudflare:workers";
+import {
+  decideWindow,
+  type RateLimitOutcome,
+  type RateLimitRule,
+  type RateLimitState,
+} from "./rate-limit";
+
+/** Storage key for the counter row. One row per object, so a constant. */
+const STATE_KEY = "s";
+
+type StoredState = RateLimitState & { expiresAt: number };
+
+export class RateLimitCounter extends DurableObject {
+  /**
+   * Record one hit against this key and report Better Auth's verdict.
+   * Return shape matches `BetterAuthRateLimitStorage["consume"]`.
+   */
+  async consume(rule: RateLimitRule): Promise<RateLimitOutcome> {
+    const now = Date.now();
+    const stored = await this.ctx.storage.get<StoredState>(STATE_KEY);
+    // Expiry mirrors the memory backend's per-entry TTL (`ttlFor(rule.window)`
+    // in better-auth/dist/api/rate-limiter/index.mjs): a lapsed entry is
+    // indistinguishable from no entry at all.
+    const state = stored && now < stored.expiresAt ? stored : undefined;
+    const decision = decideWindow(state, rule, now);
+    if (decision.allowed) {
+      const expiresAt = now + rule.window * 1000;
+      await this.ctx.storage.put<StoredState>(STATE_KEY, { ...decision.next, expiresAt });
+      // Cheap self-cleanup so an idle object doesn't keep a stale row forever.
+      // Armed only when a window is freshly started, not on every hit — the
+      // alarm handler reschedules itself if the key is still active, which
+      // keeps the hot path down to a single storage write.
+      if (!state) await this.ctx.storage.setAlarm(expiresAt + 1000);
+    }
+    return { allowed: decision.allowed, retryAfter: decision.retryAfter };
+  }
+
+  /**
+   * Fired a beat after the current window would lapse. If traffic kept the
+   * counter alive in the meantime, push the alarm out instead of deleting —
+   * dropping a live counter would silently reset someone's limit.
+   */
+  override async alarm(): Promise<void> {
+    const stored = await this.ctx.storage.get<StoredState>(STATE_KEY);
+    if (stored && Date.now() < stored.expiresAt) {
+      await this.ctx.storage.setAlarm(stored.expiresAt + 1000);
+      return;
+    }
+    await this.ctx.storage.deleteAll();
+  }
+}

--- a/apps/auth/src/rate-limit.test.ts
+++ b/apps/auth/src/rate-limit.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDurableRateLimitStorage,
+  decideWindow,
+  type RateLimitNamespaceLike,
+  type RateLimitOutcome,
+  type RateLimitRule,
+  type RateLimitState,
+} from "./rate-limit";
+
+const RULE: RateLimitRule = { window: 60, max: 3 };
+
+describe("decideWindow", () => {
+  it("starts a window at count 1 when there is no state", () => {
+    const now = 1_000_000;
+    expect(decideWindow(undefined, RULE, now)).toEqual({
+      next: { count: 1, lastRequest: now },
+      allowed: true,
+      retryAfter: null,
+    });
+  });
+
+  it("increments inside the window and slides lastRequest forward", () => {
+    const state: RateLimitState = { count: 1, lastRequest: 1_000_000 };
+    expect(decideWindow(state, RULE, 1_005_000)).toEqual({
+      next: { count: 2, lastRequest: 1_005_000 },
+      allowed: true,
+      retryAfter: null,
+    });
+  });
+
+  it("resets to count 1 once the full window has elapsed", () => {
+    const state: RateLimitState = { count: 3, lastRequest: 1_000_000 };
+    // Exactly window*1000 later — better-auth uses `>=`, so this resets.
+    expect(decideWindow(state, RULE, 1_060_000)).toEqual({
+      next: { count: 1, lastRequest: 1_060_000 },
+      allowed: true,
+      retryAfter: null,
+    });
+  });
+
+  it("denies at max and leaves the state untouched", () => {
+    const state: RateLimitState = { count: 3, lastRequest: 1_000_000 };
+    const decision = decideWindow(state, RULE, 1_010_000);
+    expect(decision.allowed).toBe(false);
+    expect(decision.next).toBe(state);
+  });
+
+  it("reports retryAfter in whole seconds, rounded up (better-auth getRetryAfter)", () => {
+    const state: RateLimitState = { count: 3, lastRequest: 1_000_000 };
+    // 50.5s remaining in the 60s window → ceil → 51.
+    expect(decideWindow(state, RULE, 1_009_500).retryAfter).toBe(51);
+    // 1ms remaining → ceil → 1, never 0.
+    expect(decideWindow(state, RULE, 1_059_999).retryAfter).toBe(1);
+  });
+
+  it("denies immediately when max is 0", () => {
+    const state: RateLimitState = { count: 0, lastRequest: 1_000_000 };
+    expect(decideWindow(state, { window: 10, max: 0 }, 1_000_100).allowed).toBe(false);
+  });
+});
+
+/** In-process stand-in for the DO: the same read-decide-write, no runtime. */
+function fakeNamespace(
+  consume: (key: string, rule: RateLimitRule) => Promise<RateLimitOutcome>,
+): RateLimitNamespaceLike<string> & { keys: string[] } {
+  const keys: string[] = [];
+  return {
+    keys,
+    idFromName(name) {
+      keys.push(name);
+      return name;
+    },
+    get(id) {
+      return { consume: (rule) => consume(id, rule) };
+    },
+  };
+}
+
+describe("createDurableRateLimitStorage", () => {
+  it("passes the verdict through on the allowed path", async () => {
+    const ns = fakeNamespace(async () => ({ allowed: true, retryAfter: null }));
+    const storage = createDurableRateLimitStorage(ns);
+    await expect(storage.consume("ip:1.2.3.4/get-session", RULE)).resolves.toEqual({
+      allowed: true,
+      retryAfter: null,
+    });
+    // One DO per key, addressed by name.
+    expect(ns.keys).toEqual(["ip:1.2.3.4/get-session"]);
+  });
+
+  it("passes the verdict through on the limited path, retryAfter included", async () => {
+    const ns = fakeNamespace(async () => ({ allowed: false, retryAfter: 42 }));
+    const storage = createDurableRateLimitStorage(ns);
+    await expect(storage.consume("k", RULE)).resolves.toEqual({
+      allowed: false,
+      retryAfter: 42,
+    });
+  });
+
+  it("fails open when the DO call rejects", async () => {
+    const onError = vi.fn();
+    const ns = fakeNamespace(async () => {
+      throw new Error("durable object unavailable");
+    });
+    const storage = createDurableRateLimitStorage(ns, { onError });
+    await expect(storage.consume("k", RULE)).resolves.toEqual({
+      allowed: true,
+      retryAfter: null,
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails open when the namespace itself throws before the RPC", async () => {
+    const onError = vi.fn();
+    const storage = createDurableRateLimitStorage(
+      {
+        idFromName() {
+          throw new Error("binding missing");
+        },
+        get() {
+          throw new Error("unreachable");
+        },
+      },
+      { onError },
+    );
+    await expect(storage.consume("k", RULE)).resolves.toEqual({
+      allowed: true,
+      retryAfter: null,
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails open when the DO call outruns the timeout", async () => {
+    const onError = vi.fn();
+    // Never settles: stands in for the stalled-storage case the 2026-08-23
+    // incident was made of.
+    const ns = fakeNamespace(() => new Promise<RateLimitOutcome>(() => {}));
+    const storage = createDurableRateLimitStorage(ns, { timeoutMs: 5, onError });
+    await expect(storage.consume("k", RULE)).resolves.toEqual({
+      allowed: true,
+      retryAfter: null,
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(String(onError.mock.calls[0]?.[0])).toContain("timed out");
+  });
+
+  it("does not leave the timer pending after a fast answer", async () => {
+    vi.useFakeTimers();
+    try {
+      const ns = fakeNamespace(async () => ({ allowed: true, retryAfter: null }));
+      const storage = createDurableRateLimitStorage(ns, { timeoutMs: 60_000 });
+      await storage.consume("k", RULE);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+/**
+ * End-to-end shape check: drive `decideWindow` through a fake DO exactly the
+ * way src/rate-limit-do.ts does (read → decide → write only when allowed) and
+ * confirm the storage wrapper produces Better Auth's fixed-window behaviour.
+ */
+describe("DO counter behaviour (decideWindow driven like rate-limit-do.ts)", () => {
+  it("allows `max` hits per window, then denies with a retryAfter", async () => {
+    let clock = 1_000_000;
+    const rows = new Map<string, RateLimitState & { expiresAt: number }>();
+    const ns = fakeNamespace(async (key, rule) => {
+      const stored = rows.get(key);
+      const state = stored && clock < stored.expiresAt ? stored : undefined;
+      const decision = decideWindow(state, rule, clock);
+      if (decision.allowed) {
+        rows.set(key, { ...decision.next, expiresAt: clock + rule.window * 1000 });
+      }
+      return { allowed: decision.allowed, retryAfter: decision.retryAfter };
+    });
+    const storage = createDurableRateLimitStorage(ns);
+
+    for (let i = 0; i < RULE.max; i++) {
+      expect((await storage.consume("k", RULE)).allowed).toBe(true);
+      clock += 1000;
+    }
+    const denied = await storage.consume("k", RULE);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfter).toBeGreaterThan(0);
+
+    // Past the window with no traffic: the counter starts over.
+    clock += RULE.window * 1000;
+    expect((await storage.consume("k", RULE)).allowed).toBe(true);
+  });
+
+  it("keeps separate counters per key", async () => {
+    const rows = new Map<string, RateLimitState>();
+    const ns = fakeNamespace(async (key, rule) => {
+      const decision = decideWindow(rows.get(key), rule, 1_000_000);
+      if (decision.allowed) rows.set(key, decision.next);
+      return { allowed: decision.allowed, retryAfter: decision.retryAfter };
+    });
+    const storage = createDurableRateLimitStorage(ns);
+    const rule: RateLimitRule = { window: 60, max: 1 };
+    expect((await storage.consume("a", rule)).allowed).toBe(true);
+    expect((await storage.consume("b", rule)).allowed).toBe(true);
+    expect((await storage.consume("a", rule)).allowed).toBe(false);
+  });
+});

--- a/apps/auth/src/rate-limit.ts
+++ b/apps/auth/src/rate-limit.ts
@@ -1,0 +1,158 @@
+/**
+ * Durable-Object-backed rate-limit storage for Better Auth (2026-08-23
+ * incident follow-up; see the `rateLimit` block in src/auth.ts).
+ *
+ * This module is deliberately free of any `cloudflare:workers` import so the
+ * plain-vitest suite can exercise every decision path in-process. The Durable
+ * Object class itself lives in src/rate-limit-do.ts and imports `decideWindow`
+ * from here.
+ *
+ * Semantics are a byte-for-byte mirror of Better Auth 1.7.1's own
+ * `decideConsume` (node_modules/better-auth/dist/api/rate-limiter/index.mjs
+ * lines 25-63) and `getRetryAfter` (lines 71-75), so swapping the built-in
+ * memory backend for this one cannot change who gets a 429:
+ *
+ *   - no state            → count = 1, allowed
+ *   - now - lastRequest >= window*1000 → window elapsed: count resets to 1, allowed
+ *   - count >= max        → denied, state untouched,
+ *                           retryAfter = ceil((lastRequest + window*1000 - now) / 1000)
+ *   - otherwise           → count + 1, lastRequest = now, allowed
+ *
+ * `window` is in SECONDS on the way in and `retryAfter` is in SECONDS on the
+ * way out; `lastRequest` is epoch milliseconds. Note that `lastRequest` is
+ * bumped on every ALLOWED request (upstream does the same), so the window
+ * slides forward with traffic rather than being pinned to the first hit.
+ */
+
+/** A resolved Better Auth rate-limit rule: `window` in seconds, `max` hits. */
+export type RateLimitRule = { window: number; max: number };
+
+/** The single counter row a per-key Durable Object holds. */
+export type RateLimitState = { count: number; lastRequest: number };
+
+export type RateLimitOutcome = { allowed: boolean; retryAfter: number | null };
+
+export type RateLimitDecision = RateLimitOutcome & {
+  /** The state to persist. Only meaningful when `allowed` is true. */
+  next: RateLimitState;
+};
+
+/**
+ * Pure fixed-window decision. Extracted so it is testable without the DO
+ * runtime; the Durable Object is nothing but storage read → this → storage
+ * write, which is atomic because a DO is single-threaded.
+ */
+export function decideWindow(
+  state: RateLimitState | undefined,
+  rule: RateLimitRule,
+  now: number,
+): RateLimitDecision {
+  const windowInMs = rule.window * 1000;
+  if (!state) {
+    return { next: { count: 1, lastRequest: now }, allowed: true, retryAfter: null };
+  }
+  if (now - state.lastRequest >= windowInMs) {
+    return { next: { count: 1, lastRequest: now }, allowed: true, retryAfter: null };
+  }
+  if (state.count >= rule.max) {
+    return {
+      next: state,
+      allowed: false,
+      // Mirrors better-auth's getRetryAfter (dist/api/rate-limiter/index.mjs:71).
+      retryAfter: Math.ceil((state.lastRequest + windowInMs - now) / 1000),
+    };
+  }
+  return {
+    next: { count: state.count + 1, lastRequest: now },
+    allowed: true,
+    retryAfter: null,
+  };
+}
+
+/** The RPC surface src/rate-limit-do.ts exposes; kept structural for testing. */
+export interface RateLimitCounterStub {
+  consume(rule: RateLimitRule): Promise<RateLimitOutcome>;
+}
+
+/**
+ * The slice of `DurableObjectNamespace<RateLimitCounter>` this module uses.
+ * Structural on purpose: unit tests pass a fake, and the real binding
+ * satisfies it without a cast.
+ */
+export interface RateLimitNamespaceLike<Id = unknown> {
+  idFromName(name: string): Id;
+  get(id: Id): RateLimitCounterStub;
+}
+
+/** Fail-open result, used for every error and for the timeout. */
+const FAIL_OPEN: RateLimitOutcome = { allowed: true, retryAfter: null };
+
+/**
+ * Default deadline for the DO round trip. A rate limiter must never be able
+ * to add unbounded latency to the hot path — that is exactly what the D1
+ * incident was. DO RPC has no abort signal, so the losing promise is simply
+ * abandoned (it settles harmlessly in the background; its write, if any,
+ * still lands in the counter).
+ */
+export const DEFAULT_RATE_LIMIT_TIMEOUT_MS = 1500;
+
+export type DurableRateLimitStorageOptions = {
+  timeoutMs?: number;
+  /** Injected in tests; defaults to `console.error`. */
+  onError?: (error: unknown) => void;
+};
+
+/**
+ * Build a Better Auth `rateLimit.customStorage` backed by one Durable Object
+ * per rate-limit key.
+ *
+ * `idFromName(key)` is deterministic, so every isolate in the fleet lands on
+ * the same object for a given key — the counter is exact and global, unlike
+ * the per-isolate memory Map — and Cloudflare places that object near its
+ * first caller, which keeps the round trip short for the IP-keyed buckets
+ * Better Auth uses.
+ */
+export function createDurableRateLimitStorage(
+  namespace: RateLimitNamespaceLike,
+  options: DurableRateLimitStorageOptions = {},
+): { consume: (key: string, rule: RateLimitRule) => Promise<RateLimitOutcome> } {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_RATE_LIMIT_TIMEOUT_MS;
+  const onError =
+    options.onError ??
+    ((error: unknown) => {
+      console.error(
+        JSON.stringify({
+          message: "auth_rate_limit_storage_failed",
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    });
+
+  return {
+    async consume(key, rule) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const stub = namespace.get(namespace.idFromName(key));
+        const call = Promise.resolve(stub.consume(rule));
+        // A rejection that lands after the timeout has already won the race
+        // would otherwise surface as an unhandled rejection — swallow it on
+        // this side branch; the race branch still observes it normally.
+        call.catch(() => {});
+        const timeout = new Promise<RateLimitOutcome | undefined>((resolve) => {
+          timer = setTimeout(() => resolve(undefined), timeoutMs);
+        });
+        const result = await Promise.race([call, timeout]);
+        if (!result) {
+          onError(new Error(`rate limit DO timed out after ${timeoutMs}ms`));
+          return FAIL_OPEN;
+        }
+        return result;
+      } catch (error) {
+        onError(error);
+        return FAIL_OPEN;
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -158,10 +158,16 @@ export const verification = sqliteTable(
 );
 
 /**
- * Better Auth's own database-backed rate limiter storage
- * (`rateLimit.storage: "database"`, see src/auth.ts). Model name is fixed at
- * "rateLimit" by Better Auth; `count`/`lastRequest` are plain epoch-ms
- * integers, not timestamp-mode columns.
+ * Better Auth's database-backed rate limiter storage model. Retained
+ * unused: since the 2026-08-23 D1 stall incident, src/auth.ts supplies its
+ * own `rateLimit.customStorage` backed by a per-key Durable Object
+ * (src/rate-limit-do.ts), falling back to Better Auth's in-process memory
+ * Map when the RATE_LIMIT binding is absent. Either way D1 is out of the
+ * rate-limit path. This table is kept only so existing deployments don't
+ * need a drop migration — nothing reads or
+ * writes it anymore. Model name is fixed at "rateLimit" by Better Auth;
+ * `count`/`lastRequest` are plain epoch-ms integers, not timestamp-mode
+ * columns.
  *
  * Paired migration: `migrations/20260712200000_better_auth_core.sql`.
  */

--- a/apps/auth/src/test/cloudflare-workers-stub.ts
+++ b/apps/auth/src/test/cloudflare-workers-stub.ts
@@ -1,0 +1,20 @@
+/**
+ * Test-only stand-in for the `cloudflare:workers` built-in module, which the
+ * workerd runtime provides but plain Node/vitest cannot resolve.
+ *
+ * apps/auth runs its suite on plain vitest with in-process fakes (see
+ * src/test/fake-d1.ts), so importing src/index.ts — which must re-export the
+ * `RateLimitCounter` Durable Object for wrangler — would otherwise fail at
+ * module load. vitest.config.ts aliases the module here.
+ *
+ * Only the surface apps/auth actually uses is stubbed: the `DurableObject`
+ * base class's `ctx`/`env` assignment. Behaviour of the DO subclass is tested
+ * through the pure `decideWindow` helper in src/rate-limit.ts, not through
+ * this class.
+ */
+export class DurableObject<TEnv = unknown> {
+  constructor(
+    readonly ctx: DurableObjectState,
+    readonly env: TEnv,
+  ) {}
+}

--- a/apps/auth/vitest.config.ts
+++ b/apps/auth/vitest.config.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+// apps/auth is otherwise on Vitest defaults (see the note in the repo-root
+// vitest.projects.ts). The single reason this file exists: src/index.ts
+// re-exports the `RateLimitCounter` Durable Object, which extends
+// `DurableObject` from the workerd-only `cloudflare:workers` module. Plain
+// Node can't resolve that specifier, so index.test.ts would fail at import
+// time. Alias it to a minimal test stub.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "cloudflare:workers": fileURLToPath(
+        new URL("./src/test/cloudflare-workers-stub.ts", import.meta.url),
+      ),
+    },
+  },
+});

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -142,13 +142,39 @@
       "service": "uploads-api",
     },
   ],
-  // Rate limiting: Better Auth's own database-backed rate limiter
-  // (storage: "database" in src/auth.ts) covers /api/auth/* abuse. An
-  // AUTH_RATE_LIMITER edge-limiter binding (namespace_id 1003) was reserved
+  // Rate limiting (2026-08-23 incident follow-up): Better Auth's limiter is
+  // backed by one `RateLimitCounter` Durable Object per rate-limit key —
+  // `rateLimit.customStorage` in src/auth.ts, class in src/rate-limit-do.ts,
+  // re-exported from src/index.ts because wrangler resolves `class_name`
+  // against the entrypoint's named exports. It replaces `storage: "database"`,
+  // whose per-request D1 read+write turned a D1 stall into a site-wide hang.
+  // The wrapper is fail-open and time-bounded, so this binding going sideways
+  // degrades to "no limiting", never to a stalled request.
+  //
+  // The `new_sqlite_classes` migration below is applied by the next
+  // `wrangler deploy` (i.e. the Workers Builds deploy of this branch); nothing
+  // to run by hand. Do not rename the class or the migration tag afterwards —
+  // renaming a DO class needs an explicit `renamed_classes` migration.
+  //
+  // An AUTH_RATE_LIMITER edge-limiter binding (namespace_id 1003) was reserved
   // here from PR #89 to #764 but never read by code — removed by the #754
-  // minimal-binding audit. If an edge limiter in front of Better Auth's is
+  // minimal-binding audit. If an edge limiter in FRONT of Better Auth's is
   // ever wired up, namespace_id 1003 is free to reuse (1001/1002 are taken
   // by apps/api and apps/mcp).
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "RATE_LIMIT",
+        "class_name": "RateLimitCounter",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["RateLimitCounter"],
+    },
+  ],
   // Workers Previews (`npx wrangler preview` from a branch). Deliberately
   // narrow for this worker: BETTER_AUTH_URL must equal the preview's own
   // origin, which is only known after the first preview deploy prints it —
@@ -197,5 +223,19 @@
         "service": "uploads-api",
       },
     ],
+    // Repeated verbatim because `previews` bindings do not inherit. No
+    // `script_name`/`environment`: those are only needed to reach a DO class
+    // defined in a DIFFERENT worker script. `RateLimitCounter` is defined and
+    // exported by this same script, so a preview gets its own object
+    // namespace on its own preview script — counters are naturally isolated
+    // from production's, which is what you want for a preview.
+    "durable_objects": {
+      "bindings": [
+        {
+          "name": "RATE_LIMIT",
+          "class_name": "RateLimitCounter",
+        },
+      ],
+    },
   },
 }

--- a/apps/web/src/lib/auth-proxy.test.ts
+++ b/apps/web/src/lib/auth-proxy.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { sessionResultFromResponse } from "./auth-client";
 import {
   proxyAuthRequest,
   serverAuthFetch,
@@ -14,6 +15,22 @@ afterEach(() => {
 function fakeAuthBinding(response: Response) {
   const fetch = vi.fn(async (_req: Request) => response);
   return { AUTH: { fetch }, fetchMock: fetch };
+}
+
+/**
+ * A binding fake that never resolves on its own — mirrors a D1-stalled auth
+ * worker holding the request open indefinitely. Rejects with an AbortError
+ * when the forwarded request's own signal aborts, same as a real `fetch`
+ * would, so it actually exercises `serverGetSession`'s timeout handling
+ * instead of just hanging forever regardless of the signal.
+ */
+function hangingBinding() {
+  return vi.fn(
+    (req: Request) =>
+      new Promise<Response>((_resolve, reject) => {
+        req.signal.addEventListener("abort", () => reject(req.signal.reason), { once: true });
+      }),
+  );
 }
 
 describe("proxyAuthRequest — binding transport", () => {
@@ -200,6 +217,82 @@ describe("serverGetSession", () => {
 
     const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
     expect(forwarded.headers.get("cookie")).toBe("");
+  });
+
+  it("settles with a synthetic 503 (not a throw) when the AUTH binding hangs past the timeout", async () => {
+    // Binding fetch never resolves — mirrors a D1-stalled auth worker holding
+    // the request open indefinitely. Uses a short injected timeoutMs so the
+    // test doesn't actually wait out the real 4s production default.
+    const hang = hangingBinding();
+    const request = new Request("https://uploads.sh/account/profile", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    const response = await serverGetSession({ AUTH: { fetch: hang } }, request, 20);
+
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(503);
+  });
+
+  it("resolving 503 timeout response parses as unavailable, distinct from a real 401 signed-out response", async () => {
+    const { AUTH: signedOutAuth } = fakeAuthBinding(Response.json(null, { status: 401 }));
+    const signedOut = await sessionResultFromResponse(
+      await serverGetSession(
+        { AUTH: signedOutAuth },
+        new Request("https://uploads.sh/account/profile"),
+      ),
+    );
+    expect(signedOut).toEqual({ kind: "signed_out" });
+
+    const hang = hangingBinding();
+    const timedOut = await sessionResultFromResponse(
+      await serverGetSession(
+        { AUTH: { fetch: hang } },
+        new Request("https://uploads.sh/account/profile"),
+        20,
+      ),
+    );
+    expect(timedOut).toEqual({ kind: "unavailable", reason: "server" });
+  });
+
+  it("normal, fast responses are unaffected by the timeout plumbing", async () => {
+    const { AUTH, fetchMock } = fakeAuthBinding(Response.json({ user: { id: "1" } }));
+    const request = new Request("https://uploads.sh/account/profile", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    });
+
+    const response = await serverGetSession({ AUTH }, request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ user: { id: "1" } });
+  });
+});
+
+describe("proxyAuthRequest — no timeout on general traffic", () => {
+  it("a hanging binding fetch leaves proxyAuthRequest unsettled (plain proxyAuthRequest carries no timeout)", async () => {
+    const hang = hangingBinding();
+    const request = new Request("https://uploads.sh/api/auth/sign-in/social", { method: "POST" });
+
+    let settled = false;
+    proxyAuthRequest({ AUTH: { fetch: hang } }, request).then(() => {
+      settled = true;
+    });
+
+    // Give any pending microtasks/timers a chance to fire; a bound request
+    // would already have rejected here, an unbound one must not have.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(settled).toBe(false);
+  });
+
+  it("does not attach a signal to the forwarded request", async () => {
+    const { AUTH, fetchMock } = fakeAuthBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/auth/sign-in/social", { method: "POST" });
+
+    await proxyAuthRequest({ AUTH }, request);
+
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.signal.aborted).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/auth-proxy.ts
+++ b/apps/web/src/lib/auth-proxy.ts
@@ -26,6 +26,16 @@ export interface AuthProxyEnv {
 const LOCAL_AUTH_ORIGIN_DEFAULT = "http://127.0.0.1:8788";
 
 /**
+ * Bound on `serverGetSession` only (2026-08-23 incident): a stalled D1 read
+ * inside the auth worker was observed holding the AUTH binding open 5–25s,
+ * which stalled every SSR page render behind it with no bound at all. This
+ * timeout is scoped to the read-only get-session lookup specifically —
+ * `proxyAuthRequest` itself stays unbounded for every other caller (sign-in,
+ * OAuth callbacks, and other mutations must never be aborted mid-write).
+ */
+const SESSION_LOOKUP_TIMEOUT_MS = 4_000;
+
+/**
  * Appended when a same-origin (host-only) session cookie is set for
  * `uploads.sh` — clears the pre-Phase-C wide `Domain=.uploads.sh` cookie so
  * the browser's jar doesn't carry both. Before Phase C the upstream
@@ -72,12 +82,39 @@ function withLegacyCookieCleared(upstream: Response, request: Request): Response
  * session` on the request's own origin, over the same transport as
  * `proxyAuthRequest`. A server-to-server fetch has no cookie jar of its own,
  * so the header must be forwarded explicitly.
+ *
+ * Carries an `AbortSignal.timeout` (see {@link SESSION_LOOKUP_TIMEOUT_MS})
+ * on the request itself — `proxyAuthRequest` forwards whatever signal the
+ * request already has, so the binding/HTTP fetch it makes is bounded without
+ * `proxyAuthRequest` needing to know about timeouts at all. `timeoutMs` is
+ * only for tests, so they can exercise a hanging binding without a real 4s
+ * wait; production callers always get the default.
  */
-export async function serverGetSession(env: AuthProxyEnv, request: Request): Promise<Response> {
+export async function serverGetSession(
+  env: AuthProxyEnv,
+  request: Request,
+  timeoutMs = SESSION_LOOKUP_TIMEOUT_MS,
+): Promise<Response> {
   const getSessionRequest = new Request(new URL("/api/auth/get-session", request.url), {
     headers: { cookie: request.headers.get("cookie") ?? "" },
+    signal: AbortSignal.timeout(timeoutMs),
   });
-  return proxyAuthRequest(env, getSessionRequest);
+  try {
+    return await proxyAuthRequest(env, getSessionRequest);
+  } catch (err) {
+    if (getSessionRequest.signal.aborted) {
+      // Synthetic response, not a throw: every current consumer parses a
+      // Response via `sessionResultFromResponse` (401 → signed_out, non-ok →
+      // `{ kind: "unavailable", reason: "server" }`) and only falls back to
+      // its own `.catch` for a *thrown* network failure. Returning a non-ok
+      // Response here — instead of letting the AbortError propagate — routes
+      // a timeout through that same already-handled "unavailable" path
+      // rather than a second, less-exercised error path, and keeps
+      // "signed out" distinguishable from "auth unavailable" either way.
+      return new Response(null, { status: 503, statusText: "auth session lookup timed out" });
+    }
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
## Incident

2026-08-23: intermittent 4–25 s page loads and hanging API requests in prod. Diagnosis (three-way `wrangler tail` + racing the worker path against direct `SELECT 1` probes on both D1 databases) localized it to Cloudflare-side stall windows on the production D1 database itself — the same query that averages <1 ms would take 5–25 s over any access path, while the preview database stayed flat in the same samples. The app amplified the stall in two ways:

1. Better Auth's rate limiter used `storage: "database"`, so **every** `/api/auth/*` request — including `get-session`, which the api worker calls over the service binding on every signed-in request — paid a D1 read+write before the handler even ran.
2. Every auth lookup in the request path awaited the AUTH binding with no timeout, so one stalled dependency hung SSR renders and API calls for the full stall duration.

## Changes

**auth**
- `/get-session` is exempt from rate limiting (`customRules: { "/get-session": false }`) — the hottest path now has no rate-limit storage dependency of any kind. It's a cheap read called by our own api worker over a trusted service binding; the old 600/min budget was defending against our own client fan-out bugs (fixed in #797).
- The remaining rate-limited endpoints (sign-in, register, magic-link, …) move to a Durable-Object `customStorage`: one `RateLimitCounter` per rate-limit key (`idFromName` → exact, fleet-wide fixed-window counts; the decision logic byte-for-byte mirrors Better Auth 1.7.1's `decideConsume`/`getRetryAfter`). The wrapper is **fail-open** (any error → allowed) and **bounded at 1.5 s** (DO call raced against a timer), so no storage backend can ever stall a request again. Memory fallback when the binding is absent (tests, bare local envs).
- The `rate_limit` D1 table is retained unused — no drop migration.

**api** — 4 s `AbortSignal.timeout` on the read-only AUTH lookups (`resolveSessionUser`, `membershipsForUser`); timeouts surface as the existing 503 shapes (`auth_session_unavailable` / `auth_lookup_failed`) instead of a 10–25 s hang. Mutation/proxy paths untouched.

**web** — same 4 s bound on the SSR `serverGetSession` lookup only, surfaced as a synthetic 503 that lands in the existing "Authentication is temporarily unavailable" path. `proxyAuthRequest` stays unbounded — sign-in/OAuth mutations must never be aborted mid-write.

## Deploy notes

- The DO binding + `v1` migration (`new_sqlite_classes: ["RateLimitCounter"]`) apply automatically on the next Workers Builds deploy of uploads-auth. Don't rename the class/tag later without a `renamed_classes` migration.
- Verified with `wrangler deploy --dry-run` (binding resolves) and the full monorepo suite (4,950 tests green).

## Recommended follow-up (zone config, not in this PR)

Add a WAF rate-limiting rule (Pro plan includes 2) on `uploads.sh/api/auth/*`, keyed per IP, as the edge backstop for browser-originated abuse — that's where volumetric protection belongs now that the app-level limiter is scoped to sensitive mutations.

Also worth filing a Cloudflare ticket for the underlying D1 stalls; app-side, this PR makes them degrade to fast 503s instead of site-wide hangs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sign-in rate limiting with reliable shared tracking and retry guidance when limits are reached.
  * Session checks are no longer rate-limited, helping authenticated experiences remain accessible.

* **Bug Fixes**
  * Added timeouts for authentication and membership lookups, preventing requests from hanging indefinitely.
  * Authentication service failures now return clear, prompt service-unavailable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->