### PR TITLE
feat(api): bound data-plane D1 reads with fail-fast 503s

### DIFF
--- a/apps/api/src/data-read-bounds.test.ts
+++ b/apps/api/src/data-read-bounds.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Stall bounds for data-plane D1 reads (issue #815). Plain vitest + in-process
+ * fakes, no real waits — every timeout path below uses fake timers so the
+ * suite stays fast regardless of the configured deadline.
+ */
+import { ServiceUnavailableError } from "@uploads/errors";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  boundedDataRead,
+  boundedRead,
+  DEFAULT_DATA_READ_TIMEOUT_MS,
+  dataReadTimeoutMs,
+} from "./data-read-bounds";
+
+describe("dataReadTimeoutMs", () => {
+  it("defaults to 8000ms when unset", () => {
+    expect(dataReadTimeoutMs(undefined)).toBe(DEFAULT_DATA_READ_TIMEOUT_MS);
+    expect(dataReadTimeoutMs({})).toBe(DEFAULT_DATA_READ_TIMEOUT_MS);
+  });
+
+  it("respects a configured override", () => {
+    expect(dataReadTimeoutMs({ DATA_READ_TIMEOUT_MS: "250" })).toBe(250);
+  });
+
+  it("treats '0' as a valid override that disables the bound", () => {
+    expect(dataReadTimeoutMs({ DATA_READ_TIMEOUT_MS: "0" })).toBe(0);
+  });
+
+  it("falls back to the default for negative or non-numeric values", () => {
+    expect(dataReadTimeoutMs({ DATA_READ_TIMEOUT_MS: "-5" })).toBe(DEFAULT_DATA_READ_TIMEOUT_MS);
+    expect(dataReadTimeoutMs({ DATA_READ_TIMEOUT_MS: "not-a-number" })).toBe(
+      DEFAULT_DATA_READ_TIMEOUT_MS,
+    );
+  });
+});
+
+describe("boundedRead", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("passes through a read that completes under the deadline", async () => {
+    const result = await boundedRead({ DATA_READ_TIMEOUT_MS: "8000" }, async () => ({ rows: 3 }), {
+      name: "d1_test",
+    });
+    expect(result).toEqual({ rows: 3 });
+  });
+
+  it("throws a typed 503 (data_unavailable) when the read hangs past a tiny injected deadline", async () => {
+    vi.useFakeTimers();
+    // Never resolves within the test — the deadline must win the race.
+    const hang = () => new Promise<never>(() => {});
+
+    const promise = boundedRead({ DATA_READ_TIMEOUT_MS: "5" }, hang, { name: "d1_test" });
+    // Attach a rejection handler before advancing timers so the race's own
+    // rejection is never briefly unobserved.
+    const assertion = expect(promise).rejects.toMatchObject({
+      code: "data_unavailable",
+      status: 503,
+    });
+    await vi.advanceTimersByTimeAsync(5);
+    await assertion;
+  });
+
+  it("the timeout error is a ServiceUnavailableError instance", async () => {
+    vi.useFakeTimers();
+    const hang = () => new Promise<never>(() => {});
+    const promise = boundedRead({ DATA_READ_TIMEOUT_MS: "5" }, hang, { name: "d1_test" });
+    const assertion = expect(promise).rejects.toBeInstanceOf(ServiceUnavailableError);
+    await vi.advanceTimersByTimeAsync(5);
+    await assertion;
+  });
+
+  it("does not surface an unhandled rejection when the losing read rejects after the deadline", async () => {
+    vi.useFakeTimers();
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    try {
+      let rejectLate: (err: unknown) => void = () => undefined;
+      const lateRejecter = () =>
+        new Promise<never>((_, reject) => {
+          rejectLate = reject;
+        });
+
+      const promise = boundedRead({ DATA_READ_TIMEOUT_MS: "5" }, lateRejecter, {
+        name: "d1_test",
+      });
+      const assertion = expect(promise).rejects.toMatchObject({ code: "data_unavailable" });
+      await vi.advanceTimersByTimeAsync(5);
+      await assertion;
+
+      // The original read finally rejects well after the deadline already won.
+      rejectLate(new Error("late D1 failure"));
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+    } finally {
+      process.off("unhandledRejection", unhandled);
+    }
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
+  it("honors DATA_READ_TIMEOUT_MS='0' by running the read unbounded", async () => {
+    vi.useFakeTimers();
+    let resolveLate: (value: string) => void = () => undefined;
+    const late = () =>
+      new Promise<string>((resolve) => {
+        resolveLate = resolve;
+      });
+
+    const promise = boundedRead({ DATA_READ_TIMEOUT_MS: "0" }, late, { name: "d1_test" });
+    await vi.advanceTimersByTimeAsync(60_000); // far past the normal default — still no timeout set
+    resolveLate("ok-eventually");
+    await expect(promise).resolves.toBe("ok-eventually");
+  });
+});
+
+describe("boundedDataRead", () => {
+  function fakeContext(env: Record<string, string>) {
+    const headers: Array<{ name: string; value: string }> = [];
+    return {
+      env,
+      req: { path: "/v1/workspaces/acme/usage" },
+      header: (name: string, value: string) => headers.push({ name, value }),
+      _headers: headers,
+    };
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("appends a Server-Timing header and returns the value on a fast read", async () => {
+    const c = fakeContext({});
+    const result = await boundedDataRead(c as never, async () => 42, {
+      name: "d1_workspace_usage",
+    });
+    expect(result).toBe(42);
+    expect(
+      c._headers.some((h) => h.name === "Server-Timing" && h.value.includes("d1_workspace_usage")),
+    ).toBe(true);
+  });
+
+  it("rejects with data_unavailable when the deadline is overridden per-call", async () => {
+    vi.useFakeTimers();
+    const c = fakeContext({});
+    const hang = () => new Promise<never>(() => {});
+    const promise = boundedDataRead(c as never, hang, { name: "d1_workspace_usage", timeoutMs: 5 });
+    const assertion = expect(promise).rejects.toMatchObject({
+      code: "data_unavailable",
+      status: 503,
+    });
+    await vi.advanceTimersByTimeAsync(5);
+    await assertion;
+  });
+});
+
+describe("writes are unaffected by the data-read bound", () => {
+  it("a write called directly (not through boundedRead) is never raced against the deadline", async () => {
+    vi.useFakeTimers();
+    let resolveWrite: (value: string) => void = () => undefined;
+    const slowWrite = () =>
+      new Promise<string>((resolve) => {
+        resolveWrite = resolve;
+      });
+
+    // This mirrors how mutation handlers call `dbFor`-backed write functions
+    // directly — no `boundedRead`/`boundedDataRead` wrapper — so nothing
+    // races them against DATA_READ_TIMEOUT_MS.
+    const result = slowWrite();
+    await vi.advanceTimersByTimeAsync(DEFAULT_DATA_READ_TIMEOUT_MS * 10);
+    resolveWrite("write-committed");
+    await expect(result).resolves.toBe("write-committed");
+  });
+});

--- a/apps/api/src/data-read-bounds.ts
+++ b/apps/api/src/data-read-bounds.ts
@@ -1,0 +1,150 @@
+/**
+ * Stall bounds for the api worker's data-plane D1 reads (issue #815, follow-up
+ * to the 2026-08-23 D1 stall incident #808). Auth's D1 dependency is already
+ * bounded (`AUTH_FETCH_TIMEOUT_MS` in session-auth.ts, `#805`/`#806`); this
+ * covers the other side — file listings, by-path/screenshots grouping,
+ * search, workspace usage summaries, and galleries. Those reads can't fail
+ * open (there is no safe empty-list fallback that isn't misleading), but they
+ * can fail *fast*: a stalled read becomes a typed 503 instead of an
+ * open-ended hang, so the web app's per-widget error states (already
+ * retryable) render in seconds instead of riding out the full stall window.
+ *
+ * Deliberately NOT applied to writes/mutations (an aborted write still needs
+ * to know whether it landed) or to the auth path (already bounded via its own
+ * mechanism). Built on top of `timeOp`/`ServerTiming` (`@uploads/observability`,
+ * issue #812) so a bounded read still gets the same Server-Timing entry and
+ * slow-op log as every other instrumented D1 call, plus one addition: a read
+ * that trips the deadline logs with `outcome: "error"` and the response
+ * carries `data_unavailable`.
+ */
+import { ServiceUnavailableError } from "@uploads/errors";
+import {
+  ServerTiming,
+  serverTimingDisabled,
+  slowOpThresholdMs,
+  timeOp,
+  type TimingEnv,
+} from "@uploads/observability";
+import type { Context } from "hono";
+
+/** Env surface {@link dataReadTimeoutMs} reads. Also extends `TimingEnv` since callers pass the same `env`. */
+export interface DataReadEnv extends TimingEnv {
+  /**
+   * Deadline in ms for one bounded data-plane read. Unset/negative/NaN falls
+   * back to {@link DEFAULT_DATA_READ_TIMEOUT_MS}. `"0"` is a valid override
+   * that disables the bound entirely (the read runs unbounded, same as
+   * before this issue) — for local debugging or an environment that wants
+   * the old behavior back without a code change.
+   */
+  DATA_READ_TIMEOUT_MS?: string;
+}
+
+export const DEFAULT_DATA_READ_TIMEOUT_MS = 8000;
+
+/**
+ * Resolves the deadline for a bounded read. `0` means "disabled" and is
+ * returned as-is; anything else non-finite or negative falls back to the
+ * default; unset also falls back to the default.
+ */
+export function dataReadTimeoutMs(env: DataReadEnv | undefined): number {
+  const raw = env?.DATA_READ_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_DATA_READ_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_DATA_READ_TIMEOUT_MS;
+  return parsed;
+}
+
+/**
+ * Races `fn()` against `timeoutMs`. On timeout, throws a typed
+ * `ServiceUnavailableError` (`code: "data_unavailable"`) that the api
+ * worker's error middleware maps to a 503 — same mapping `session-auth.ts`
+ * already relies on for `auth_session_unavailable`.
+ *
+ * The losing promise is never awaited further, but a `.catch(() => {})` is
+ * attached before racing so a `fn()` that eventually rejects after the
+ * timeout has already won doesn't surface as an unhandled rejection (same
+ * hygiene as `apps/auth/src/rate-limit.ts`'s DO-timeout race).
+ */
+async function raceWithDeadline<T>(fn: () => Promise<T>, timeoutMs: number): Promise<T> {
+  if (timeoutMs === 0) return fn();
+
+  const call = fn();
+  call.catch(() => {});
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new ServiceUnavailableError("data read timed out", {
+          code: "data_unavailable",
+          details: { timeoutMs },
+        }),
+      );
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([call, deadline]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+export interface BoundedReadOptions {
+  /** Op name — same role as `TimeOpOptions.name` (Server-Timing entry + slow-op log). */
+  name: string;
+  /** Collector to record the timing entry into; typically appended to the response afterward. */
+  timing?: ServerTiming;
+  /** Request path, carried into the slow-op log only. */
+  route?: string;
+  /** Overrides the resolved env deadline for this call (mainly for tests). */
+  timeoutMs?: number;
+}
+
+/**
+ * Wraps one data-plane D1 read with both the deadline race above and
+ * `timeOp` instrumentation. Behaves exactly like `timeOp` on the happy path;
+ * a hang past the deadline throws the typed 503 instead of resolving.
+ */
+export function boundedRead<T>(
+  env: DataReadEnv,
+  fn: () => Promise<T>,
+  opts: BoundedReadOptions,
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? dataReadTimeoutMs(env);
+  return timeOp(() => raceWithDeadline(fn, timeoutMs), {
+    name: opts.name,
+    timing: opts.timing,
+    route: opts.route,
+    thresholdMs: slowOpThresholdMs(env),
+  });
+}
+
+/**
+ * Route-handler convenience: creates its own `ServerTiming`, runs `fn`
+ * through {@link boundedRead}, and appends the resulting header to `c`
+ * (merging with anything a prior middleware already appended — same pattern
+ * as `workspace.ts`'s private `appendServerTiming`). Use this at a route's
+ * top level; use {@link boundedRead} directly when a handler already
+ * maintains its own `ServerTiming` across multiple ops.
+ */
+export async function boundedDataRead<T, E extends { Bindings: Env }>(
+  c: Context<E>,
+  fn: () => Promise<T>,
+  opts: { name: string; timeoutMs?: number },
+): Promise<T> {
+  const timing = new ServerTiming();
+  try {
+    return await boundedRead(c.env as DataReadEnv, fn, {
+      name: opts.name,
+      timing,
+      route: c.req.path,
+      timeoutMs: opts.timeoutMs,
+    });
+  } finally {
+    if (!serverTimingDisabled(c.env as TimingEnv)) {
+      const value = timing.header();
+      if (value) c.header("Server-Timing", value, { append: true });
+    }
+  }
+}

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -101,4 +101,10 @@ interface Env {
   SLOW_OP_THRESHOLD_MS?: string;
   /** Kill switch for `Server-Timing` header emission only — slow-op logging is unaffected. */
   SERVER_TIMING_DISABLED?: string;
+  /**
+   * Stall bound for data-plane D1 reads (issue #815) — file listings,
+   * by-path/screenshots grouping, search, usage summaries, galleries. Unset
+   * defaults to 8000ms; `"0"` disables the bound. See `data-read-bounds.ts`.
+   */
+  DATA_READ_TIMEOUT_MS?: string;
 }

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -17,6 +17,7 @@ import {
   signFileHandler,
 } from "./files-shared-handlers";
 import { dbFor } from "../db-session";
+import { boundedDataRead } from "../data-read-bounds";
 
 export const files = new Hono<WorkspaceVars>()
 
@@ -49,12 +50,17 @@ export const files = new Hono<WorkspaceVars>()
       const pageSize = clampSearchLimit(limitParam ? Number(limitParam) || undefined : undefined);
       const [cfg, result] = await Promise.all([
         storageConfig(c.env, ws),
-        searchFilesByNameAndMeta(c.env, ws, c.get("workspaceName"), {
-          filters: hasMeta ? filters : undefined,
-          nameTerm,
-          prefix: query.prefix,
-          pageSize,
-        }),
+        boundedDataRead(
+          c,
+          () =>
+            searchFilesByNameAndMeta(c.env, ws, c.get("workspaceName"), {
+              filters: hasMeta ? filters : undefined,
+              nameTerm,
+              prefix: query.prefix,
+              pageSize,
+            }),
+          { name: "d1_files_search" },
+        ),
       ]);
       const items = result.matches.map((match) => {
         const urls = objectPublicUrls(c.env, cfg, match.key);
@@ -82,10 +88,15 @@ export const files = new Hono<WorkspaceVars>()
     const metadataParam = c.req.query("metadata");
     if (metadataParam !== "1" && metadataParam !== "true") return c.json(page);
 
-    const metaByKey = await getMetadataForKeys(
-      dbFor(c.env),
-      c.get("workspaceName"),
-      page.items.map((item) => item.key),
+    const metaByKey = await boundedDataRead(
+      c,
+      () =>
+        getMetadataForKeys(
+          dbFor(c.env),
+          c.get("workspaceName"),
+          page.items.map((item) => item.key),
+        ),
+      { name: "d1_files_meta" },
     );
     return c.json({
       ...page,
@@ -99,7 +110,15 @@ export const files = new Hono<WorkspaceVars>()
   // Static path must register before `/:key{.+}` so "facets" is not treated
   // as an object key.
   .get("/facets", requireScope("files:read"), async (c) => {
-    return c.json(await listFacets(dbFor(c.env), c.get("workspaceName"), c.req.query("key")));
+    return c.json(
+      await boundedDataRead(
+        c,
+        () => listFacets(dbFor(c.env), c.get("workspaceName"), c.req.query("key")),
+        {
+          name: "d1_files_facets",
+        },
+      ),
+    );
   })
 
   // Metadata now lives on the key-at-tail routes (same shape PUT/GET/DELETE

--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -38,6 +38,7 @@ import { publicUrl, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { jsonBody } from "./json-body";
 import { dbFor } from "../db-session";
+import { boundedDataRead } from "../data-read-bounds";
 
 async function ownerGallery(c: Context<WorkspaceVars>, id: string) {
   const record = await getGallery(dbFor(c.env), c.get("workspaceName"), id);
@@ -80,10 +81,15 @@ export async function listGalleriesHandler(c: Context<WorkspaceVars>) {
   const limit = rawLimit === undefined ? 50 : Number(rawLimit);
   if (!Number.isInteger(limit) || limit < 1 || limit > 100)
     throw new ValidationError("limit must be an integer from 1 to 100.");
-  const page = await listGalleries(dbFor(c.env), c.get("workspaceName"), {
-    limit,
-    cursor: decodeGalleryCursor(c.req.query("cursor")),
-  });
+  const page = await boundedDataRead(
+    c,
+    () =>
+      listGalleries(dbFor(c.env), c.get("workspaceName"), {
+        limit,
+        cursor: decodeGalleryCursor(c.req.query("cursor")),
+      }),
+    { name: "d1_galleries_list" },
+  );
   const result = page.galleries.map((gallery) => gallerySummary(c.env, gallery));
   return c.json({
     galleries: result,
@@ -98,11 +104,14 @@ export async function galleriesByReferenceHandler(c: Context<WorkspaceVars>) {
   const limit = rawLimit === undefined ? 50 : Number(rawLimit);
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100)
     throw new ValidationError("limit must be an integer from 1 to 100.");
-  const page = await findGalleriesByReference(
-    dbFor(c.env),
-    c.get("workspaceName"),
-    parsed.value.normalizedKey,
-    { limit, cursor: decodeGalleryCursor(c.req.query("cursor")) },
+  const page = await boundedDataRead(
+    c,
+    () =>
+      findGalleriesByReference(dbFor(c.env), c.get("workspaceName"), parsed.value.normalizedKey, {
+        limit,
+        cursor: decodeGalleryCursor(c.req.query("cursor")),
+      }),
+    { name: "d1_galleries_by_reference" },
   );
   return c.json({
     galleries: page.galleries.map((gallery) => gallerySummary(c.env, gallery)),
@@ -111,7 +120,8 @@ export async function galleriesByReferenceHandler(c: Context<WorkspaceVars>) {
 }
 
 export async function getGalleryHandler(c: Context<WorkspaceVars>) {
-  return c.json(await ownerGallery(c, c.req.param("id") as string));
+  const id = c.req.param("id") as string;
+  return c.json(await boundedDataRead(c, () => ownerGallery(c, id), { name: "d1_gallery_get" }));
 }
 
 export async function updateGalleryHandler(c: Context<WorkspaceVars>) {
@@ -238,17 +248,20 @@ export async function removeGalleryItemHandler(c: Context<WorkspaceVars>) {
 }
 
 export async function listExternalReferencesHandler(c: Context<WorkspaceVars>) {
-  const gallery = await getGallery(
-    dbFor(c.env),
-    c.get("workspaceName"),
-    c.req.param("id") as string,
+  const references = await boundedDataRead(
+    c,
+    async () => {
+      const gallery = await getGallery(
+        dbFor(c.env),
+        c.get("workspaceName"),
+        c.req.param("id") as string,
+      );
+      if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+      return listExternalReferences(dbFor(c.env), c.get("workspaceName"), gallery.id);
+    },
+    { name: "d1_gallery_external_references" },
   );
-  if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
-  return c.json({
-    references: (
-      await listExternalReferences(dbFor(c.env), c.get("workspaceName"), gallery.id)
-    ).map(referenceDto),
-  });
+  return c.json({ references: references.map(referenceDto) });
 }
 
 export async function addExternalReferenceHandler(c: Context<WorkspaceVars>) {

--- a/apps/api/src/routes/public-galleries.ts
+++ b/apps/api/src/routes/public-galleries.ts
@@ -7,6 +7,7 @@ import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
 import { dbFor } from "../db-session";
+import { boundedDataRead } from "../data-read-bounds";
 
 /** Runs `action`, mapping any thrown error to the 503 the gallery storage routes commit to. */
 async function withGalleryStorageErrors<T>(action: () => Promise<T>): Promise<T> {
@@ -34,7 +35,11 @@ export const publicGalleries = new Hono<WorkspaceVars>()
       throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
     }
 
-    const items = await listGalleryItems(dbFor(c.env), record.workspace, record.id);
+    const items = await boundedDataRead(
+      c,
+      () => listGalleryItems(dbFor(c.env), record.workspace, record.id),
+      { name: "d1_gallery_items" },
+    );
     const item = items.find((entry) => entry.id === c.req.param("item"));
     if (!item) {
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
@@ -75,8 +80,12 @@ export const publicGalleries = new Hono<WorkspaceVars>()
       throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
     }
     const [items, references] = await Promise.all([
-      listGalleryItems(dbFor(c.env), record.workspace, record.id),
-      listExternalReferences(dbFor(c.env), record.workspace, record.id),
+      boundedDataRead(c, () => listGalleryItems(dbFor(c.env), record.workspace, record.id), {
+        name: "d1_gallery_items",
+      }),
+      boundedDataRead(c, () => listExternalReferences(dbFor(c.env), record.workspace, record.id), {
+        name: "d1_gallery_external_references",
+      }),
     ]);
     return c.json(await hydratePublicGallery(c.env, workspace, record, items, references));
   });

--- a/apps/api/src/routes/usage.ts
+++ b/apps/api/src/routes/usage.ts
@@ -6,6 +6,7 @@ import { purgeExpiredObjects } from "../retention";
 import { getWorkspaceUsage } from "../usage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { dbFor } from "../db-session";
+import { boundedDataRead } from "../data-read-bounds";
 
 /**
  * Usage snapshot + maintenance:
@@ -15,7 +16,11 @@ import { dbFor } from "../db-session";
  */
 export const usage = new Hono<WorkspaceVars>()
   .get("/", requireScope("files:read"), async (c) => {
-    const snapshot = await getWorkspaceUsage(dbFor(c.env), c.get("workspaceName"));
+    const snapshot = await boundedDataRead(
+      c,
+      () => getWorkspaceUsage(dbFor(c.env), c.get("workspaceName")),
+      { name: "d1_workspace_usage" },
+    );
     const workspace = c.get("workspace");
     // `scopes` reflects the presented credential, not the workspace — doctor
     // uses it to surface a token that can't delete before the user hits a

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -29,6 +29,7 @@
  */
 import { ForbiddenError, NotFoundError, ValidationError } from "@uploads/errors";
 import { dbFor } from "../db-session";
+import { boundedDataRead } from "../data-read-bounds";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context, type Handler, type MiddlewareHandler } from "hono";
 import {
@@ -118,10 +119,15 @@ export const workspaceFiles = new Hono<DualAuthVars>()
       prefixes,
     } = await listObjects(c.env, record, { prefix, delimiter, limit, cursor });
 
-    const metaByKey = await getMetadataForKeys(
-      dbFor(c.env),
-      name,
-      items.map((item) => item.key),
+    const metaByKey = await boundedDataRead(
+      c,
+      () =>
+        getMetadataForKeys(
+          dbFor(c.env),
+          name,
+          items.map((item) => item.key),
+        ),
+      { name: "d1_files_meta" },
     );
     const files = items.map((item) => ({ ...item, metadata: metaByKey.get(item.key) }));
 
@@ -157,19 +163,29 @@ export const workspaceFiles = new Hono<DualAuthVars>()
     // key and once from the promoted `pull/<n>/` copy. Opt-in: a bare search
     // (and the `find_files` tool) still returns every matching object.
     const collapsePromotedShadows = c.req.query("collapse") === "promoted";
-    const { matches, truncated } = await searchFilesByNameAndMeta(c.env, record, name, {
-      filters: hasMeta ? filters : undefined,
-      nameTerm,
-      prefix: query.prefix,
-      pageSize,
-      collapsePromotedShadows,
-    });
+    const { matches, truncated } = await boundedDataRead(
+      c,
+      () =>
+        searchFilesByNameAndMeta(c.env, record, name, {
+          filters: hasMeta ? filters : undefined,
+          nameTerm,
+          prefix: query.prefix,
+          pageSize,
+          collapsePromotedShadows,
+        }),
+      { name: "d1_files_search" },
+    );
     // Upload time per match so the screenshots drill-in pop-over can show it
     // (the grouped by-path route surfaces the same via `updatedAt`).
-    const updatedByKey = await getObjectUpdatedAt(
-      dbFor(c.env),
-      name,
-      matches.map((m) => m.key),
+    const updatedByKey = await boundedDataRead(
+      c,
+      () =>
+        getObjectUpdatedAt(
+          dbFor(c.env),
+          name,
+          matches.map((m) => m.key),
+        ),
+      { name: "d1_files_updated_at" },
     );
 
     return c.json({
@@ -191,7 +207,15 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // Facet discovery for the files filter bar: which metadata keys this
   // workspace actually contains, and (with `?key=`) that key's values.
   .get("/:workspace/files/facets", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
-    return c.json(await listFacets(dbFor(c.env), c.get("workspaceName"), c.req.query("key")));
+    return c.json(
+      await boundedDataRead(
+        c,
+        () => listFacets(dbFor(c.env), c.get("workspaceName"), c.req.query("key")),
+        {
+          name: "d1_files_facets",
+        },
+      ),
+    );
   })
 
   // Recent uploads grouped by their `path` metadata value — the screenshots
@@ -214,7 +238,9 @@ export const workspaceFiles = new Hono<DualAuthVars>()
     // semantics untouched.
     const mergedOnly = c.req.query("merged") === "1";
     const { groups, catalog, projects, latest, truncated, catalogTruncated } =
-      await groupObjectsByPath(dbFor(c.env), name, { mergedOnly });
+      await boundedDataRead(c, () => groupObjectsByPath(dbFor(c.env), name, { mergedOnly }), {
+        name: "d1_screenshots_by_path",
+      });
     const shotKeys = [
       ...groups.flatMap((group) => group.recent),
       ...latest.map((item) => item.key),
@@ -222,10 +248,19 @@ export const workspaceFiles = new Hono<DualAuthVars>()
     // `gh.ref` lets the pop-over resolve live PR/issue status via /github/titles;
     // `updatedAt` gives it the shot's upload time (the `latest` feed already
     // carries `uploadedAt`, this brings the same to the grouped `recent` strips).
-    const metaByKey = await getMetadataForKeys(dbFor(c.env), name, shotKeys, {
-      metaKeys: ["state", "gh.kind", "gh.number", "gh.ref"],
-    });
-    const updatedByKey = await getObjectUpdatedAt(dbFor(c.env), name, shotKeys);
+    const metaByKey = await boundedDataRead(
+      c,
+      () =>
+        getMetadataForKeys(dbFor(c.env), name, shotKeys, {
+          metaKeys: ["state", "gh.kind", "gh.number", "gh.ref"],
+        }),
+      { name: "d1_files_meta" },
+    );
+    const updatedByKey = await boundedDataRead(
+      c,
+      () => getObjectUpdatedAt(dbFor(c.env), name, shotKeys),
+      { name: "d1_files_updated_at" },
+    );
     const cfg = await storageConfig(c.env, record);
     const shotItem = (key: string) => {
       const urls = objectPublicUrls(c.env, cfg, key);

--- a/apps/api/src/routes/workspace-galleries.ts
+++ b/apps/api/src/routes/workspace-galleries.ts
@@ -26,6 +26,7 @@
  */
 import { ValidationError } from "@uploads/errors";
 import { dbFor } from "../db-session";
+import { boundedDataRead } from "../data-read-bounds";
 import { Hono, type Context, type MiddlewareHandler } from "hono";
 import { dualWorkspaceAuth, type DualAuthVars } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
@@ -66,10 +67,15 @@ async function listGalleriesEnrichedHandler(c: Context<WorkspaceVars>) {
   if (!Number.isInteger(limit) || limit < 1 || limit > 100)
     throw new ValidationError("limit must be an integer from 1 to 100.");
   const name = c.get("workspaceName");
-  const page = await listGalleries(dbFor(c.env), name, {
-    limit,
-    cursor: decodeGalleryCursor(c.req.query("cursor")),
-  });
+  const page = await boundedDataRead(
+    c,
+    () =>
+      listGalleries(dbFor(c.env), name, {
+        limit,
+        cursor: decodeGalleryCursor(c.req.query("cursor")),
+      }),
+    { name: "d1_galleries_list" },
+  );
   return c.json({
     // The workspace record (not just the name) so `galleryListSummaries` can
     // resolve storage for each row's cover `previewUrl` (additive field).

--- a/apps/api/src/routes/workspace-usage.ts
+++ b/apps/api/src/routes/workspace-usage.ts
@@ -17,6 +17,7 @@ import { purgeExpiredObjects } from "../retention";
 import { getWorkspaceUsage } from "../usage";
 import { requireScope } from "../workspace";
 import { dbFor } from "../db-session";
+import { boundedDataRead } from "../data-read-bounds";
 
 function scoped(scope: Parameters<typeof requireScope>[0]): MiddlewareHandler<DualAuthVars> {
   return requireScope(scope) as unknown as MiddlewareHandler<DualAuthVars>;
@@ -42,7 +43,11 @@ const requireToken: MiddlewareHandler<DualAuthVars> = async (c, next) => {
 
 export const workspaceUsage = new Hono<DualAuthVars>()
   .get("/:workspace/usage", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
-    const snapshot = await getWorkspaceUsage(dbFor(c.env), c.get("workspaceName"));
+    const snapshot = await boundedDataRead(
+      c,
+      () => getWorkspaceUsage(dbFor(c.env), c.get("workspaceName")),
+      { name: "d1_workspace_usage" },
+    );
     const workspace = c.get("workspace");
     // `scopes` reflects the presented credential — for a session caller this
     // is the `FILE_SCOPES` set `dualWorkspaceAuth` grants (matching the


### PR DESCRIPTION
Closes #815.

## Problem

Auth's D1 dependency is already bounded (#805/#806); the data plane wasn't. During a D1 stall window, file listings, by-path/screenshots grouping, search, workspace usage summaries, and galleries could hang open-ended, riding out the full stall instead of failing fast.

## What changed

- `apps/api/src/data-read-bounds.ts`: a `boundedRead`/`boundedDataRead` helper that races a D1 read against `DATA_READ_TIMEOUT_MS` (default 8000ms; `"0"` disables the bound). On timeout it throws `ServiceUnavailableError` with `code: "data_unavailable"` — the same `AppError` → 503 mapping `session-auth.ts` already relies on for `auth_session_unavailable`, so no error-middleware change was needed. Built on `@uploads/observability`'s `timeOp`/`ServerTiming` (#814), so a bounded read still gets its Server-Timing entry and slow-op log, and a hung read logs as `outcome: "error"`. The timed-out promise is never left dangling into an unhandled rejection — same `.catch(() => {})` hygiene as `apps/auth/src/rate-limit.ts`'s DO-timeout race.
- Applied to the data-plane read routes:
  - Legacy bearer files router (`routes/files.ts`): listing metadata hydration, meta/name search, facets.
  - Canonical dual-auth files router (`routes/workspace-files.ts`): listing, search, facets, and the by-path/screenshots grouping route.
  - Workspace usage summary (`routes/usage.ts`, `routes/workspace-usage.ts`).
  - Galleries reads (`routes/galleries.ts`, `routes/workspace-galleries.ts`, `routes/public-galleries.ts`): list, by-reference, get, external references, public gallery detail/download — the mutation handlers that also read (e.g. version-check reads inside a write) are left unbounded, since the instruction is to bound reads, not writes.
- `DATA_READ_TIMEOUT_MS` added to `env.d.ts`.

## Deliberately not bounded

- Writes/mutations (create/update/delete on files, galleries, tokens, etc.) — an aborted write still needs to know whether it landed.
- Auth paths — already bounded via `AUTH_FETCH_TIMEOUT_MS` in `session-auth.ts`.
- `reconcile`/`purge-expired` maintenance ops and admin routes — out of scope for this issue's data-plane reads.

## Tests

New `apps/api/src/data-read-bounds.test.ts` (plain vitest, fake timers, no real waits): fast read passes through, a hung read trips a tiny injected deadline and rejects with the typed 503 (`data_unavailable`), the losing promise doesn't surface as an unhandled rejection, `DATA_READ_TIMEOUT_MS="0"` disables the bound, env var override is respected, and a control test confirms an unwrapped write-style call is never raced against the deadline.

`pnpm test` from repo root: 334 files / 5018 tests passing.