### PR TITLE
fix(web,auth): bound browser get-session and stretch the session cookie cache

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -771,7 +771,14 @@ function buildAuth(
       // /list-sessions uses freshSessionMiddleware (default 24h → SESSION_NOT_FRESH).
       // We only use it for account UX, not high-sensitivity actions — disable.
       freshAge: 0,
-      cookieCache: { enabled: true, maxAge: 5 * 60 },
+      // 15 min (was 5): during the 2026-08-23 D1 stall incident, every
+      // cookie-cache expiry forced a D1 session read that could land in a
+      // stall window and surface as a fast "auth unavailable" 503. A longer
+      // cache means signed-in users touch D1 a third as often, at the cost
+      // of session revocation (sign-out elsewhere, ban) taking up to 15 min
+      // to propagate to cached readers — acceptable for this product's
+      // threat model; high-sensitivity actions re-verify server-side.
+      cookieCache: { enabled: true, maxAge: 15 * 60 },
       // CLI package version — set/refreshed via POST /update-session (not core
       // userAgent, which Better Auth freezes after create). See account Sessions.
       additionalFields: {

--- a/apps/web/src/lib/auth-proxy.test.ts
+++ b/apps/web/src/lib/auth-proxy.test.ts
@@ -296,6 +296,44 @@ describe("proxyAuthRequest — no timeout on general traffic", () => {
   });
 });
 
+describe("proxyAuthRequest — bounded browser get-session", () => {
+  it("settles with a synthetic 503 when the binding hangs on GET get-session", async () => {
+    const hang = hangingBinding();
+    const request = new Request("https://uploads.sh/api/auth/get-session");
+
+    const response = await proxyAuthRequest({ AUTH: { fetch: hang } }, request, 20);
+
+    expect(response.status).toBe(503);
+    expect(await sessionResultFromResponse(response)).toEqual({
+      kind: "unavailable",
+      reason: "server",
+    });
+  });
+
+  it("propagates the caller's own abort as a throw, not a synthetic 503", async () => {
+    const hang = hangingBinding();
+    const controller = new AbortController();
+    const request = new Request("https://uploads.sh/api/auth/get-session", {
+      signal: controller.signal,
+    });
+
+    const pending = proxyAuthRequest({ AUTH: { fetch: hang } }, request, 5_000);
+    controller.abort(new DOMException("gone", "AbortError"));
+
+    await expect(pending).rejects.toThrow();
+  });
+
+  it("normal GET get-session responses pass through untouched", async () => {
+    const { AUTH } = fakeAuthBinding(Response.json({ user: { id: "1" } }));
+    const request = new Request("https://uploads.sh/api/auth/get-session");
+
+    const response = await proxyAuthRequest({ AUTH }, request, 20);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ user: { id: "1" } });
+  });
+});
+
 describe("serverAuthFetch", () => {
   it("resolves a relative path against the request's own origin and forwards its cookie header", async () => {
     const { AUTH, fetchMock } = fakeAuthBinding(Response.json(null));

--- a/apps/web/src/lib/auth-proxy.ts
+++ b/apps/web/src/lib/auth-proxy.ts
@@ -45,13 +45,54 @@ const SESSION_LOOKUP_TIMEOUT_MS = 4_000;
 const LEGACY_CLEAR_COOKIE =
   "__Secure-better-auth.session_token=; Path=/; Domain=.uploads.sh; Max-Age=0; Secure; HttpOnly; SameSite=Lax";
 
-/** Forwards `request` to the auth worker (binding, else HTTP fallback). */
-export async function proxyAuthRequest(env: AuthProxyEnv, request: Request): Promise<Response> {
-  const forwarded = new Request(request, { redirect: "manual" });
-  const upstream = env.AUTH
-    ? await env.AUTH.fetch(forwarded)
-    : await fetch(rewriteOrigin(forwarded, env.UPLOADS_AUTH_ORIGIN ?? LOCAL_AUTH_ORIGIN_DEFAULT));
-  return withLegacyCookieCleared(upstream, request);
+/**
+ * True for the one auth-proxy request that is safe to time-bound: a GET of
+ * `/api/auth/get-session`. Every other `/api/auth/*` request may be a
+ * mutation (sign-in, OAuth callback) that must never be aborted mid-write.
+ */
+function isGetSessionRead(request: Request): boolean {
+  return request.method === "GET" && new URL(request.url).pathname === "/api/auth/get-session";
+}
+
+/**
+ * Forwards `request` to the auth worker (binding, else HTTP fallback).
+ *
+ * Browser-facing `GET /api/auth/get-session` carries the same
+ * {@link SESSION_LOOKUP_TIMEOUT_MS} bound as the SSR path
+ * ({@link serverGetSession}): during the 2026-08-23 D1 stall incident this
+ * raw XHR path was the last unbounded auth read and was observed hanging
+ * client fetches for the full stall duration. A timeout surfaces as the
+ * same synthetic 503 the SSR path returns — parsed by
+ * `sessionResultFromResponse` as "unavailable", distinct from signed-out.
+ * The caller's own abort (navigation away) still propagates as a throw.
+ */
+export async function proxyAuthRequest(
+  env: AuthProxyEnv,
+  request: Request,
+  // Injected in tests only, like serverGetSession's `timeoutMs`.
+  sessionTimeoutMs = SESSION_LOOKUP_TIMEOUT_MS,
+): Promise<Response> {
+  const bounded = isGetSessionRead(request);
+  const forwarded = new Request(
+    request,
+    bounded
+      ? {
+          redirect: "manual",
+          signal: AbortSignal.any([request.signal, AbortSignal.timeout(sessionTimeoutMs)]),
+        }
+      : { redirect: "manual" },
+  );
+  try {
+    const upstream = env.AUTH
+      ? await env.AUTH.fetch(forwarded)
+      : await fetch(rewriteOrigin(forwarded, env.UPLOADS_AUTH_ORIGIN ?? LOCAL_AUTH_ORIGIN_DEFAULT));
+    return withLegacyCookieCleared(upstream, request);
+  } catch (err) {
+    if (bounded && forwarded.signal.aborted && !request.signal.aborted) {
+      return new Response(null, { status: 503, statusText: "auth session lookup timed out" });
+    }
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
Follow-up to #805 while the underlying Cloudflare D1 stalls continue (ticket recommended in that PR).

- **web**: browser-facing `GET /api/auth/get-session` now carries the same 4 s bound as the SSR path — it was the last unbounded auth read, observed hanging a client fetch 100 s+ during a stall window after #805 merged. Timeouts surface as the same synthetic 503 the SSR path returns (parsed as "unavailable", distinct from signed-out); a caller's own abort still propagates as a throw; every other `/api/auth/*` request stays unbounded because it may be a mutation.
- **auth**: session `cookieCache` maxAge 5 min → 15 min. Each cookie-cache expiry forces a D1 session read that can land in a stall window and surface as a fast "auth unavailable" 503; a longer cache means signed-in users fall through to D1 a third as often. Trade-off (documented in-code): session revocation takes up to 15 min to reach cookie-cached readers.

Tests: web 863 pass (3 new for the bounded path), auth 334 pass.