### PR TITLE
feat(api,web): Server-Timing headers and slow-op logs for D1 and auth calls

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -44,6 +44,7 @@
     "@uploads/comment-render": "workspace:^",
     "@uploads/email": "workspace:^",
     "@uploads/errors": "workspace:^",
+    "@uploads/observability": "workspace:^",
     "@uploads/storage": "workspace:^",
     "aws4fetch": "^1.0.20",
     "hono": "^4.13.3",

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -444,16 +444,20 @@ export async function revokeTokenForMintingUser(
 /**
  * Stamp last_used_at on a successful auth. No-ops when the column was
  * written in the last hour so a busy token does not pay a D1 write per request.
+ *
+ * Returns the raw `D1Result` (or `null` on the no-op path) so callers can
+ * read `meta.duration` for Server-Timing exec-ms reporting (issue #812)
+ * without this helper needing to know about timing itself.
  */
 export async function touchTokenLastUsed(
   db: D1Queryable,
   tokenId: string,
   now = new Date(),
-): Promise<void> {
-  if (!tokenId) return;
+): Promise<D1Result | null> {
+  if (!tokenId) return null;
   const iso = now.toISOString();
   const staleBefore = new Date(now.getTime() - LAST_USED_TOUCH_SECONDS * 1000).toISOString();
-  await db
+  return db
     .prepare(
       `UPDATE auth_tokens SET last_used_at = ?
        WHERE id = ? AND revoked_at IS NULL

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -92,4 +92,13 @@ interface Env {
    * sub-app directly instead of the full `app`.
    */
   DB_SESSION?: D1DatabaseSession;
+  /**
+   * Server-Timing + slow-op logging (issue #812). Both read by
+   * `@uploads/observability`; unset means the defaults apply (1000ms
+   * threshold, header emission on). See session-auth.ts and workspace.ts for
+   * the instrumented choke points.
+   */
+  SLOW_OP_THRESHOLD_MS?: string;
+  /** Kill switch for `Server-Timing` header emission only — slow-op logging is unaffected. */
+  SERVER_TIMING_DISABLED?: string;
 }

--- a/apps/api/src/session-auth.test.ts
+++ b/apps/api/src/session-auth.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { respondError } from "./error-response";
 import {
   requireAdminUser,
@@ -28,8 +28,8 @@ function appWith(_auth: Pick<Fetcher, "fetch">) {
     .onError((err, c) => respondError(c, err));
 }
 
-function env(auth: Pick<Fetcher, "fetch">) {
-  return { AUTH: auth } as unknown as Env;
+function env(auth: Pick<Fetcher, "fetch">, extra: Record<string, string> = {}) {
+  return { AUTH: auth, ...extra } as unknown as Env;
 }
 
 describe("sessionAuth", () => {
@@ -201,6 +201,53 @@ describe("sessionAuth", () => {
     );
     const res = await appWith(auth).request("/admin-only", {}, env(auth));
     expect(res.status).toBe(200);
+  });
+});
+
+describe("sessionAuth Server-Timing wiring (issue #812)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("emits an auth;dur=… Server-Timing header on success", async () => {
+    const auth = stubAuth(() => new Response(JSON.stringify(null), { status: 200 }));
+    const res = await appWith(auth).request("/whoami", {}, env(auth));
+    expect(res.headers.get("Server-Timing")).toMatch(/^auth;dur=\d+(\.\d+)?$/);
+  });
+
+  it("still emits the header on a 503 (the timing that explains the failure)", async () => {
+    const auth = stubAuth(() => new Response(null, { status: 503 }));
+    const res = await appWith(auth).request("/whoami", {}, env(auth));
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Server-Timing")).toMatch(/^auth;dur=\d+(\.\d+)?$/);
+  });
+
+  it("silences the header when SERVER_TIMING_DISABLED is set", async () => {
+    const auth = stubAuth(() => new Response(JSON.stringify(null), { status: 200 }));
+    const res = await appWith(auth).request(
+      "/whoami",
+      {},
+      env(auth, { SERVER_TIMING_DISABLED: "1" }),
+    );
+    expect(res.headers.get("Server-Timing")).toBeNull();
+  });
+
+  it("logs a slow-op line only above the threshold", async () => {
+    const auth = stubAuth(() => new Response(JSON.stringify(null), { status: 200 }));
+
+    await appWith(auth).request("/whoami", {}, env(auth, { SLOW_OP_THRESHOLD_MS: "1000000" }));
+    expect(logSpy).not.toHaveBeenCalled();
+
+    await appWith(auth).request("/whoami", {}, env(auth, { SLOW_OP_THRESHOLD_MS: "0" }));
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(logged).toMatchObject({ msg: "slow_op", op: "auth", outcome: "ok" });
   });
 });
 

--- a/apps/api/src/session-auth.ts
+++ b/apps/api/src/session-auth.ts
@@ -11,6 +11,12 @@ import {
   ServiceUnavailableError,
   UnauthorizedError,
 } from "@uploads/errors";
+import {
+  ServerTiming,
+  serverTimingDisabled,
+  slowOpThresholdMs,
+  timeOp,
+} from "@uploads/observability";
 import type { MiddlewareHandler } from "hono";
 
 /** Minimal shape of Better Auth's `get-session` response body. */
@@ -68,7 +74,26 @@ export function authRateLimitError(response: Response): RateLimitedError {
  * lost access to every workspace.
  */
 export const sessionAuth: MiddlewareHandler<SessionVars> = async (c, next) => {
-  c.set("sessionUser", await resolveSessionUser(c.env, c.req.raw));
+  // One entry per request (issue #812): the AUTH-binding get-session round
+  // trip is this middleware's whole job, so its wall time IS the interesting
+  // number — the exact "auth;dur=3998" the 2026-08-23 D1 stall incident
+  // needed. Server-Timing is appended even when the call throws (a 503), so
+  // a stalled-auth response still carries the timing that explains it.
+  const timing = new ServerTiming();
+  try {
+    c.set(
+      "sessionUser",
+      await timeOp(() => resolveSessionUser(c.env, c.req.raw), {
+        name: "auth",
+        timing,
+        route: c.req.path,
+        thresholdMs: slowOpThresholdMs(c.env),
+      }),
+    );
+  } finally {
+    const value = timing.header();
+    if (value && !serverTimingDisabled(c.env)) c.header("Server-Timing", value, { append: true });
+  }
   await next();
 };
 

--- a/apps/api/src/workspace-server-timing.test.ts
+++ b/apps/api/src/workspace-server-timing.test.ts
@@ -1,0 +1,159 @@
+import { Hono } from "hono";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { respondError } from "./error-response";
+import { sha256Hex, workspaceAuth, type WorkspaceVars } from "./workspace";
+
+const TOKEN = "up_acme_secrettoken";
+
+beforeAll(() => {
+  // Miniflare/workerd ship crypto.subtle.timingSafeEqual; Node's vitest
+  // environment doesn't (same shim other tests in this app already need).
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+/** Minimal fake D1 backing just the two `auth_tokens` queries `workspaceAuth` issues. */
+function fakeD1(opts: { tokenHash: string; touchDurationMs: number }) {
+  return {
+    prepare(sql: string) {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      let args: unknown[] = [];
+      return {
+        bind(...values: unknown[]) {
+          args = values;
+          return this;
+        },
+        async first() {
+          if (!normalized.startsWith("SELECT id, workspace, token_hash")) return null;
+          const [, hash] = args as [string, string, string];
+          return hash === opts.tokenHash
+            ? {
+                id: "token-1",
+                workspace: "acme",
+                token_hash: opts.tokenHash,
+                label: null,
+                scopes: JSON.stringify(["files:read", "files:write"]),
+                created_at: "2026-08-01T00:00:00.000Z",
+                expires_at: null,
+                revoked_at: null,
+                minting_user_id: null,
+              }
+            : null;
+        },
+        async run() {
+          if (!normalized.startsWith("UPDATE auth_tokens SET last_used_at")) {
+            throw new Error(`unsupported run: ${normalized}`);
+          }
+          return { success: true, meta: { changes: 1, duration: opts.touchDurationMs } };
+        },
+      };
+    },
+  };
+}
+
+function appWith(db: unknown) {
+  return new Hono<WorkspaceVars>()
+    .use("/:workspace/*", workspaceAuth)
+    .get("/:workspace/whoami", (c) => c.json({ ok: true }))
+    .onError((err, c) => respondError(c, err));
+}
+
+async function env(
+  tokenHash: string,
+  opts: { touchDurationMs?: number; extra?: Record<string, string> } = {},
+) {
+  return {
+    REGISTRY: {
+      get: async () => ({
+        provider: "r2",
+        bucket: "uploads-default",
+        binding: "UPLOADS_DEFAULT",
+        prefix: "acme/",
+        publicBaseUrl: "https://storage.uploads.sh",
+      }),
+      put: async () => undefined,
+    },
+    DB: fakeD1({ tokenHash, touchDurationMs: opts.touchDurationMs ?? 0.5 }),
+    ...opts.extra,
+  } as unknown as Env;
+}
+
+describe("workspaceAuth Server-Timing wiring (issue #812)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("emits a Server-Timing header with wall + D1 exec ms on a matched token", async () => {
+    const hash = await sha256Hex(TOKEN);
+    const res = await appWith(null).request(
+      "/acme/whoami",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      await env(hash, { touchDurationMs: 0.42 }),
+    );
+    expect(res.status).toBe(200);
+    const header = res.headers.get("Server-Timing");
+    expect(header).toMatch(
+      /^d1;dur=\d+(\.\d+)?, d1_touch;dur=\d+(\.\d+)?, d1_touchexec;dur=0\.42$/,
+    );
+  });
+
+  it("silences the header when SERVER_TIMING_DISABLED is set, without affecting slow-op logging", async () => {
+    const hash = await sha256Hex(TOKEN);
+    const res = await appWith(null).request(
+      "/acme/whoami",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      await env(hash, { extra: { SERVER_TIMING_DISABLED: "1", SLOW_OP_THRESHOLD_MS: "0" } }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Server-Timing")).toBeNull();
+    // Threshold of 0 means every op is "slow" — logging must still fire.
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it("logs a slow-op line when the D1 lookup exceeds the threshold, not below it", async () => {
+    const hash = await sha256Hex(TOKEN);
+
+    await appWith(null).request(
+      "/acme/whoami",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      await env(hash, { extra: { SLOW_OP_THRESHOLD_MS: "1000000" } }),
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+
+    logSpy.mockClear();
+    await appWith(null).request(
+      "/acme/whoami",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      await env(hash, { extra: { SLOW_OP_THRESHOLD_MS: "0" } }),
+    );
+    expect(logSpy).toHaveBeenCalled();
+    const logged = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(logged).toMatchObject({ msg: "slow_op", op: "d1", outcome: "ok" });
+    expect(logged.route).toBe("/acme/whoami");
+  });
+
+  it("never emits a header for an unmatched token (401, no D1 exec info to leak)", async () => {
+    const res = await appWith(null).request(
+      "/acme/whoami",
+      { headers: { Authorization: "Bearer up_acme_wrongtoken" } },
+      await env(await sha256Hex(TOKEN)),
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -1,5 +1,12 @@
 import { ForbiddenError, InsufficientScopeError, UnauthorizedError } from "@uploads/errors";
-import type { MiddlewareHandler } from "hono";
+import {
+  d1ExecMs,
+  ServerTiming,
+  serverTimingDisabled,
+  slowOpThresholdMs,
+  timeOp,
+} from "@uploads/observability";
+import type { Context, MiddlewareHandler } from "hono";
 import type { R2Jurisdiction, StorageProvider } from "@uploads/storage";
 import {
   FILE_SCOPES,
@@ -13,6 +20,22 @@ import {
 import { dbFor } from "./db-session";
 
 export type { FileScope } from "./auth-db";
+
+/**
+ * Appends `timing`'s Server-Timing entries to the response (issue #812) —
+ * merges with anything a downstream middleware (e.g. `sessionAuth` on a
+ * dual-auth route) already appended, since Hono joins multiple `append`ed
+ * values for the same header name. No-ops when the kill switch is set or
+ * there's nothing to report.
+ */
+function appendServerTiming<T extends { Bindings: Env }>(
+  c: Context<T>,
+  timing: ServerTiming,
+): void {
+  if (serverTimingDisabled(c.env)) return;
+  const value = timing.header();
+  if (value) c.header("Server-Timing", value, { append: true });
+}
 
 /**
  * A workspace is a tenant: its own bucket, credentials, and auth token.
@@ -495,11 +518,21 @@ function workspaceAuthWith(
     // Always pay the D1 round-trip, with dummy inputs when the workspace is
     // unknown or the token empty, so response latency doesn't reveal whether
     // a workspace name exists (uniform-401 guarantee above).
-    const d1Token = await findActiveToken(
-      dbFor(c.env),
-      record && name ? name : "__unknown__",
-      token || "__unknown__",
-    );
+    // One collector per request (issue #812) — findActiveToken's `.first()`
+    // carries no D1 `meta`, so only wall time is recorded for it; the
+    // touch-below `.run()` does carry `meta.duration` and reports exec ms too.
+    const timing = new ServerTiming();
+    const thresholdMs = slowOpThresholdMs(c.env);
+    let d1Token: Awaited<ReturnType<typeof findActiveToken>>;
+    try {
+      d1Token = await timeOp(
+        () =>
+          findActiveToken(dbFor(c.env), record && name ? name : "__unknown__", token || "__unknown__"),
+        { name: "d1", timing, route: c.req.path, thresholdMs },
+      );
+    } finally {
+      appendServerTiming(c, timing);
+    }
     const ok = legacyOk || (record !== null && d1Token !== null);
 
     if (!ok || !record || !name) throw new UnauthorizedError();
@@ -510,7 +543,20 @@ function workspaceAuthWith(
     c.set("authSource", d1Token ? "d1" : "legacy");
     // Uploader attribution (issue #340) — null for legacy/enrollment tokens.
     c.set("mintingUserId", d1Token?.minting_user_id ?? null);
-    if (d1Token) await touchTokenLastUsed(dbFor(c.env), d1Token.id);
+    if (d1Token) {
+      const touchTiming = new ServerTiming();
+      try {
+        await timeOp(() => touchTokenLastUsed(dbFor(c.env), d1Token.id), {
+          name: "d1_touch",
+          timing: touchTiming,
+          route: c.req.path,
+          thresholdMs,
+          execMs: d1ExecMs,
+        });
+      } finally {
+        appendServerTiming(c, touchTiming);
+      }
+    }
     await next();
   };
 }
@@ -602,7 +648,19 @@ export function workspaceGovernanceAuth(scope: WorkspaceScope): MiddlewareHandle
     const tokenWorkspace = token ? workspaceNameFromToken(token) : undefined;
     if (!tokenWorkspace) throw new UnauthorizedError();
 
-    const record = await findActiveToken(dbFor(c.env), tokenWorkspace, token);
+    const thresholdMs = slowOpThresholdMs(c.env);
+    const timing = new ServerTiming();
+    let record: Awaited<ReturnType<typeof findActiveToken>>;
+    try {
+      record = await timeOp(() => findActiveToken(dbFor(c.env), tokenWorkspace, token), {
+        name: "d1",
+        timing,
+        route: c.req.path,
+        thresholdMs,
+      });
+    } finally {
+      appendServerTiming(c, timing);
+    }
     if (!record) throw new UnauthorizedError();
 
     const name = c.req.param("name");
@@ -618,7 +676,18 @@ export function workspaceGovernanceAuth(scope: WorkspaceScope): MiddlewareHandle
     if (!scopes.has(scope)) throw new ForbiddenError();
 
     c.set("governanceMintingUserId", record.minting_user_id);
-    await touchTokenLastUsed(dbFor(c.env), record.id);
+    const touchTiming = new ServerTiming();
+    try {
+      await timeOp(() => touchTokenLastUsed(dbFor(c.env), record.id), {
+        name: "d1_touch",
+        timing: touchTiming,
+        route: c.req.path,
+        thresholdMs,
+        execMs: d1ExecMs,
+      });
+    } finally {
+      appendServerTiming(c, touchTiming);
+    }
     await next();
   };
 }

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -527,7 +527,11 @@ function workspaceAuthWith(
     try {
       d1Token = await timeOp(
         () =>
-          findActiveToken(dbFor(c.env), record && name ? name : "__unknown__", token || "__unknown__"),
+          findActiveToken(
+            dbFor(c.env),
+            record && name ? name : "__unknown__",
+            token || "__unknown__",
+          ),
         { name: "d1", timing, route: c.req.path, thresholdMs },
       );
     } finally {

--- a/apps/api/test/auth-db.test.ts
+++ b/apps/api/test/auth-db.test.ts
@@ -285,4 +285,29 @@ describe("touchTokenLastUsed", () => {
     expect(updates[0]?.[0]).toBe(now.toISOString());
     expect(updates[0]?.[1]).toBe("tok-1");
   });
+
+  // Issue #812: touchTokenLastUsed now returns the raw D1Result so callers
+  // can read `meta.duration` for Server-Timing exec-ms reporting.
+  it("returns the D1Result (carrying meta.duration) instead of void", async () => {
+    const db = {
+      prepare() {
+        return {
+          bind() {
+            return { run: async () => ({ meta: { changes: 1, duration: 0.42 } }) };
+          },
+        };
+      },
+    } as unknown as D1Database;
+    const result = await touchTokenLastUsed(db, "tok-1");
+    expect(result?.meta.duration).toBe(0.42);
+  });
+
+  it("returns null (no D1 round trip) for an empty tokenId", async () => {
+    const db = {
+      prepare() {
+        throw new Error("unexpected D1 query");
+      },
+    } as unknown as D1Database;
+    expect(await touchTokenLastUsed(db, "")).toBeNull();
+  });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@astrojs/react": "^6.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@uploads/billing": "workspace:^",
+    "@uploads/observability": "workspace:^",
     "@uploads/ui": "workspace:*",
     "astro": "^7.2.4",
     "files-sdk": "^2.2.5",

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -16,4 +16,12 @@ interface Env {
   AUTH?: Fetcher;
   API?: Fetcher;
   FLAGS?: Flagship;
+  /**
+   * Server-Timing + slow-op logging (issue #812), read by
+   * `@uploads/observability` — see `lib/auth-proxy.ts` and `lib/api-proxy.ts`.
+   * Unset means the defaults apply (1000ms threshold, header emission on).
+   */
+  SLOW_OP_THRESHOLD_MS?: string;
+  /** Kill switch for `Server-Timing` header emission only — slow-op logging is unaffected. */
+  SERVER_TIMING_DISABLED?: string;
 }

--- a/apps/web/src/lib/api-proxy.test.ts
+++ b/apps/web/src/lib/api-proxy.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { proxyApiRequest, serverApiFetch, serverApiFetchImpl } from "./api-proxy";
 
 afterEach(() => {
@@ -237,19 +237,50 @@ describe("serverApiFetchImpl", () => {
   });
 });
 
-describe("serverApiFetchImpl", () => {
-  it("adapts serverApiFetch to a fetch(input, init) shape for api-client's fetchImpl", async () => {
-    const { API, fetchMock } = fakeApiBinding(Response.json({ workspaces: [] }));
-    const request = new Request("https://uploads.sh/account/workspaces", {
-      headers: { cookie: "better-auth.session_token=abc" },
-    });
+describe("proxyApiRequest — Server-Timing wiring (issue #812)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
 
-    const fetchImpl = serverApiFetchImpl({ API }, request);
-    const response = await fetchImpl("/api/me/workspaces", { cache: "no-store" });
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
 
-    expect(await response.json()).toEqual({ workspaces: [] });
-    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
-    expect(forwarded.url).toBe("https://uploads.sh/me/workspaces");
-    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("emits an api;dur=… Server-Timing header on the returned response", async () => {
+    const { API } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/me/workspaces");
+
+    const response = await proxyApiRequest({ API }, request);
+    expect(response.headers.get("Server-Timing")).toMatch(/^api;dur=\d+(\.\d+)?$/);
+  });
+
+  it("silences the header when SERVER_TIMING_DISABLED is set", async () => {
+    const { API } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/me/workspaces");
+
+    const response = await proxyApiRequest({ API, SERVER_TIMING_DISABLED: "1" }, request);
+    expect(response.headers.get("Server-Timing")).toBeNull();
+  });
+
+  it("logs a slow-op line only above the threshold", async () => {
+    const { API } = fakeApiBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/me/workspaces");
+
+    await proxyApiRequest({ API, SLOW_OP_THRESHOLD_MS: "1000000" }, request);
+    expect(logSpy).not.toHaveBeenCalled();
+
+    await proxyApiRequest({ API, SLOW_OP_THRESHOLD_MS: "0" }, request);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(logged).toMatchObject({ msg: "slow_op", op: "api", outcome: "ok" });
+  });
+
+  it("never emits a header on the /auth guard's 404 (no upstream call was timed)", async () => {
+    const request = new Request("https://uploads.sh/api/auth/get-session");
+    const response = await proxyApiRequest({}, request);
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Server-Timing")).toBeNull();
   });
 });

--- a/apps/web/src/lib/api-proxy.ts
+++ b/apps/web/src/lib/api-proxy.ts
@@ -16,9 +16,16 @@
  * router upstream.
  */
 
+import {
+  ServerTiming,
+  serverTimingDisabled,
+  slowOpThresholdMs,
+  timeOp,
+  type TimingEnv,
+} from "@uploads/observability";
 import { rewriteOrigin, withInheritedCookie } from "./proxy-transport";
 
-export interface ApiProxyEnv {
+export interface ApiProxyEnv extends TimingEnv {
   API?: { fetch(req: Request): Promise<Response> };
   UPLOADS_API_ORIGIN?: string;
 }
@@ -67,9 +74,18 @@ export async function proxyApiRequest(env: ApiProxyEnv, request: Request): Promi
   url.pathname = strippedPath;
   const forwarded = new Request(url.toString(), manual);
 
-  return env.API
-    ? env.API.fetch(forwarded)
-    : fetch(rewriteOrigin(forwarded, env.UPLOADS_API_ORIGIN ?? LOCAL_API_ORIGIN_DEFAULT));
+  // Structural choke point (issue #812): the one upstream hop every
+  // `/api/*` proxy request makes, api-worker-bound rather than auth-bound —
+  // see auth-proxy.ts's proxyAuthRequest for the "auth" counterpart.
+  const timing = new ServerTiming();
+  const upstream = await timeOp(
+    () =>
+      env.API
+        ? env.API.fetch(forwarded)
+        : fetch(rewriteOrigin(forwarded, env.UPLOADS_API_ORIGIN ?? LOCAL_API_ORIGIN_DEFAULT)),
+    { name: "api", timing, route: decodedPath, thresholdMs: slowOpThresholdMs(env) },
+  );
+  return timing.applyTo(upstream, { disabled: serverTimingDisabled(env) });
 }
 
 /**

--- a/apps/web/src/lib/auth-proxy.test.ts
+++ b/apps/web/src/lib/auth-proxy.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sessionResultFromResponse } from "./auth-client";
 import {
   proxyAuthRequest,
@@ -399,5 +399,57 @@ describe("serverAuthFetchImpl", () => {
     const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
     expect(forwarded.url).toBe("https://uploads.sh/api/auth/get-session");
     expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
+  });
+});
+
+describe("proxyAuthRequest — Server-Timing wiring (issue #812)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("emits an auth;dur=… Server-Timing header on the returned response", async () => {
+    const { AUTH } = fakeAuthBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/auth/get-session");
+
+    const response = await proxyAuthRequest({ AUTH }, request);
+    expect(response.headers.get("Server-Timing")).toMatch(/^auth;dur=\d+(\.\d+)?$/);
+  });
+
+  it("silences the header when SERVER_TIMING_DISABLED is set", async () => {
+    const { AUTH } = fakeAuthBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/auth/get-session");
+
+    const response = await proxyAuthRequest({ AUTH, SERVER_TIMING_DISABLED: "1" }, request);
+    expect(response.headers.get("Server-Timing")).toBeNull();
+  });
+
+  it("logs a slow-op line only above the threshold", async () => {
+    const { AUTH } = fakeAuthBinding(Response.json({ ok: true }));
+    const request = new Request("https://uploads.sh/api/auth/get-session");
+
+    await proxyAuthRequest({ AUTH, SLOW_OP_THRESHOLD_MS: "1000000" }, request);
+    expect(logSpy).not.toHaveBeenCalled();
+
+    await proxyAuthRequest({ AUTH, SLOW_OP_THRESHOLD_MS: "0" }, request);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(logged).toMatchObject({ msg: "slow_op", op: "auth", outcome: "ok" });
+  });
+
+  it("still emits the header on the synthetic 503 timeout response", async () => {
+    const request = new Request("https://uploads.sh/api/auth/get-session");
+    const response = await proxyAuthRequest(
+      { AUTH: { fetch: hangingBinding() } },
+      request,
+      5, // tiny sessionTimeoutMs to force the abort path fast
+    );
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Server-Timing")).toMatch(/^auth;dur=\d+(\.\d+)?$/);
   });
 });

--- a/apps/web/src/lib/auth-proxy.ts
+++ b/apps/web/src/lib/auth-proxy.ts
@@ -16,9 +16,16 @@
  * 302s must reach the browser unfollowed, not be resolved inside the worker.
  */
 
+import {
+  ServerTiming,
+  serverTimingDisabled,
+  slowOpThresholdMs,
+  timeOp,
+  type TimingEnv,
+} from "@uploads/observability";
 import { rewriteOrigin, withInheritedCookie } from "./proxy-transport";
 
-export interface AuthProxyEnv {
+export interface AuthProxyEnv extends TimingEnv {
   AUTH?: { fetch(req: Request): Promise<Response> };
   UPLOADS_AUTH_ORIGIN?: string;
 }
@@ -82,14 +89,33 @@ export async function proxyAuthRequest(
         }
       : { redirect: "manual" },
   );
+  // Structural choke point (issue #812): every auth-proxy path (this
+  // function, and serverGetSession/serverAuthFetch below, which both call
+  // through here) times the one upstream hop it makes. Named "auth" to match
+  // apps/api's session-auth.ts timing entry for the same logical call.
+  const timing = new ServerTiming();
   try {
-    const upstream = env.AUTH
-      ? await env.AUTH.fetch(forwarded)
-      : await fetch(rewriteOrigin(forwarded, env.UPLOADS_AUTH_ORIGIN ?? LOCAL_AUTH_ORIGIN_DEFAULT));
-    return withLegacyCookieCleared(upstream, request);
+    const upstream = await timeOp(
+      () =>
+        env.AUTH
+          ? env.AUTH.fetch(forwarded)
+          : fetch(rewriteOrigin(forwarded, env.UPLOADS_AUTH_ORIGIN ?? LOCAL_AUTH_ORIGIN_DEFAULT)),
+      {
+        name: "auth",
+        timing,
+        route: new URL(request.url).pathname,
+        thresholdMs: slowOpThresholdMs(env),
+      },
+    );
+    return timing.applyTo(withLegacyCookieCleared(upstream, request), {
+      disabled: serverTimingDisabled(env),
+    });
   } catch (err) {
     if (bounded && forwarded.signal.aborted && !request.signal.aborted) {
-      return new Response(null, { status: 503, statusText: "auth session lookup timed out" });
+      return timing.applyTo(
+        new Response(null, { status: 503, statusText: "auth session lookup timed out" }),
+        { disabled: serverTimingDisabled(env) },
+      );
     }
     throw err;
   }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@uploads/observability",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260706.1",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/observability/src/index.test.ts
+++ b/packages/observability/src/index.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  d1ExecMs,
+  DEFAULT_SLOW_OP_THRESHOLD_MS,
+  ServerTiming,
+  serverTimingDisabled,
+  slowOpThresholdMs,
+  timeOp,
+} from "./index";
+
+describe("ServerTiming", () => {
+  it("renders a header from collected entries, exec ms only when present", () => {
+    const timing = new ServerTiming();
+    timing.record({ name: "d1", wallMs: 4012, execMs: 0.4 });
+    timing.record({ name: "auth", wallMs: 3998 });
+    expect(timing.header()).toBe("d1;dur=4012, d1exec;dur=0.4, auth;dur=3998");
+  });
+
+  it("returns null when nothing was recorded", () => {
+    expect(new ServerTiming().header()).toBeNull();
+    expect(new ServerTiming().isEmpty()).toBe(true);
+  });
+
+  it("sanitizes op names into bare tokens", () => {
+    const timing = new ServerTiming();
+    timing.record({ name: "d1 read/write", wallMs: 1 });
+    expect(timing.header()).toBe("d1_read_write;dur=1");
+  });
+
+  it("applyTo sets the header without mutating the original response", () => {
+    const timing = new ServerTiming();
+    timing.record({ name: "d1", wallMs: 12.3 });
+    const original = new Response("ok", { status: 201 });
+    const decorated = timing.applyTo(original);
+    expect(decorated).not.toBe(original);
+    expect(decorated.status).toBe(201);
+    expect(decorated.headers.get("Server-Timing")).toBe("d1;dur=12.3");
+    expect(original.headers.get("Server-Timing")).toBeNull();
+  });
+
+  it("applyTo returns the same response instance when disabled", () => {
+    const timing = new ServerTiming();
+    timing.record({ name: "d1", wallMs: 12 });
+    const original = new Response("ok");
+    const result = timing.applyTo(original, { disabled: true });
+    expect(result).toBe(original);
+    expect(result.headers.get("Server-Timing")).toBeNull();
+  });
+
+  it("applyTo returns the same response instance when there is nothing to report", () => {
+    const original = new Response("ok");
+    const result = new ServerTiming().applyTo(original);
+    expect(result).toBe(original);
+  });
+});
+
+describe("d1ExecMs", () => {
+  it("reads meta.duration off a D1-result-shaped value", () => {
+    expect(d1ExecMs({ meta: { duration: 0.42 } })).toBe(0.42);
+  });
+
+  it("returns undefined for a result with no meta (e.g. .first())", () => {
+    expect(d1ExecMs({})).toBeUndefined();
+    expect(d1ExecMs(null)).toBeUndefined();
+    expect(d1ExecMs(undefined)).toBeUndefined();
+  });
+});
+
+describe("timeOp", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("records wall ms and exec ms (from a D1-shaped result) into the collector", async () => {
+    const timing = new ServerTiming();
+    const result = await timeOp(async () => ({ meta: { duration: 1.5 }, results: [] }), {
+      name: "d1",
+      timing,
+      execMs: d1ExecMs,
+    });
+    expect(result.results).toEqual([]);
+    expect(timing.header()).toMatch(/^d1;dur=\d+(\.\d+)?, d1exec;dur=1\.5$/);
+  });
+
+  it("logs a slow-op line when wall ms exceeds the threshold", async () => {
+    await timeOp(
+      () =>
+        new Promise((resolve) => {
+          // Force a measurable, real wall-clock delay rather than faking timers,
+          // since Date.now() inside timeOp is the thing under test.
+          setTimeout(() => resolve("ok"), 5);
+        }),
+      { name: "auth", route: "/v1/files/x", thresholdMs: 1 },
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(logged).toMatchObject({
+      msg: "slow_op",
+      op: "auth",
+      route: "/v1/files/x",
+      outcome: "ok",
+    });
+    expect(logged.wallMs).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not log below the threshold", async () => {
+    await timeOp(async () => "fast", { name: "d1", thresholdMs: 1_000_000 });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs an error outcome (with no exec ms) and rethrows on failure", async () => {
+    const err = new Error("boom");
+    await expect(
+      timeOp(
+        async () => {
+          throw err;
+        },
+        { name: "d1", thresholdMs: 0 },
+      ),
+    ).rejects.toThrow(err);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(logged).toMatchObject({ op: "d1", outcome: "error", execMs: null });
+  });
+
+  it("uses the default threshold when none is given", async () => {
+    await timeOp(async () => "fast", { name: "d1" });
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(DEFAULT_SLOW_OP_THRESHOLD_MS).toBe(1000);
+  });
+});
+
+describe("env helpers", () => {
+  it("slowOpThresholdMs falls back to the default on unset/invalid values", () => {
+    expect(slowOpThresholdMs(undefined)).toBe(DEFAULT_SLOW_OP_THRESHOLD_MS);
+    expect(slowOpThresholdMs({})).toBe(DEFAULT_SLOW_OP_THRESHOLD_MS);
+    expect(slowOpThresholdMs({ SLOW_OP_THRESHOLD_MS: "not-a-number" })).toBe(
+      DEFAULT_SLOW_OP_THRESHOLD_MS,
+    );
+    expect(slowOpThresholdMs({ SLOW_OP_THRESHOLD_MS: "-5" })).toBe(DEFAULT_SLOW_OP_THRESHOLD_MS);
+  });
+
+  it("slowOpThresholdMs reads a valid override", () => {
+    expect(slowOpThresholdMs({ SLOW_OP_THRESHOLD_MS: "250" })).toBe(250);
+  });
+
+  it("serverTimingDisabled recognizes '1' and 'true' (any case), nothing else", () => {
+    expect(serverTimingDisabled(undefined)).toBe(false);
+    expect(serverTimingDisabled({})).toBe(false);
+    expect(serverTimingDisabled({ SERVER_TIMING_DISABLED: "0" })).toBe(false);
+    expect(serverTimingDisabled({ SERVER_TIMING_DISABLED: "1" })).toBe(true);
+    expect(serverTimingDisabled({ SERVER_TIMING_DISABLED: "true" })).toBe(true);
+    expect(serverTimingDisabled({ SERVER_TIMING_DISABLED: "TRUE" })).toBe(true);
+  });
+});

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,0 +1,179 @@
+/**
+ * Server-Timing headers + slow-op structured logs (issue #812).
+ *
+ * A small, dependency-free helper any Worker can wrap its D1/service-binding
+ * awaits with: it measures wall-clock ms across the `await` (Date.now
+ * advances across I/O awaits on Workers — see issue #812), optionally reads
+ * a D1 result's `meta.duration` as execution ms, collects entries per
+ * request for a standard `Server-Timing` response header, and logs one
+ * structured line when an op is slow.
+ *
+ * Deliberately emits only op names and durations — never query text, ids,
+ * tokens, or any other value that could leak into logs or a response header.
+ */
+
+/** One measured operation: a name plus wall-clock ms, and execution ms when known (D1's `meta.duration`). */
+export interface TimingEntry {
+  name: string;
+  wallMs: number;
+  execMs?: number;
+}
+
+export type SlowOpOutcome = "ok" | "error";
+
+/** Structured shape logged for an operation that exceeds the slow-op threshold. */
+export interface SlowOpEvent {
+  route?: string;
+  op: string;
+  wallMs: number;
+  execMs?: number;
+  outcome: SlowOpOutcome;
+}
+
+/** Env var names read by {@link slowOpThresholdMs} / {@link serverTimingDisabled}. Both optional. */
+export interface TimingEnv {
+  /** Slow-op log threshold in ms. Defaults to {@link DEFAULT_SLOW_OP_THRESHOLD_MS} when unset/invalid. */
+  SLOW_OP_THRESHOLD_MS?: string;
+  /** Kill switch for `Server-Timing` header emission — logging is unaffected. "1" or "true" disables. */
+  SERVER_TIMING_DISABLED?: string;
+}
+
+export const DEFAULT_SLOW_OP_THRESHOLD_MS = 1000;
+
+function truthyFlag(value: string | undefined): boolean {
+  return value === "1" || (value?.toLowerCase() ?? "") === "true";
+}
+
+/**
+ * Reads `SLOW_OP_THRESHOLD_MS` from env (Worker env vars are always
+ * strings); falls back to the default on unset/negative/NaN. `0` is a valid
+ * override (logs every op) — only a negative or non-numeric value is
+ * treated as misconfigured.
+ */
+export function slowOpThresholdMs(env: TimingEnv | undefined): number {
+  const raw = Number(env?.SLOW_OP_THRESHOLD_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_SLOW_OP_THRESHOLD_MS;
+}
+
+/** Reads the `SERVER_TIMING_DISABLED` kill switch — silences header emission only, never the slow-op log. */
+export function serverTimingDisabled(env: TimingEnv | undefined): boolean {
+  return truthyFlag(env?.SERVER_TIMING_DISABLED);
+}
+
+// Server-Timing metric names are tokens (RFC 9110 token grammar); strip
+// anything else rather than risk a malformed header from an unexpected op name.
+function sanitizeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function formatDur(ms: number): string {
+  return (ms < 10 ? ms.toFixed(3) : ms.toFixed(1)).replace(/\.?0+$/, "") || "0";
+}
+
+/**
+ * Collects {@link TimingEntry} values across one request and renders them as
+ * a `Server-Timing` header value, e.g.
+ * `d1;dur=4012, d1exec;dur=0.4, auth;dur=3998`.
+ */
+export class ServerTiming {
+  private readonly entries: TimingEntry[] = [];
+
+  record(entry: TimingEntry): void {
+    this.entries.push(entry);
+  }
+
+  isEmpty(): boolean {
+    return this.entries.length === 0;
+  }
+
+  /** Renders the collected entries, or `null` when there is nothing to report. */
+  header(): string | null {
+    if (this.entries.length === 0) return null;
+    const parts: string[] = [];
+    for (const entry of this.entries) {
+      const name = sanitizeName(entry.name);
+      parts.push(`${name};dur=${formatDur(entry.wallMs)}`);
+      if (entry.execMs !== undefined) {
+        parts.push(`${name}exec;dur=${formatDur(entry.execMs)}`);
+      }
+    }
+    return parts.join(", ");
+  }
+
+  /**
+   * Returns `response` with a `Server-Timing` header set, unless `disabled`
+   * is true or there is nothing to report — in which case `response` is
+   * returned unchanged (same instance, no header set).
+   */
+  applyTo(response: Response, opts?: { disabled?: boolean }): Response {
+    const value = opts?.disabled ? null : this.header();
+    if (value === null) return response;
+    const headers = new Headers(response.headers);
+    headers.set("Server-Timing", value);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}
+
+/** Extracts D1's execution-duration meta from a `.run()`/`.all()` result, when present. `.first()` results carry no `meta`. */
+export function d1ExecMs(
+  result: { meta?: { duration?: number } } | null | undefined,
+): number | undefined {
+  return typeof result?.meta?.duration === "number" ? result.meta.duration : undefined;
+}
+
+function logSlowOp(event: SlowOpEvent, thresholdMs: number): void {
+  if (event.wallMs < thresholdMs) return;
+  // One structured line, values only — no query text, ids, or tokens.
+  console.log(
+    JSON.stringify({
+      msg: "slow_op",
+      route: event.route ?? null,
+      op: event.op,
+      wallMs: Math.round(event.wallMs),
+      execMs: event.execMs !== undefined ? Math.round(event.execMs * 100) / 100 : null,
+      outcome: event.outcome,
+    }),
+  );
+}
+
+export interface TimeOpOptions<T> {
+  /** Op name, e.g. `"d1"`, `"auth"`. Rendered verbatim into the Server-Timing header (sanitized) and the slow-op log. */
+  name: string;
+  /** Collector to record this entry into. Omit to only get slow-op logging (e.g. a fire-and-forget call with no response to attach a header to). */
+  timing?: ServerTiming;
+  /** Request path/route, carried into the slow-op log only. */
+  route?: string;
+  /** Slow-op log threshold in ms. Defaults to {@link DEFAULT_SLOW_OP_THRESHOLD_MS}. */
+  thresholdMs?: number;
+  /** Extracts execution ms from the resolved value, e.g. {@link d1ExecMs}. */
+  execMs?: (result: T) => number | undefined;
+}
+
+/**
+ * Wraps an awaited operation: measures wall-clock ms across the await,
+ * records a {@link TimingEntry} (with exec ms when `execMs` yields one), and
+ * logs a structured line when the op is slow. Rethrows on failure after
+ * recording/logging it as an `"error"` outcome (with wall ms but no exec ms,
+ * since a rejected promise carries no result to extract it from).
+ */
+export async function timeOp<T>(fn: () => Promise<T>, opts: TimeOpOptions<T>): Promise<T> {
+  const thresholdMs = opts.thresholdMs ?? DEFAULT_SLOW_OP_THRESHOLD_MS;
+  const start = Date.now();
+  try {
+    const result = await fn();
+    const wallMs = Date.now() - start;
+    const execMs = opts.execMs?.(result);
+    opts.timing?.record({ name: opts.name, wallMs, execMs });
+    logSlowOp({ route: opts.route, op: opts.name, wallMs, execMs, outcome: "ok" }, thresholdMs);
+    return result;
+  } catch (err) {
+    const wallMs = Date.now() - start;
+    opts.timing?.record({ name: opts.name, wallMs });
+    logSlowOp({ route: opts.route, op: opts.name, wallMs, outcome: "error" }, thresholdMs);
+    throw err;
+  }
+}

--- a/packages/observability/tsconfig.json
+++ b/packages/observability/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@uploads/errors':
         specifier: workspace:^
         version: link:../../packages/errors
+      '@uploads/observability':
+        specifier: workspace:^
+        version: link:../../packages/observability
       '@uploads/storage':
         specifier: workspace:^
         version: link:../../packages/storage
@@ -188,6 +191,9 @@ importers:
       '@uploads/billing':
         specifier: workspace:^
         version: link:../../packages/billing
+      '@uploads/observability':
+        specifier: workspace:^
+        version: link:../../packages/observability
       '@uploads/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -280,6 +286,18 @@ importers:
 
   packages/errors:
     devDependencies:
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+
+  packages/observability:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^5.20260706.1
+        version: 5.20260706.1
       typescript:
         specifier: ^7.0.2
         version: 7.0.2


### PR DESCRIPTION
## Summary

Implements tiers 1+2 of #812: a shared `@uploads/observability` timing
helper, wired into apps/api and apps/web at their per-request auth/D1
choke points. Tier 3 (Analytics Engine trend dataset) is left as a
follow-up, as scoped in the issue.

## `@uploads/observability`

New package (`packages/observability`, mirrors `@uploads/errors`'s shape).
Exports:

- `ServerTiming` — collects `{ name, wallMs, execMs? }` entries for one
  request and renders them into a standard `Server-Timing` header value,
  e.g. `d1;dur=4012, d1exec;dur=0.4, auth;dur=3998`. `applyTo(response)`
  sets the header without mutating the original `Response`.
- `timeOp(fn, { name, timing?, route?, thresholdMs?, execMs? })` — wraps an
  awaited operation, measures wall-clock ms across the await via
  `Date.now()` (this advances across I/O awaits on Workers; it doesn't
  advance during pure CPU, which is fine here), records the entry, and logs
  one structured `slow_op` line (route, op, wallMs, execMs, outcome) when
  wall time exceeds the threshold. Records/logs on both success and
  failure (rethrows either way).
- `d1ExecMs(result)` — reads `meta.duration` off a D1 `.run()`/`.all()`
  result (`.first()` results carry no `meta`).
- `slowOpThresholdMs(env)` / `serverTimingDisabled(env)` — read
  `SLOW_OP_THRESHOLD_MS` (default 1000ms; `0` is a valid "log everything"
  override, only negative/NaN falls back to the default) and
  `SERVER_TIMING_DISABLED` ("1"/"true", case-insensitive) from env.

Only op names and durations are ever recorded or logged — never query
text, user ids, tokens, or keys.

## Wired in

**apps/api** — two structural choke points, not per-route:
- `session-auth.ts`'s `sessionAuth` middleware: times the `AUTH` binding's
  `get-session` fetch (`auth;dur=…`). The header is appended even when the
  call throws (a 503), so a stalled-auth response still carries the timing
  that explains it — this is the exact signal the 2026-08-23 D1 stall
  incident (#808) needed.
- `workspace.ts`'s `workspaceAuth`/`workspaceGovernanceAuth` (the
  `/v1/:workspace/*` and workspace-governance bearer guards, which run on
  nearly every token-authenticated request): times `findActiveToken`
  (`d1;dur=…`, no exec — it's a `.first()`) and `touchTokenLastUsed`
  (`d1_touch;dur=…, d1_touchexec;dur=…` — a `.run()`, so `meta.duration` is
  captured). `touchTokenLastUsed` now returns the raw `D1Result` (was
  `void`) so the exec ms is readable; its two existing callers
  (`workspace.ts`, `admin.ts`) are unaffected since they never used the
  return value.

**apps/web** — the auth and api same-origin proxies (#731):
- `auth-proxy.ts`'s `proxyAuthRequest` times its one upstream hop
  (`auth;dur=…`). `serverGetSession` and `serverAuthFetch` both call
  through `proxyAuthRequest`, so they're covered for free.
- `api-proxy.ts`'s `proxyApiRequest` times its one upstream hop
  (`api;dur=…`), same shape.

**apps/api's `admin.ts`** (bearer `/admin/*` guard) also calls
`findActiveToken`/`touchTokenLastUsed` but isn't instrumented in this PR —
kept the diff to the two highest-traffic choke points (file-plane bearer
auth + session auth). Straightforward to add as a follow-up with the same
pattern.

**apps/auth is not instrumented** — it uses `drizzleAdapter` (Better
Auth's Drizzle/D1 adapter) rather than a hand-rolled D1 access layer or a
single Kysely dialect wrapper, so there's no clean single point to time
without patching into Better Auth's adapter internals. Per the issue's own
allowance, skipping it for this PR rather than doing something invasive.

## Kill switch / threshold

- `SERVER_TIMING_DISABLED=1` (or `true`) silences `Server-Timing` header
  emission only, on both workers — slow-op logging is unaffected, so you
  can turn off the header in prod without losing the logs.
- `SLOW_OP_THRESHOLD_MS` overrides the 1000ms default per-worker.

Both are read straight from the Worker `env` (no deploy needed to tune
them where they're already declared as plain vars/secrets).

## Coordination with `claude/d1-sessions-api` (#813)

That branch is routing `apps/api`'s D1 access (`auth-db.ts`'s functions,
including `findActiveToken`/`touchTokenLastUsed`) through a new
`D1Queryable`/`db-session.ts` wrapper — branched from `origin/main`
independently of this PR, not built on top of it.

**Expected conflict surface on rebase/merge (whichever lands second):**
- `apps/api/src/auth-db.ts` — #813 retypes every function's `db` param
  from `D1Database` to `D1Queryable`; this PR additionally changes
  `touchTokenLastUsed`'s return type from `void` to `D1Result | null`.
  Same function signature, two independent edits — trivial line-level
  conflict, resolves to `db: D1Queryable` + `Promise<D1Result | null>`.
- `apps/api/src/env.d.ts` — both PRs append new optional fields to the
  `Env` interface. No semantic conflict, just adjacent additions.
- `apps/api/src/workspace.ts` — not touched by #813 as far as its diff
  shows, so the `timeOp`/`ServerTiming` wiring here should apply cleanly
  regardless of merge order.

This PR's `timeOp`/`d1ExecMs` wrapper is intentionally D1-shape-agnostic
(it just awaits whatever's handed to it and reads `.meta.duration` off the
result), so once #813's `D1Queryable`/session wrapper lands, timing it
instead of the raw `D1Database` call is a call-site change, not a redesign
of this helper.

## Tests

- `packages/observability`: header rendering (incl. the exact
  `d1;dur=4012, d1exec;dur=0.4, auth;dur=3998` shape from the issue), name
  sanitization, `applyTo` non-mutation + kill-switch + no-op cases,
  `d1ExecMs` extraction, `timeOp` recording/logging/threshold/error-path
  behavior, and the env-var helpers.
- `apps/api`: new `workspace-server-timing.test.ts` (header + exec ms on a
  matched token, kill switch, slow-op log above/below threshold, no header
  leak on a 401) and new cases in `session-auth.test.ts` (header on
  success and on 503, kill switch, slow-op threshold) and
  `auth-db.test.ts` (`touchTokenLastUsed`'s new return value).
- `apps/web`: new cases in `auth-proxy.test.ts` and `api-proxy.test.ts`
  (header, kill switch, slow-op threshold, header still present on the
  synthetic 503 timeout response).

`pnpm test` from repo root: **332 test files, 5000 tests, all passing.**
`apps/api` and `apps/web` both typecheck clean (`wrangler types && tsc
--noEmit`; apps/web's `astro check` step itself can't run in this
environment's Node 22 — a pre-existing, unrelated local-Node-version gap,
not something this PR introduced).

## Scope not included

Tier 3 (writing slow-op events to the `ANALYTICS` binding for an
`/admin/metrics` panel) is explicitly out of scope for this PR per the
issue — follow-up.
