### PR TITLE
feat(api): route D1 queries through the Sessions API

### DIFF
--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -2,6 +2,7 @@ import { ForbiddenError, UnauthorizedError } from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
 import { findActiveToken, isOperatorScope, touchTokenLastUsed } from "./auth-db";
 import { hexToBytes, sha256Hex, workspaceNameFromToken } from "./workspace";
+import { dbFor } from "./db-session";
 
 const READ_METHODS = new Set(["GET", "HEAD"]);
 
@@ -39,9 +40,9 @@ export const adminAuth: MiddlewareHandler<{
   const workspace = token ? workspaceNameFromToken(token) : undefined;
   if (!workspace) throw new UnauthorizedError();
 
-  const record = await findActiveToken(c.env.DB, workspace, token);
+  const record = await findActiveToken(dbFor(c.env), workspace, token);
   if (!record) throw new UnauthorizedError();
-  await touchTokenLastUsed(c.env.DB, record.id);
+  await touchTokenLastUsed(dbFor(c.env), record.id);
 
   // record.scopes is operator-token-or-file-token JSON; parseScopes (auth-db.ts)
   // is file-scope-only, so parse directly here and keep just the operator ones.

--- a/apps/api/src/adoption-queries.ts
+++ b/apps/api/src/adoption-queries.ts
@@ -25,6 +25,7 @@
 
 import type { AdoptionMetric } from "./adoption";
 import { ADOPTION_METRICS, utcDay } from "./adoption";
+import { type D1Queryable } from "./db-session";
 
 export interface DayPoint {
   day: string;
@@ -55,7 +56,7 @@ export function windowStart(days: number, now = new Date()): string {
 
 /** Daily platform totals for one metric. One index entry per day in window. */
 export async function platformSeries(
-  db: D1Database,
+  db: D1Queryable,
   metric: AdoptionMetric,
   since: string,
 ): Promise<DayPoint[]> {
@@ -72,7 +73,7 @@ export async function platformSeries(
 
 /** Per-workspace upload activity in the window, busiest first. */
 export async function workspaceActivity(
-  db: D1Database,
+  db: D1Queryable,
   since: string,
   limit = DEFAULT_LIMIT,
 ): Promise<WorkspaceActivity[]> {
@@ -108,7 +109,7 @@ export interface ActiveWorkspace {
  * read, and the last 7 days are always a subset of the last 30).
  */
 export async function activeWorkspacesSince(
-  db: D1Database,
+  db: D1Queryable,
   since: string,
 ): Promise<ActiveWorkspace[]> {
   const result = await db
@@ -134,7 +135,7 @@ export async function activeWorkspacesSince(
  * mirroring the pattern the other queries in this module already use.
  */
 export async function featureTotals(
-  db: D1Database,
+  db: D1Queryable,
   since: string,
 ): Promise<Record<string, number>> {
   const results = await db.batch<{ total: number | null }>(
@@ -166,7 +167,7 @@ export async function featureTotals(
  * One aggregate over a table with one row per workspace.
  */
 export async function platformStorage(
-  db: D1Database,
+  db: D1Queryable,
 ): Promise<{ workspaces: number; storedBytes: number }> {
   const row = await db
     .prepare(
@@ -192,7 +193,7 @@ export interface MultiIdentityWorkspace {
  * had multiple minters", not "how many active tokens exist right now".
  */
 export async function multiIdentityWorkspaces(
-  db: D1Database,
+  db: D1Queryable,
   limit = DEFAULT_LIMIT,
 ): Promise<MultiIdentityWorkspace[]> {
   const result = await db

--- a/apps/api/src/adoption.ts
+++ b/apps/api/src/adoption.ts
@@ -9,6 +9,7 @@
  * Like `recordUsageSafe`, metering is best-effort: `recordAdoptionSafe` logs
  * and continues on failure, because a metrics write must never fail an upload.
  */
+import { dbFor, type D1Queryable } from "./db-session";
 
 /**
  * Every adoption metric. The union is DERIVED from this array so the two can
@@ -77,7 +78,7 @@ function normalizeBytes(bytes: number | undefined): number {
  * request path should use `recordAdoptionSafe` instead.
  */
 export async function bumpDailyMetric(
-  db: D1Database,
+  db: D1Queryable,
   event: AdoptionEvent,
   now = new Date(),
 ): Promise<void> {
@@ -199,7 +200,7 @@ export async function recordAdoptionSafe(
 ): Promise<void> {
   writeAdoptionPoint(env, event);
   try {
-    await bumpDailyMetric(env.DB, event, now);
+    await bumpDailyMetric(dbFor(env), event, now);
   } catch (err) {
     logAdoptionFailure(event.metric, event.workspace, err);
   }

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -1,4 +1,5 @@
 import { sha256Hex } from "./workspace";
+import { type D1Queryable } from "./db-session";
 
 export const FILE_SCOPES = ["files:read", "files:write", "files:delete"] as const;
 export type FileScope = (typeof FILE_SCOPES)[number];
@@ -115,7 +116,7 @@ function id(): string {
 }
 
 export async function findActiveToken(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   rawToken: string,
   now = new Date(),
@@ -135,7 +136,7 @@ export async function findActiveToken(
 }
 
 export async function createToken(
-  db: D1Database,
+  db: D1Queryable,
   input: {
     workspace: string;
     label?: string;
@@ -184,7 +185,7 @@ export async function createToken(
 }
 
 export async function createEnrollment(
-  db: D1Database,
+  db: D1Queryable,
   input: {
     workspace: string;
     label?: string;
@@ -231,7 +232,7 @@ export async function createEnrollment(
 }
 
 export async function findEnrollmentPage(
-  db: D1Database,
+  db: D1Queryable,
   pageId: string,
   now = new Date(),
 ): Promise<{ workspace: string; expiresAt: string; used: boolean } | null> {
@@ -249,7 +250,7 @@ export async function findEnrollmentPage(
 }
 
 export async function exchangeEnrollment(
-  db: D1Database,
+  db: D1Queryable,
   code: string,
   now = new Date(),
 ): Promise<{ workspace: string; token: string; scopes: FileScope[]; expiresAt: string } | null> {
@@ -309,7 +310,7 @@ export async function exchangeEnrollment(
  * `includeRevoked: true` for admin audit listing.
  */
 export async function listTokens(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   opts?: { includeRevoked?: boolean },
 ): Promise<AuthTokenRecord[]> {
@@ -328,7 +329,7 @@ export async function listTokens(
 }
 
 export async function revokeToken(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   selector: { hashPrefix?: string; label?: string },
   now = new Date(),
@@ -356,7 +357,7 @@ export async function revokeToken(
  * Tokens with a null `minting_user_id` (pre-tracking rows) are left alone.
  */
 export async function revokeTokensForMintingUser(
-  db: D1Database,
+  db: D1Queryable,
   userId: string,
   now = new Date(),
 ): Promise<number> {
@@ -377,7 +378,7 @@ export async function revokeTokensForMintingUser(
  * workspace-admin token list.
  */
 export async function listTokensForMintingUser(
-  db: D1Database,
+  db: D1Queryable,
   userId: string,
   now = new Date(),
 ): Promise<AuthTokenRecord[]> {
@@ -400,7 +401,7 @@ export async function listTokensForMintingUser(
  * someone else's id all return null so callers can collapse them to the same 404.
  */
 export async function findTokenForMintingUser(
-  db: D1Database,
+  db: D1Queryable,
   userId: string,
   tokenId: string,
   now = new Date(),
@@ -423,7 +424,7 @@ export async function findTokenForMintingUser(
 
 /** Soft-revoke one token this user minted. Same null contract as find. */
 export async function revokeTokenForMintingUser(
-  db: D1Database,
+  db: D1Queryable,
   userId: string,
   tokenId: string,
   now = new Date(),
@@ -445,7 +446,7 @@ export async function revokeTokenForMintingUser(
  * written in the last hour so a busy token does not pay a D1 write per request.
  */
 export async function touchTokenLastUsed(
-  db: D1Database,
+  db: D1Queryable,
   tokenId: string,
   now = new Date(),
 ): Promise<void> {

--- a/apps/api/src/before-after.ts
+++ b/apps/api/src/before-after.ts
@@ -25,6 +25,7 @@
  */
 
 import { findObjectsByMetadata } from "./file-metadata";
+import { type D1Queryable } from "./db-session";
 
 export type BeforeAfterState = "before" | "after";
 
@@ -95,7 +96,7 @@ export function isPairableImageContentType(contentType: string): boolean {
  * module doc.
  */
 export async function findCounterpartCandidate(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   key: string,
   metadata: Record<string, string>,

--- a/apps/api/src/content-hash.ts
+++ b/apps/api/src/content-hash.ts
@@ -14,6 +14,7 @@
  */
 
 import { addMissingFileMetadata, getFileMetadata } from "./file-metadata";
+import { type D1Queryable } from "./db-session";
 
 /**
  * The closed set of keys inheritance may copy — a restatement of
@@ -64,7 +65,7 @@ interface HashRow {
  * a missing index row costs a future inheritance, not correctness.
  */
 export async function recordContentHash(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
   contentSha256: string,
@@ -98,7 +99,7 @@ export async function recordContentHash(
  * in both cloud and self-hosted.
  */
 export async function inheritableMetaForHash(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   contentSha256: string,
   selfKey: string,
@@ -149,7 +150,7 @@ export async function inheritableMetaForHash(
  * second read.
  */
 export async function applyInheritedMetaAdditively(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
   inherited: Record<string, string>,

--- a/apps/api/src/db-session.test.ts
+++ b/apps/api/src/db-session.test.ts
@@ -1,0 +1,79 @@
+/**
+ * D1 Sessions API wiring (issue #808). Confirms the top-level app creates one
+ * Session per request via the `db.withSession(...)` binding call, and that
+ * `dbFor` picks it up (falling back to the raw binding when no session was
+ * created).
+ */
+import { describe, expect, it } from "vitest";
+import { app } from "./index";
+import { dbFor } from "./db-session";
+
+function fakeDb(withSession: (constraint?: string) => unknown) {
+  return { prepare: () => ({}), batch: () => Promise.resolve([]), withSession };
+}
+
+describe("D1 Sessions API middleware", () => {
+  it("creates one session per request via db.withSession('first-unconstrained')", async () => {
+    const calls: (string | undefined)[] = [];
+    const session = { prepare: () => ({}), batch: () => Promise.resolve([]) };
+    const env = {
+      DB: fakeDb((constraint) => {
+        calls.push(constraint);
+        return session;
+      }),
+    } as unknown as Env;
+
+    await app.request("https://api.uploads.sh/health", {}, env);
+
+    expect(calls).toEqual(["first-unconstrained"]);
+    expect(env.DB_SESSION).toBe(session);
+  });
+
+  it("calls withSession again for a second request (one session per request, not shared)", async () => {
+    let sessionCount = 0;
+    const env = {
+      DB: fakeDb(() => {
+        sessionCount++;
+        return { id: sessionCount };
+      }),
+    } as unknown as Env;
+
+    await app.request("https://api.uploads.sh/health", {}, env);
+    await app.request("https://api.uploads.sh/health", {}, env);
+
+    expect(sessionCount).toBe(2);
+  });
+
+  it("skips session creation when the DB binding has no withSession (plain test fakes)", async () => {
+    const env = { DB: { prepare: () => ({}), batch: () => Promise.resolve([]) } } as unknown as Env;
+
+    await app.request("https://api.uploads.sh/health", {}, env);
+
+    expect(env.DB_SESSION).toBeUndefined();
+  });
+
+  it("skips session creation when DB is absent", async () => {
+    const env = {} as unknown as Env;
+
+    await app.request("https://api.uploads.sh/health", {}, env);
+
+    expect(env.DB_SESSION).toBeUndefined();
+  });
+});
+
+describe("dbFor", () => {
+  it("prefers the per-request session over the raw binding", () => {
+    const session = { tag: "session" };
+    const db = { tag: "raw" };
+    const env = { DB: db, DB_SESSION: session } as unknown as Env;
+
+    expect(dbFor(env)).toBe(session);
+  });
+
+  it("falls back to the raw binding when no session was created", () => {
+    const db = { tag: "raw" };
+    const env = { DB: db } as unknown as Env;
+
+    expect(dbFor(env)).toBe(db);
+  });
+});

--- a/apps/api/src/db-session.ts
+++ b/apps/api/src/db-session.ts
@@ -1,0 +1,58 @@
+/**
+ * D1 Sessions API wiring (issue #808, Case #02293891).
+ *
+ * `uploads-production` has had Cloudflare-side D1 stall incidents. Read
+ * replication is one mitigation we may enable — but replicas only ever serve
+ * queries issued through a `D1DatabaseSession` (`db.withSession(...)`).
+ * Every plain `env.DB.prepare(...)` / `env.DB.batch(...)` call bypasses
+ * sessions entirely and always goes to the primary, replicas or not.
+ *
+ * This module creates one Session per HTTP request (wired up in
+ * `index.ts`) and `dbFor` is what every call site uses to reach it instead
+ * of the raw `DB` binding. While replication stays disabled (as it is
+ * today), a session-routed query still lands on the primary — behavior is
+ * unchanged. Flipping replication on later needs no code change here, only
+ * enabling it for the database and, if desired, revisiting the constraint
+ * below.
+ */
+
+/**
+ * Anything queryable via `.prepare()` / `.batch()` — either the raw `DB`
+ * binding (as used in tests, and as `dbFor`'s fallback) or a per-request
+ * `D1DatabaseSession`. Every function in this worker that used to take
+ * `db: D1Database` now takes this instead, so it works unchanged with
+ * either.
+ */
+export type D1Queryable = Pick<D1Database, "prepare" | "batch">;
+
+/**
+ * Creates the per-request Session, anchored with `"first-unconstrained"`:
+ * the first query on the session may be served by the primary or any
+ * replica (best latency), and subsequent queries on that same session stay
+ * consistent with whichever instance answered the first one. We don't need
+ * read-your-writes guarantees *across separate requests* today — each
+ * request gets its own fresh session — so this optimizes for latency over
+ * consistency.
+ *
+ * This is the knob to revisit once replication is actually enabled: switch
+ * to `"first-primary"` if a flow needs its first query to observe its own
+ * immediately-preceding write, or thread through an explicit
+ * `D1SessionBookmark` if a flow needs read-your-writes across requests.
+ */
+export function createDbSession(db: D1Database): D1DatabaseSession {
+  return db.withSession("first-unconstrained");
+}
+
+/**
+ * The queryable to use for the current request: the Session set up by the
+ * request-scoped middleware in `index.ts`, or the raw `DB` binding as a
+ * fallback. The fallback matters for two cases — both behaviorally
+ * identical to today, since replication is disabled either way: unit tests
+ * that mount a route sub-app directly instead of the full `app` (so the
+ * session middleware never runs), and the daily cron jobs
+ * (`retention-sweep.ts`, `observability-retention.ts`'s `scheduled()`
+ * caller), which aren't HTTP requests and so never get a session either.
+ */
+export function dbFor(env: Env): D1Queryable {
+  return env.DB_SESSION ?? env.DB;
+}

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -83,4 +83,13 @@ interface Env {
   RENDER_LIMITER?: RateLimit;
   WS_CREATE_LIMITER?: RateLimit;
   INVITE_LIMITER?: RateLimit;
+  /**
+   * Per-request D1 Sessions API session (issue #808). Set once per HTTP
+   * request by middleware in index.ts (see src/db-session.ts); every D1
+   * call site reads it via `dbFor(env)` instead of `env.DB` directly. Not a
+   * wrangler binding — populated at runtime, so it's optional here, and
+   * absent for cron invocations and for tests that exercise a route
+   * sub-app directly instead of the full `app`.
+   */
+  DB_SESSION?: D1DatabaseSession;
 }

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -10,6 +10,7 @@
 
 import { InternalError, ValidationError } from "@uploads/errors";
 import { PROVENANCE_SERVER_KEYS } from "./provenance";
+import { type D1Queryable } from "./db-session";
 
 /** Lowercase key, optionally namespaced with dots (e.g. `gh.repo`). */
 export const META_KEY_RE = /^[a-z][a-z0-9._-]{0,63}$/;
@@ -248,7 +249,7 @@ interface MetaRow {
 
 /** All metadata for one object, keyed by `(workspace, object_key)`. */
 export async function getFileMetadata(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
 ): Promise<Record<string, string>> {
@@ -275,7 +276,7 @@ export async function getFileMetadata(
  * exactly one place; does not change SQL semantics for any of them.
  */
 function upsertStatements(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
   entries: Record<string, string>,
@@ -312,7 +313,7 @@ function upsertStatements(
  * rate limiter). Caps are re-enforced on the next merge.
  */
 export async function setFileMetadata(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
   set: Record<string, string>,
@@ -378,7 +379,7 @@ export async function setFileMetadata(
  * `undefined` so a caller can tell "nothing to do" from "wrote an empty map".
  */
 export async function addMissingFileMetadata(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
   candidates: Record<string, string>,
@@ -407,7 +408,7 @@ export async function addMissingFileMetadata(
  * other row. No-op (no row created) if the key isn't already present.
  */
 export async function updateFileMetadataValue(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
   metaKey: string,
@@ -423,7 +424,7 @@ export async function updateFileMetadataValue(
 
 /** Deletes all metadata rows for an object (e.g. on object delete). */
 export async function deleteFileMetadata(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
 ): Promise<void> {
@@ -435,7 +436,7 @@ export async function deleteFileMetadata(
 
 /** Deletes every metadata row for a workspace being torn down. */
 export async function deleteFileMetadataForWorkspace(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
 ): Promise<void> {
   await db.prepare(`DELETE FROM file_metadata WHERE workspace = ?`).bind(workspace).run();
@@ -447,7 +448,7 @@ export async function deleteFileMetadataForWorkspace(
  * stay under D1's bound-parameter limit. No-op on an empty list.
  */
 export async function deleteFileMetadataForKeys(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   keys: string[],
 ): Promise<void> {
@@ -471,7 +472,7 @@ export async function deleteFileMetadataForKeys(
  * would otherwise incur. Used by `putObject`'s full-replace-on-upload path.
  */
 export async function replaceFileMetadata(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
   metadata: Record<string, string>,
@@ -549,7 +550,7 @@ const MERGED_STATUS_SQL = `s2.meta_key = 'gh.merged' AND s2.meta_value = 'true'`
  * show a shot twice; general search keeps them.
  */
 export async function findObjectsByMetadata(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   filters: Record<string, string>,
   opts: { prefix?: string; limit?: number; collapsePromotedShadows?: boolean } = {},
@@ -635,7 +636,7 @@ const EXCLUDE_SERVER_KEYS = SERVER_META_PREFIXES.map(
  * Fetches one row beyond the cap so `truncated` is exact.
  */
 export async function facetKeys(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
 ): Promise<{
   keys: Array<{ key: string; count: number; distinctValues: number }>;
@@ -674,7 +675,7 @@ export async function facetKeys(
  * rows-read is proportional to the one key rather than the whole workspace.
  */
 export async function facetValues(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   key: string,
 ): Promise<{ values: Array<{ value: string; count: number }>; truncated: boolean }> {
@@ -775,7 +776,7 @@ export type ProjectSummary = { label: string; count: number; lastUpdated: string
  * `catalog`, `projects`, and `latest` all reflect the same filtered rows.
  */
 export async function groupObjectsByPath(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   opts: { mergedOnly?: boolean } = {},
 ): Promise<{
@@ -952,7 +953,7 @@ export type FacetValuesResult = {
  * `key` → that key's values (validated against `META_KEY_RE`).
  */
 export async function listFacets(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   key?: string,
 ): Promise<FacetKeysResult | FacetValuesResult> {
@@ -1002,7 +1003,7 @@ function metadataLookupChunk(reservedParams: number): number {
  * worse failure mode for a caller that built the list dynamically.
  */
 export async function getMetadataForKeys(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   keys: string[],
   opts: { metaKeys?: string[] } = {},
@@ -1048,7 +1049,7 @@ export async function getMetadataForKeys(
  * bound-parameter limit.
  */
 export async function getObjectUpdatedAt(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   keys: string[],
 ): Promise<Map<string, string>> {
@@ -1080,7 +1081,7 @@ export async function getObjectUpdatedAt(
  * request's own custom metadata.
  */
 export async function setServerFileMetadata(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
   metadata: Record<string, string>,
@@ -1094,7 +1095,7 @@ export async function setServerFileMetadata(
 
 /** Drop specific server-owned rows — used to clear a stale poster pointer. */
 export async function deleteServerFileMetadataKeys(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
   keys: string[],

--- a/apps/api/src/file-search.ts
+++ b/apps/api/src/file-search.ts
@@ -18,6 +18,7 @@ import {
 } from "./file-metadata";
 import { storage } from "./storage";
 import type { WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 /** Max characters accepted in a `?name=` / `name` filename search term. */
 export const SEARCH_NAME_MAX = 128;
@@ -109,7 +110,7 @@ export async function searchFilesByNameAndMeta(
   const fetchLimit = pageSize + 1;
 
   if (hasMeta) {
-    const found = await findObjectsByMetadata(env.DB, workspaceName, filters, {
+    const found = await findObjectsByMetadata(dbFor(env), workspaceName, filters, {
       prefix,
       limit: fetchLimit,
       collapsePromotedShadows: opts.collapsePromotedShadows,
@@ -137,7 +138,7 @@ export async function searchFilesByNameAndMeta(
   }
   const truncated = keys.length > pageSize;
   const pageKeys = keys.slice(0, pageSize);
-  const metaByKey = await getMetadataForKeys(env.DB, workspaceName, pageKeys);
+  const metaByKey = await getMetadataForKeys(dbFor(env), workspaceName, pageKeys);
   return {
     matches: pageKeys.map((key) => ({ key, metadata: metaByKey.get(key) ?? {} })),
     truncated,

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -75,6 +75,7 @@ import {
 import { objectVisibility, VISIBILITY_META_KEY, type Visibility } from "./visibility";
 import { webOrigin } from "./web-url";
 import type { WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 // The freshness floor on overwrite for every bucket. This is the operative lever
 // for GitHub embeds: they're proxied through GitHub's Camo/Fastly cache, and
@@ -243,11 +244,11 @@ export async function generateAndStorePoster(
       const stale = await existingSize(store, posterKey);
       if (stale !== null) {
         await store.delete(posterKey);
-        await deleteServerFileMetadataKeys(env.DB, workspaceName, key, POSTER_META_KEYS);
+        await deleteServerFileMetadataKeys(dbFor(env), workspaceName, key, POSTER_META_KEYS);
         // Single-winner claim (issue #570) — same gate as deleteObject.
-        if (await claimDeleteUsageSafe(env.DB, workspaceName, posterKey)) {
+        if (await claimDeleteUsageSafe(dbFor(env), workspaceName, posterKey)) {
           await recordUsageSafe(
-            env.DB,
+            dbFor(env),
             workspaceName,
             {
               bytes: -stale,
@@ -272,11 +273,11 @@ export async function generateAndStorePoster(
       ...(visibility === "private" ? { metadata: { [VISIBILITY_META_KEY]: "private" } } : {}),
     });
     // A re-created poster must be able to debit the ledger on a later delete.
-    await clearDeleteUsageClaimSafe(env.DB, workspaceName, posterKey);
+    await clearDeleteUsageClaimSafe(dbFor(env), workspaceName, posterKey);
     // Counted because reconcileWorkspaceUsage walks every object under the
     // prefix and would otherwise disagree with the ledger permanently.
     await recordUsageSafe(
-      env.DB,
+      dbFor(env),
       workspaceName,
       {
         bytes: made.jpeg.byteLength - (previous ?? 0),
@@ -289,8 +290,8 @@ export async function generateAndStorePoster(
     // Full replace, not upsert: a regeneration whose probe/extraction found
     // fewer fields than the prior poster (e.g. no dims this time) must not
     // leave stale video.width/height/duration rows behind.
-    await deleteServerFileMetadataKeys(env.DB, workspaceName, key, POSTER_META_KEYS);
-    await setServerFileMetadata(env.DB, workspaceName, key, made.meta);
+    await deleteServerFileMetadataKeys(dbFor(env), workspaceName, key, POSTER_META_KEYS);
+    await setServerFileMetadata(dbFor(env), workspaceName, key, made.meta);
   } catch (err) {
     console.error({ event: "poster_generation_failed", workspace: workspaceName, key, err });
   }
@@ -469,7 +470,7 @@ export async function putObject(
   const deltaBytes = newSize - (prior?.size ?? 0);
   const uploadedAt = resolveUploadedAtMeta(prior);
 
-  const usage = await getWorkspaceUsage(env.DB, workspaceName);
+  const usage = await getWorkspaceUsage(dbFor(env), workspaceName);
   // Cheap read-side reject for obviously spent budgets (both caps). Concurrent
   // puts at the boundary still need the atomic reservations below.
   const denial = checkPutBudget(usage, ws, { bytes: deltaBytes, uploads: 1 });
@@ -482,7 +483,7 @@ export async function putObject(
   const { maxUploadsPerPeriod } = resolveBudgetLimits(ws);
   const maxStorageBytes = enforcedMaxStorageBytes(ws);
   const sharedLane = isSharedLane(ws);
-  const uploadReservation = await reserveUploads(env.DB, workspaceName, 1, maxUploadsPerPeriod);
+  const uploadReservation = await reserveUploads(dbFor(env), workspaceName, 1, maxUploadsPerPeriod);
   if (!uploadReservation.ok) {
     throw budgetDenialError(
       uploadBudgetDenial(uploadReservation.usage, uploadReservation.maxUploadsPerPeriod),
@@ -490,7 +491,7 @@ export async function putObject(
   }
 
   const storageReservation = await reserveStorageBytes(
-    env.DB,
+    dbFor(env),
     workspaceName,
     deltaBytes,
     maxStorageBytes,
@@ -498,7 +499,7 @@ export async function putObject(
     { sharedLane },
   );
   if (!storageReservation.ok) {
-    await releaseUploadsSafe(env.DB, workspaceName, 1);
+    await releaseUploadsSafe(dbFor(env), workspaceName, 1);
     throw budgetDenialError(
       storageBudgetDenial(
         storageReservation.usage,
@@ -526,7 +527,12 @@ export async function putObject(
   // R2 write and usage accounting instead of adding its latency after them. Safe
   // to leave in flight: inheritableMetaForHash never rejects (it resolves to `{}`
   // on any failure), so an upload that throws below cannot orphan a rejection.
-  const inheritedPromise = inheritableMetaForHash(env.DB, workspaceName, contentSha256, finalKey);
+  const inheritedPromise = inheritableMetaForHash(
+    dbFor(env),
+    workspaceName,
+    contentSha256,
+    finalKey,
+  );
   const provenance: ProvenanceMap = {
     ...sanitizeProvenance(opts?.provenance, { clientOnly: true }),
     "content-sha256": contentSha256,
@@ -552,8 +558,10 @@ export async function putObject(
     // resolves to `{}` rather than rejecting, so this only discards a result.
     await inheritedPromise;
     // Nothing was stored — return both reservations to the budget.
-    await releaseUploadsSafe(env.DB, workspaceName, 1);
-    await releaseStorageBytesSafe(env.DB, workspaceName, reservedBytes, undefined, { sharedLane });
+    await releaseUploadsSafe(dbFor(env), workspaceName, 1);
+    await releaseStorageBytesSafe(dbFor(env), workspaceName, reservedBytes, undefined, {
+      sharedLane,
+    });
     throw err;
   }
 
@@ -578,7 +586,7 @@ export async function putObject(
   // round trips on every upload.
   await Promise.all([
     recordUsageSafe(
-      env.DB,
+      dbFor(env),
       workspaceName,
       {
         bytes: reservedBytes > 0 ? 0 : deltaBytes,
@@ -588,7 +596,7 @@ export async function putObject(
       undefined,
       { sharedLane },
     ),
-    clearDeleteUsageClaimSafe(env.DB, workspaceName, finalKey),
+    clearDeleteUsageClaimSafe(dbFor(env), workspaceName, finalKey),
     recordAdoptionSafe(env, {
       metric: "upload",
       workspace: workspaceName,
@@ -617,23 +625,28 @@ export async function putObject(
     // one atomic batch (replaceFileMetadata) rather than a delete followed
     // by a separate re-read-then-write.
     storedMetadata = mergeWithinMetadataCaps(opts.metadata, inherited);
-    await replaceFileMetadata(env.DB, workspaceName, finalKey, storedMetadata);
+    await replaceFileMetadata(dbFor(env), workspaceName, finalKey, storedMetadata);
     // Explicit metadata only, never the inherited merge: inherited keys
     // describe the bytes, and letting them reach PR activity would attribute
     // the donor upload's PR to this one. (`gh.*` is not inheritable, so this
     // is belt and braces rather than the only guard.)
-    await recordPrActivityFromMetadata(env.DB, workspaceName, opts.metadata);
+    await recordPrActivityFromMetadata(dbFor(env), workspaceName, opts.metadata);
   } else {
     // No `X-Uploads-Meta-*` headers: this put deliberately leaves an existing
     // object's tags alone, so inheritance must be additive rather than a
     // replace, which would wipe tags the caller never asked to change.
-    storedMetadata = await applyInheritedMetaAdditively(env.DB, workspaceName, finalKey, inherited);
+    storedMetadata = await applyInheritedMetaAdditively(
+      dbFor(env),
+      workspaceName,
+      finalKey,
+      inherited,
+    );
   }
 
   // Index this object's bytes for future inheritance. Last, and best-effort:
   // the object is durably stored by now, so a failed index write costs a later
   // inheritance rather than this upload.
-  await recordContentHash(env.DB, workspaceName, finalKey, contentSha256);
+  await recordContentHash(dbFor(env), workspaceName, finalKey, contentSha256);
 
   // After the metadata replace, never before: replaceFileMetadata is
   // delete-then-insert and would wipe the server-owned video.* rows.
@@ -1097,7 +1110,7 @@ async function recordDeletedLaneUsage(
   await Promise.all(
     hits.map((hit) =>
       recordUsageSafe(
-        env.DB,
+        dbFor(env),
         workspaceName,
         { bytes: -hit.size, objects: -1, uploads: 0 },
         undefined,
@@ -1118,14 +1131,14 @@ export async function deleteObject(
 
   const configs = await storageConfigs(env, ws);
   const { hits, failures } = await deleteFromEveryLane(configs, key);
-  await deleteFileMetadata(env.DB, workspaceName, key);
+  await deleteFileMetadata(dbFor(env), workspaceName, key);
 
   if (hits.length > 0) {
     // Single-winner claim (issue #570): concurrent DELETEs can both observe
     // the object and both reach this branch; only the first claimer debits
     // the ledger (and records the adoption delete metric). Claim after the
     // storage delete so a failed delete never burns the slot.
-    const wonClaim = await claimDeleteUsageSafe(env.DB, workspaceName, key);
+    const wonClaim = await claimDeleteUsageSafe(dbFor(env), workspaceName, key);
     if (wonClaim) {
       // Positive magnitude under the `delete` metric — never negative bytes
       // under `upload`. Net change is computed at read time. These two writes
@@ -1159,7 +1172,7 @@ export async function deleteObject(
       posterKey,
     );
     if (posterHits.length > 0) {
-      if (await claimDeleteUsageSafe(env.DB, workspaceName, posterKey)) {
+      if (await claimDeleteUsageSafe(dbFor(env), workspaceName, posterKey)) {
         await recordDeletedLaneUsage(env, workspaceName, posterHits);
       }
     }

--- a/apps/api/src/galleries.ts
+++ b/apps/api/src/galleries.ts
@@ -1,4 +1,5 @@
 /** Per-workspace cap; gallery membership remains independently capped below. */
+import { type D1Queryable } from "./db-session";
 export const MAX_GALLERIES_PER_WORKSPACE = 100;
 export const MAX_GALLERY_ITEMS = 100;
 export const MAX_GALLERY_REFERENCES = 20;
@@ -140,7 +141,7 @@ function randomGalleryId(): string {
 }
 
 async function classifyVersion(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   id: string,
   expectedVersion: number,
@@ -153,7 +154,7 @@ async function classifyVersion(
 }
 
 export async function createGallery(
-  db: D1Database,
+  db: D1Queryable,
   input: { workspace: string; title: string; description?: string | null; now?: Date },
 ): Promise<MutationResult<GalleryRecord>> {
   const titleError = validateTitle(input.title);
@@ -200,7 +201,7 @@ export async function createGallery(
 }
 
 export async function getGallery(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   id: string,
 ): Promise<GalleryRecord | null> {
@@ -215,7 +216,7 @@ export async function getGallery(
 
 /** Internal resolver. Do not return this record from a public route; use projectPublicGallery. */
 export async function resolvePublicGallery(
-  db: D1Database,
+  db: D1Queryable,
   id: string,
 ): Promise<GalleryRecord | null> {
   return db
@@ -241,7 +242,7 @@ export function projectPublicGallery(record: GalleryRecord): PublicGallery {
 }
 
 export async function listGalleries(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   options: { limit?: number; cursor?: GalleryCursor } = {},
 ): Promise<GalleryPage> {
@@ -275,7 +276,7 @@ export async function listGalleries(
 }
 
 export async function updateGallery(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   id: string,
   input: {
@@ -345,7 +346,7 @@ export async function updateGallery(
  * config ever changes.
  */
 export async function deleteGalleriesForWorkspace(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
 ): Promise<{ galleries: number }> {
   await db
@@ -368,7 +369,7 @@ export async function deleteGalleriesForWorkspace(
 }
 
 export async function softDeleteGallery(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   id: string,
   expectedVersion: number,
@@ -388,7 +389,7 @@ export async function softDeleteGallery(
 }
 
 export async function listGalleryItems(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   galleryId: string,
 ): Promise<GalleryItemRecord[]> {
@@ -405,7 +406,7 @@ export async function listGalleryItems(
 
 /** Item counts for many galleries in one query (avoids N+1 on the account list). */
 export async function countItemsForGalleries(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   galleryIds: string[],
 ): Promise<Map<string, number>> {
@@ -430,7 +431,7 @@ export async function countItemsForGalleries(
 
 /** External references for many galleries in one query, ordered by created_at. */
 export async function listExternalReferencesForGalleries(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   galleryIds: string[],
 ): Promise<Map<string, GalleryExternalReferenceRecord[]>> {
@@ -470,7 +471,7 @@ export async function listExternalReferencesForGalleries(
  * `itemKeysByIds`) and only fall back to this.
  */
 export async function firstItemKeyForGalleries(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   galleryIds: string[],
 ): Promise<Map<string, string>> {
@@ -504,7 +505,7 @@ export async function firstItemKeyForGalleries(
  * leaking another workspace's key. Returns a Map keyed by item id.
  */
 export async function itemKeysByIds(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   itemIds: string[],
 ): Promise<Map<string, string>> {
@@ -528,7 +529,7 @@ export async function itemKeysByIds(
 
 /** Persistence primitive: callers must first verify objectKey exists and has a public URL. */
 export async function addGalleryItem(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   galleryId: string,
   input: {
@@ -606,7 +607,7 @@ export async function addGalleryItem(
 }
 
 export async function removeGalleryItem(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   galleryId: string,
   itemId: string,
@@ -636,7 +637,7 @@ export async function removeGalleryItem(
 }
 
 export async function reorderGalleryItems(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   galleryId: string,
   orderedItemIds: string[],
@@ -702,7 +703,7 @@ export async function reorderGalleryItems(
 }
 
 export async function listExternalReferences(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   galleryId: string,
 ): Promise<GalleryExternalReferenceRecord[]> {
@@ -719,7 +720,7 @@ export async function listExternalReferences(
 }
 
 export async function addExternalReference(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   galleryId: string,
   input: {
@@ -826,7 +827,7 @@ export async function addExternalReference(
 }
 
 export async function removeExternalReference(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   galleryId: string,
   referenceId: string,
@@ -855,7 +856,7 @@ export async function removeExternalReference(
 }
 
 export async function findGalleriesByReference(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   normalizedKey: string,
   options: { limit?: number; cursor?: GalleryCursor } = {},

--- a/apps/api/src/gallery-service.ts
+++ b/apps/api/src/gallery-service.ts
@@ -27,6 +27,7 @@ import type { StorageConfig } from "@uploads/storage";
 import { objectVisibility } from "./visibility";
 import { webOrigin } from "./web-url";
 import type { WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 /** Fields we read from a Files SDK head when hydrating gallery items. */
 type GalleryObjectHead = {
@@ -358,7 +359,7 @@ export async function hydrateGalleryItems(
     .map((item) => item.objectKey);
   if (videoKeys.length > 0 && workspace.name) {
     try {
-      const metadataByKey = await getMetadataForKeys(env.DB, workspace.name, videoKeys, {
+      const metadataByKey = await getMetadataForKeys(dbFor(env), workspace.name, videoKeys, {
         metaKeys: ["video.poster", "video.width", "video.height"],
       });
       for (const item of hydrated) {
@@ -465,10 +466,10 @@ export async function galleryListSummaries(
     .map((record) => record.cover_item_id)
     .filter((id): id is string => id !== null);
   const [itemCounts, refsByGallery, firstKeys, coverKeys] = await Promise.all([
-    countItemsForGalleries(env.DB, name, ids),
-    listExternalReferencesForGalleries(env.DB, name, ids),
-    firstItemKeyForGalleries(env.DB, name, ids),
-    itemKeysByIds(env.DB, name, coverIds),
+    countItemsForGalleries(dbFor(env), name, ids),
+    listExternalReferencesForGalleries(dbFor(env), name, ids),
+    firstItemKeyForGalleries(dbFor(env), name, ids),
+    itemKeysByIds(dbFor(env), name, coverIds),
   ]);
   const resolver = createLaneResolver(env, workspace);
   return Promise.all(

--- a/apps/api/src/github-attach-service.ts
+++ b/apps/api/src/github-attach-service.ts
@@ -17,6 +17,7 @@ import {
 import { postManagedComment, type PostCommentResult } from "./github-comment-service";
 import { findRepoLink, recordRepoLink } from "./github-repo-links";
 import type { WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 export type { AttachExistingRequest, AttachExistingResult };
 
@@ -36,11 +37,11 @@ export async function postAttachExisting(
   // Implicit claim (mirrors postPromoteBranchAttachments): first-claim-wins,
   // never affects the attach result. Cross-tenant gate on NEW claims only
   // (issue #297) — already-bound repos re-record via INSERT OR IGNORE (no-op).
-  const existingLink = await findRepoLink(env.DB, req.target.repo);
+  const existingLink = await findRepoLink(dbFor(env), req.target.repo);
   const canClaim =
     existingLink !== null || (await isEntitledToClaimRepo(env, req.target.repo, mintingUserId));
   if (canClaim) {
-    await recordRepoLink(env.DB, req.target.repo, workspaceName, "attach");
+    await recordRepoLink(dbFor(env), req.target.repo, workspaceName, "attach");
   }
 
   // Comment sync (the piece promote leaves to a separate CLI call) — never

--- a/apps/api/src/github-attach.ts
+++ b/apps/api/src/github-attach.ts
@@ -34,6 +34,7 @@ import { storage, storageConfig } from "./storage";
 import { objectVisibility } from "./visibility";
 import { webOrigin } from "./web-url";
 import type { WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 /** Single-key call to `Files["download"]` — pulled out so its return type
  * (the single-key `StoredFile` overload) is inferred rather than spelled out. */
@@ -194,7 +195,7 @@ export async function attachExistingObject(
       ? ghPrivateAttachmentKey(mode.prefixId, req.target, filename)
       : `${ghKeyPrefix(req.target)}${sanitizeKeySegment(filename)}`;
 
-  const sourceMeta = await getFileMetadata(env.DB, workspaceName, sourceKey);
+  const sourceMeta = await getFileMetadata(dbFor(env), workspaceName, sourceKey);
   const bytes = new Uint8Array(await source.arrayBuffer());
   const visibility = objectVisibility(source.metadata);
   const ref = `${owner}/${name}#${req.target.num}`.toLowerCase();
@@ -208,7 +209,7 @@ export async function attachExistingObject(
 
   // Additive merge (PR #157 preserve mode): the source's existing metadata
   // rides along unchanged, gh.* is stamped fresh on top and always wins.
-  await setFileMetadata(env.DB, workspaceName, destKey, {
+  await setFileMetadata(dbFor(env), workspaceName, destKey, {
     ...sourceMeta,
     "gh.repo": `${owner}/${name}`.toLowerCase(),
     "gh.kind": req.target.kind,

--- a/apps/api/src/github-comment-service.ts
+++ b/apps/api/src/github-comment-service.ts
@@ -16,6 +16,7 @@ import { resolveUploaderAccountId } from "./uploader-identity";
 import { findRepoLinkStrict, recordRepoLink } from "./github-repo-links";
 import type { GhTarget } from "./github-comment-render";
 import type { WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 /**
  * Cross-tenant authorization gate (issue #297). The App is installed
@@ -48,7 +49,7 @@ export async function checkRepoAuthorization(
   mintingUserId: string | null,
   installId: number | null,
 ): Promise<{ posted: false; reason: "not_authorized"; message: string } | null> {
-  const link = await findRepoLinkStrict(env.DB, repo);
+  const link = await findRepoLinkStrict(dbFor(env), repo);
   if (link) {
     if (link.workspaceName === workspaceName) return null;
     return {
@@ -254,7 +255,7 @@ export async function postManagedComment(
   // workspace has proven authenticated write access to this repo's
   // PR/issue thread — best-effort record it as the repo's bound workspace.
   // First-claim-wins (recordRepoLink) and never affects this response.
-  await recordRepoLink(env.DB, target.repo, workspaceName, "comment", installId);
+  await recordRepoLink(dbFor(env), target.repo, workspaceName, "comment", installId);
 
   // Both `created` and `updated` converge here — editing an existing managed
   // comment counts as one posted comment, not zero. `skipped` and every

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -7,6 +7,7 @@
  * D1 rows scoped by workspace name).
  */
 
+import { dbFor } from "./db-session";
 import { listObjects } from "./files-core";
 import { getMetadataForKeys } from "./file-metadata";
 import { findGalleriesByReference, listGalleryItems, type GalleryCursor } from "./galleries";
@@ -119,7 +120,7 @@ async function gatherAttachments(
   // also listed — a private-repo attachment can land under any of them, not
   // just the plain `ghKeyPrefix`. Plain prefix listed first so ordering
   // stays stable regardless of listActivePrefixIds' order.
-  const activePrefixIds = await listActivePrefixIds(env.DB, target.repo);
+  const activePrefixIds = await listActivePrefixIds(dbFor(env), target.repo);
   const prefixes = [
     ghKeyPrefix(target),
     ...activePrefixIds.map((id) => ghPrivateKeyPrefix(id, target)),
@@ -161,7 +162,7 @@ async function gatherAttachments(
   // settings are both off, but this one always runs since a detached copy
   // must never render regardless.
   const detachByKey = await getMetadataForKeys(
-    env.DB,
+    dbFor(env),
     workspaceName,
     items.map((item) => item.key),
     { metaKeys: [DETACH_META_KEY] },
@@ -171,7 +172,7 @@ async function gatherAttachments(
   if (!showMetadata || items.length === 0) return items;
 
   const metaByKey = await getMetadataForKeys(
-    env.DB,
+    dbFor(env),
     workspaceName,
     items.map((item) => item.key),
     { metaKeys: COMMENT_META_KEYS },
@@ -230,17 +231,22 @@ async function gatherGalleries(
   const galleries: GalleryCommentItem[] = [];
   let gCursor: GalleryCursor | undefined;
   do {
-    const page = await findGalleriesByReference(env.DB, workspaceName, ref.value.normalizedKey, {
-      limit: 100,
-      cursor: gCursor,
-    });
+    const page = await findGalleriesByReference(
+      dbFor(env),
+      workspaceName,
+      ref.value.normalizedKey,
+      {
+        limit: 100,
+        cursor: gCursor,
+      },
+    );
     const pageItems = await Promise.all(
       page.galleries.map(async (rec) => {
         const dto = await hydrateOwnerGallery(
           env,
           ws,
           rec,
-          await listGalleryItems(env.DB, workspaceName, rec.id),
+          await listGalleryItems(dbFor(env), workspaceName, rec.id),
         );
         const previews = dto.items
           .filter((i) => i.status === "available" && i.url && i.contentType?.startsWith("image/"))

--- a/apps/api/src/github-ingest-ledger.ts
+++ b/apps/api/src/github-ingest-ledger.ts
@@ -14,6 +14,7 @@
  * github-repo-links.ts's `findRepoLink`/`recordRepoLink`, nothing here
  * swallows errors.
  */
+import { type D1Queryable } from "./db-session";
 
 export interface IngestLedgerRow {
   repo: string; // lowercase owner/name
@@ -65,7 +66,7 @@ function fromRow(row: IngestLedgerDbRow): IngestLedgerRow {
  * existing row.
  */
 export async function recordIngestedAsset(
-  db: D1Database,
+  db: D1Queryable,
   row: Omit<IngestLedgerRow, "detachedAt">,
 ): Promise<void> {
   await db
@@ -89,7 +90,7 @@ export async function recordIngestedAsset(
 
 /** The ledger row for a single (repo, asset id), or null if never recorded. */
 export async function ledgerRow(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   assetId: string,
 ): Promise<IngestLedgerRow | null> {
@@ -105,7 +106,7 @@ export async function ledgerRow(
 
 /** All ledger rows for `repo` currently attributed to `source` ("body" or "comment:<id>"). */
 export async function ledgerRowsForSource(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   source: string,
 ): Promise<IngestLedgerRow[]> {
@@ -121,7 +122,7 @@ export async function ledgerRowsForSource(
 
 /** All ledger rows for `repo` currently attributed to `kind`/`num` (across every source). */
 export async function ledgerRowsForTarget(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   kind: "pull" | "issues",
   num: number,
@@ -142,7 +143,7 @@ export async function ledgerRowsForTarget(
  * reappears.
  */
 export async function setLedgerDetached(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   assetId: string,
   detachedAt: string | null,
@@ -159,7 +160,7 @@ export async function setLedgerDetached(
  * from a comment into the body).
  */
 export async function setLedgerSource(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   assetId: string,
   source: string,

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -53,6 +53,7 @@ import { putObject } from "./files-core";
 import { findRepoLinkStrict } from "./github-repo-links";
 import { resolveRepoCommentOptions } from "./repo-comment-config";
 import { loadWorkspaceRecord, type WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 export interface IngestSourceRef {
   repo: string;
@@ -292,7 +293,7 @@ async function fetchAndStore(
     throw err;
   }
 
-  await recordIngestedAsset(env.DB, {
+  await recordIngestedAsset(dbFor(env), {
     repo: ref.repo,
     assetId: attachment.id,
     workspace: workspaceName,
@@ -320,7 +321,7 @@ export async function reconcileIngestSource(
   author: string | null,
   deps: IngestDeps = {},
 ): Promise<IngestSummary> {
-  const db = env.DB;
+  const db = dbFor(env);
   const summary = emptySummary();
   const found = text === null ? [] : extractUserAttachments(text);
   const foundIds = new Set(found.map((a) => a.id));
@@ -425,7 +426,7 @@ export async function ingestForWebhook(
   ref: IngestSourceRef,
   deps: IngestDeps = {},
 ): Promise<void> {
-  const link = await findRepoLinkStrict(env.DB, ref.repo);
+  const link = await findRepoLinkStrict(dbFor(env), ref.repo);
   if (!link) return;
   const ws = await loadWorkspaceRecord(env, link.workspaceName);
   if (!ws) return;
@@ -597,14 +598,20 @@ export async function reconcileIngestTarget(
     // non-detached row for this target whose source we didn't just scan.
     // Skipped entirely when the scan was truncated (above): unseen later
     // pages mean an absent source isn't proof of deletion.
-    const rows = await ledgerRowsForTarget(env.DB, target.repo, target.kind, target.num);
+    const rows = await ledgerRowsForTarget(dbFor(env), target.repo, target.kind, target.num);
     for (const row of rows) {
       if (row.detachedAt !== null) continue;
       if (seenSources.has(row.source)) continue;
       // Metadata-first, same retry-safety ordering as the per-source detach
       // path in reconcileIngestSource.
-      await updateFileMetadataValue(env.DB, row.workspace, row.objectKey, "gh.detached", "true");
-      await setLedgerDetached(env.DB, target.repo, row.assetId, new Date().toISOString());
+      await updateFileMetadataValue(
+        dbFor(env),
+        row.workspace,
+        row.objectKey,
+        "gh.detached",
+        "true",
+      );
+      await setLedgerDetached(dbFor(env), target.repo, row.assetId, new Date().toISOString());
       merged.detached.push(row.objectKey);
     }
   }

--- a/apps/api/src/github-install-status.ts
+++ b/apps/api/src/github-install-status.ts
@@ -21,6 +21,7 @@
 
 import { githubAppConfig, installationForRepo } from "./github-app";
 import { listRepoLinksForWorkspace } from "./github-repo-links";
+import { dbFor } from "./db-session";
 
 export interface GithubInstallStatus {
   /** false when the App env isn't configured on this worker — the integration is off entirely. */
@@ -53,7 +54,7 @@ export async function githubInstallStatus(
 
   let repos: string[];
   try {
-    const links = await listRepoLinksForWorkspace(env.DB, workspaceName);
+    const links = await listRepoLinksForWorkspace(dbFor(env), workspaceName);
     repos = links.slice(0, GITHUB_STATUS_REPO_CAP).map((link) => link.repo);
   } catch (err) {
     console.error(

--- a/apps/api/src/github-link-adopt-ledger.ts
+++ b/apps/api/src/github-link-adopt-ledger.ts
@@ -17,6 +17,7 @@
  * surface as a thrown error so the queue retries the delivery — nothing here
  * swallows errors, same doctrine as the ingest ledger.
  */
+import { type D1Queryable } from "./db-session";
 
 export interface AdoptLedgerRow {
   repo: string; // lowercase owner/name
@@ -71,7 +72,7 @@ const SELECT_COLUMNS =
  * ways to update an existing row.
  */
 export async function recordAdoptedLink(
-  db: D1Database,
+  db: D1Queryable,
   row: Omit<AdoptLedgerRow, "detachedAt">,
 ): Promise<void> {
   await db
@@ -95,7 +96,7 @@ export async function recordAdoptedLink(
 
 /** The ledger row for a single (repo, kind, num, source key), or null if never recorded. */
 export async function adoptLedgerRow(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   kind: "pull" | "issues",
   num: number,
@@ -113,7 +114,7 @@ export async function adoptLedgerRow(
 
 /** All ledger rows for (repo, kind, num) currently attributed to `source` ("body" or "comment:<id>"). */
 export async function adoptLedgerRowsForSource(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   kind: "pull" | "issues",
   num: number,
@@ -133,7 +134,7 @@ export async function adoptLedgerRowsForSource(
  * for the noise guard's total-adopted count (detached rows excluded by the
  * caller, same as ingest's own target-scoped reads). */
 export async function adoptLedgerRowsForTarget(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   kind: "pull" | "issues",
   num: number,
@@ -153,7 +154,7 @@ export async function adoptLedgerRowsForTarget(
  * reappears.
  */
 export async function setAdoptLedgerDetached(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   kind: "pull" | "issues",
   num: number,
@@ -175,7 +176,7 @@ export async function setAdoptLedgerDetached(
  * a comment into the body).
  */
 export async function setAdoptLedgerSource(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   kind: "pull" | "issues",
   num: number,

--- a/apps/api/src/github-link-adopt.ts
+++ b/apps/api/src/github-link-adopt.ts
@@ -73,6 +73,7 @@ import {
   installationToken,
 } from "./github-app";
 import { loadWorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 export interface AdoptSourceRef {
   repo: string;
@@ -228,7 +229,7 @@ export async function adoptLinkedFiles(
   const ws = await loadWorkspaceRecord(env, workspaceName);
   if (!ws) return summary;
 
-  const db = env.DB;
+  const db = dbFor(env);
   const { repo, kind, num } = target;
   const foundKeys = new Set(keys);
 
@@ -361,7 +362,7 @@ export async function adoptLinkedFilesForWebhook(
   ref: AdoptSourceRef,
   deps: { fetchImpl?: typeof fetch } = {},
 ): Promise<void> {
-  const link = await findRepoLinkStrict(env.DB, ref.repo);
+  const link = await findRepoLinkStrict(dbFor(env), ref.repo);
   if (!link) return;
   const ws = await loadWorkspaceRecord(env, link.workspaceName);
   if (!ws) return;

--- a/apps/api/src/github-pr-activity.ts
+++ b/apps/api/src/github-pr-activity.ts
@@ -11,6 +11,7 @@
  * the last workspace that wrote media for the PR (in practice one workspace
  * per repo, per the `github_repo_links` binding model).
  */
+import { type D1Queryable } from "./db-session";
 
 export interface PrActivity {
   ref: string;
@@ -64,7 +65,7 @@ export interface PrMediaEvent {
  * branch never clobbers a previously recorded one.
  */
 export async function recordPrMediaActivity(
-  db: D1Database,
+  db: D1Queryable,
   event: PrMediaEvent,
   now = new Date(),
 ): Promise<void> {
@@ -114,7 +115,7 @@ export async function recordPrMediaActivity(
  * Never throws (recordPrMediaActivity swallows D1 failures).
  */
 export async function recordPrActivityFromMetadata(
-  db: D1Database,
+  db: D1Queryable,
   workspaceName: string,
   metadata: Record<string, string>,
 ): Promise<void> {
@@ -136,7 +137,7 @@ export async function recordPrActivityFromMetadata(
  * read endpoint should surface a D1 failure as a 5xx, not an empty feed.
  */
 export async function listPrActivityForWorkspace(
-  db: D1Database,
+  db: D1Queryable,
   workspaceName: string,
   limit: number,
 ): Promise<PrActivity[]> {

--- a/apps/api/src/github-private-prefix-service.ts
+++ b/apps/api/src/github-private-prefix-service.ts
@@ -28,6 +28,7 @@ import {
 import { storage } from "./storage";
 import { objectVisibility } from "./visibility";
 import type { WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 export type GhKeyMode = { mode: "plain" } | { mode: "private"; prefixId: string };
 
@@ -89,7 +90,7 @@ export async function resolveGhKeyContext(
   // sits directly in front of an upload, and the "never block an upload"
   // invariant applies to every step, not just the lookups above it.
   try {
-    const prefixId = await getOrMintPrefixId(env.DB, req.repo, branch);
+    const prefixId = await getOrMintPrefixId(dbFor(env), req.repo, branch);
     return { mode: "private", prefixId };
   } catch (err) {
     console.error(
@@ -208,16 +209,16 @@ export async function rotatePrivatePrefix(
     throw new ForbiddenError(decline.message, { code: "not_authorized" });
   }
 
-  const oldId = await getActivePrefixId(env.DB, repo, branch);
+  const oldId = await getActivePrefixId(dbFor(env), repo, branch);
   if (oldId === null) return { rotated: false, reason: "no_prefix" };
 
-  await retirePrefixId(env.DB, repo, branch, oldId);
-  const newId = await getOrMintPrefixId(env.DB, repo, branch);
+  await retirePrefixId(dbFor(env), repo, branch, oldId);
+  const newId = await getOrMintPrefixId(dbFor(env), repo, branch);
 
   // Includes `oldId` (just retired above) plus any tombstone left behind by
   // an earlier, interrupted rotation for this same (repo, branch) — see the
   // resumability note above.
-  const sourceIds = await listRetiredPrefixIds(env.DB, repo, branch);
+  const sourceIds = await listRetiredPrefixIds(dbFor(env), repo, branch);
 
   const store = await storage(env, ws);
   const newPrefixRoot = `${GH_PRIVATE_ROOT}${newId}/`;
@@ -269,10 +270,11 @@ export async function rotatePrivatePrefix(
           // truth for `newKey`'s resulting rows; a plain `UPDATE` into an
           // already-occupied (workspace, object_key, meta_key) row would
           // otherwise throw a UNIQUE constraint violation.
-          await deleteFileMetadata(env.DB, workspaceName, newKey);
-          await env.DB.prepare(
-            `UPDATE file_metadata SET object_key = ? WHERE workspace = ? AND object_key = ?`,
-          )
+          await deleteFileMetadata(dbFor(env), workspaceName, newKey);
+          await dbFor(env)
+            .prepare(
+              `UPDATE file_metadata SET object_key = ? WHERE workspace = ? AND object_key = ?`,
+            )
             .bind(newKey, workspaceName, item.key)
             .run();
 
@@ -283,9 +285,8 @@ export async function rotatePrivatePrefix(
           // bytes are identical). This only removes the now-stale OLD row so
           // it can't linger as a dead inheritance donor pointing at a
           // shortly-to-be-deleted key.
-          await env.DB.prepare(
-            `DELETE FROM file_content_hash WHERE workspace = ? AND object_key = ?`,
-          )
+          await dbFor(env)
+            .prepare(`DELETE FROM file_content_hash WHERE workspace = ? AND object_key = ?`)
             .bind(workspaceName, item.key)
             .run();
 
@@ -293,9 +294,10 @@ export async function rotatePrivatePrefix(
           // R2-bucket-relative and can collide across workspaces sharing a
           // bucket prefix, so an unscoped match could rename another
           // workspace's row that merely happens to share this tail.
-          await env.DB.prepare(
-            `UPDATE github_ingested_assets SET object_key = ? WHERE object_key = ? AND workspace = ?`,
-          )
+          await dbFor(env)
+            .prepare(
+              `UPDATE github_ingested_assets SET object_key = ? WHERE object_key = ? AND workspace = ?`,
+            )
             .bind(newKey, item.key, workspaceName)
             .run();
           // Gallery items referencing this object follow the move too, so a
@@ -303,11 +305,12 @@ export async function rotatePrivatePrefix(
           // `gallery_items` has no `workspace` column of its own, so scope
           // through its parent `galleries` row instead — same
           // cross-workspace-collision reasoning as the ledger update above.
-          await env.DB.prepare(
-            `UPDATE gallery_items SET object_key = ?
+          await dbFor(env)
+            .prepare(
+              `UPDATE gallery_items SET object_key = ?
              WHERE object_key = ?
                AND gallery_id IN (SELECT id FROM galleries WHERE workspace = ?)`,
-          )
+            )
             .bind(newKey, item.key, workspaceName)
             .run();
 

--- a/apps/api/src/github-private-prefixes.ts
+++ b/apps/api/src/github-private-prefixes.ts
@@ -12,6 +12,7 @@
  * application logic — `getOrMintPrefixId` is race-safe because of that
  * index, not despite the lack of one.
  */
+import { type D1Queryable } from "./db-session";
 
 interface PrefixRow {
   prefix_id: string;
@@ -37,7 +38,7 @@ export const PRIVATE_PREFIX_ID_RE = /^[0-9a-f]{32}$/;
 
 /** The currently active prefix id for (repo, branch), or null if none has been minted. */
 export async function getActivePrefixId(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   branch: string,
 ): Promise<string | null> {
@@ -60,7 +61,7 @@ export async function getActivePrefixId(
  * they all converge on the same id regardless of who won.
  */
 export async function getOrMintPrefixId(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   branch: string,
   now = new Date(),
@@ -94,7 +95,7 @@ export async function getOrMintPrefixId(
 }
 
 /** All active (non-retired) prefix ids for `repo`, across every branch. */
-export async function listActivePrefixIds(db: D1Database, repo: string): Promise<string[]> {
+export async function listActivePrefixIds(db: D1Queryable, repo: string): Promise<string[]> {
   const { results } = await db
     .prepare(
       `SELECT prefix_id FROM github_private_prefixes
@@ -116,7 +117,7 @@ export async function listActivePrefixIds(db: D1Database, repo: string): Promise
  * scoped to non-retired rows across an entire repo, not one branch.
  */
 export async function listRetiredPrefixIds(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   branch: string,
 ): Promise<string[]> {
@@ -138,7 +139,7 @@ export async function listRetiredPrefixIds(
  * longer sees an active row.
  */
 export async function retirePrefixId(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   branch: string,
   prefixId: string,

--- a/apps/api/src/github-promote-service.ts
+++ b/apps/api/src/github-promote-service.ts
@@ -12,6 +12,7 @@ import { isEntitledToClaimRepo } from "./github-claim-authz";
 import { promoteBranchAttachments, type PromoteResult, type PromoteTarget } from "./github-promote";
 import { findRepoLink, recordRepoLink } from "./github-repo-links";
 import type { WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 export type { PromoteResult, PromoteTarget };
 
@@ -31,11 +32,11 @@ export async function postPromoteBranchAttachments(
   // Implicit claim (phase 3): first-claim-wins; never affects the promote
   // result. Cross-tenant gate on NEW claims only (issue #297) — already-bound
   // repos re-record via INSERT OR IGNORE (no-op).
-  const existingLink = await findRepoLink(env.DB, target.repo);
+  const existingLink = await findRepoLink(dbFor(env), target.repo);
   const canClaim =
     existingLink !== null || (await isEntitledToClaimRepo(env, target.repo, mintingUserId));
   if (canClaim) {
-    await recordRepoLink(env.DB, target.repo, workspaceName, "promote");
+    await recordRepoLink(dbFor(env), target.repo, workspaceName, "promote");
   }
 
   return result;

--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -24,6 +24,7 @@ import { resolveGhKeyContextSafe } from "./github-private-prefix-service";
 import { storage } from "./storage";
 import { objectVisibility } from "./visibility";
 import type { WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 /**
  * Max staged files processed per call — bounds the work a pathological branch
@@ -223,7 +224,7 @@ export async function promoteBranchAttachments(
   }
 
   const metaByKey = await getMetadataForKeys(
-    env.DB,
+    dbFor(env),
     workspaceName,
     toProcess
       .filter((i) => i.kind === "unit")
@@ -238,7 +239,7 @@ export async function promoteBranchAttachments(
    * throw, never affect promoted/skipped). */
   async function tagShadowOriginal(shadow: StagedEntry, destKey: string): Promise<void> {
     try {
-      await setFileMetadata(env.DB, workspaceName, shadow.key, {
+      await setFileMetadata(dbFor(env), workspaceName, shadow.key, {
         "gh.promoted-to": ref,
         "gh.promoted-at": nowIso,
         "gh.status": "promoted",
@@ -331,7 +332,7 @@ export async function promoteBranchAttachments(
       // without disturbing its own gh.repo/gh.kind/gh.branch/gh.staged-at
       // tags. `gh.status` (issue #339) flips so in-flight staged media is a
       // plain equality query (`meta.gh.status=staged`).
-      await setFileMetadata(env.DB, workspaceName, key, {
+      await setFileMetadata(dbFor(env), workspaceName, key, {
         "gh.promoted-to": ref,
         "gh.promoted-at": nowIso,
         "gh.status": "promoted",

--- a/apps/api/src/github-repo-links.ts
+++ b/apps/api/src/github-repo-links.ts
@@ -16,6 +16,7 @@
  */
 
 import { bumpDailyMetric, logAdoptionFailure } from "./adoption";
+import { type D1Queryable } from "./db-session";
 
 export interface RepoLink {
   repo: string;
@@ -55,7 +56,7 @@ function rowToLink(row: RepoLinkRow): RepoLink {
  * failures are logged and swallowed.
  */
 export async function recordRepoLink(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   workspaceName: string,
   source: string,
@@ -99,7 +100,7 @@ export async function recordRepoLink(
 }
 
 /** The workspace bound to `repo`, or null if unclaimed. Never throws (callers treat a D1 failure as "no link"). */
-export async function findRepoLink(db: D1Database, repo: string): Promise<RepoLink | null> {
+export async function findRepoLink(db: D1Queryable, repo: string): Promise<RepoLink | null> {
   try {
     const row = await db
       .prepare(
@@ -144,7 +145,7 @@ export function deriveRepoBinding(link: RepoLink | null, workspaceName: string):
  * #318 CodeRabbit review) — a lookup failure here throws instead of being
  * reported as an honest-looking `{unlinked: false, reason: "not_linked"}`.
  */
-export async function findRepoLinkStrict(db: D1Database, repo: string): Promise<RepoLink | null> {
+export async function findRepoLinkStrict(db: D1Queryable, repo: string): Promise<RepoLink | null> {
   const row = await db
     .prepare(
       `SELECT repo_full_name, workspace_name, installation_id, source, created_at
@@ -160,7 +161,7 @@ export async function findRepoLinkStrict(db: D1Database, repo: string): Promise<
  * throws — cleanup is best-effort; a failed delete just means the next
  * webhook delivery re-discovers the same stale state and retries the cleanup.
  */
-export async function deleteRepoLink(db: D1Database, repo: string): Promise<void> {
+export async function deleteRepoLink(db: D1Queryable, repo: string): Promise<void> {
   try {
     await db
       .prepare(`DELETE FROM github_repo_links WHERE repo_full_name = ?`)
@@ -184,7 +185,7 @@ export async function deleteRepoLink(db: D1Database, repo: string): Promise<void
  * failures instead of catching/logging them. Returns whether a row existed
  * to delete (not just whether the statement ran).
  */
-export async function deleteRepoLinkStrict(db: D1Database, repo: string): Promise<boolean> {
+export async function deleteRepoLinkStrict(db: D1Queryable, repo: string): Promise<boolean> {
   const result = await db
     .prepare(`DELETE FROM github_repo_links WHERE repo_full_name = ?`)
     .bind(normalizeRepo(repo))
@@ -201,7 +202,7 @@ export async function deleteRepoLinkStrict(db: D1Database, repo: string): Promis
  * Returns true only if a row owned by `workspaceName` was deleted.
  */
 export async function deleteRepoLinkForWorkspace(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   workspaceName: string,
 ): Promise<boolean> {
@@ -218,7 +219,7 @@ export async function deleteRepoLinkForWorkspace(
  * workspace has claimed without querying D1 directly.
  */
 export async function listRepoLinksForWorkspace(
-  db: D1Database,
+  db: D1Queryable,
   workspaceName: string,
 ): Promise<RepoLink[]> {
   const { results } = await db
@@ -238,7 +239,7 @@ export async function listRepoLinksForWorkspace(
  * admin-gated route; self-serve callers never get this power.
  */
 export async function setRepoLink(
-  db: D1Database,
+  db: D1Queryable,
   repo: string,
   workspaceName: string,
   source: string,

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -70,6 +70,7 @@ import { promoteBranchAttachments } from "./github-promote";
 // consumer retries the event, not read as "repo not linked" and ack-drop it.
 import { deleteRepoLink, findRepoLinkStrict, type RepoLink } from "./github-repo-links";
 import { loadWorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 const enc = new TextEncoder();
 
@@ -172,7 +173,7 @@ async function gatherAndUpsert(env: Env, link: RepoLink, target: GhTarget): Prom
     // The bound workspace is gone or tombstoned — the link is stale;
     // clean it up so a future claim (e.g. from another workspace) isn't
     // blocked by first-claim-wins forever.
-    await deleteRepoLink(env.DB, target.repo);
+    await deleteRepoLink(dbFor(env), target.repo);
     return;
   }
 
@@ -223,12 +224,12 @@ async function resolveLinkedWorkspaceOrCleanup(
   link: RepoLink;
   ws: NonNullable<Awaited<ReturnType<typeof loadWorkspaceRecord>>>;
 } | null> {
-  const link = await findRepoLinkStrict(env.DB, repo);
+  const link = await findRepoLinkStrict(dbFor(env), repo);
   if (!link) return null;
 
   const ws = await loadWorkspaceRecord(env, link.workspaceName);
   if (!ws) {
-    await deleteRepoLink(env.DB, repo);
+    await deleteRepoLink(dbFor(env), repo);
     return null;
   }
   return { link, ws };
@@ -281,14 +282,14 @@ async function stampMergedScreenshots(env: Env, repo: string, num: number): Prom
 
   const [owner, name] = repo.split("/");
   const ref = `${owner}/${name}#${num}`.toLowerCase();
-  const matches = await findObjectsByMetadata(env.DB, link.workspaceName, {
+  const matches = await findObjectsByMetadata(dbFor(env), link.workspaceName, {
     "gh.ref": ref,
     "gh.kind": "pull",
   });
 
   for (const match of matches) {
     try {
-      await setFileMetadata(env.DB, link.workspaceName, match.key, { "gh.merged": "true" });
+      await setFileMetadata(dbFor(env), link.workspaceName, match.key, { "gh.merged": "true" });
     } catch (err) {
       console.error(
         JSON.stringify({
@@ -364,7 +365,7 @@ async function reconcileBotComment(
   num: number,
   kind: GhTarget["kind"],
 ): Promise<void> {
-  const link = await findRepoLinkStrict(env.DB, repo);
+  const link = await findRepoLinkStrict(dbFor(env), repo);
   if (!link) return;
 
   const target: GhTarget = { repo, kind, num };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import { AppError, NotFoundError } from "@uploads/errors";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { createDbSession } from "./db-session";
 import { respondError } from "./error-response";
 import { workspaceAuth, type WorkspaceVars } from "./workspace";
 import { files } from "./routes/files";
@@ -86,6 +87,21 @@ const adminUiCors = cors({
 
 /** Hono app — also re-exported for vitest (`app.request`). */
 export const app = new Hono<WorkspaceVars>()
+  // D1 Sessions API (issue #808): one Session per request, set before any
+  // handler runs. Everything downstream reads D1 via `dbFor(env)`
+  // (src/db-session.ts) instead of `env.DB` directly, so it's ready to have
+  // reads served by a replica once D1 read replication is enabled — while
+  // replication stays disabled, this is a no-op (queries still land on the
+  // primary). `DB` is a required binding in production, but some tests and
+  // local setups omit it (or fake it with a plain object that doesn't
+  // implement `withSession`), hence the guards — `dbFor` falls back to the
+  // raw binding whenever no session was created here.
+  .use("*", async (c, next) => {
+    if (c.env?.DB && typeof c.env.DB.withSession === "function") {
+      c.env.DB_SESSION = createDbSession(c.env.DB);
+    }
+    await next();
+  })
   .get("/health", (c) => c.json({ ok: true }))
   .get("/robots.txt", (c) =>
     c.text(ROBOTS_TXT, 200, {

--- a/apps/api/src/metrics-overview.ts
+++ b/apps/api/src/metrics-overview.ts
@@ -9,6 +9,7 @@
  * that governs `ws:` keys does not apply here.
  */
 
+import { dbFor } from "./db-session";
 import {
   activeWorkspacesSince,
   featureTotals,
@@ -122,18 +123,18 @@ export async function buildOverview(
   const since30 = windowStart(30, now);
 
   const [uploads, features, table, active30, storage, auth, multiIdentity] = await Promise.all([
-    platformSeries(env.DB, "upload", since),
-    featureTotals(env.DB, since),
-    workspaceActivity(env.DB, since),
+    platformSeries(dbFor(env), "upload", since),
+    featureTotals(dbFor(env), since),
+    workspaceActivity(dbFor(env), since),
     // Scans the 30-day window ONCE; the 7-day count is derived below by
     // filtering these same rows rather than issuing a second query — the
     // last 7 days of index entries are always a subset of the last 30, so a
     // separate activeWorkspaceCount(since7) call would just re-read them
     // (D1 bills rows read).
-    activeWorkspacesSince(env.DB, since30),
-    platformStorage(env.DB),
+    activeWorkspacesSince(dbFor(env), since30),
+    platformStorage(dbFor(env)),
     authMetrics(env, since),
-    multiIdentityWorkspaces(env.DB),
+    multiIdentityWorkspaces(dbFor(env)),
   ]);
 
   return {

--- a/apps/api/src/observability-retention.ts
+++ b/apps/api/src/observability-retention.ts
@@ -7,6 +7,7 @@
  * loop, with a per-table batch cap so a backlog cannot blow the Worker cron
  * CPU budget. Residual rows clear on subsequent days.
  */
+import { dbFor, type D1Queryable } from "./db-session";
 
 export const TELEMETRY_RETENTION_DAYS = 30;
 export const ENROLLMENT_RETENTION_DAYS = 7;
@@ -38,7 +39,7 @@ function placeholders(n: number): string {
 const D1_MAX_BOUND_PARAMS = 100;
 
 async function deleteByIdsChunked(
-  db: D1Database,
+  db: D1Queryable,
   table: "uploads_telemetry_events" | "auth_enrollments",
   ids: string[],
 ): Promise<void> {
@@ -56,7 +57,7 @@ async function deleteByIdsChunked(
  * “the last batch happened to be full” (exact-cap runs must report truncated=false).
  */
 async function purgeInBatches(
-  db: D1Database,
+  db: D1Queryable,
   selectIds: (limit: number) => Promise<string[]>,
   deleteIds: (ids: string[]) => Promise<void>,
 ): Promise<{ deleted: number; truncated: boolean }> {
@@ -85,7 +86,7 @@ async function purgeInBatches(
 }
 
 async function purgeTelemetry(
-  db: D1Database,
+  db: D1Queryable,
   cutoffMs: number,
 ): Promise<{
   deleted: number;
@@ -107,7 +108,7 @@ async function purgeTelemetry(
 }
 
 async function purgeEnrollments(
-  db: D1Database,
+  db: D1Queryable,
   cutoffIso: string,
 ): Promise<{
   deleted: number;
@@ -152,8 +153,8 @@ export async function runObservabilityRetention(
   const enrollmentCutoff = new Date(now.getTime() - ENROLLMENT_RETENTION_DAYS * MS_PER_DAY);
   const cutoffIso = enrollmentCutoff.toISOString();
 
-  const telemetry = await purgeTelemetry(env.DB, cutoffMs);
-  const enrollments = await purgeEnrollments(env.DB, cutoffIso);
+  const telemetry = await purgeTelemetry(dbFor(env), cutoffMs);
+  const enrollments = await purgeEnrollments(dbFor(env), cutoffIso);
 
   const result: ObservabilityRetentionResult = {
     telemetryDeleted: telemetry.deleted,

--- a/apps/api/src/reconcile.ts
+++ b/apps/api/src/reconcile.ts
@@ -13,6 +13,7 @@ import { createStorage } from "@uploads/storage";
 import { isSharedLane, storageConfigs } from "./storage";
 import { getWorkspaceUsage, setUsageTotals, type WorkspaceUsage } from "./usage";
 import { isUnprefixedDedicatedBucket, type WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 export interface ReconcileResult {
   workspace: string;
@@ -42,7 +43,7 @@ export async function reconcileWorkspaceUsage(
   workspaceName: string,
   now = new Date(),
 ): Promise<ReconcileResult> {
-  const previous = await getWorkspaceUsage(env.DB, workspaceName, now);
+  const previous = await getWorkspaceUsage(dbFor(env), workspaceName, now);
   const configs = await storageConfigs(env, ws);
   const unprefixedBucket = isUnprefixedDedicatedBucket(ws);
   if (unprefixedBucket) {
@@ -87,7 +88,7 @@ export async function reconcileWorkspaceUsage(
   }
 
   const usage = await setUsageTotals(
-    env.DB,
+    dbFor(env),
     workspaceName,
     { bytes, objects, sharedBytes, sharedObjects },
     now,

--- a/apps/api/src/retention.ts
+++ b/apps/api/src/retention.ts
@@ -19,6 +19,7 @@ import { deleteFileMetadataForKeys } from "./file-metadata";
 import { reconcileWorkspaceUsage, type ReconcileResult } from "./reconcile";
 import { storage } from "./storage";
 import { isUnprefixedDedicatedBucket, type WorkspaceRecord } from "./workspace";
+import { dbFor } from "./db-session";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /** Cap listed deleted keys in the response so agents don't get huge payloads. */
@@ -86,7 +87,7 @@ export async function purgeExpiredObjects(
     if (batch.length === 0) return;
     // Bulk form: native multi-delete on R2/S3 when available.
     await store.delete(batch);
-    await deleteFileMetadataForKeys(env.DB, workspaceName, batch);
+    await deleteFileMetadataForKeys(dbFor(env), workspaceName, batch);
     batch = [];
   }
 

--- a/apps/api/src/routes/abuse.ts
+++ b/apps/api/src/routes/abuse.ts
@@ -12,6 +12,7 @@ import { Hono } from "hono";
 import { notifyAbuseReport } from "../abuse-email";
 import { envFlagOn, newId, readJsonObjectBody, sanitizeString, stripControl } from "../cli-intake";
 import type { WorkspaceVars } from "../workspace";
+import { dbFor } from "../db-session";
 
 export const ABUSE_REASONS = ["abuse", "copyright", "spam", "privacy", "other"] as const;
 
@@ -86,11 +87,12 @@ abuse.post("/", async (c) => {
   const createdAt = new Date().toISOString();
 
   try {
-    await c.env.DB.prepare(
-      `INSERT INTO abuse_reports (
+    await dbFor(c.env)
+      .prepare(
+        `INSERT INTO abuse_reports (
         id, created_at, reason, message, contact, page_url, workspace, object_key, surface
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
+      )
       .bind(id, createdAt, reason, message, contact, pageUrl, workspace, objectKey, surface)
       .run();
   } catch (err) {

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -64,6 +64,7 @@ import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { LIMIT_FIELDS, validateLimitsPatch } from "../workspace-limits";
 import { planResponse, planSourceFor, validatePlanPatch } from "../workspace-plan";
 import { storageStatusResponse } from "./workspace-storage";
+import { dbFor } from "../db-session";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const BAN_REASON_MAX = 500;
@@ -437,7 +438,7 @@ async function limitsResponse(env: Env, name: string, record: WorkspaceRecord) {
   };
   let usage: { bytes: number; uploads: number } | null = null;
   try {
-    const u = await getWorkspaceUsage(env.DB, name);
+    const u = await getWorkspaceUsage(dbFor(env), name);
     usage = { bytes: u.bytes, uploads: u.uploadsInPeriod };
   } catch {
     usage = null;
@@ -628,7 +629,7 @@ export const adminUi = new Hono<SessionVars>()
     const scopes = validateScopes(body.scopes, ["files:read", "files:write"]);
     if (!scopes) throw new ValidationError("invalid scopes", { code: "invalid_scopes" });
 
-    const enrollment = await createEnrollment(c.env.DB, {
+    const enrollment = await createEnrollment(dbFor(c.env), {
       workspace: name,
       label,
       scopes,
@@ -823,7 +824,7 @@ export const adminUi = new Hono<SessionVars>()
   // workspace), not scoped to one workspace's list.
   .get("/workspaces/:name/github-links", async (c) => {
     const name = c.req.param("name");
-    const links = await listRepoLinksForWorkspace(c.env.DB, name);
+    const links = await listRepoLinksForWorkspace(dbFor(c.env), name);
     return c.json({ workspace: name, links: links.map(repoLinkResponse) });
   })
 
@@ -858,7 +859,7 @@ export const adminUi = new Hono<SessionVars>()
     if (!(await allowWrite(c.env, workspace))) {
       throw new RateLimitedError("rate limit exceeded");
     }
-    await setRepoLink(c.env.DB, repo, workspace, "admin");
+    await setRepoLink(dbFor(c.env), repo, workspace, "admin");
     return c.json({ repo, workspace, reassigned: true });
   })
 
@@ -871,14 +872,14 @@ export const adminUi = new Hono<SessionVars>()
   // (there's no destination workspace to key on, unlike PUT above).
   .delete("/github-links", async (c) => {
     const repo = parseRepoParam(c.req.query("repo"));
-    const before = await findRepoLinkStrict(c.env.DB, repo);
+    const before = await findRepoLinkStrict(dbFor(c.env), repo);
     if (!before) {
       return c.json({ repo, unlinked: false, reason: "not_linked" as const });
     }
     if (!(await allowWrite(c.env, before.workspaceName))) {
       throw new RateLimitedError("rate limit exceeded");
     }
-    const removed = await deleteRepoLinkStrict(c.env.DB, repo);
+    const removed = await deleteRepoLinkStrict(dbFor(c.env), repo);
     return c.json({ repo, unlinked: removed });
   })
 
@@ -899,7 +900,7 @@ export const adminUi = new Hono<SessionVars>()
     // Best-effort: ban already wiped sessions; a D1 blip must not undo it.
     let tokensRevoked = 0;
     try {
-      tokensRevoked = await revokeTokensForMintingUser(c.env.DB, userId);
+      tokensRevoked = await revokeTokensForMintingUser(dbFor(c.env), userId);
     } catch {
       tokensRevoked = 0;
     }

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -34,6 +34,7 @@ import {
   stampSoftDelete,
   type WorkspaceRecord,
 } from "../workspace";
+import { dbFor } from "../db-session";
 
 const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 const HASH_PREFIX_LEN = 8;
@@ -226,7 +227,7 @@ export const admin = new Hono<{ Bindings: Env }>()
     const expiresAt = body.expiresInDays
       ? new Date(Date.now() + body.expiresInDays * 24 * 60 * 60 * 1000)
       : undefined;
-    const created = await createToken(c.env.DB, {
+    const created = await createToken(dbFor(c.env), {
       workspace: name,
       label,
       scopes,
@@ -311,7 +312,7 @@ export const admin = new Hono<{ Bindings: Env }>()
       }
     }
 
-    const enrollment = await createEnrollment(c.env.DB, {
+    const enrollment = await createEnrollment(dbFor(c.env), {
       workspace: name,
       label,
       scopes,
@@ -361,7 +362,7 @@ export const admin = new Hono<{ Bindings: Env }>()
       throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
     }
 
-    const d1 = (await listTokens(c.env.DB, name, { includeRevoked: true })).map((token) => ({
+    const d1 = (await listTokens(dbFor(c.env), name, { includeRevoked: true })).map((token) => ({
       label: token.label,
       createdAt: token.created_at,
       hashPrefix: token.token_hash.slice(0, HASH_PREFIX_LEN),
@@ -406,7 +407,7 @@ export const admin = new Hono<{ Bindings: Env }>()
       hashPrefix ? token.hash.startsWith(hashPrefix) : token.label === label,
     );
     // Active-only list (default) — revoked tokens cannot be re-revoked here.
-    const activeD1 = (await listTokens(c.env.DB, name)).filter((token) =>
+    const activeD1 = (await listTokens(dbFor(c.env), name)).filter((token) =>
       hashPrefix ? token.token_hash.startsWith(hashPrefix) : token.label === label,
     );
     const count = kvMatches.length + activeD1.length;
@@ -414,7 +415,7 @@ export const admin = new Hono<{ Bindings: Env }>()
     if (count > 1) throw new ConflictError("selector matches multiple tokens");
 
     if (activeD1.length === 1) {
-      const result = await revokeToken(c.env.DB, name, { hashPrefix, label });
+      const result = await revokeToken(dbFor(c.env), name, { hashPrefix, label });
       if (!result.match) throw new NotFoundError("no matching token");
       return c.json({
         workspace: name,

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { RateLimitedError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import { exchangeEnrollment, findEnrollmentPage } from "../auth-db";
+import { dbFor } from "../db-session";
 
 const INVALID_ENROLLMENT = () =>
   new ValidationError("invalid or expired enrollment code", { code: "invalid_enrollment" });
@@ -20,7 +21,7 @@ export const auth = new Hono<{ Bindings: Env }>()
   .get("/enrollments/:pageId", async (c) => {
     c.header("Cache-Control", "no-store");
     c.header("Access-Control-Allow-Origin", "https://uploads.sh");
-    const result = await findEnrollmentPage(c.env.DB, c.req.param("pageId"));
+    const result = await findEnrollmentPage(dbFor(c.env), c.req.param("pageId"));
     if (!result) throw INVALID_ENROLLMENT();
     return c.json(result);
   })
@@ -48,7 +49,7 @@ export const auth = new Hono<{ Bindings: Env }>()
     }
     const code = parsed.code.trim();
     if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) throw INVALID_ENROLLMENT();
-    const result = await exchangeEnrollment(c.env.DB, code);
+    const result = await exchangeEnrollment(dbFor(c.env), code);
     if (!result) throw INVALID_ENROLLMENT();
     return c.json(result, 201);
   });

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -19,6 +19,7 @@ import { createLaneResolver, objectPublicUrls, resolveObjectLane, storage } from
 import { hasGithubTags, uploaderTags } from "../uploader-identity";
 import { sanitizeVisibility } from "../visibility";
 import type { WorkspaceVars } from "../workspace";
+import { dbFor } from "../db-session";
 
 /** Handler shape shared by the legacy bearer and canonical dual-auth routers. */
 export type SharedFilesHandler = Handler<WorkspaceVars>;
@@ -238,7 +239,7 @@ export async function getFileHandler(c: Context<WorkspaceVars>) {
 
   const metadataParam = c.req.query("metadata");
   if (metadataParam === "1" || metadataParam === "true") {
-    const metadata = await getFileMetadata(c.env.DB, c.get("workspaceName"), key);
+    const metadata = await getFileMetadata(dbFor(c.env), c.get("workspaceName"), key);
     return c.json({ metadata });
   }
 
@@ -284,7 +285,7 @@ export async function patchFileHandler(c: Context<WorkspaceVars>) {
   }
 
   const metadata = await setFileMetadata(
-    c.env.DB,
+    dbFor(c.env),
     c.get("workspaceName"),
     key,
     (set as Record<string, string> | undefined) ?? {},

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -16,6 +16,7 @@ import {
   putFileHandler,
   signFileHandler,
 } from "./files-shared-handlers";
+import { dbFor } from "../db-session";
 
 export const files = new Hono<WorkspaceVars>()
 
@@ -82,7 +83,7 @@ export const files = new Hono<WorkspaceVars>()
     if (metadataParam !== "1" && metadataParam !== "true") return c.json(page);
 
     const metaByKey = await getMetadataForKeys(
-      c.env.DB,
+      dbFor(c.env),
       c.get("workspaceName"),
       page.items.map((item) => item.key),
     );
@@ -98,7 +99,7 @@ export const files = new Hono<WorkspaceVars>()
   // Static path must register before `/:key{.+}` so "facets" is not treated
   // as an object key.
   .get("/facets", requireScope("files:read"), async (c) => {
-    return c.json(await listFacets(c.env.DB, c.get("workspaceName"), c.req.query("key")));
+    return c.json(await listFacets(dbFor(c.env), c.get("workspaceName"), c.req.query("key")));
   })
 
   // Metadata now lives on the key-at-tail routes (same shape PUT/GET/DELETE

--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -37,11 +37,12 @@ import { parseExternalReference } from "../external-references";
 import { publicUrl, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { jsonBody } from "./json-body";
+import { dbFor } from "../db-session";
 
 async function ownerGallery(c: Context<WorkspaceVars>, id: string) {
-  const record = await getGallery(c.env.DB, c.get("workspaceName"), id);
+  const record = await getGallery(dbFor(c.env), c.get("workspaceName"), id);
   if (!record) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
-  const items = await listGalleryItems(c.env.DB, c.get("workspaceName"), id);
+  const items = await listGalleryItems(dbFor(c.env), c.get("workspaceName"), id);
   return hydrateOwnerGallery(c.env, c.get("workspace"), record, items);
 }
 
@@ -58,7 +59,7 @@ async function ownerGallery(c: Context<WorkspaceVars>, id: string) {
 export async function createGalleryHandler(c: Context<WorkspaceVars>) {
   const body = await jsonBody(c);
   const result = unwrapMutation(
-    await createGallery(c.env.DB, {
+    await createGallery(dbFor(c.env), {
       workspace: c.get("workspaceName"),
       title: typeof body.title === "string" ? body.title : "",
       description:
@@ -79,7 +80,7 @@ export async function listGalleriesHandler(c: Context<WorkspaceVars>) {
   const limit = rawLimit === undefined ? 50 : Number(rawLimit);
   if (!Number.isInteger(limit) || limit < 1 || limit > 100)
     throw new ValidationError("limit must be an integer from 1 to 100.");
-  const page = await listGalleries(c.env.DB, c.get("workspaceName"), {
+  const page = await listGalleries(dbFor(c.env), c.get("workspaceName"), {
     limit,
     cursor: decodeGalleryCursor(c.req.query("cursor")),
   });
@@ -98,7 +99,7 @@ export async function galleriesByReferenceHandler(c: Context<WorkspaceVars>) {
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100)
     throw new ValidationError("limit must be an integer from 1 to 100.");
   const page = await findGalleriesByReference(
-    c.env.DB,
+    dbFor(c.env),
     c.get("workspaceName"),
     parsed.value.normalizedKey,
     { limit, cursor: decodeGalleryCursor(c.req.query("cursor")) },
@@ -116,7 +117,7 @@ export async function getGalleryHandler(c: Context<WorkspaceVars>) {
 export async function updateGalleryHandler(c: Context<WorkspaceVars>) {
   const body = await jsonBody(c);
   const { value } = unwrapMutation(
-    await updateGallery(c.env.DB, c.get("workspaceName"), c.req.param("id") as string, {
+    await updateGallery(dbFor(c.env), c.get("workspaceName"), c.req.param("id") as string, {
       expectedVersion: requireExpectedVersion(body.expectedVersion),
       title: typeof body.title === "string" ? body.title : undefined,
       description:
@@ -135,7 +136,7 @@ export async function updateGalleryHandler(c: Context<WorkspaceVars>) {
 export async function deleteGalleryHandler(c: Context<WorkspaceVars>) {
   const body = await jsonBody(c);
   const result = await softDeleteGallery(
-    c.env.DB,
+    dbFor(c.env),
     c.get("workspaceName"),
     c.req.param("id") as string,
     requireExpectedVersion(body.expectedVersion),
@@ -149,10 +150,10 @@ export async function addGalleryItemHandler(c: Context<WorkspaceVars>) {
   const key = typeof body.objectKey === "string" ? body.objectKey : "";
   if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
   const galleryId = c.req.param("id") as string;
-  const gallery = await getGallery(c.env.DB, c.get("workspaceName"), galleryId);
+  const gallery = await getGallery(dbFor(c.env), c.get("workspaceName"), galleryId);
   if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
   const expectedVersion = requireExpectedVersion(body.expectedVersion);
-  const existing = (await listGalleryItems(c.env.DB, c.get("workspaceName"), galleryId)).find(
+  const existing = (await listGalleryItems(dbFor(c.env), c.get("workspaceName"), galleryId)).find(
     (item) => item.object_key === key,
   );
   if (existing) {
@@ -190,7 +191,7 @@ export async function addGalleryItemHandler(c: Context<WorkspaceVars>) {
   if (publicUrl(config, key) === null)
     throw new ValidationError("Object has no public URL.", { code: "gallery_object_not_public" });
   const result = unwrapMutation(
-    await addGalleryItem(c.env.DB, c.get("workspaceName"), c.req.param("id") as string, {
+    await addGalleryItem(dbFor(c.env), c.get("workspaceName"), c.req.param("id") as string, {
       expectedVersion,
       objectKey: key,
       caption: body.caption === null || typeof body.caption === "string" ? body.caption : undefined,
@@ -210,7 +211,7 @@ export async function reorderGalleryItemsHandler(c: Context<WorkspaceVars>) {
     throw new ValidationError("itemIds must be an array of strings.");
   const result = unwrapMutation(
     await reorderGalleryItems(
-      c.env.DB,
+      dbFor(c.env),
       c.get("workspaceName"),
       c.req.param("id") as string,
       body.itemIds,
@@ -226,7 +227,7 @@ export async function reorderGalleryItemsHandler(c: Context<WorkspaceVars>) {
 export async function removeGalleryItemHandler(c: Context<WorkspaceVars>) {
   const body = await jsonBody(c);
   const result = await removeGalleryItem(
-    c.env.DB,
+    dbFor(c.env),
     c.get("workspaceName"),
     c.req.param("id") as string,
     c.req.param("itemId") as string,
@@ -237,23 +238,31 @@ export async function removeGalleryItemHandler(c: Context<WorkspaceVars>) {
 }
 
 export async function listExternalReferencesHandler(c: Context<WorkspaceVars>) {
-  const gallery = await getGallery(c.env.DB, c.get("workspaceName"), c.req.param("id") as string);
+  const gallery = await getGallery(
+    dbFor(c.env),
+    c.get("workspaceName"),
+    c.req.param("id") as string,
+  );
   if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
   return c.json({
-    references: (await listExternalReferences(c.env.DB, c.get("workspaceName"), gallery.id)).map(
-      referenceDto,
-    ),
+    references: (
+      await listExternalReferences(dbFor(c.env), c.get("workspaceName"), gallery.id)
+    ).map(referenceDto),
   });
 }
 
 export async function addExternalReferenceHandler(c: Context<WorkspaceVars>) {
   const body = await jsonBody(c);
-  const gallery = await getGallery(c.env.DB, c.get("workspaceName"), c.req.param("id") as string);
+  const gallery = await getGallery(
+    dbFor(c.env),
+    c.get("workspaceName"),
+    c.req.param("id") as string,
+  );
   if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
   const parsed = parseExternalReference(body.provider, body.coordinate);
   if (!parsed.ok) throw new ValidationError(parsed.message, { code: "gallery_invalid_reference" });
   const result = unwrapMutation(
-    await addExternalReference(c.env.DB, c.get("workspaceName"), c.req.param("id") as string, {
+    await addExternalReference(dbFor(c.env), c.get("workspaceName"), c.req.param("id") as string, {
       expectedVersion: requireExpectedVersion(body.expectedVersion),
       ...parsed.value,
     }),
@@ -264,7 +273,7 @@ export async function addExternalReferenceHandler(c: Context<WorkspaceVars>) {
 export async function removeExternalReferenceHandler(c: Context<WorkspaceVars>) {
   const body = await jsonBody(c);
   const result = await removeExternalReference(
-    c.env.DB,
+    dbFor(c.env),
     c.get("workspaceName"),
     c.req.param("id") as string,
     c.req.param("referenceId") as string,

--- a/apps/api/src/routes/github-activity.ts
+++ b/apps/api/src/routes/github-activity.ts
@@ -9,6 +9,7 @@ import { ValidationError } from "@uploads/errors";
 import { Hono, type Context } from "hono";
 import { listPrActivityForWorkspace } from "../github-pr-activity";
 import { requireScope, type WorkspaceVars } from "../workspace";
+import { dbFor } from "../db-session";
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
@@ -32,7 +33,7 @@ function parseLimit(raw: string | undefined): number {
 export async function githubActivityHandler(c: Context<WorkspaceVars>) {
   const limit = parseLimit(c.req.query("limit"));
   const workspaceName = c.get("workspaceName");
-  const activity = await listPrActivityForWorkspace(c.env.DB, workspaceName, limit);
+  const activity = await listPrActivityForWorkspace(dbFor(c.env), workspaceName, limit);
   return c.json({ workspace: workspaceName, activity });
 }
 

--- a/apps/api/src/routes/github-link.ts
+++ b/apps/api/src/routes/github-link.ts
@@ -22,6 +22,7 @@ import {
 import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { jsonBody } from "./json-body";
+import { dbFor } from "../db-session";
 
 // Same owner/name grammar + dot-only-segment guard as routes/github-comment.ts's
 // parseTarget (this repo string is looked up/stored, not interpolated into an
@@ -57,7 +58,7 @@ function linkResponse(repo: string, link: RepoLink | null) {
  */
 export async function githubLinkGetHandler(c: Context<WorkspaceVars>) {
   const repo = parseRepo(c.req.query("repo"));
-  const link = await findRepoLink(c.env.DB, repo);
+  const link = await findRepoLink(dbFor(c.env), repo);
   return c.json(linkResponse(repo, link));
 }
 
@@ -76,7 +77,7 @@ export async function githubLinkGetHandler(c: Context<WorkspaceVars>) {
 export async function githubRepoLinkGetHandler(c: Context<WorkspaceVars>) {
   const repo = parseRepo(c.req.query("repo"));
   const workspaceName = c.get("workspaceName");
-  const link = await findRepoLink(c.env.DB, repo);
+  const link = await findRepoLink(dbFor(c.env), repo);
   return c.json({ binding: deriveRepoBinding(link, workspaceName) });
 }
 
@@ -84,7 +85,7 @@ export async function githubLinkPostHandler(c: Context<WorkspaceVars>) {
   const repo = parseRepo((await jsonBody(c)).repo);
   const workspaceName = c.get("workspaceName");
 
-  const before = await findRepoLink(c.env.DB, repo);
+  const before = await findRepoLink(dbFor(c.env), repo);
   if (before) {
     // Already bound — honestly report the owner rather than claiming
     // success. First-claim-wins: this call never overwrites it, whether
@@ -113,8 +114,8 @@ export async function githubLinkPostHandler(c: Context<WorkspaceVars>) {
     });
   }
 
-  await recordRepoLink(c.env.DB, repo, workspaceName, "cli");
-  const after = await findRepoLink(c.env.DB, repo);
+  await recordRepoLink(dbFor(c.env), repo, workspaceName, "cli");
+  const after = await findRepoLink(dbFor(c.env), repo);
   return c.json({
     claimed: after?.workspaceName === workspaceName,
     ...linkResponse(repo, after),
@@ -133,7 +134,7 @@ export async function githubLinkDeleteHandler(c: Context<WorkspaceVars>) {
   // degrading to "unclaimed" is an acceptable inspect-only fallback), a
   // D1 read failure here must surface as a 5xx, not silently report
   // `{unlinked: false, reason: "not_linked"}` (CodeRabbit, issue #318).
-  const before = await findRepoLinkStrict(c.env.DB, repo);
+  const before = await findRepoLinkStrict(dbFor(c.env), repo);
   if (!before) {
     return c.json({ repo, unlinked: false, reason: "not_linked" as const });
   }
@@ -143,7 +144,7 @@ export async function githubLinkDeleteHandler(c: Context<WorkspaceVars>) {
       { code: "not_link_owner" },
     );
   }
-  const removed = await deleteRepoLinkForWorkspace(c.env.DB, repo, workspaceName);
+  const removed = await deleteRepoLinkForWorkspace(dbFor(c.env), repo, workspaceName);
   return c.json({ repo, unlinked: removed });
 }
 

--- a/apps/api/src/routes/github-private-prefix.ts
+++ b/apps/api/src/routes/github-private-prefix.ts
@@ -24,6 +24,7 @@ import { listActivePrefixIds } from "../github-private-prefixes";
 import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { jsonBody } from "./json-body";
+import { dbFor } from "../db-session";
 
 // Same grammar as routes/github-comment.ts's REPO_RE/DOTS_ONLY_RE.
 const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
@@ -84,7 +85,7 @@ export async function githubPrivatePrefixHandler(c: Context<WorkspaceVars>) {
   // `resolveGhKeyContext` itself) — degrade to an empty list instead.
   let activePrefixIds: string[] = [];
   try {
-    activePrefixIds = await listActivePrefixIds(c.env.DB, req.repo);
+    activePrefixIds = await listActivePrefixIds(dbFor(c.env), req.repo);
   } catch (err) {
     console.error(
       JSON.stringify({

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -15,6 +15,7 @@ import { objectPublicUrls, resolveObjectLane } from "../storage";
 import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceRecord, type WorkspaceVars } from "../workspace";
 import { requestOrigin } from "../well-known";
+import { dbFor } from "../db-session";
 
 type GithubKind = "pull" | "issue";
 
@@ -175,7 +176,7 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
   }
 
   // After the visibility gate — private objects 401 before this D1 read.
-  const metadata = await getFileMetadata(c.env.DB, workspace, key);
+  const metadata = await getFileMetadata(dbFor(c.env), workspace, key);
   let github = deriveGithubContext(metadata);
 
   // `video.*` rows are server-owned (issue #299) and never meant to reach
@@ -200,7 +201,7 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
   let counterpart: { key: string; url: string; state: BeforeAfterState } | undefined;
   const ownContentType = meta.type ?? "application/octet-stream";
   const candidate = isPairableImageContentType(ownContentType)
-    ? await findCounterpartCandidate(c.env.DB, workspace, key, metadata)
+    ? await findCounterpartCandidate(dbFor(c.env), workspace, key, metadata)
     : null;
   if (candidate && candidate.key !== key) {
     const counterpartLane = await resolveObjectLane(env, record, candidate.key);

--- a/apps/api/src/routes/public-galleries.ts
+++ b/apps/api/src/routes/public-galleries.ts
@@ -6,6 +6,7 @@ import { galleryItemFilename, hydratePublicGallery } from "../gallery-service";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
+import { dbFor } from "../db-session";
 
 /** Runs `action`, mapping any thrown error to the 503 the gallery storage routes commit to. */
 async function withGalleryStorageErrors<T>(action: () => Promise<T>): Promise<T> {
@@ -21,7 +22,7 @@ async function withGalleryStorageErrors<T>(action: () => Promise<T>): Promise<T>
 
 export const publicGalleries = new Hono<WorkspaceVars>()
   .get("/:id/items/:item/download", async (c) => {
-    const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));
+    const record = await resolvePublicGallery(dbFor(c.env), c.req.param("id"));
     if (!record) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
 
     // Soft-deleted / purged workspaces collapse to null — same uniform 404 as
@@ -33,7 +34,7 @@ export const publicGalleries = new Hono<WorkspaceVars>()
       throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
     }
 
-    const items = await listGalleryItems(c.env.DB, record.workspace, record.id);
+    const items = await listGalleryItems(dbFor(c.env), record.workspace, record.id);
     const item = items.find((entry) => entry.id === c.req.param("item"));
     if (!item) {
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
@@ -67,15 +68,15 @@ export const publicGalleries = new Hono<WorkspaceVars>()
     );
   })
   .get("/:id", async (c) => {
-    const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));
+    const record = await resolvePublicGallery(dbFor(c.env), c.req.param("id"));
     if (!record) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
     const workspace = await loadWorkspaceRecord(c.env, record.workspace);
     if (!workspace) {
       throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
     }
     const [items, references] = await Promise.all([
-      listGalleryItems(c.env.DB, record.workspace, record.id),
-      listExternalReferences(c.env.DB, record.workspace, record.id),
+      listGalleryItems(dbFor(c.env), record.workspace, record.id),
+      listExternalReferences(dbFor(c.env), record.workspace, record.id),
     ]);
     return c.json(await hydratePublicGallery(c.env, workspace, record, items, references));
   });

--- a/apps/api/src/routes/render.ts
+++ b/apps/api/src/routes/render.ts
@@ -22,6 +22,7 @@ import { renderRateLimit } from "../guards";
 import { browserRenderer, MAX_RENDER_HTML_BYTES, parseRenderRequest } from "../render";
 import { releaseUploadsSafe, reserveUploads } from "../usage";
 import { requireScope, tokenWorkspaceAuth, type WorkspaceVars } from "../workspace";
+import { dbFor } from "../db-session";
 
 // Headroom over the 2 MiB `html` cap for JSON-encoding overhead (escaped
 // backslashes/unicode, the surrounding object). Checked (via
@@ -50,7 +51,7 @@ export const render = new Hono<WorkspaceVars>().post(
     // call; the reservation IS the count, so success records nothing further
     // and failure releases it.
     const { maxUploadsPerPeriod } = resolveBudgetLimits(ws);
-    const reservation = await reserveUploads(c.env.DB, workspaceName, 1, maxUploadsPerPeriod);
+    const reservation = await reserveUploads(dbFor(c.env), workspaceName, 1, maxUploadsPerPeriod);
     if (!reservation.ok) {
       throw budgetDenialError(
         uploadBudgetDenial(reservation.usage, reservation.maxUploadsPerPeriod),
@@ -61,7 +62,7 @@ export const render = new Hono<WorkspaceVars>().post(
     try {
       result = await browserRenderer(c.env.BROWSER).screenshot(input);
     } catch (err) {
-      await releaseUploadsSafe(c.env.DB, workspaceName, 1);
+      await releaseUploadsSafe(dbFor(c.env), workspaceName, 1);
       throw err;
     }
 

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -29,6 +29,7 @@ import {
   stripControl,
 } from "../cli-intake";
 import type { WorkspaceVars } from "../workspace";
+import { dbFor } from "../db-session";
 
 export { MAX_ATTACHMENT_BYTES };
 
@@ -114,13 +115,14 @@ reports.post("/", async (c) => {
 
   // Persist metadata first so a successful response always has a D1 row.
   try {
-    await c.env.DB.prepare(
-      `INSERT INTO uploads_cli_reports (
+    await dbFor(c.env)
+      .prepare(
+        `INSERT INTO uploads_cli_reports (
         id, message, type, contact, surface, client_kind, anon_id,
         cli_version, os, arch, runtime, command, error_code,
         attachment_key, attachment_filename, attachment_bytes
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
+      )
       .bind(
         id,
         message,
@@ -174,7 +176,7 @@ reports.post("/", async (c) => {
         }),
       );
       try {
-        await c.env.DB.prepare("DELETE FROM uploads_cli_reports WHERE id = ?").bind(id).run();
+        await dbFor(c.env).prepare("DELETE FROM uploads_cli_reports WHERE id = ?").bind(id).run();
       } catch {
         // best-effort cleanup
       }

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -22,6 +22,7 @@ import {
   SURFACES,
 } from "../cli-intake";
 import type { WorkspaceVars } from "../workspace";
+import { dbFor } from "../db-session";
 
 export const telemetry = new Hono<WorkspaceVars>();
 
@@ -68,13 +69,14 @@ telemetry.post("/", async (c) => {
   const durationMs = clampInt(sanitizeInt(body.durationMs), 0, MAX_DURATION_MS);
 
   try {
-    await c.env.DB.prepare(
-      `INSERT INTO uploads_telemetry_events (
+    await dbFor(c.env)
+      .prepare(
+        `INSERT INTO uploads_telemetry_events (
         id, anon_id, timestamp, surface, client_kind, agent_name,
         command, exit_code, duration_ms, error_code, cli_version,
         os, arch, runtime
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
+      )
       .bind(
         newId("tel"),
         anonId,

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -39,6 +39,7 @@ import {
 } from "../session-auth";
 import { loadWorkspaceRecord, WS_NAME_RE } from "../workspace";
 import { suggestWorkspaceName } from "../workspace-suggestion";
+import { dbFor } from "../db-session";
 
 /** Redacted scope list for the issued-token surface — never garbage entries. */
 function parseIssuedScopes(value: string): string[] {
@@ -239,7 +240,7 @@ export const tokens = new Hono<SessionVars>()
     }
 
     const expiresAt = ttlSeconds === null ? undefined : new Date(Date.now() + ttlSeconds * 1000);
-    const { token, record: tokenRecord } = await createToken(c.env.DB, {
+    const { token, record: tokenRecord } = await createToken(dbFor(c.env), {
       workspace: grant.workspace,
       label,
       scopes,
@@ -263,7 +264,7 @@ export const tokens = new Hono<SessionVars>()
   // token on that workspace). Members only see their own rows.
   .get("/issued", sessionAuth, requireSessionUser, async (c) => {
     const user = c.get("sessionUser")!;
-    const issued = (await listTokensForMintingUser(c.env.DB, user.id)).map((token) => ({
+    const issued = (await listTokensForMintingUser(dbFor(c.env), user.id)).map((token) => ({
       id: token.id,
       workspace: token.workspace,
       label: token.label,
@@ -280,14 +281,14 @@ export const tokens = new Hono<SessionVars>()
     if (!id) {
       throw new NotFoundError("no matching token", { code: "token_not_found" });
     }
-    const match = await findTokenForMintingUser(c.env.DB, user.id, id);
+    const match = await findTokenForMintingUser(dbFor(c.env), user.id, id);
     if (!match) {
       throw new NotFoundError("no matching token", { code: "token_not_found" });
     }
     if (!(await allowWrite(c.env, match.workspace))) {
       throw new RateLimitedError("token revoke rate limit exceeded");
     }
-    const revoked = await revokeTokenForMintingUser(c.env.DB, user.id, id);
+    const revoked = await revokeTokenForMintingUser(dbFor(c.env), user.id, id);
     if (!revoked) {
       throw new NotFoundError("no matching token", { code: "token_not_found" });
     }

--- a/apps/api/src/routes/usage.ts
+++ b/apps/api/src/routes/usage.ts
@@ -5,6 +5,7 @@ import { reconcileWorkspaceUsage } from "../reconcile";
 import { purgeExpiredObjects } from "../retention";
 import { getWorkspaceUsage } from "../usage";
 import { requireScope, type WorkspaceVars } from "../workspace";
+import { dbFor } from "../db-session";
 
 /**
  * Usage snapshot + maintenance:
@@ -14,7 +15,7 @@ import { requireScope, type WorkspaceVars } from "../workspace";
  */
 export const usage = new Hono<WorkspaceVars>()
   .get("/", requireScope("files:read"), async (c) => {
-    const snapshot = await getWorkspaceUsage(c.env.DB, c.get("workspaceName"));
+    const snapshot = await getWorkspaceUsage(dbFor(c.env), c.get("workspaceName"));
     const workspace = c.get("workspace");
     // `scopes` reflects the presented credential, not the workspace — doctor
     // uses it to surface a token that can't delete before the user hits a

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -28,6 +28,7 @@
  * Kept out of scope for this phase — see `.context/613-api-consolidation-plan.md`.
  */
 import { ForbiddenError, NotFoundError, ValidationError } from "@uploads/errors";
+import { dbFor } from "../db-session";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context, type Handler, type MiddlewareHandler } from "hono";
 import {
@@ -118,7 +119,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
     } = await listObjects(c.env, record, { prefix, delimiter, limit, cursor });
 
     const metaByKey = await getMetadataForKeys(
-      c.env.DB,
+      dbFor(c.env),
       name,
       items.map((item) => item.key),
     );
@@ -166,7 +167,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
     // Upload time per match so the screenshots drill-in pop-over can show it
     // (the grouped by-path route surfaces the same via `updatedAt`).
     const updatedByKey = await getObjectUpdatedAt(
-      c.env.DB,
+      dbFor(c.env),
       name,
       matches.map((m) => m.key),
     );
@@ -190,7 +191,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // Facet discovery for the files filter bar: which metadata keys this
   // workspace actually contains, and (with `?key=`) that key's values.
   .get("/:workspace/files/facets", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
-    return c.json(await listFacets(c.env.DB, c.get("workspaceName"), c.req.query("key")));
+    return c.json(await listFacets(dbFor(c.env), c.get("workspaceName"), c.req.query("key")));
   })
 
   // Recent uploads grouped by their `path` metadata value — the screenshots
@@ -213,7 +214,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
     // semantics untouched.
     const mergedOnly = c.req.query("merged") === "1";
     const { groups, catalog, projects, latest, truncated, catalogTruncated } =
-      await groupObjectsByPath(c.env.DB, name, { mergedOnly });
+      await groupObjectsByPath(dbFor(c.env), name, { mergedOnly });
     const shotKeys = [
       ...groups.flatMap((group) => group.recent),
       ...latest.map((item) => item.key),
@@ -221,10 +222,10 @@ export const workspaceFiles = new Hono<DualAuthVars>()
     // `gh.ref` lets the pop-over resolve live PR/issue status via /github/titles;
     // `updatedAt` gives it the shot's upload time (the `latest` feed already
     // carries `uploadedAt`, this brings the same to the grouped `recent` strips).
-    const metaByKey = await getMetadataForKeys(c.env.DB, name, shotKeys, {
+    const metaByKey = await getMetadataForKeys(dbFor(c.env), name, shotKeys, {
       metaKeys: ["state", "gh.kind", "gh.number", "gh.ref"],
     });
-    const updatedByKey = await getObjectUpdatedAt(c.env.DB, name, shotKeys);
+    const updatedByKey = await getObjectUpdatedAt(dbFor(c.env), name, shotKeys);
     const cfg = await storageConfig(c.env, record);
     const shotItem = (key: string) => {
       const urls = objectPublicUrls(c.env, cfg, key);

--- a/apps/api/src/routes/workspace-galleries.ts
+++ b/apps/api/src/routes/workspace-galleries.ts
@@ -25,6 +25,7 @@
  * docblock.
  */
 import { ValidationError } from "@uploads/errors";
+import { dbFor } from "../db-session";
 import { Hono, type Context, type MiddlewareHandler } from "hono";
 import { dualWorkspaceAuth, type DualAuthVars } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
@@ -65,7 +66,7 @@ async function listGalleriesEnrichedHandler(c: Context<WorkspaceVars>) {
   if (!Number.isInteger(limit) || limit < 1 || limit > 100)
     throw new ValidationError("limit must be an integer from 1 to 100.");
   const name = c.get("workspaceName");
-  const page = await listGalleries(c.env.DB, name, {
+  const page = await listGalleries(dbFor(c.env), name, {
     limit,
     cursor: decodeGalleryCursor(c.req.query("cursor")),
   });

--- a/apps/api/src/routes/workspace-github.ts
+++ b/apps/api/src/routes/workspace-github.ts
@@ -92,6 +92,7 @@ import {
   githubPrivatePrefixRotateHandler,
 } from "./github-private-prefix";
 import { githubPromoteHandler } from "./github-promote";
+import { dbFor } from "../db-session";
 
 // Same owner/name grammar as routes/github-comment.ts's `REPO_RE` — repeated
 // here rather than imported since that copy is module-private (deliberately
@@ -125,7 +126,7 @@ const githubIngestHandler: Handler<DualAuthVars> = async (c) => {
       code: "github_ingest_target",
     });
   }
-  const link = await findRepoLink(c.env.DB, repo);
+  const link = await findRepoLink(dbFor(c.env), repo);
   if (deriveRepoBinding(link, workspaceName) !== "self") {
     // 404 (not 403) so an "other"-bound repo can't be told apart from an
     // unlinked one — never leaks whether/where it's linked (issue #398).
@@ -266,7 +267,7 @@ const githubStatusHandler: Handler<DualAuthVars> = async (c) => {
  */
 const githubRepoLinksHandler: Handler<DualAuthVars> = async (c) => {
   const name = c.req.param("workspace") ?? "";
-  const links = await listRepoLinksForWorkspace(c.env.DB, name);
+  const links = await listRepoLinksForWorkspace(dbFor(c.env), name);
   return c.json({ repos: links.map((link) => link.repo) });
 };
 

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -60,6 +60,7 @@ import {
   ValidationError,
 } from "@uploads/errors";
 import { createStorage, type R2Jurisdiction } from "@uploads/storage";
+import { dbFor } from "../db-session";
 import { Hono, type Context, type MiddlewareHandler } from "hono";
 import { usageWithLimits } from "../budget";
 import { previewFixtureItems } from "../comment-preview-fixtures";
@@ -807,7 +808,7 @@ export async function storageDeleteHandler(c: Context<SettingsVars>) {
     return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));
   }
 
-  const usage = await getWorkspaceUsage(c.env.DB, name);
+  const usage = await getWorkspaceUsage(dbFor(c.env), name);
   if (!force && usage.objects > 0) {
     throw new ConflictError(
       "this workspace still has files on its BYO bucket — pass force to detach anyway",
@@ -885,7 +886,7 @@ export async function summaryHandler(c: Context<SettingsVars>) {
   const publicBaseUrl = record.publicBaseUrl;
   let usage: ReturnType<typeof usageWithLimits> | null = null;
   try {
-    usage = usageWithLimits(await getWorkspaceUsage(c.env.DB, name), record);
+    usage = usageWithLimits(await getWorkspaceUsage(dbFor(c.env), name), record);
   } catch {
     usage = null;
   }
@@ -934,7 +935,7 @@ export async function billingHandler(c: Context<SettingsVars>) {
   const { plan, available, planApplied, limits } = planResponse(name, record);
 
   const [usage, authSubscription] = await Promise.all([
-    getWorkspaceUsage(c.env.DB, name)
+    getWorkspaceUsage(dbFor(c.env), name)
       .then((raw) => usageWithLimits(raw, record))
       .catch(() => null),
     subscriptionForOrg(c.env, ws.organization.slug),
@@ -997,7 +998,7 @@ export async function commentPreviewHandler(c: Context<SettingsVars>) {
     if (!REPO_SHAPE_RE.test(repo)) {
       throw new ValidationError("repo must be in owner/name form", { code: "invalid_repo" });
     }
-    const link = await findRepoLink(c.env.DB, repo);
+    const link = await findRepoLink(dbFor(c.env), repo);
     if (!link || link.workspaceName !== name) {
       throw new NotFoundError("repo not linked to this workspace", { code: "repo_not_linked" });
     }
@@ -1031,7 +1032,7 @@ export async function commentPreviewHandler(c: Context<SettingsVars>) {
     // Same narrow key set and skip condition as gatherAttachments — the
     // preview must caption and pair exactly like the production comment.
     const metaByKey = await getMetadataForKeys(
-      c.env.DB,
+      dbFor(c.env),
       name,
       items.map((item) => item.key),
       { metaKeys: ["path", "state"] },

--- a/apps/api/src/routes/workspace-usage.ts
+++ b/apps/api/src/routes/workspace-usage.ts
@@ -16,6 +16,7 @@ import { reconcileWorkspaceUsage } from "../reconcile";
 import { purgeExpiredObjects } from "../retention";
 import { getWorkspaceUsage } from "../usage";
 import { requireScope } from "../workspace";
+import { dbFor } from "../db-session";
 
 function scoped(scope: Parameters<typeof requireScope>[0]): MiddlewareHandler<DualAuthVars> {
   return requireScope(scope) as unknown as MiddlewareHandler<DualAuthVars>;
@@ -41,7 +42,7 @@ const requireToken: MiddlewareHandler<DualAuthVars> = async (c, next) => {
 
 export const workspaceUsage = new Hono<DualAuthVars>()
   .get("/:workspace/usage", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
-    const snapshot = await getWorkspaceUsage(c.env.DB, c.get("workspaceName"));
+    const snapshot = await getWorkspaceUsage(dbFor(c.env), c.get("workspaceName"));
     const workspace = c.get("workspace");
     // `scopes` reflects the presented credential — for a session caller this
     // is the `FILE_SCOPES` set `dualWorkspaceAuth` grants (matching the

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -52,6 +52,7 @@ import {
   type GovernanceVars,
 } from "../workspace";
 import { mutateWorkspaceRecord } from "../workspace-mutate";
+import { dbFor } from "../db-session";
 
 const HASH_PREFIX_LEN = 8;
 
@@ -479,7 +480,7 @@ workspaces.get("/:name/tokens", workspaceManageAuth(), async (c) => {
 
   const now = new Date().toISOString();
   // listTokens is active-only by default; also drop expired actives for UX.
-  const tokens = (await listTokens(c.env.DB, name))
+  const tokens = (await listTokens(dbFor(c.env), name))
     .filter((token) => token.expires_at === null || token.expires_at > now)
     .map((token) => ({
       label: token.label,
@@ -518,7 +519,7 @@ workspaces.delete("/:name/tokens", workspaceManageAuth(), async (c) => {
     });
   }
 
-  const result = await revokeToken(c.env.DB, name, { hashPrefix, label });
+  const result = await revokeToken(dbFor(c.env), name, { hashPrefix, label });
   if (result.ambiguous) {
     throw new ConflictError("selector matches multiple tokens");
   }

--- a/apps/api/src/usage.ts
+++ b/apps/api/src/usage.ts
@@ -12,6 +12,7 @@
  * total usage includes BYO lanes, while the shared subset lets `budget.ts`
  * enforce platform-owned storage residue after a workspace switches to BYO.
  */
+import { type D1Queryable } from "./db-session";
 
 export interface WorkspaceUsage {
   workspace: string;
@@ -77,7 +78,7 @@ export function emptyUsage(workspace: string, now = new Date()): WorkspaceUsage 
 }
 
 export async function getWorkspaceUsage(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   now = new Date(),
 ): Promise<WorkspaceUsage> {
@@ -100,7 +101,7 @@ export async function getWorkspaceUsage(
 
 /** Apply a delta. `bytes`/`objects` may be negative; `uploads` only on puts. */
 export async function applyUsageDelta(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   delta: UsageDelta,
   now = new Date(),
@@ -167,7 +168,7 @@ export type UploadReservation =
  * precondition of the work, not best-effort metering.
  */
 export async function reserveUploads(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   count: number,
   maxUploadsPerPeriod: number | undefined,
@@ -220,7 +221,7 @@ export async function reserveUploads(
  * reservation belonged to the old period.
  */
 export async function releaseUploadsSafe(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   count: number,
   now = new Date(),
@@ -265,7 +266,7 @@ export type StorageReservation =
  * work and must NOT re-count reserved bytes in `recordUsageSafe`.
  */
 export async function reserveStorageBytes(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   deltaBytes: number,
   maxStorageBytes: number | undefined,
@@ -325,7 +326,7 @@ export async function reserveStorageBytes(
  * Best-effort (same rationale as releaseUploadsSafe).
  */
 export async function releaseStorageBytesSafe(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   reservedBytes: number,
   now = new Date(),
@@ -363,7 +364,7 @@ export async function releaseStorageBytesSafe(
 
 /** Best-effort metering: log and continue if D1 fails. */
 export async function recordUsageSafe(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   delta: UsageDelta,
   now = new Date(),
@@ -392,7 +393,7 @@ export async function recordUsageSafe(
  * dropping a successful single delete's accounting).
  */
 export async function claimDeleteUsageSafe(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
   now = new Date(),
@@ -426,7 +427,7 @@ export async function claimDeleteUsageSafe(
  * (reconcile repairs absolute totals).
  */
 export async function clearDeleteUsageClaimSafe(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   objectKey: string,
 ): Promise<void> {
@@ -454,7 +455,7 @@ export async function clearDeleteUsageClaimSafe(
  * `deleteFileMetadataForWorkspace`: teardown's fail-safe ordering wants a
  * loud failure before the KV record is removed, not a silent leak.
  */
-export async function deleteUsageForWorkspace(db: D1Database, workspace: string): Promise<void> {
+export async function deleteUsageForWorkspace(db: D1Queryable, workspace: string): Promise<void> {
   await db.batch([
     db.prepare(`DELETE FROM workspace_usage WHERE workspace = ?`).bind(workspace),
     db.prepare(`DELETE FROM delete_usage_claims WHERE workspace = ?`).bind(workspace),
@@ -466,7 +467,7 @@ export async function deleteUsageForWorkspace(db: D1Database, workspace: string)
  * Preserves uploads_in_period for the current period when the row exists.
  */
 export async function setUsageTotals(
-  db: D1Database,
+  db: D1Queryable,
   workspace: string,
   totals: { bytes: number; objects: number; sharedBytes: number; sharedObjects: number },
   now = new Date(),

--- a/apps/api/src/workspace-teardown.ts
+++ b/apps/api/src/workspace-teardown.ts
@@ -15,6 +15,7 @@
  * passes `purgeObjects: true` (see `TeardownOptions`, issue #583) — platform
  * state is still torn down either way.
  */
+import { dbFor } from "./db-session";
 import { deleteFileMetadataForWorkspace } from "./file-metadata";
 import { deleteGalleriesForWorkspace } from "./galleries";
 import { deleteOrg } from "./org-workspaces";
@@ -98,9 +99,9 @@ export async function teardownWorkspace(
     if (batch.length > 0) await store.delete(batch);
   }
 
-  const { galleries } = await deleteGalleriesForWorkspace(env.DB, name);
-  await deleteFileMetadataForWorkspace(env.DB, name);
-  await deleteUsageForWorkspace(env.DB, name);
+  const { galleries } = await deleteGalleriesForWorkspace(dbFor(env), name);
+  await deleteFileMetadataForWorkspace(dbFor(env), name);
+  await deleteUsageForWorkspace(dbFor(env), name);
 
   // Best-effort, like the self-serve rollback path in routes/workspaces.ts
   // — an org left behind after this point is orphaned (no KV record means

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -10,6 +10,7 @@ import {
   type FileScope,
   type WorkspaceScope,
 } from "./auth-db";
+import { dbFor } from "./db-session";
 
 export type { FileScope } from "./auth-db";
 
@@ -495,7 +496,7 @@ function workspaceAuthWith(
     // unknown or the token empty, so response latency doesn't reveal whether
     // a workspace name exists (uniform-401 guarantee above).
     const d1Token = await findActiveToken(
-      c.env.DB,
+      dbFor(c.env),
       record && name ? name : "__unknown__",
       token || "__unknown__",
     );
@@ -509,7 +510,7 @@ function workspaceAuthWith(
     c.set("authSource", d1Token ? "d1" : "legacy");
     // Uploader attribution (issue #340) — null for legacy/enrollment tokens.
     c.set("mintingUserId", d1Token?.minting_user_id ?? null);
-    if (d1Token) await touchTokenLastUsed(c.env.DB, d1Token.id);
+    if (d1Token) await touchTokenLastUsed(dbFor(c.env), d1Token.id);
     await next();
   };
 }
@@ -601,7 +602,7 @@ export function workspaceGovernanceAuth(scope: WorkspaceScope): MiddlewareHandle
     const tokenWorkspace = token ? workspaceNameFromToken(token) : undefined;
     if (!tokenWorkspace) throw new UnauthorizedError();
 
-    const record = await findActiveToken(c.env.DB, tokenWorkspace, token);
+    const record = await findActiveToken(dbFor(c.env), tokenWorkspace, token);
     if (!record) throw new UnauthorizedError();
 
     const name = c.req.param("name");
@@ -617,7 +618,7 @@ export function workspaceGovernanceAuth(scope: WorkspaceScope): MiddlewareHandle
     if (!scopes.has(scope)) throw new ForbiddenError();
 
     c.set("governanceMintingUserId", record.minting_user_id);
-    await touchTokenLastUsed(c.env.DB, record.id);
+    await touchTokenLastUsed(dbFor(c.env), record.id);
     await next();
   };
 }

--- a/apps/api/test/helpers/sqlite-d1.ts
+++ b/apps/api/test/helpers/sqlite-d1.ts
@@ -116,6 +116,12 @@ export class SqliteD1 {
   close() {
     this.db.close();
   }
+
+  /** D1 Sessions API stub (see src/db-session.ts) — this fake has no
+   *  primary/replica split, so a "session" is just itself. */
+  withSession() {
+    return this;
+  }
 }
 
 export function database(sqlite: SqliteD1): D1Database {

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -333,4 +333,8 @@ export class UsageFakeD1 {
     for (const stmt of statements) results.push(await stmt.run());
     return results;
   };
+
+  /** D1 Sessions API stub (see src/db-session.ts) — this fake has no
+   *  primary/replica split, so a "session" is just itself. */
+  withSession = () => this;
 }


### PR DESCRIPTION
## What

Routes every D1 query in the `api` worker through the [D1 Sessions API](https://developers.cloudflare.com/d1/best-practices/read-replication/) instead of the raw `DB` binding, so read replication can be enabled for `uploads-production` later without any further code change.

- `src/db-session.ts`: a small helper module — `createDbSession(db)` creates a per-request `D1DatabaseSession`, and `dbFor(env)` is what every call site now uses instead of `env.DB` directly (falling back to the raw binding when no session was created — see "Fallback behavior" below).
- `src/index.ts`: one `app.use("*", ...)` middleware creates the session at the top of the request, before any handler runs.
- Every other changed file is a mechanical call-site swap: `env.DB` → `dbFor(env)` (or `c.env.DB` → `dbFor(c.env)`), and function signatures that took `db: D1Database` now take `db: D1Queryable` (a `Pick<D1Database, "prepare" | "batch">` — the only two methods any call site actually uses), so they work unchanged with either the raw binding or a session.

**Scope:** `apps/api` only. `apps/auth` and `apps/web` are untouched — Better Auth's Kysely D1 adapter can't use Sessions, and `apps/web` doesn't touch D1 directly.

## Why

`uploads-production` has had Cloudflare-side D1 stall incidents (#808, Case #02293891). D1 read replication is one mitigation we may enable — but replicas only ever serve queries issued through `db.withSession(...)`. A plain `env.DB.prepare(...)` call always goes to the primary, replicated or not. This PR opens that possibility with **zero behavior change** while replication stays disabled.

## Consistency constraint

The session is anchored with `"first-unconstrained"`: the first query on a session may be served by the primary or any replica (best latency), and later queries on that session stay consistent with whichever instance answered first. This request doesn't need read-your-writes guarantees *across separate requests* — each request gets its own fresh session — so this optimizes for latency over consistency. It's called out as the knob to revisit in `src/db-session.ts`'s comment: switch to `"first-primary"` if a flow needs its first query to observe an immediately-preceding write, or thread through an explicit bookmark for cross-request read-your-writes.

## Writes through the session

Writes issued through a session still go to the primary automatically, so routing every call site through the session — not just reads — keeps this mechanical and avoids splitting call sites by read/write.

## Fallback behavior

`dbFor(env)` returns `env.DB_SESSION ?? env.DB`. `DB_SESSION` is only set when the request middleware ran *and* the `DB` binding exposes `withSession` — this degrades gracefully for the cron jobs (`retention-sweep.ts`, `observability-retention.ts`'s `scheduled()` caller, which aren't HTTP requests) and for the handful of tests that mount a route sub-app directly or fake D1 with a plain object lacking `withSession`. All of these fall back to the raw binding, which is exactly today's behavior.

## What flipping replication on later requires

Just enabling read replication for the `uploads-production` D1 database on the Cloudflare side — no further code change here. The constraint noted above is the only thing worth revisiting at that point.

## Status

**Replication remains DISABLED.** This PR is purely option-opening.

## Testing

- `pnpm --filter @uploads/api test` — 156 files / 2156 tests passing (includes a new `src/db-session.test.ts` asserting the app creates one session per request via `db.withSession("first-unconstrained")`, that it's a per-request session rather than a shared one, and `dbFor`'s fallback behavior).
- `pnpm test` (repo root) — 330 files / 4963 tests passing.
- `pnpm --filter @uploads/api typecheck` — clean.
- Test fakes (`SqliteD1`, `UsageFakeD1`) gained a no-op `withSession()` returning themselves, since neither simulates a primary/replica split.

Not merging this — flagging for review.
