### PR TITLE
fix(cli): add request timeouts and bounded retry to core API calls

### DIFF
--- a/.changeset/cli-request-resilience.md
+++ b/.changeset/cli-request-resilience.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Add request timeouts and bounded retry to the CLI's core API calls. JSON control calls now time out after ~15s and content uploads after ~60s instead of hanging for undici's ~5 minute default; a single retry follows network errors, 503, and 429 for idempotent GET/PUT calls, honoring the API's `X-Retry-After` header (capped at ~10s) when present.

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -507,16 +507,123 @@ export interface EnrollmentCreateResult {
   emailed?: boolean;
 }
 
-async function jsonRequest<T>(url: string, init: RequestInit): Promise<T> {
-  let res: Response;
+// --- Request resilience (issue #809) ---------------------------------------
+//
+// Bare `fetch` has no timeout — undici's default header timeout is ~5
+// minutes, so a backend stall (see the 2026-08-23 D1 stall incident, #808)
+// hangs the CLI silently for that whole window instead of failing fast like
+// the workers now do (#805-#807). Every core API call routes through
+// `resilientFetch` for a bounded timeout and a single bounded retry.
+//
+// Timeouts: short for JSON control calls, longer for the one content-bytes
+// call (file `put`), matching the side-channel calls' pattern (telemetry.ts,
+// update-check.ts already carry AbortController timeouts — this closes the
+// gap on the core path).
+const JSON_TIMEOUT_MS = 15_000;
+const CONTENT_TIMEOUT_MS = 60_000;
+
+// At most one retry. Retried on network errors, 503, and 429 — and only for
+// GET/PUT, since a `put` is byte-idempotent (same key, same bytes) but a
+// POST/DELETE/PATCH might not be, and telling "no bytes sent" apart from "the
+// mutation already landed" isn't reliable enough to risk a double-apply.
+const MAX_ATTEMPTS = 2;
+const RETRYABLE_METHODS = new Set(["GET", "PUT"]);
+const RETRYABLE_STATUSES = new Set([429, 503]);
+const DEFAULT_RETRY_DELAY_MS = 2_000;
+// Cap an honored X-Retry-After so a large server-suggested backoff can't
+// stall a hook/CI step for minutes.
+const MAX_RETRY_AFTER_DELAY_MS = 10_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Seconds-valued retry delay from the response, capped; falls back to the default backoff. */
+function retryDelayMs(res: Response | undefined): number {
+  const raw = res?.headers.get("x-retry-after") ?? res?.headers.get("retry-after");
+  const seconds = raw ? Number(raw) : NaN;
+  if (Number.isFinite(seconds) && seconds > 0) {
+    return Math.min(seconds * 1000, MAX_RETRY_AFTER_DELAY_MS);
+  }
+  return DEFAULT_RETRY_DELAY_MS;
+}
+
+/** One-line stderr notice so a hook/CI log explains the pause (issue #809). */
+function printRetryNotice(label: string, delayMs: number): void {
+  const seconds = delayMs % 1000 === 0 ? `${delayMs / 1000}s` : `${Math.round(delayMs) / 1000}s`;
+  process.stderr.write(`warning: uploads.sh ${label}, retrying in ${seconds}…\n`);
+}
+
+/**
+ * fetch with a per-request AbortController timeout. A timeout (or any other
+ * fetch rejection) surfaces as `UploadsError` code `NETWORK`, naming the
+ * timeout so hook/CI logs are diagnosable.
+ */
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    res = await fetch(url, init);
+    return await fetch(url, { ...init, signal: controller.signal });
   } catch (err) {
+    if (controller.signal.aborted) {
+      throw new UploadsError(`request timed out after ${timeoutMs}ms`, "NETWORK");
+    }
     throw new UploadsError(
       err instanceof Error ? err.message : "network request failed",
       "NETWORK",
     );
+  } finally {
+    clearTimeout(timer);
   }
+}
+
+/**
+ * The shared resilience core for both `jsonRequest` and
+ * `createUploadsClient`'s `request`: bounded timeout + bounded retry on
+ * network errors, 503, and 429, honoring `X-Retry-After` when present.
+ * Never retries a non-idempotent method (see `RETRYABLE_METHODS` above).
+ * Returns the raw `Response` on the final attempt — callers still handle
+ * `!res.ok` themselves via `parseErrorResponse`.
+ */
+async function resilientFetch(
+  method: string,
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const retryable = RETRYABLE_METHODS.has(method.toUpperCase());
+  for (let attempt = 1; ; attempt++) {
+    let res: Response | undefined;
+    let networkErr: UploadsError | undefined;
+    try {
+      res = await fetchWithTimeout(url, init, timeoutMs);
+    } catch (err) {
+      networkErr = err as UploadsError;
+    }
+
+    const canRetry =
+      retryable &&
+      attempt < MAX_ATTEMPTS &&
+      (networkErr !== undefined || (res !== undefined && RETRYABLE_STATUSES.has(res.status)));
+
+    if (!canRetry) {
+      if (networkErr) throw networkErr;
+      return res as Response;
+    }
+
+    const delayMs = retryDelayMs(res);
+    printRetryNotice(res ? `responded ${res.status}` : "request failed", delayMs);
+    await sleep(delayMs);
+  }
+}
+
+async function jsonRequest<T>(url: string, init: RequestInit): Promise<T> {
+  const method = (init.method ?? "GET").toUpperCase();
+  const res = await resilientFetch(method, url, init, JSON_TIMEOUT_MS);
   if (!res.ok) throw await parseErrorResponse(res);
   return (await res.json()) as T;
 }
@@ -922,24 +1029,30 @@ export function createUploadsClient(config: UploadsClientConfig) {
   async function request<T>(
     method: string,
     path: string,
-    opts?: { body?: Uint8Array; headers?: Record<string, string>; auth?: boolean },
+    opts?: {
+      body?: Uint8Array;
+      headers?: Record<string, string>;
+      auth?: boolean;
+      /**
+       * Content PUT/GET calls (byte bodies/downloads) get the longer
+       * timeout; every JSON control call uses the default. Set by `put`'s
+       * real (non-dry-run) write below — the only content-bytes call this
+       * client makes today.
+       */
+      longTimeout?: boolean;
+    },
   ): Promise<T> {
     const headers: Record<string, string> = { ...opts?.headers };
     if (opts?.auth !== false) {
       headers.Authorization = `Bearer ${config.token}`;
     }
 
-    let res: Response;
-    try {
-      res = await fetch(path, {
-        method,
-        headers,
-        body: opts?.body,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "network request failed";
-      throw new UploadsError(message, "NETWORK");
-    }
+    const res = await resilientFetch(
+      method,
+      path,
+      { method, headers, body: opts?.body },
+      opts?.longTimeout ? CONTENT_TIMEOUT_MS : JSON_TIMEOUT_MS,
+    );
 
     if (!res.ok) {
       throw await parseErrorResponse(res);
@@ -1056,6 +1169,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
       }>("PUT", `${canonicalFilesBase(config)}/${encodeKeyPath(key)}`, {
         body,
         headers,
+        longTimeout: true,
       });
 
       if (result.url == null) {

--- a/packages/uploads/test/client-resilience.test.ts
+++ b/packages/uploads/test/client-resilience.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createUploadsClient } from "../src/client.js";
+import { UploadsError } from "../src/errors.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function client() {
+  return createUploadsClient({
+    apiUrl: "https://api.test",
+    workspace: "test",
+    token: "up_test_x",
+  });
+}
+
+/** A fetch stub that only settles when its AbortSignal fires — simulates a stall. */
+function stallingFetch() {
+  return vi.fn(
+    (_url: string, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      }),
+  );
+}
+
+const listBody = JSON.stringify({ files: [], cursor: null });
+
+describe("request timeouts", () => {
+  it("times out a non-retried JSON call and maps to a NETWORK error naming the timeout", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", stallingFetch());
+
+    const promise = client()
+      .createGallery({ title: "t" })
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+    await vi.advanceTimersByTimeAsync(15_000);
+    const err = await promise;
+
+    expect(err).toBeInstanceOf(UploadsError);
+    expect((err as UploadsError).code).toBe("NETWORK");
+    expect((err as UploadsError).message).toContain("15000ms");
+  });
+
+  it("times out a GET once and retries before ultimately failing", async () => {
+    vi.useFakeTimers();
+    const fetchMock = stallingFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = client()
+      .list()
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+    // First attempt times out (15s), backoff (2s default — no response to read
+    // X-Retry-After from), then the retried attempt also times out (15s).
+    await vi.advanceTimersByTimeAsync(15_000 + 2_000 + 15_000);
+    const err = await promise;
+
+    expect(err).toBeInstanceOf(UploadsError);
+    expect((err as UploadsError).code).toBe("NETWORK");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("bounded retry", () => {
+  it("retries a 503 GET once and succeeds", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls++;
+      if (calls === 1) return new Response(null, { status: 503 });
+      return new Response(listBody, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = client().list();
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await promise;
+
+    expect(result.items).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a 429 GET once and succeeds", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls++;
+      if (calls === 1) return new Response(null, { status: 429 });
+      return new Response(listBody, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = client().list();
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await promise;
+
+    expect(result.items).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the single retry (max 2 attempts total)", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = client()
+      .list()
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+    await vi.advanceTimersByTimeAsync(2_000);
+    const err = await promise;
+
+    expect(err).toBeInstanceOf(UploadsError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors X-Retry-After, capped at ~10s", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls++;
+      if (calls === 1) {
+        return new Response(null, { status: 503, headers: { "X-Retry-After": "100" } });
+      }
+      return new Response(listBody, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = client().list();
+    await vi.advanceTimersByTimeAsync(9_999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors a short X-Retry-After under the cap", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls++;
+      if (calls === 1) {
+        return new Response(null, { status: 503, headers: { "X-Retry-After": "1" } });
+      }
+      return new Response(listBody, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = client().list();
+    await vi.advanceTimersByTimeAsync(999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a non-idempotent POST on 503", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const err = await client()
+      .createGallery({ title: "t" })
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+
+    expect(err).toBeInstanceOf(UploadsError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry DELETE on 503", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const err = await client()
+      .delete("a.png")
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+
+    expect(err).toBeInstanceOf(UploadsError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("prints a one-line stderr notice when a retry happens", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls++;
+      if (calls === 1) return new Response(null, { status: 503 });
+      return new Response(listBody, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const promise = client().list();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await promise;
+
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining("uploads.sh responded 503, retrying in 2s"),
+    );
+    writeSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #809

## Problem

`packages/uploads/src/client.ts`'s two core wrappers — `jsonRequest` (device login, enrollment exchange) and `createUploadsClient.request` (put, list, meta, delete, comment sync, and everything else) — used bare `fetch` with no timeout, so a backend stall hung the CLI silently for undici's ~5 minute default header timeout. There was also no retry, so a single 503 (including the fail-fast 503s the workers now return mid-stall, per #805-#807) failed the whole command, which is a hard failure in a pre-commit hook or CI step for what's a transient window. The API's `X-Retry-After` header (#797) was never read.

## What changed

Both wrappers now route through a shared `resilientFetch` helper in `client.ts`:

- **Timeout**: ~15s for JSON control calls, ~60s for the content-bytes PUT (file upload, the one call that sends raw bytes instead of a JSON body). A timeout surfaces as `UploadsError` with code `NETWORK` and a message naming the timeout, so hook/CI logs are diagnosable.
- **Bounded retry**: at most one retry (2 attempts total) on network errors, 503, and 429 — restricted to GET/PUT, since those are the byte-idempotent methods here. POST/DELETE/PATCH are never retried, since telling "no bytes landed" apart from "the mutation already applied" isn't reliable enough to risk a double-apply.
- **`X-Retry-After`**: honored when present (seconds, capped at ~10s); otherwise a ~2s backoff.
- **Stderr notice**: one line on retry (`warning: uploads.sh responded 503, retrying in 2s…`), matching the CLI's existing `warning: …` stderr convention.

This mirrors the pattern the side-channel calls already use (`telemetry.ts`, `update-check.ts` both carry AbortController timeouts) — the core path was the holdout.

## Tests

Added `packages/uploads/test/client-resilience.test.ts` (plain vitest, in-process fetch fakes, fake timers — no real multi-second waits): timeout maps to `NETWORK`, 503-then-success and 429-then-success retry and succeed, retry is capped at 2 attempts, `X-Retry-After` is honored and capped, POST/DELETE are not retried, and the retry notice is printed.

`pnpm test` from repo root: 330 files / 4967 tests passing.

Also adds a patch changeset for `@buildinternet/uploads`.