### PR TITLE
feat(api): slow-op Analytics Engine events + admin metrics panel

### DIFF
--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -1,8 +1,16 @@
 import { ForbiddenError, UnauthorizedError } from "@uploads/errors";
+import {
+  d1ExecMs,
+  ServerTiming,
+  serverTimingDisabled,
+  slowOpThresholdMs,
+  timeOp,
+} from "@uploads/observability";
 import type { MiddlewareHandler } from "hono";
 import { findActiveToken, isOperatorScope, touchTokenLastUsed } from "./auth-db";
 import { hexToBytes, sha256Hex, workspaceNameFromToken } from "./workspace";
 import { dbFor } from "./db-session";
+import { writeSlowOpPoint } from "./slow-op-analytics";
 
 const READ_METHODS = new Set(["GET", "HEAD"]);
 
@@ -40,9 +48,45 @@ export const adminAuth: MiddlewareHandler<{
   const workspace = token ? workspaceNameFromToken(token) : undefined;
   if (!workspace) throw new UnauthorizedError();
 
-  const record = await findActiveToken(dbFor(c.env), workspace, token);
+  // Instrumented per issue #814's noted follow-up: this bearer guard runs
+  // the same two D1 calls as workspace.ts's workspaceAuthWith, just not on
+  // the file-plane's highest-traffic path — same op names/shape so a
+  // "d1"/"d1_touch" slow-op line or Analytics Engine row means the same
+  // thing regardless of which guard produced it.
+  const thresholdMs = slowOpThresholdMs(c.env);
+  const timing = new ServerTiming();
+  let record: Awaited<ReturnType<typeof findActiveToken>>;
+  try {
+    record = await timeOp(() => findActiveToken(dbFor(c.env), workspace, token), {
+      name: "d1",
+      timing,
+      route: c.req.path,
+      thresholdMs,
+      onSlowOp: (event) => writeSlowOpPoint(c.env, event),
+    });
+  } finally {
+    if (!serverTimingDisabled(c.env)) {
+      const value = timing.header();
+      if (value) c.header("Server-Timing", value, { append: true });
+    }
+  }
   if (!record) throw new UnauthorizedError();
-  await touchTokenLastUsed(dbFor(c.env), record.id);
+  const touchTiming = new ServerTiming();
+  try {
+    await timeOp(() => touchTokenLastUsed(dbFor(c.env), record.id), {
+      name: "d1_touch",
+      timing: touchTiming,
+      route: c.req.path,
+      thresholdMs,
+      execMs: d1ExecMs,
+      onSlowOp: (event) => writeSlowOpPoint(c.env, event),
+    });
+  } finally {
+    if (!serverTimingDisabled(c.env)) {
+      const value = touchTiming.header();
+      if (value) c.header("Server-Timing", value, { append: true });
+    }
+  }
 
   // record.scopes is operator-token-or-file-token JSON; parseScopes (auth-db.ts)
   // is file-scope-only, so parse directly here and keep just the operator ones.

--- a/apps/api/src/analytics-engine.test.ts
+++ b/apps/api/src/analytics-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { breakdownQuery, fetchBreakdown } from "./analytics-engine";
+import { breakdownQuery, fetchBreakdown, fetchSlowOps, slowOpsQuery } from "./analytics-engine";
 
 function env(overrides: Record<string, unknown> = {}): Env {
   return {
@@ -146,5 +146,64 @@ describe("breakdownQuery non-finite days guard", () => {
 
   it("falls back to a 30-day window when days is Infinity", () => {
     expect(breakdownQuery("surface", Number.POSITIVE_INFINITY)).toContain("INTERVAL '30' DAY");
+  });
+});
+
+describe("slowOpsQuery", () => {
+  it("windows 24h as a 24-hour interval and 7d as a 168-hour interval", () => {
+    expect(slowOpsQuery("24h")).toContain("INTERVAL '24' HOUR");
+    expect(slowOpsQuery("7d")).toContain("INTERVAL '168' HOUR");
+  });
+
+  it("groups by op (blob1) and computes p50/p95 wall ms from double1", () => {
+    const sql = slowOpsQuery("24h");
+    expect(sql).toContain("blob1 AS op");
+    expect(sql).toContain("quantile(0.5)(double1) AS p50WallMs");
+    expect(sql).toContain("quantile(0.95)(double1) AS p95WallMs");
+    expect(sql).toContain("GROUP BY op");
+  });
+
+  it("scales the count by _sample_interval like breakdownQuery", () => {
+    expect(slowOpsQuery("24h")).toContain("_sample_interval");
+  });
+});
+
+describe("fetchSlowOps", () => {
+  it("returns rows on success", async () => {
+    const impl = jsonFetch({
+      data: [{ op: "d1", count: 12, p50WallMs: 1200, p95WallMs: 4500 }],
+    });
+    const result = await fetchSlowOps(env(), "24h", impl);
+    expect(result).toEqual({
+      available: true,
+      rows: [{ op: "d1", count: 12, p50WallMs: 1200, p95WallMs: 4500 }],
+    });
+  });
+
+  it("reports unavailable when the token is missing", async () => {
+    const result = await fetchSlowOps(
+      env({ ANALYTICS_API_TOKEN: undefined }),
+      "24h",
+      jsonFetch({}),
+    );
+    expect(result).toEqual({ available: false, reason: "not_configured" });
+  });
+
+  it("reports unavailable on a non-OK response rather than throwing", async () => {
+    const result = await fetchSlowOps(env(), "24h", jsonFetch({ errors: ["nope"] }, 403));
+    expect(result).toEqual({ available: false, reason: "query_failed" });
+  });
+
+  it("reports unavailable when the request throws", async () => {
+    const impl = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const result = await fetchSlowOps(env(), "24h", impl);
+    expect(result).toEqual({ available: false, reason: "query_failed" });
+  });
+
+  it("reports unavailable when the response body's data field is not an array", async () => {
+    const result = await fetchSlowOps(env(), "24h", jsonFetch({ data: "not-an-array" }));
+    expect(result).toEqual({ available: false, reason: "query_failed" });
   });
 });

--- a/apps/api/src/analytics-engine.ts
+++ b/apps/api/src/analytics-engine.ts
@@ -1,5 +1,8 @@
 /**
- * Analytics Engine read path for the operator metrics breakdown panel.
+ * Analytics Engine read path for the operator metrics panels: the upload
+ * breakdown (dataset `uploads_adoption`) and the slow-op trend (dataset
+ * `uploads_slow_ops`, issue #812 tier 3 — see `slow-op-analytics.ts` for the
+ * write side).
  *
  * AE has no read binding, so this goes over the Cloudflare SQL API with an
  * account token (ANALYTICS_API_TOKEN, an account token carrying "Account
@@ -7,7 +10,7 @@
  * from the local wrangler token in .env.
  *
  * EVERY failure mode returns `{ available: false, reason }` rather than
- * throwing: this panel is additive, and the D1-backed half of the metrics
+ * throwing: these panels are additive, and the D1-backed half of the metrics
  * page must keep working when AE is unconfigured or unreachable.
  *
  * Retention is 90 days — AE is for recent dimensional curiosity, never the
@@ -15,9 +18,11 @@
  */
 
 import { BLOB_ORDER } from "./adoption";
+import { SLOW_OP_BLOB_ORDER } from "./slow-op-analytics";
 
 const SQL_ENDPOINT = "https://api.cloudflare.com/client/v4/accounts";
 const DATASET = "uploads_adoption";
+const SLOW_OP_DATASET = "uploads_slow_ops";
 
 /**
  * Dimensions the breakdown panel lets an operator group by — a DELIBERATELY
@@ -110,6 +115,75 @@ export async function fetchBreakdown(
       return { available: false, reason: "query_failed" };
     }
     return { available: true, rows: (payload.data as BreakdownRow[] | undefined) ?? [] };
+  } catch {
+    return { available: false, reason: "query_failed" };
+  }
+}
+
+/** Windows the /admin-ui/metrics/slow-ops panel offers — 24 hours or 7 days. */
+export type SlowOpWindow = "24h" | "7d";
+
+const SLOW_OP_WINDOW_HOURS: Record<SlowOpWindow, number> = { "24h": 24, "7d": 168 };
+
+export interface SlowOpRow {
+  op: string;
+  count: number;
+  p50WallMs: number;
+  p95WallMs: number;
+}
+
+export type SlowOpsResult =
+  | { available: true; rows: SlowOpRow[] }
+  | { available: false; reason: string };
+
+const SLOW_OP_BLOB_COLUMN: Record<(typeof SLOW_OP_BLOB_ORDER)[number], string> = Object.fromEntries(
+  SLOW_OP_BLOB_ORDER.map((key, index) => [key, `blob${index + 1}`]),
+) as Record<(typeof SLOW_OP_BLOB_ORDER)[number], string>;
+
+/**
+ * Aggregates the `uploads_slow_ops` dataset (written by
+ * `slow-op-analytics.ts`'s `writeSlowOpPoint`) by op name: an event count
+ * (scaled by `_sample_interval` the same way `breakdownQuery` does) plus
+ * median/p95 wall-clock ms. `quantile(0.5|0.95)(...)` is Analytics Engine
+ * SQL's ClickHouse-derived quantile function — approximate, which is the
+ * right tradeoff for an operator trend panel.
+ */
+export function slowOpsQuery(window: SlowOpWindow): string {
+  const opColumn = SLOW_OP_BLOB_COLUMN.op;
+  const wallColumn = "double1";
+  const hours = SLOW_OP_WINDOW_HOURS[window];
+  return `SELECT ${opColumn} AS op,
+                 SUM(_sample_interval) AS count,
+                 quantile(0.5)(${wallColumn}) AS p50WallMs,
+                 quantile(0.95)(${wallColumn}) AS p95WallMs
+          FROM ${SLOW_OP_DATASET}
+          WHERE timestamp > NOW() - INTERVAL '${hours}' HOUR
+          GROUP BY op
+          ORDER BY count DESC
+          LIMIT 20`;
+}
+
+export async function fetchSlowOps(
+  env: Env,
+  window: SlowOpWindow,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SlowOpsResult> {
+  const account = (env as { CLOUDFLARE_ACCOUNT_ID?: string }).CLOUDFLARE_ACCOUNT_ID;
+  const token = (env as { ANALYTICS_API_TOKEN?: string }).ANALYTICS_API_TOKEN;
+  if (!account || !token) return { available: false, reason: "not_configured" };
+
+  try {
+    const res = await fetchImpl(`${SQL_ENDPOINT}/${account}/analytics_engine/sql`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: slowOpsQuery(window),
+    });
+    if (!res.ok) return { available: false, reason: "query_failed" };
+    const payload = (await res.json()) as { data?: unknown };
+    if (payload.data !== undefined && !Array.isArray(payload.data)) {
+      return { available: false, reason: "query_failed" };
+    }
+    return { available: true, rows: (payload.data as SlowOpRow[] | undefined) ?? [] };
   } catch {
     return { available: false, reason: "query_failed" };
   }

--- a/apps/api/src/routes/admin-ui-metrics.test.ts
+++ b/apps/api/src/routes/admin-ui-metrics.test.ts
@@ -399,3 +399,79 @@ describe("GET /admin-ui/metrics/breakdown", () => {
     }
   });
 });
+
+describe("GET /admin-ui/metrics/slow-ops", () => {
+  it("401s with no session", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = { AUTH: stubAuth(null), DB: db, REGISTRY: fakeKv().binding } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/slow-ops", {}, env);
+      expect(res.status).toBe(401);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("403s for a non-admin session", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(NON_ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/slow-ops", {}, env);
+      expect(res.status).toBe(403);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns 200 for an admin even when Analytics Engine is unconfigured", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/slow-ops", {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ available: false, reason: "not_configured" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("defaults the window to 24h and passes 7d through when requested", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+        CLOUDFLARE_ACCOUNT_ID: "acct-123",
+        ANALYTICS_API_TOKEN: "tok-abc",
+      } as unknown as Env;
+      const originalFetch = globalThis.fetch;
+      let capturedBody: string | undefined;
+      globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string | undefined;
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }) as typeof fetch;
+      try {
+        const res = await app().request("/admin-ui/metrics/slow-ops", {}, env);
+        expect(res.status).toBe(200);
+        expect(capturedBody).toContain("INTERVAL '24' HOUR");
+
+        await app().request("/admin-ui/metrics/slow-ops?window=7d", {}, env);
+        expect(capturedBody).toContain("INTERVAL '168' HOUR");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -21,7 +21,12 @@ import {
   resolvePreviewRecipient,
   sendEmailPreview,
 } from "../admin-email-preview";
-import { fetchBreakdown, type BreakdownDimension } from "../analytics-engine";
+import {
+  fetchBreakdown,
+  fetchSlowOps,
+  type BreakdownDimension,
+  type SlowOpWindow,
+} from "../analytics-engine";
 import {
   DEFAULT_ENROLLMENT_SECONDS,
   DEFAULT_TOKEN_SECONDS,
@@ -512,6 +517,17 @@ export const adminUi = new Hono<SessionVars>()
     const dimension = (c.req.query("dimension") ?? "surface") as BreakdownDimension;
     const days = Number(c.req.query("days") ?? 30);
     return c.json(await fetchBreakdown(c.env, dimension, Number.isFinite(days) ? days : 30));
+  })
+
+  // Slow-op trend (issue #812 tier 3): counts + p50/p95 wall ms per op name,
+  // from the `uploads_slow_ops` Analytics Engine dataset written by
+  // slow-op-analytics.ts's writeSlowOpPoint. Same additive/best-effort
+  // contract as the breakdown panel above — always 200, an unconfigured or
+  // unreachable Analytics Engine just renders as a panel message.
+  .get("/metrics/slow-ops", async (c) => {
+    const raw = c.req.query("window");
+    const window: SlowOpWindow = raw === "7d" ? "7d" : "24h";
+    return c.json(await fetchSlowOps(c.env, window));
   })
 
   // List every KV workspace joined with its org + member/invite counts.

--- a/apps/api/src/session-auth.test.ts
+++ b/apps/api/src/session-auth.test.ts
@@ -28,8 +28,8 @@ function appWith(_auth: Pick<Fetcher, "fetch">) {
     .onError((err, c) => respondError(c, err));
 }
 
-function env(auth: Pick<Fetcher, "fetch">, extra: Record<string, string> = {}) {
-  return { AUTH: auth, ...extra } as unknown as Env;
+function env(auth: Pick<Fetcher, "fetch">, extra: Record<string, string> = {}, slowOps?: unknown) {
+  return { AUTH: auth, ...(slowOps ? { SLOW_OPS: slowOps } : {}), ...extra } as unknown as Env;
 }
 
 describe("sessionAuth", () => {
@@ -248,6 +248,49 @@ describe("sessionAuth Server-Timing wiring (issue #812)", () => {
     expect(logSpy).toHaveBeenCalledTimes(1);
     const logged = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
     expect(logged).toMatchObject({ msg: "slow_op", op: "auth", outcome: "ok" });
+  });
+});
+
+describe("sessionAuth Analytics Engine slow-op sink (issue #812 tier 3)", () => {
+  function fakeAnalytics() {
+    const points: unknown[] = [];
+    return { points, binding: { writeDataPoint: (point: unknown) => points.push(point) } };
+  }
+
+  it("writes one AE point above the threshold, carrying op/route/wall/outcome", async () => {
+    const auth = stubAuth(() => new Response(JSON.stringify(null), { status: 200 }));
+    const analytics = fakeAnalytics();
+    await appWith(auth).request(
+      "/whoami",
+      {},
+      env(auth, { SLOW_OP_THRESHOLD_MS: "0" }, analytics.binding),
+    );
+    expect(analytics.points).toHaveLength(1);
+    expect(analytics.points[0]).toMatchObject({
+      indexes: ["auth"],
+      blobs: ["auth", "/whoami", "ok"],
+    });
+  });
+
+  it("writes nothing below the threshold", async () => {
+    const auth = stubAuth(() => new Response(JSON.stringify(null), { status: 200 }));
+    const analytics = fakeAnalytics();
+    await appWith(auth).request(
+      "/whoami",
+      {},
+      env(auth, { SLOW_OP_THRESHOLD_MS: "1000000" }, analytics.binding),
+    );
+    expect(analytics.points).toHaveLength(0);
+  });
+
+  it("is a graceful no-op when the SLOW_OPS binding is absent, even above the threshold", async () => {
+    const auth = stubAuth(() => new Response(JSON.stringify(null), { status: 200 }));
+    const res = await appWith(auth).request(
+      "/whoami",
+      {},
+      env(auth, { SLOW_OP_THRESHOLD_MS: "0" }),
+    );
+    expect(res.status).toBe(200);
   });
 });
 

--- a/apps/api/src/session-auth.ts
+++ b/apps/api/src/session-auth.ts
@@ -18,6 +18,7 @@ import {
   timeOp,
 } from "@uploads/observability";
 import type { MiddlewareHandler } from "hono";
+import { writeSlowOpPoint } from "./slow-op-analytics";
 
 /** Minimal shape of Better Auth's `get-session` response body. */
 export interface SessionUser {
@@ -88,6 +89,9 @@ export const sessionAuth: MiddlewareHandler<SessionVars> = async (c, next) => {
         timing,
         route: c.req.path,
         thresholdMs: slowOpThresholdMs(c.env),
+        // Issue #812 tier 3: fan a slow op out to the Analytics Engine trend
+        // dataset too, not just the structured log line.
+        onSlowOp: (event) => writeSlowOpPoint(c.env, event),
       }),
     );
   } finally {

--- a/apps/api/src/slow-op-analytics.test.ts
+++ b/apps/api/src/slow-op-analytics.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { SLOW_OP_BLOB_ORDER, writeSlowOpPoint } from "./slow-op-analytics";
+
+interface Captured {
+  blobs?: unknown[];
+  doubles?: number[];
+  indexes?: string[];
+}
+
+function fakeAnalytics() {
+  const points: Captured[] = [];
+  return {
+    points,
+    binding: { writeDataPoint: (point: Captured) => points.push(point) },
+  };
+}
+
+describe("writeSlowOpPoint", () => {
+  it("writes one point with op/route/outcome blobs and wall/exec doubles", () => {
+    const analytics = fakeAnalytics();
+    const env = { SLOW_OPS: analytics.binding } as unknown as Env;
+    writeSlowOpPoint(env, {
+      op: "d1",
+      route: "/v1/acme/files",
+      wallMs: 1234,
+      execMs: 0.4,
+      outcome: "ok",
+    });
+    expect(analytics.points).toHaveLength(1);
+    expect(analytics.points[0]?.indexes).toEqual(["d1"]);
+    expect(analytics.points[0]?.blobs).toEqual(["d1", "/v1/acme/files", "ok"]);
+    expect(analytics.points[0]?.doubles).toEqual([1234, 0.4]);
+  });
+
+  it("writes -1 for execMs when the event carries none (e.g. a .first() read or an error outcome)", () => {
+    const analytics = fakeAnalytics();
+    const env = { SLOW_OPS: analytics.binding } as unknown as Env;
+    writeSlowOpPoint(env, { op: "auth", wallMs: 4001, outcome: "error" });
+    expect(analytics.points[0]?.doubles).toEqual([4001, -1]);
+    // route is optional on SlowOpEvent — substitutes "" to keep blob
+    // positions stable, same convention as adoption.ts's writeAdoptionPoint.
+    expect(analytics.points[0]?.blobs).toEqual(["auth", "", "error"]);
+  });
+
+  it("is a no-op when the SLOW_OPS binding is absent", () => {
+    expect(() =>
+      writeSlowOpPoint({} as unknown as Env, { op: "d1", wallMs: 1, outcome: "ok" }),
+    ).not.toThrow();
+  });
+
+  it("never throws when the binding itself fails", () => {
+    const env = {
+      SLOW_OPS: {
+        writeDataPoint: () => {
+          throw new Error("AE down");
+        },
+      },
+    } as unknown as Env;
+    expect(() => writeSlowOpPoint(env, { op: "d1", wallMs: 1, outcome: "ok" })).not.toThrow();
+  });
+
+  it("derives the blob layout from SLOW_OP_BLOB_ORDER without shifting an ordinal", () => {
+    expect(SLOW_OP_BLOB_ORDER).toEqual(["op", "route", "outcome"]);
+  });
+});

--- a/apps/api/src/slow-op-analytics.ts
+++ b/apps/api/src/slow-op-analytics.ts
@@ -1,0 +1,59 @@
+/**
+ * Analytics Engine write side for the slow-op trend dataset (issue #812
+ * tier 3). One point per operation that `@uploads/observability`'s `timeOp`
+ * measured above `SLOW_OP_THRESHOLD_MS` — the same `SlowOpEvent` shape
+ * already logged as a structured `slow_op` line, fanned out to a second sink
+ * so /admin-ui/metrics can show a trend instead of an operator grepping logs.
+ *
+ * `@uploads/observability` deliberately has no Worker-binding dependency
+ * (packages/README.md convention), so it exposes `timeOp`'s `onSlowOp` hook
+ * instead of writing to Analytics Engine itself — every `timeOp` call site in
+ * this app passes `onSlowOp: (event) => writeSlowOpPoint(c.env, event)` to
+ * wire this up. apps/web has no `ANALYTICS`/`SLOW_OPS` binding and omits the
+ * hook entirely, so its slow-ops stay console-log-only (per issue #812's own
+ * scope note that apps/web has no such binding).
+ *
+ * Separate dataset from `uploads_adoption` (adoption.ts's `writeAdoptionPoint`)
+ * rather than a new blob column on it: the two datasets have unrelated
+ * shapes and cardinalities, and keeping them apart means neither's blob
+ * ordinal contract (adoption.ts's `BLOB_ORDER`) has to make room for the
+ * other's fields.
+ *
+ * Only op name, route, durations, and outcome are ever written — never a
+ * user id, token, key, or query text (same posture as `logSlowOp` in
+ * `@uploads/observability`, which already logs this same event to Workers
+ * Logs).
+ *
+ * `writeSlowOpPoint` never throws and never awaits — an absent binding
+ * (self-hosters, tests, local dev) is a silent no-op, same contract as
+ * `writeAdoptionPoint`.
+ */
+import type { SlowOpEvent } from "@uploads/observability";
+
+/**
+ * Blob positions are a contract with the SQL read path
+ * (`fetchSlowOps` in analytics-engine.ts) — Analytics Engine has no column
+ * names, only ordinals. Append new fields at the END; never reorder or
+ * remove, or historical rows change meaning retroactively.
+ */
+export const SLOW_OP_BLOB_ORDER = ["op", "route", "outcome"] as const;
+
+export function writeSlowOpPoint(env: Env, event: SlowOpEvent): void {
+  const analytics = (env as { SLOW_OPS?: AnalyticsEngineDataset }).SLOW_OPS;
+  if (!analytics) return;
+  try {
+    analytics.writeDataPoint({
+      // Sampling key: keeps one noisy op from crowding out the rest.
+      indexes: [event.op],
+      blobs: [event.op, event.route ?? "", event.outcome],
+      // execMs is -1 (not null/undefined — AE doubles can't carry either)
+      // when the underlying result carried no D1 meta (e.g. a `.first()`
+      // read, or the error-outcome path); the read side treats a negative
+      // value as "unknown" rather than a real duration.
+      doubles: [event.wallMs, event.execMs ?? -1],
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(JSON.stringify({ message: "slow-op analytics write failed", error: message }));
+  }
+}

--- a/apps/api/src/workspace-server-timing.test.ts
+++ b/apps/api/src/workspace-server-timing.test.ts
@@ -70,7 +70,11 @@ function appWith(db: unknown) {
 
 async function env(
   tokenHash: string,
-  opts: { touchDurationMs?: number; extra?: Record<string, string> } = {},
+  opts: {
+    touchDurationMs?: number;
+    extra?: Record<string, string>;
+    slowOps?: { writeDataPoint: (point: unknown) => void };
+  } = {},
 ) {
   return {
     REGISTRY: {
@@ -84,6 +88,7 @@ async function env(
       put: async () => undefined,
     },
     DB: fakeD1({ tokenHash, touchDurationMs: opts.touchDurationMs ?? 0.5 }),
+    ...(opts.slowOps ? { SLOW_OPS: opts.slowOps } : {}),
     ...opts.extra,
   } as unknown as Env;
 }
@@ -155,5 +160,51 @@ describe("workspaceAuth Server-Timing wiring (issue #812)", () => {
       await env(await sha256Hex(TOKEN)),
     );
     expect(res.status).toBe(401);
+  });
+});
+
+describe("workspaceAuth Analytics Engine slow-op sink (issue #812 tier 3)", () => {
+  it("writes AE points for both the d1 and d1_touch ops above the threshold", async () => {
+    const hash = await sha256Hex(TOKEN);
+    const points: unknown[] = [];
+    const res = await appWith(null).request(
+      "/acme/whoami",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      await env(hash, {
+        extra: { SLOW_OP_THRESHOLD_MS: "0" },
+        slowOps: { writeDataPoint: (point) => points.push(point) },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(points).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ indexes: ["d1"], blobs: ["d1", "/acme/whoami", "ok"] }),
+        expect.objectContaining({
+          indexes: ["d1_touch"],
+          blobs: ["d1_touch", "/acme/whoami", "ok"],
+        }),
+      ]),
+    );
+  });
+
+  it("writes nothing below the threshold", async () => {
+    const hash = await sha256Hex(TOKEN);
+    const points: unknown[] = [];
+    await appWith(null).request(
+      "/acme/whoami",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      await env(hash, { slowOps: { writeDataPoint: (point) => points.push(point) } }),
+    );
+    expect(points).toHaveLength(0);
+  });
+
+  it("is a graceful no-op when the SLOW_OPS binding is absent, even above the threshold", async () => {
+    const hash = await sha256Hex(TOKEN);
+    const res = await appWith(null).request(
+      "/acme/whoami",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      await env(hash, { extra: { SLOW_OP_THRESHOLD_MS: "0" } }),
+    );
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -18,6 +18,7 @@ import {
   type WorkspaceScope,
 } from "./auth-db";
 import { dbFor } from "./db-session";
+import { writeSlowOpPoint } from "./slow-op-analytics";
 
 export type { FileScope } from "./auth-db";
 
@@ -532,7 +533,13 @@ function workspaceAuthWith(
             record && name ? name : "__unknown__",
             token || "__unknown__",
           ),
-        { name: "d1", timing, route: c.req.path, thresholdMs },
+        {
+          name: "d1",
+          timing,
+          route: c.req.path,
+          thresholdMs,
+          onSlowOp: (event) => writeSlowOpPoint(c.env, event),
+        },
       );
     } finally {
       appendServerTiming(c, timing);
@@ -556,6 +563,7 @@ function workspaceAuthWith(
           route: c.req.path,
           thresholdMs,
           execMs: d1ExecMs,
+          onSlowOp: (event) => writeSlowOpPoint(c.env, event),
         });
       } finally {
         appendServerTiming(c, touchTiming);
@@ -661,6 +669,7 @@ export function workspaceGovernanceAuth(scope: WorkspaceScope): MiddlewareHandle
         timing,
         route: c.req.path,
         thresholdMs,
+        onSlowOp: (event) => writeSlowOpPoint(c.env, event),
       });
     } finally {
       appendServerTiming(c, timing);
@@ -688,6 +697,7 @@ export function workspaceGovernanceAuth(scope: WorkspaceScope): MiddlewareHandle
         route: c.req.path,
         thresholdMs,
         execMs: d1ExecMs,
+        onSlowOp: (event) => writeSlowOpPoint(c.env, event),
       });
     } finally {
       appendServerTiming(c, touchTiming);

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -142,6 +142,18 @@
       "binding": "ANALYTICS",
       "dataset": "uploads_adoption",
     },
+    // Slow-op trend dataset (issue #812 tier 3): one point per operation
+    // that crosses SLOW_OP_THRESHOLD_MS, written by
+    // src/slow-op-analytics.ts's writeSlowOpPoint via @uploads/observability's
+    // timeOp `onSlowOp` hook. Separate dataset (not a blob added to
+    // `uploads_adoption`) so its schema can evolve independently and the
+    // existing adoption breakdown's blob ordinals never have to shift.
+    // Purely additive: an absent binding is a silent no-op, same contract as
+    // ANALYTICS above.
+    {
+      "binding": "SLOW_OPS",
+      "dataset": "uploads_slow_ops",
+    },
   ],
   // Service binding to apps/auth (Phase 2, plan D1): forwards Cookie/
   // Authorization to GET /api/auth/get-session over the binding — no public
@@ -319,6 +331,10 @@
       {
         "binding": "ANALYTICS",
         "dataset": "uploads_adoption_preview",
+      },
+      {
+        "binding": "SLOW_OPS",
+        "dataset": "uploads_slow_ops_preview",
       },
     ],
     // Everything below repeats the production bindings verbatim — stateless,

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -38,6 +38,15 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
   [{ width: "96px" }, { width: "34px", num: true }, { width: "58px", num: true }],
   5,
 );
+const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
+  [
+    { width: "72px" },
+    { width: "34px", num: true },
+    { width: "58px", num: true },
+    { width: "58px", num: true },
+  ],
+  4,
+);
 ---
 
 <AdminLayout section="metrics">
@@ -389,6 +398,64 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
           </table>
         </div>
       </section>
+
+      <section class="metrics-section mt-2 pt-8 border-t border-border" id="slow-ops-panel">
+        <h3
+          class="m-0 mb-3.5 text-(length:--text-micro) font-semibold tracking-[0.04em] uppercase text-foreground"
+        >
+          Slow operations
+        </h3>
+        <p
+          class="admin-hint m-0 mb-3 text-muted-foreground text-(length:--text-meta) leading-[1.55]"
+        >
+          Ops that crossed the slow-op threshold (issue #812), from Analytics Engine. Wall-clock ms,
+          not D1 execution ms — a high count with a low p50 usually means round-trip latency, not a
+          slow query.
+        </p>
+        <div
+          class="metrics-range flex flex-wrap gap-2 mb-3"
+          role="group"
+          aria-label="Slow-op window"
+        >
+          <button
+            type="button"
+            class={`admin-btn ${ADMIN_BTN} aria-pressed:bg-primary aria-pressed:text-background aria-pressed:border-primary`}
+            data-slow-ops-window="24h"
+            aria-pressed="true">24 hours</button
+          >
+          <button
+            type="button"
+            class={`admin-btn ${ADMIN_BTN} aria-pressed:bg-primary aria-pressed:text-background aria-pressed:border-primary`}
+            data-slow-ops-window="7d"
+            aria-pressed="false">7 days</button
+          >
+        </div>
+        <div
+          id="slow-ops-status"
+          class="admin-status my-2 text-(length:--text-meta) text-muted-foreground"
+          role="status"
+          hidden
+        >
+        </div>
+        <div class="metrics-table-wrap mt-4 overflow-x-auto">
+          <table
+            class="admin-table w-full border-collapse text-(length:--text-meta) leading-[1.4]"
+            id="slow-ops-table"
+            aria-label="Slow operations"
+            aria-busy="true"
+          >
+            <thead>
+              <tr>
+                <th class={`keep ${ADMIN_TH}`} scope="col">Op</th>
+                <th class={`keep num ${ADMIN_TH_NUM}`} scope="col">Count</th>
+                <th class={`keep num ${ADMIN_TH_NUM}`} scope="col">p50 wall ms</th>
+                <th class={`keep num ${ADMIN_TH_NUM}`} scope="col">p95 wall ms</th>
+              </tr>
+            </thead>
+            <tbody set:html={slowOpsSkeleton} />
+          </table>
+        </div>
+      </section>
     </div>
   </section>
 
@@ -460,6 +527,8 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
       // run independently.
       let loadSeq = 0;
       let breakdownSeq = 0;
+      let slowOpsSeq = 0;
+      let slowOpsWindow: "24h" | "7d" = "24h";
 
       // The four genuine feature-adoption metrics (excludes `upload`/
       // `delete`, already shown elsewhere) mapped to their tile element ids.
@@ -898,6 +967,61 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
         }
       }
 
+      // Analytics Engine slow-op trend (issue #812 tier 3). Same
+      // additive/never-blocks-the-page contract as loadBreakdown above — an
+      // unconfigured/unreachable Analytics Engine renders as a panel message,
+      // not an error, and never blocks the D1-backed half of the page.
+      async function loadSlowOps(): Promise<void> {
+        const panelStatus = requireElement<HTMLElement>("#slow-ops-status", "admin");
+        const table = requireElement<HTMLElement>("#slow-ops-table", "admin");
+        const seq = ++slowOpsSeq;
+        try {
+          const res = await fetch(
+            `${apiOrigin}/admin-ui/metrics/slow-ops?window=${slowOpsWindow}`,
+            { credentials: "include", cache: "no-store" },
+          );
+          if (seq !== slowOpsSeq) return;
+          // Same reasoning as loadBreakdown: check res.ok before parsing, so
+          // a 401/5xx AppError body doesn't get misreported as "unavailable".
+          if (!res.ok) throw new Error(`request failed: ${res.status}`);
+          const body = (await res.json()) as
+            | {
+                available: true;
+                rows: { op: string; count: number; p50WallMs: number; p95WallMs: number }[];
+              }
+            | { available: false; reason: string };
+          if (seq !== slowOpsSeq) return;
+          const tableBody = table.querySelector<HTMLElement>("tbody");
+          if (!body.available) {
+            if (tableBody) tableBody.innerHTML = "";
+            table.removeAttribute("aria-busy");
+            panelStatus.hidden = false;
+            panelStatus.textContent =
+              body.reason === "not_configured"
+                ? "Analytics Engine is not configured. Set ANALYTICS_API_TOKEN to enable this panel."
+                : "Slow-op trend is temporarily unavailable.";
+            return;
+          }
+          panelStatus.hidden = true;
+          if (tableBody) {
+            tableBody.innerHTML = body.rows.length
+              ? body.rows
+                  .map(
+                    (row) =>
+                      `<tr class="admin-row"><td class="${ADMIN_TD}">${escapeHtml(row.op)}</td><td class="num ${ADMIN_TD_NUM}">${num(row.count)}</td><td class="num ${ADMIN_TD_NUM}">${num(Math.round(row.p50WallMs))}</td><td class="num ${ADMIN_TD_NUM}">${num(Math.round(row.p95WallMs))}</td></tr>`,
+                  )
+                  .join("")
+              : `<tr class="admin-row"><td colspan="4" class="muted ${ADMIN_TD}">No slow operations in this window.</td></tr>`;
+          }
+          table.removeAttribute("aria-busy");
+        } catch {
+          if (seq !== slowOpsSeq) return;
+          table.removeAttribute("aria-busy");
+          panelStatus.hidden = false;
+          panelStatus.textContent = "Slow-op trend is temporarily unavailable.";
+        }
+      }
+
       async function load(): Promise<void> {
         const seq = ++loadSeq;
         status.hidden = false;
@@ -915,6 +1039,7 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
           render(overview);
           status.hidden = true;
           void loadBreakdown();
+          void loadSlowOps();
         } catch {
           if (seq !== loadSeq) return;
           status.hidden = false;
@@ -931,6 +1056,19 @@ const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
       breakdownSelect.addEventListener("change", () => {
         void loadBreakdown();
       });
+
+      for (const button of document.querySelectorAll<HTMLButtonElement>("[data-slow-ops-window]")) {
+        button.addEventListener("click", () => {
+          const value = button.dataset.slowOpsWindow;
+          slowOpsWindow = value === "7d" ? "7d" : "24h";
+          for (const other of document.querySelectorAll<HTMLButtonElement>(
+            "[data-slow-ops-window]",
+          )) {
+            other.setAttribute("aria-pressed", other === button ? "true" : "false");
+          }
+          void loadSlowOps();
+        });
+      }
 
       for (const button of document.querySelectorAll<HTMLButtonElement>("[data-days]")) {
         button.addEventListener("click", () => {

--- a/packages/observability/src/index.test.ts
+++ b/packages/observability/src/index.test.ts
@@ -136,6 +136,58 @@ describe("timeOp", () => {
   });
 });
 
+describe("timeOp onSlowOp hook (issue #812 tier 3)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("calls onSlowOp with the same event shape as the log line when the op is slow", async () => {
+    const onSlowOp = vi.fn();
+    await timeOp(async () => "ok", {
+      name: "d1",
+      route: "/v1/files/x",
+      thresholdMs: 0,
+      onSlowOp,
+    });
+    expect(onSlowOp).toHaveBeenCalledTimes(1);
+    expect(onSlowOp).toHaveBeenCalledWith(
+      expect.objectContaining({ op: "d1", route: "/v1/files/x", outcome: "ok" }),
+    );
+  });
+
+  it("does not call onSlowOp for a fast op", async () => {
+    const onSlowOp = vi.fn();
+    await timeOp(async () => "fast", { name: "d1", thresholdMs: 1_000_000, onSlowOp });
+    expect(onSlowOp).not.toHaveBeenCalled();
+  });
+
+  it("calls onSlowOp on the error outcome path too, after rethrowing is set up", async () => {
+    const onSlowOp = vi.fn();
+    const err = new Error("boom");
+    await expect(
+      timeOp(
+        async () => {
+          throw err;
+        },
+        { name: "d1", thresholdMs: 0, onSlowOp },
+      ),
+    ).rejects.toThrow(err);
+    expect(onSlowOp).toHaveBeenCalledTimes(1);
+    expect(onSlowOp).toHaveBeenCalledWith(expect.objectContaining({ op: "d1", outcome: "error" }));
+  });
+
+  it("omitting onSlowOp is a no-op — it never becomes required", async () => {
+    await expect(timeOp(async () => "ok", { name: "d1", thresholdMs: 0 })).resolves.toBe("ok");
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("env helpers", () => {
   it("slowOpThresholdMs falls back to the default on unset/invalid values", () => {
     expect(slowOpThresholdMs(undefined)).toBe(DEFAULT_SLOW_OP_THRESHOLD_MS);

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -125,7 +125,11 @@ export function d1ExecMs(
   return typeof result?.meta?.duration === "number" ? result.meta.duration : undefined;
 }
 
-function logSlowOp(event: SlowOpEvent, thresholdMs: number): void {
+function logSlowOp(
+  event: SlowOpEvent,
+  thresholdMs: number,
+  onSlowOp?: (event: SlowOpEvent) => void,
+): void {
   if (event.wallMs < thresholdMs) return;
   // One structured line, values only — no query text, ids, or tokens.
   console.log(
@@ -138,6 +142,12 @@ function logSlowOp(event: SlowOpEvent, thresholdMs: number): void {
       outcome: event.outcome,
     }),
   );
+  // Optional sink (issue #812 tier 3): this package must not depend on any
+  // Worker binding, so it never writes to Analytics Engine itself — a caller
+  // that has an ANALYTICS binding (apps/api) passes `onSlowOp` to timeOp and
+  // does the write there. apps/web has no such binding and simply omits it,
+  // keeping web slow-ops console-log-only.
+  onSlowOp?.(event);
 }
 
 export interface TimeOpOptions<T> {
@@ -151,6 +161,15 @@ export interface TimeOpOptions<T> {
   thresholdMs?: number;
   /** Extracts execution ms from the resolved value, e.g. {@link d1ExecMs}. */
   execMs?: (result: T) => number | undefined;
+  /**
+   * Called with the same {@link SlowOpEvent} the structured log line carries,
+   * only when the op is slow (never on a fast op). Lets a caller with a
+   * binding this package can't depend on (e.g. apps/api's ANALYTICS Analytics
+   * Engine dataset) fan the event out to a second sink without this package
+   * knowing anything about Worker bindings. Never called for a fast op; called
+   * on both the success and error outcome paths, same as the log line.
+   */
+  onSlowOp?: (event: SlowOpEvent) => void;
 }
 
 /**
@@ -168,12 +187,20 @@ export async function timeOp<T>(fn: () => Promise<T>, opts: TimeOpOptions<T>): P
     const wallMs = Date.now() - start;
     const execMs = opts.execMs?.(result);
     opts.timing?.record({ name: opts.name, wallMs, execMs });
-    logSlowOp({ route: opts.route, op: opts.name, wallMs, execMs, outcome: "ok" }, thresholdMs);
+    logSlowOp(
+      { route: opts.route, op: opts.name, wallMs, execMs, outcome: "ok" },
+      thresholdMs,
+      opts.onSlowOp,
+    );
     return result;
   } catch (err) {
     const wallMs = Date.now() - start;
     opts.timing?.record({ name: opts.name, wallMs });
-    logSlowOp({ route: opts.route, op: opts.name, wallMs, outcome: "error" }, thresholdMs);
+    logSlowOp(
+      { route: opts.route, op: opts.name, wallMs, outcome: "error" },
+      thresholdMs,
+      opts.onSlowOp,
+    );
     throw err;
   }
 }


### PR DESCRIPTION
Part of #812

## Summary

Implements the deferred tier 3 of #812 (the Analytics Engine slow-op trend
dataset + an `/admin/metrics` panel), building on #814's `@uploads/observability`
`timeOp`/`ServerTiming` helper.

## Design: `onSlowOp` hook

`@uploads/observability` still has zero Worker-binding dependency, so it
doesn't write to Analytics Engine itself. `timeOp`'s options gained one
optional field:

```ts
onSlowOp?: (event: SlowOpEvent) => void;
```

Called with the same `SlowOpEvent` shape the structured `slow_op` log line
already carries — only when the op is slow, on both the success and error
outcome paths, never for a fast op. apps/api's four `timeOp` call sites
(`session-auth.ts`'s `sessionAuth`, `workspace.ts`'s `workspaceAuthWith` and
`workspaceGovernanceAuth`) now pass `onSlowOp: (event) => writeSlowOpPoint(c.env, event)`.
apps/web has no `ANALYTICS`/`SLOW_OPS` binding and simply omits the hook, so
web slow-ops stay console-log-only, as scoped in #812.

## `apps/api/src/slow-op-analytics.ts` (write side)

New `SLOW_OPS` Analytics Engine binding (separate dataset,
`uploads_slow_ops`/`uploads_slow_ops_preview` — not a new blob column on the
existing `uploads_adoption` dataset, so neither dataset's blob-ordinal
contract has to make room for the other). `writeSlowOpPoint(env, event)`:

- `indexes: [op]` (sampling key)
- `blobs: [op, route ?? "", outcome]`
- `doubles: [wallMs, execMs ?? -1]` (`-1` marks "no exec ms available", since
  AE doubles can't carry `null`/`undefined`)

Only op name, route, durations, and outcome are ever written — never a user
id, key, token, or query text. Never throws, never awaits; an absent binding
is a silent no-op, same contract as `adoption.ts`'s `writeAdoptionPoint`.

## `analytics-engine.ts` (read side)

Added `fetchSlowOps`/`slowOpsQuery` alongside the existing `fetchBreakdown`,
same additive contract: every failure mode (unconfigured, unreachable,
malformed) returns `{ available: false, reason }` rather than throwing.
Aggregates the `uploads_slow_ops` dataset by op name over a 24h or 7d window
(`quantile(0.5|0.95)(...)`, Analytics Engine SQL's ClickHouse-derived
quantile function, for p50/p95 wall ms; `SUM(_sample_interval)` for count,
same sampling-correction convention `breakdownQuery` already uses).

New `GET /admin-ui/metrics/slow-ops?window=24h|7d` route.

## `/admin/metrics` panel

New "Slow operations" section below the existing "Upload breakdown" panel:
a 24h/7d window toggle (same button pattern as the page's top date-range
selector) and a table of op / count / p50 wall ms / p95 wall ms. Same
loading/skeleton/error conventions as the breakdown panel — an unconfigured
or unreachable Analytics Engine renders as a panel message, never blocks the
rest of the page.

## `apps/api/src/admin.ts` follow-up (noted in #814)

Instrumented the `/admin/*` bearer guard's two D1 calls
(`findActiveToken`/`touchTokenLastUsed`) with `timeOp` + `ServerTiming`,
same op names/shape as `workspace.ts`'s `workspaceAuthWith` — a "d1" or
"d1_touch" slow-op line or Analytics Engine row means the same thing
regardless of which guard produced it.

## Tests

- `packages/observability`: `onSlowOp` called on a slow op (both outcomes),
  never called on a fast op, and remains fully optional (omitting it is a
  no-op, not a type error).
- `apps/api`: `slow-op-analytics.test.ts` (write side — one point with the
  expected shape, `-1` execMs substitution, no-op on an absent binding,
  never throws on a binding failure); `analytics-engine.test.ts`
  (`slowOpsQuery`/`fetchSlowOps` — window→hours, blob/column derivation,
  every failure mode); `session-auth.test.ts` and
  `workspace-server-timing.test.ts` gained an "Analytics Engine slow-op
  sink" describe block each (fake `SLOW_OPS.writeDataPoint`, asserting a
  slow op writes, a fast op doesn't, and a missing binding degrades
  gracefully); `admin-ui-metrics.test.ts` gained a `GET
  /admin-ui/metrics/slow-ops` describe block mirroring the existing
  breakdown-route tests (401/403/not_configured/window param).

`pnpm test` from repo root: **334 test files, 5033 tests, all passing.**
`apps/api` typechecks clean (`wrangler types && tsc --noEmit`).
`apps/web`'s `astro check` still can't run in this environment (Node 22;
needs 24 — same pre-existing gap #814 noted, not introduced by this PR); the
new script block was manually reviewed and follows the existing
`loadBreakdown` pattern closely.

## Scope notes

- apps/web has no `ANALYTICS`/`SLOW_OPS` binding — web slow-ops remain
  console-log-only, as #812 itself scoped.
- apps/auth is still not instrumented (no single D1/session choke point —
  same reasoning #814 gave).
