### PR TITLE
chore(dev): collapse local stack to a single named origin (#741)

### DIFF
--- a/apps/web/.dev.vars.example
+++ b/apps/web/.dev.vars.example
@@ -11,9 +11,9 @@
 # the ports used by standalone `pnpm dev:web` against loopback workers.
 #
 # NOTE: `pnpm dev:stack` runs through portless (see docs/local-dev.md) and
-# injects the named origins (https://auth.uploads.localhost etc.) via process
-# env at startup — it does not need this file. If you run the portless stack
-# and signed-in pages still resolve loopback/prod origins, a stale .dev.vars
-# here is the usual culprit.
+# injects the resolved auth/API upstream origins (plain loopback ports; only
+# web gets a named `.localhost` origin) via process env at startup — it does
+# not need this file. If you run the portless stack and signed-in pages still
+# resolve loopback/prod origins, a stale .dev.vars here is the usual culprit.
 UPLOADS_AUTH_ORIGIN=http://127.0.0.1:8788
 UPLOADS_API_ORIGIN=http://127.0.0.1:8787

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -18,26 +18,26 @@ pnpm typecheck        # wrangler types + tsc across workspaces
 
 ## Named local URLs (portless)
 
-`pnpm dev:stack` runs through [portless](https://npmjs.com/portless), so the
-stack gets stable named `.localhost` origins instead of bare ports:
+`pnpm dev:stack` runs through [portless](https://npmjs.com/portless), so WEB
+gets a stable named `.localhost` origin instead of a bare port:
 
-| Service | URL                              | Browser-visible?                                            |
-| ------- | -------------------------------- | ----------------------------------------------------------- |
-| web     | `https://uploads.localhost`      | yes — the only origin the browser talks to                  |
-| auth    | `https://auth.uploads.localhost` | no — internal upstream behind web's `/api/auth` proxy       |
-| api     | `https://api.uploads.localhost`  | not yet (phase D moves browser api traffic same-origin too) |
+| Service | URL                         | Browser-visible?                                      |
+| ------- | --------------------------- | ----------------------------------------------------- |
+| web     | `https://uploads.localhost` | yes — the only origin the browser talks to            |
+| auth    | plain loopback (dynamic)    | no — internal upstream behind web's `/api/auth` proxy |
+| api     | plain loopback (dynamic)    | no — internal upstream behind web's `/api` proxy      |
 
-All three processes still run — auth and api each get their own named origin
-— but since #731 phase C the browser only ever talks to `uploads.localhost`:
-auth is served same-origin through web's `/api/auth` proxy (mirroring
-production), so `auth.uploads.localhost` is now an internal upstream the web
-worker forwards to, not something a signed-in page's own requests hit
-directly. The Better Auth session cookie is host-only on `uploads.localhost`
-(no shared `.uploads.localhost` parent needed anymore — same shape as prod's
-host-only `uploads.sh` cookie), and signed-in pages (`/account/*`, `/admin/*`)
-just work in a local browser, including agent browser panels. In a linked git
-worktree, portless prefixes the branch name (`fix-ui.uploads.localhost` /
-`fix-ui.auth.uploads.localhost` for the internal upstream); nothing else
+Since #731 the browser only ever talks to `uploads.localhost`: auth and api
+are served same-origin through web's `/api/auth` and `/api` proxies (mirroring
+production), so they're internal upstreams the web worker forwards to, not
+origins a signed-in page's own requests hit. Because nothing browser-facing
+needs their hostnames, only WEB gets a portless-named origin; auth and api run
+as plain `127.0.0.1` loopback processes on ports assigned dynamically at boot
+(so concurrent worktree stacks don't collide). The Better Auth session cookie
+is host-only on `uploads.localhost` (same shape as prod's host-only
+`uploads.sh` cookie), and signed-in pages (`/account/*`, `/admin/*`) just work
+in a local browser, including agent browser panels. In a linked git worktree,
+portless prefixes the branch name (`fix-ui.uploads.localhost`); nothing else
 changes. `dev:stack` prints the resolved `previewUrl` when ready, and
 `pnpm dev:stack:check --json` reports it too.
 
@@ -76,9 +76,8 @@ the stack can run under a real TLD instead — on the shared
 
 ```bash
 PORTLESS_TLD=dev PORTLESS_NAME=uploads.local.buildinternet pnpm dev:stack
-# -> https://uploads.local.buildinternet.dev
-#    https://auth.uploads.local.buildinternet.dev
-#    https://api.uploads.local.buildinternet.dev
+# -> https://uploads.local.buildinternet.dev   (web; auth + api stay on plain
+#    loopback ports, same as the default `.localhost` mode)
 ```
 
 The zone is deliberately NOT under uploads.sh: even though prod's session
@@ -94,18 +93,17 @@ loopback on any machine, worktree prefixes included.
 
 The proxy only serves TLDs it was started with, so if yours runs with the
 default `.localhost` only, this mode auto-starts a second proxy on `:1355`
-and the URLs carry that port. For clean port-free URLs, run one proxy with
-both TLDs: `sudo portless proxy stop && sudo portless proxy start --https
+and the web URL carries that port. For a clean port-free URL, run one proxy
+with both TLDs: `sudo portless proxy stop && sudo portless proxy start --https
 --tld localhost --tld dev` (or bake it in with
 `portless service install --tld localhost --tld dev`).
 
-These origins are trusted by the auth worker outside production (https only).
+The web origin is trusted by the auth worker outside production (https only).
 Same-origin mode applies here too (`BETTER_AUTH_URL` is the web origin), so
-register the provider's redirect URI as
-`https://uploads.local.buildinternet.dev/api/auth/callback/<provider>` — NOT
-the `auth.` subdomain, even though that's where the auth worker's own process
-listens; `auth.uploads.local.buildinternet.dev` is now only the internal
-upstream web forwards `/api/auth/*` to.
+register the provider's redirect URI on the web origin:
+`https://uploads.local.buildinternet.dev/api/auth/callback/<provider>`. Auth
+has no real-TLD subdomain of its own — it's a plain loopback upstream web
+forwards `/api/auth/*` to, exactly as in the default mode.
 Note the `dev-session` bypass is intentionally unavailable in this mode —
 sign in through the real provider flow you're testing. GitHub accepts
 loopback callbacks, so day-to-day GitHub testing can stay on `PORTLESS=0`

--- a/scripts/dev-stack-common.mjs
+++ b/scripts/dev-stack-common.mjs
@@ -1,14 +1,18 @@
 /** Shared local-stack endpoints, cookie jar, fixture uploads, and smoke flow. */
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { createServer } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-// Portless (see the `portless` skill) gives the stack named HTTPS origins with
-// a shared `.uploads.localhost` cookie parent, so the Better Auth session
-// spans web/auth/api locally the same way `.uploads.sh` does in prod.
-// `PORTLESS=0` falls back to the legacy loopback ports (also the path for the
-// dev GitHub OAuth app, whose callback is pinned to 127.0.0.1:8788).
+// Portless (see the `portless` skill) gives WEB a stable named HTTPS origin
+// (`https://uploads.localhost`), the only origin the browser ever talks to.
+// Since #731 auth and api are internal upstreams reached through web's
+// same-origin `/api/auth` + `/api` proxies, so they need no hostname of their
+// own — they run as plain loopback ports (dynamically assigned here so
+// concurrent worktree stacks don't collide). `PORTLESS=0` falls back to the
+// legacy pinned ports (also the path for the dev GitHub OAuth app, whose
+// callback is pinned to 127.0.0.1:8788).
 export const USE_PORTLESS = process.env.PORTLESS !== "0";
 export const PORTLESS_BASE = process.env.PORTLESS_NAME || "uploads";
 
@@ -53,11 +57,33 @@ function portlessUrl(name) {
   return url;
 }
 
+/**
+ * Reserve a free loopback port for an internal upstream (auth/api). Binds to
+ * :0, reads the OS-assigned port, then releases it so wrangler can claim it a
+ * moment later. The small release→bind window is fine for a local dev stack
+ * and lets concurrent worktree stacks each get their own ports without a
+ * named portless route. `dev-stack.mjs` passes the resolved port to wrangler.
+ */
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+// Auth and api are internal upstreams (web proxies to them), so they need no
+// portless hostname — just a loopback port. In portless mode that port is
+// dynamic (concurrent worktree stacks stay collision-free); `PORTLESS=0` keeps
+// the legacy pinned ports. Only WEB gets a portless-named origin.
 export const AUTH_ORIGIN = USE_PORTLESS
-  ? portlessUrl(`auth.${PORTLESS_BASE}`)
+  ? `http://127.0.0.1:${await freePort()}`
   : "http://127.0.0.1:8788";
 export const API_ORIGIN = USE_PORTLESS
-  ? portlessUrl(`api.${PORTLESS_BASE}`)
+  ? `http://127.0.0.1:${await freePort()}`
   : "http://127.0.0.1:8787";
 export const WEB_ORIGIN = USE_PORTLESS ? portlessUrl(PORTLESS_BASE) : "http://127.0.0.1:4321";
 export const PREVIEW_URL = `${WEB_ORIGIN}/account/workspaces`;

--- a/scripts/dev-stack.mjs
+++ b/scripts/dev-stack.mjs
@@ -120,12 +120,16 @@ async function main() {
   );
   if (stopping) return;
 
-  // Portless mode: `portless run` assigns a free port via $PORT, registers the
-  // named HTTPS route (auto-starting the proxy), and prefixes worktree branch
-  // names — wrangler/astro just bind the assigned loopback port. PORTLESS=0
-  // keeps the legacy pinned ports (also the dev GitHub OAuth callback path).
+  // Only WEB gets a portless-named origin (`portless run` assigns a free port
+  // via $PORT, registers the named HTTPS route, and prefixes worktree branch
+  // names). Auth and api are internal upstreams web proxies to, so they run as
+  // plain loopback wrangler processes on the ports encoded in AUTH_ORIGIN /
+  // API_ORIGIN — dynamic in portless mode, the pinned 8788/8787 under
+  // PORTLESS=0 (also the dev GitHub OAuth callback path).
   const portlessWrap = (name, script) =>
     USE_PORTLESS ? ["exec", "portless", "run", "--name", name, "sh", "-c", script] : null;
+  const authPort = new URL(AUTH_ORIGIN).port;
+  const apiPort = new URL(API_ORIGIN).port;
 
   // #731 phase C: BETTER_AUTH_URL is the WEB origin, not this worker's own
   // AUTH_ORIGIN — the auth worker still binds/listens on AUTH_ORIGIN (see
@@ -133,66 +137,51 @@ async function main() {
   // Better Auth is configured as if it's served through web's same-origin
   // proxy, so deriveCookieDomain (auth.ts) emits a host-only cookie locally
   // the same way it will in production.
-  const authVars =
-    `--var LOCAL_STACK:true --var ENVIRONMENT:development ` +
-    `--var BETTER_AUTH_URL:${WEB_ORIGIN} --var WEB_ORIGIN:${WEB_ORIGIN}`;
+  //
   // --persist-to points auth's local D1 simulation at apps/api's own
   // .wrangler/state directory (issue #754 item 1 cutover): both workers now
   // bind the same database_id, and wrangler's local D1 state is otherwise
   // keyed by cwd, so without this each worker would get its own empty local
   // copy instead of sharing the one apps/api's migrate:d1:local populates.
-  const authPersist = "--persist-to ../api/.wrangler/state";
-  start(
-    "auth",
-    portlessWrap(
-      `auth.${PORTLESS_BASE}`,
-      `pnpm --filter @uploads/auth exec wrangler dev --local ${authPersist} --ip 127.0.0.1 --port "$PORT" ${authVars}`,
-    ) ?? [
-      "--filter",
-      "@uploads/auth",
-      "exec",
-      "wrangler",
-      "dev",
-      "--local",
-      "--persist-to",
-      "../api/.wrangler/state",
-      "--ip",
-      "127.0.0.1",
-      "--port",
-      "8788",
-      "--var",
-      "LOCAL_STACK:true",
-      "--var",
-      "ENVIRONMENT:development",
-      "--var",
-      `BETTER_AUTH_URL:${WEB_ORIGIN}`,
-      "--var",
-      `WEB_ORIGIN:${WEB_ORIGIN}`,
-    ],
-  );
+  start("auth", [
+    "--filter",
+    "@uploads/auth",
+    "exec",
+    "wrangler",
+    "dev",
+    "--local",
+    "--persist-to",
+    "../api/.wrangler/state",
+    "--ip",
+    "127.0.0.1",
+    "--port",
+    authPort,
+    "--var",
+    "LOCAL_STACK:true",
+    "--var",
+    "ENVIRONMENT:development",
+    "--var",
+    `BETTER_AUTH_URL:${WEB_ORIGIN}`,
+    "--var",
+    `WEB_ORIGIN:${WEB_ORIGIN}`,
+  ]);
   await waitFor(`${AUTH_ORIGIN}/health`, "auth");
   if (stopping) return;
 
-  start(
-    "api",
-    portlessWrap(
-      `api.${PORTLESS_BASE}`,
-      `pnpm --filter @uploads/api exec wrangler dev --local --ip 127.0.0.1 --port "$PORT" --var WEB_ORIGIN:${WEB_ORIGIN}`,
-    ) ?? [
-      "--filter",
-      "@uploads/api",
-      "exec",
-      "wrangler",
-      "dev",
-      "--local",
-      "--ip",
-      "127.0.0.1",
-      "--port",
-      "8787",
-      "--var",
-      `WEB_ORIGIN:${WEB_ORIGIN}`,
-    ],
-  );
+  start("api", [
+    "--filter",
+    "@uploads/api",
+    "exec",
+    "wrangler",
+    "dev",
+    "--local",
+    "--ip",
+    "127.0.0.1",
+    "--port",
+    apiPort,
+    "--var",
+    `WEB_ORIGIN:${WEB_ORIGIN}`,
+  ]);
   await waitFor(`${API_ORIGIN}/health`, "api");
   if (stopping) return;
 
@@ -248,10 +237,13 @@ async function main() {
 
   await seedFixtures(token);
   if (stopping) return;
-  // Real-TLD mode (e.g. *.local.uploads.sh for OAuth testing — see
-  // docs/local-dev.md) intentionally disables the dev-session bypass the
-  // smoke relies on; report ready without it.
-  const demoAvailable = /(\.localhost|^127\.0\.0\.1)$/.test(new URL(AUTH_ORIGIN).hostname);
+  // Real-TLD mode (e.g. *.uploads.local.buildinternet.dev for OAuth testing —
+  // see docs/local-dev.md) intentionally disables the dev-session bypass the
+  // smoke relies on; report ready without it. The bypass is gated on the WEB
+  // origin's shape (auth's localDemoEnabled → isLocalStackWebOrigin), so key
+  // off WEB_ORIGIN here — AUTH_ORIGIN is now always a bare loopback port and no
+  // longer signals the mode.
+  const demoAvailable = /(\.localhost|^127\.0\.0\.1)$/.test(new URL(WEB_ORIGIN).hostname);
   const smoke = demoAvailable ? await runSmoke() : "skipped (real-TLD mode has no dev-session)";
   if (stopping) return;
   console.log(JSON.stringify({ ready: true, previewUrl: PREVIEW_URL, smoke }));


### PR DESCRIPTION
Closes #741 (dev-only slice; the cookie/trusted-origins pruning is deferred — see below).

Follow-up to #731: now that the browser only ever talks to the web origin, auth and api don't need named portless hostnames. They're internal upstreams reached through web's same-origin `/api/auth` and `/api` proxies, so this collapses the local stack's origin topology.

## What changed

- **auth + api run as unnamed loopback wrangler processes.** In portless mode they get a dynamically-assigned free port (`scripts/dev-stack-common.mjs`'s new `freePort()`), so concurrent worktree stacks stay collision-free; under `PORTLESS=0` they keep the pinned `8788`/`8787`. Only **web** keeps a portless-named origin. The stack drops from **three `portless run` processes to one**.
- **`dev-stack.mjs`** launches auth/api with the port encoded in `AUTH_ORIGIN`/`API_ORIGIN` (no more `portlessWrap` branch for them; the raw-vs-portless arg duplication is gone).
- **dev-session smoke gating keys off `WEB_ORIGIN`, not `AUTH_ORIGIN`.** `AUTH_ORIGIN` is now always a bare loopback port, so it no longer signals real-TLD mode; the gate mirrors auth's own `localDemoEnabled` → `isLocalStackWebOrigin`.
- **`docs/local-dev.md`** sheds the three-origin topology; the real-TLD OAuth section now registers only the web redirect URI (auth/api have no real-TLD subdomain). Stale comment in `apps/web/.dev.vars.example` updated.

## Constraints kept

- `stack-raw` (pinned `127.0.0.1:4321/8787/8788`) still works — the signed-in in-app-browser recipe and the dev GitHub OAuth `:8788` callback path are unchanged.
- Real-TLD OAuth mode (`dev:stack:oauth`) still available; only the web origin is named there now.

## Deferred (coordinate with #731 phase E)

`deriveCookieDomain`'s `.localhost`/real-TLD branches and `trusted-origins.ts`'s portless regexes still govern prod's differing-host shape, so per the issue they're left until #731 phase E prunes the prod legacy branch — pruning happens once.

## Verification

- **Portless boot:** auth/api came up on dynamic loopback ports (`54907`/`54908`), a single `portless run` process (web), web served — no errors.
- **Raw boot:** full authenticated smoke passed — `dev-session` 200, `get-session` 200, `/me/workspaces` 200, `/me/workspaces/dev-demo/files` 200, plus the web same-origin proxy routes (`/api/auth/*`, `/api/*`) that `runSmoke` asserts.
