### PR TITLE
fix(web): keep signed-in shell visible through auth outages

### DIFF
--- a/apps/web/src/lib/account-shell.test.ts
+++ b/apps/web/src/lib/account-shell.test.ts
@@ -11,7 +11,8 @@ vi.mock("./auth-client", async (importOriginal) => ({
   ...auth,
 }));
 
-import { resolveSessionGate, type SessionGateOptions } from "./account-shell";
+import { resolveSessionGate, SESSION_CACHE_KEY, type SessionGateOptions } from "./account-shell";
+import { markPageLoad, resetPageVisitForTests } from "./page-visit";
 
 function element(): HTMLElement {
   return { hidden: false, textContent: "" } as HTMLElement;
@@ -63,8 +64,14 @@ afterEach(() => {
   auth.getSession.mockReset();
   auth.signOut.mockReset();
   auth.startLocalDemoSession.mockReset();
+  resetPageVisitForTests();
   vi.unstubAllGlobals();
 });
+
+/** Resolves once queued zero-delay retry timers and their promises have run. */
+function flushRetries(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
 
 describe("resolveSessionGate", () => {
   it("shows unavailable when local demo session creation cannot reach Auth", async () => {
@@ -146,6 +153,85 @@ describe("resolveSessionGate", () => {
     );
     expect(options.denied.hidden).toBe(true);
     expect(options.app.hidden).toBe(true);
+  });
+
+  it("keeps the shell visible on auth-unavailable when an identity is cached", async () => {
+    const { values } = installBrowser();
+    values.set(
+      SESSION_CACHE_KEY,
+      JSON.stringify({ id: "user", email: "user@example.com", name: "User", role: "user" }),
+    );
+    markPageLoad();
+    const options = { ...gate(), retryDelaysMs: [0] };
+    const session = {
+      session: {},
+      user: { id: "user", email: "user@example.com", name: "User", role: "user" },
+    };
+    auth.getSession
+      .mockResolvedValueOnce({ kind: "unavailable", reason: "server" })
+      .mockResolvedValueOnce({ kind: "signed_in", session });
+
+    await expect(resolveSessionGate(options)).resolves.toBeNull();
+    expect(options.app.hidden).toBe(false);
+    expect(options.unavailable.hidden).toBe(true);
+
+    await flushRetries();
+    expect(auth.getSession).toHaveBeenCalledTimes(2);
+    expect(options.app.hidden).toBe(false);
+    expect(values.get(SESSION_CACHE_KEY)).toContain("user@example.com");
+  });
+
+  it("keeps the shell visible when every background retry stays unavailable", async () => {
+    const { values } = installBrowser();
+    values.set(
+      SESSION_CACHE_KEY,
+      JSON.stringify({ id: "user", email: "user@example.com", name: "User", role: "user" }),
+    );
+    markPageLoad();
+    const options = { ...gate(), retryDelaysMs: [0, 0] };
+    auth.getSession.mockResolvedValue({ kind: "unavailable", reason: "server" });
+
+    await expect(resolveSessionGate(options)).resolves.toBeNull();
+    await flushRetries();
+    await flushRetries();
+    expect(auth.getSession).toHaveBeenCalledTimes(3);
+    expect(options.app.hidden).toBe(false);
+    expect(options.unavailable.hidden).toBe(true);
+  });
+
+  it("still blocks on auth-unavailable when no identity is known", async () => {
+    installBrowser();
+    const options = gate();
+    auth.getSession.mockResolvedValue({ kind: "unavailable", reason: "server" });
+
+    await expect(resolveSessionGate(options)).resolves.toBeNull();
+    expect(options.unavailable.hidden).toBe(false);
+    expect(options.app.hidden).toBe(true);
+  });
+
+  it("redirects to login when a background retry finds the session signed out", async () => {
+    const replace = vi.fn();
+    const { values } = installBrowser();
+    vi.stubGlobal("location", {
+      origin: "https://uploads.sh",
+      pathname: "/account",
+      search: "",
+      replace,
+    });
+    values.set(
+      SESSION_CACHE_KEY,
+      JSON.stringify({ id: "user", email: "user@example.com", name: "User", role: "user" }),
+    );
+    markPageLoad();
+    const options = { ...gate(), retryDelaysMs: [0] };
+    auth.getSession
+      .mockResolvedValueOnce({ kind: "unavailable", reason: "server" })
+      .mockResolvedValueOnce({ kind: "signed_out" });
+
+    await expect(resolveSessionGate(options)).resolves.toBeNull();
+    await flushRetries();
+    expect(replace).toHaveBeenCalledWith("/login?callbackURL=%2Faccount");
+    expect(values.has(SESSION_CACHE_KEY)).toBe(false);
   });
 
   it("shows the app without a who node when the header owns session UI", async () => {

--- a/apps/web/src/lib/account-shell.ts
+++ b/apps/web/src/lib/account-shell.ts
@@ -17,7 +17,7 @@ import {
   type SessionResponse,
   type SessionUser,
 } from "./auth-client";
-import { markPageLoad } from "./page-visit";
+import { getPageVisit, isCurrentPageVisit, markPageLoad } from "./page-visit";
 import { loginHref } from "./signed-in-page";
 import { clearWorkspaceSnapshots } from "./workspace-cache";
 
@@ -155,7 +155,52 @@ export type SessionGateOptions = {
   who?: HTMLElement | null;
   /** When set, only accept sessions with this `user.role` (e.g. `"admin"`). */
   requireRole?: string;
+  /** Test seam: background-retry delays after an "unavailable" revalidation. */
+  retryDelaysMs?: number[];
 };
+
+/**
+ * Background revalidation retries after "auth unavailable" with a cached
+ * identity (2026-08-23 D1 stall incident): auth outages come in ~10s windows,
+ * so a shell kept visible usually revalidates successfully on the next try.
+ * Spread wider than a stall window; give up quietly after the last one — the
+ * next navigation re-gates anyway.
+ */
+const UNAVAILABLE_RETRY_DELAYS_MS = [10_000, 30_000, 60_000];
+
+function retryGateInBackground(options: SessionGateOptions): void {
+  const visit = getPageVisit();
+  const delays = options.retryDelaysMs ?? UNAVAILABLE_RETRY_DELAYS_MS;
+  let attempt = 0;
+  const tick = (): void => {
+    if (attempt >= delays.length) return;
+    const delay = delays[attempt++];
+    setTimeout(() => {
+      if (!isCurrentPageVisit(visit)) return;
+      void getSession(options.authOrigin).then((result) => {
+        if (!isCurrentPageVisit(visit)) return;
+        if (result.kind === "unavailable") {
+          tick();
+          return;
+        }
+        if (result.kind === "signed_out") {
+          clearCachedSessionUser();
+          redirectToSignIn();
+          return;
+        }
+        if (options.requireRole && result.session.user.role !== options.requireRole) {
+          clearCachedSessionUser();
+          showDenied(options);
+          return;
+        }
+        writeCachedSessionUser(result.session.user);
+        showApp(result.session.user, options);
+        publishSession(result.session.user, true);
+      });
+    }, delay);
+  };
+  tick();
+}
 
 /**
  * Toggle checking / denied / app shells from the session.
@@ -186,6 +231,19 @@ export async function resolveSessionGate(
   }
 
   if (result.kind === "unavailable") {
+    // An auth outage is not a sign-out. With a known identity the shell is
+    // already painted (cache or SSR seed) — keep it up and revalidate in the
+    // background instead of blanking the whole app; per-request auth is still
+    // enforced server-side on every API call. Only a visit with no identity
+    // at all gets the blocking "try again" screen.
+    if (cached) {
+      // Re-assert the shell state: showApp(cached) ran before the network
+      // check, but make the outage panel's hidden state explicit here too.
+      showApp(cached, options);
+      options.unavailable.hidden = true;
+      retryGateInBackground(options);
+      return null;
+    }
     showUnavailable(options);
     return null;
   }


### PR DESCRIPTION
## What

During an auth outage (like today's D1 stalls), the session gate's background revalidation returns "unavailable" — and until now that blanked the entire already-rendered app into the blocking **"Authentication is temporarily unavailable"** screen, even though the user's identity was already known from the sessionStorage cache or the SSR seed.

Now `resolveSessionGate` treats an outage with a known identity as a soft failure:

- The painted shell stays visible (the outage panel stays hidden).
- get-session retries in the background at 10s / 30s / 60s — matched to the observed ~10s stall windows — then gives up quietly (the next navigation re-gates).
- A retry that finds the session **signed out** still redirects to /login; a role mismatch still shows denied.
- A visit with **no** known identity (cold cache, first load) keeps the blocking screen — there's nothing meaningful to render.

This is safe because the cache was always a UX affordance only: every API call re-enforces the real session server-side, so page data degrades to its own per-request error states while the chrome stays usable.

## Why now

Follow-up to #805/#806. With get-session bounded at 4s, a D1 stall window turns into fast 503s — correct fail-fast behavior, but the gate was amplifying one failed revalidation into a full-app hard failure on pages that were already rendered and usable.

## Testing

- 4 new `resolveSessionGate` tests: shell stays up on unavailable-with-cache, stays up through exhausted retries, still blocks with no identity, redirects when a retry finds signed-out.
- Full apps/web suite: 58 files / 867 tests green.