### PR TITLE
refactor(auth,cli): host-only cookie + trimmed trusted-origins; CLI same-origin auth default (#731 phase E, #741)

### DIFF
--- a/.changeset/cli-auth-url-same-origin.md
+++ b/.changeset/cli-auth-url-same-origin.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Default the CLI auth base to the same-origin app origin (`uploads.sh`) instead of the retired `auth.uploads.sh` subdomain. Since #731 the auth endpoints are served at `<origin>/api/auth`, so an `api.<domain>` base now derives its parent (`api.uploads.sh` → `uploads.sh`). Explicit `--auth-url` / `UPLOADS_AUTH_URL` still override, and `auth.uploads.sh` continues to serve during the transition, so pinned configs keep working.

--- a/apps/auth/src/auth.test.ts
+++ b/apps/auth/src/auth.test.ts
@@ -1,12 +1,6 @@
 import { drizzle } from "drizzle-orm/d1";
 import { describe, expect, it } from "vitest";
-import {
-  createAuth,
-  deriveCookieDomain,
-  isCliSessionUserAgent,
-  upsertGithubLogin,
-  type AuthEnv,
-} from "./auth";
+import { createAuth, isCliSessionUserAgent, upsertGithubLogin, type AuthEnv } from "./auth";
 import * as schema from "./schema";
 import { createFakeD1 } from "./test/fake-d1";
 
@@ -20,86 +14,6 @@ describe("isCliSessionUserAgent", () => {
     expect(isCliSessionUserAgent("Mozilla/5.0 (Macintosh) Chrome/120")).toBe(false);
     expect(isCliSessionUserAgent(null)).toBe(false);
     expect(isCliSessionUserAgent(undefined)).toBe(false);
-  });
-});
-
-describe("deriveCookieDomain", () => {
-  // Legacy (differing-host) derivation — pinned with an explicit webOrigin
-  // that differs from betterAuthUrl, so these keep covering the
-  // cross-subdomain-sharing behavior untouched by the #731 same-origin
-  // short-circuit below.
-  it("shares the whole apex host for a 2-label domain (no public-suffix leak)", () => {
-    expect(deriveCookieDomain("https://uploads.sh", "https://web.uploads.sh")).toBe(".uploads.sh");
-  });
-
-  it("strips the first label for a 3+-label host", () => {
-    expect(deriveCookieDomain("https://auth.uploads.sh", "https://uploads.sh")).toBe(".uploads.sh");
-    expect(deriveCookieDomain("https://api.auth.uploads.sh", "https://uploads.sh")).toBe(
-      ".auth.uploads.sh",
-    );
-  });
-
-  it("returns undefined for localhost", () => {
-    expect(deriveCookieDomain("http://localhost:8788")).toBeUndefined();
-  });
-
-  it("returns undefined for a bare *.localhost host (no shareable parent)", () => {
-    expect(deriveCookieDomain("http://auth.localhost:8788")).toBeUndefined();
-  });
-
-  it("anchors the real-TLD portless zone parent across worktree prefixes", () => {
-    expect(
-      deriveCookieDomain(
-        "https://auth.uploads.local.buildinternet.dev",
-        "https://uploads.local.buildinternet.dev",
-      ),
-    ).toBe(".uploads.local.buildinternet.dev");
-    expect(
-      deriveCookieDomain(
-        "https://fix-ui.auth.uploads.local.buildinternet.dev",
-        "https://uploads.local.buildinternet.dev",
-      ),
-    ).toBe(".uploads.local.buildinternet.dev");
-  });
-
-  it("shares the last-two-label parent for portless *.localhost hosts", () => {
-    expect(deriveCookieDomain("https://auth.uploads.localhost", "https://uploads.localhost")).toBe(
-      ".uploads.localhost",
-    );
-    expect(
-      deriveCookieDomain("http://auth.uploads.localhost:1355", "http://uploads.localhost:1355"),
-    ).toBe(".uploads.localhost");
-    expect(
-      deriveCookieDomain("https://fix-ui.auth.uploads.localhost", "https://uploads.localhost"),
-    ).toBe(".uploads.localhost");
-  });
-
-  it("returns undefined for an IP host", () => {
-    expect(deriveCookieDomain("http://127.0.0.1:8788")).toBeUndefined();
-  });
-
-  it("returns undefined for an invalid URL", () => {
-    expect(deriveCookieDomain("not-a-url")).toBeUndefined();
-  });
-
-  it("returns undefined when the URL is undefined", () => {
-    expect(deriveCookieDomain(undefined)).toBeUndefined();
-  });
-
-  // #731 Phase C: same-origin short-circuit.
-  it("returns undefined (host-only) when auth and web share a host", () => {
-    expect(deriveCookieDomain("https://uploads.sh", "https://uploads.sh")).toBeUndefined();
-    expect(
-      deriveCookieDomain("https://uploads.localhost", "https://uploads.localhost"),
-    ).toBeUndefined();
-  });
-
-  it("keeps cross-subdomain behavior when hosts differ", () => {
-    expect(deriveCookieDomain("https://auth.uploads.sh", "https://uploads.sh")).toBe(".uploads.sh");
-  });
-
-  it("ignores an unparseable webOrigin and falls through to legacy derivation", () => {
-    expect(deriveCookieDomain("https://auth.uploads.sh", "not-a-url")).toBe(".uploads.sh");
   });
 });
 

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -375,71 +375,6 @@ export async function upsertGithubLogin(
   }
 }
 
-/**
- * Derive the cookie domain for `advanced.crossSubDomainCookies` from
- * BETTER_AUTH_URL: `https://auth.uploads.sh` -> `.uploads.sh`, so a session
- * cookie set on the auth worker is visible on `uploads.sh` and
- * `api.uploads.sh` (D1's cross-subdomain requirement). Falls back to
- * `undefined` (cross-subdomain cookies disabled) for bare hosts/IPs/localhost
- * where there is no parent domain to share.
- *
- * A 2-label apex host (e.g. `uploads.sh`) shares the whole host instead of
- * stripping the first label — stripping would yield a bare public suffix
- * (`.sh`), which browsers reject as a cookie domain.
- *
- * #731 Phase C: `webOrigin` is the web app's origin (env.WEB_ORIGIN). When it
- * resolves to the SAME hostname as `betterAuthUrl` — auth is being served
- * through the web origin's same-origin proxy — the cookie needs no domain
- * scoping at all; a host-only cookie is both sufficient and strictly safer.
- * This short-circuits before all the legacy derivation below, which still
- * governs every differing-host case (auth.uploads.sh serving uploads.sh, the
- * portless dev stack, etc).
- */
-export function deriveCookieDomain(
-  betterAuthUrl: string | undefined,
-  webOrigin?: string,
-): string | undefined {
-  if (!betterAuthUrl) return undefined;
-  if (webOrigin) {
-    try {
-      if (new URL(betterAuthUrl).hostname === new URL(webOrigin).hostname) {
-        return undefined; // same-origin mode: host-only session cookie
-      }
-    } catch {
-      // Unparseable webOrigin — fall through to legacy derivation below.
-    }
-  }
-  let host: string;
-  try {
-    host = new URL(betterAuthUrl).hostname;
-  } catch {
-    return undefined;
-  }
-  if (host === "localhost" || /^\d{1,3}(\.\d{1,3}){3}$/.test(host)) {
-    return undefined;
-  }
-  if (host.endsWith(".localhost")) {
-    // Portless dev (see the `portless` skill): auth.uploads.localhost shares a
-    // session cookie with uploads.localhost via the `.<name>.localhost` parent.
-    // Always anchor on the last two labels so worktree-prefixed hosts
-    // (fix-ui.auth.uploads.localhost) land on the same parent as the web app.
-    // A bare `<name>.localhost` has no shareable parent — host-only cookie.
-    const parts = host.split(".");
-    return parts.length >= 3 ? "." + parts.slice(-2).join(".") : undefined;
-  }
-  const parts = host.split(".");
-  // Real-TLD portless zone (see trusted-origins.ts): anchor on
-  // `.uploads.local.buildinternet.dev` so worktree-prefixed hosts
-  // (fix-ui.auth.uploads.local.buildinternet.dev) share the same parent as
-  // the web app, mirroring the `.localhost` rule above.
-  if (host.endsWith(".uploads.local.buildinternet.dev")) {
-    return "." + parts.slice(-4).join(".");
-  }
-  if (parts.length < 2) return undefined;
-  if (parts.length === 2) return "." + host;
-  return "." + parts.slice(1).join(".");
-}
-
 function buildAuth(
   env: AuthEnv,
   signingSecret: string,
@@ -449,7 +384,6 @@ function buildAuth(
   const db = drizzle(env.DB, { schema });
   const betterAuthUrl = env.BETTER_AUTH_URL || "https://auth.uploads.sh";
   const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
-  const cookieDomain = deriveCookieDomain(betterAuthUrl, webOrigin);
   const isProduction = env.ENVIRONMENT === "production";
 
   return betterAuth({
@@ -725,12 +659,12 @@ function buildAuth(
       // D5/Phase 4: RFC 8628 device flow for `uploads login`.
       //
       // verificationUri MUST be an ABSOLUTE URL on the WEB origin — the /device
-      // approval page is served by apps/web (uploads.sh), not this worker
-      // (auth.uploads.sh). The plugin only prefixes baseURL when the value is
-      // relative, so a bare "/device" would resolve to
-      // https://auth.uploads.sh/device and 404. The session cookie is
-      // `.uploads.sh`-scoped (crossSubDomainCookies below) so it rides across
-      // the two subdomains.
+      // approval page is served by apps/web (uploads.sh), and since #731 auth
+      // is reached same-origin through web's `/api/auth` proxy. The plugin only
+      // prefixes baseURL when the value is relative, so a bare "/device" would
+      // resolve under the auth baseURL and 404. The session cookie is host-only
+      // on the web origin (crossSubDomainCookies disabled below); the /device
+      // page and the auth endpoints share that one origin, so it rides along.
       //
       // validateClient is fail-closed against the oauth_client table: the id
       // must be registered, enabled, and carry the device-code grant type
@@ -877,9 +811,10 @@ function buildAuth(
       ipAddress: {
         ipAddressHeaders: ["cf-connecting-ip", "x-forwarded-for"],
       },
-      crossSubDomainCookies: cookieDomain
-        ? { enabled: true, domain: cookieDomain }
-        : { enabled: false },
+      // #731: the session cookie is host-only on the web origin (uploads.sh)
+      // in every environment — auth is always served same-origin through web's
+      // `/api/auth` proxy, so it never needs a shared parent domain.
+      crossSubDomainCookies: { enabled: false },
     },
   });
 }

--- a/apps/auth/src/trusted-origins.test.ts
+++ b/apps/auth/src/trusted-origins.test.ts
@@ -37,37 +37,36 @@ describe("isTrustedOrigin", () => {
     expect(isTrustedOrigin("http://localhost:4321", prodEnv)).toBe(false);
   });
 
-  it("allows localhost with any port outside production", () => {
+  it("allows bare loopback with any port outside production", () => {
     const env = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
     expect(isTrustedOrigin("http://localhost:4321", env)).toBe(true);
     expect(isTrustedOrigin("http://127.0.0.1:8788", env)).toBe(true);
   });
 
-  it("allows portless *.localhost origins outside production", () => {
-    const env = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
-    expect(isTrustedOrigin("https://uploads.localhost", env)).toBe(true);
-    expect(isTrustedOrigin("https://auth.uploads.localhost", env)).toBe(true);
-    expect(isTrustedOrigin("https://fix-ui.auth.uploads.localhost", env)).toBe(true);
-    expect(isTrustedOrigin("http://uploads.localhost:1355", env)).toBe(true);
-  });
+  it("trusts the dev web origin via the static WEB_ORIGIN entry, not a regex", () => {
+    // #731/#741: portless `*.localhost` and real-TLD OAuth-testing origins are
+    // reached same-origin, so the exact web origin is passed as WEB_ORIGIN and
+    // covered by the static list — including any worktree prefix. Other
+    // `.localhost` / real-TLD hosts (e.g. the retired `auth.*` subdomains) are
+    // no longer implicitly trusted.
+    const portless = { WEB_ORIGIN: "https://uploads.localhost", ENVIRONMENT: "development" };
+    expect(isTrustedOrigin("https://uploads.localhost", portless)).toBe(true);
+    expect(isTrustedOrigin("https://auth.uploads.localhost", portless)).toBe(false);
 
-  it("allows the real-TLD portless OAuth zone outside production only", () => {
-    const env = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
+    const worktree = { WEB_ORIGIN: "https://fix-ui.uploads.localhost", ENVIRONMENT: "development" };
+    expect(isTrustedOrigin("https://fix-ui.uploads.localhost", worktree)).toBe(true);
+
     const zone = "uploads.local.buildinternet.dev";
-    expect(isTrustedOrigin(`https://${zone}`, env)).toBe(true);
-    expect(isTrustedOrigin(`https://auth.${zone}`, env)).toBe(true);
-    expect(isTrustedOrigin(`https://fix-ui.auth.${zone}`, env)).toBe(true);
-    expect(isTrustedOrigin(`http://auth.${zone}`, env)).toBe(false);
-    expect(isTrustedOrigin("https://evil-uploads.local.buildinternet.dev", env)).toBe(false);
-    // Never under uploads.sh — the local zone must not share prod's
-    // registrable domain (cookie scope).
-    expect(isTrustedOrigin("https://auth.local.uploads.sh", env)).toBe(false);
-    expect(isTrustedOrigin(`https://auth.${zone}`, prodEnv)).toBe(false);
+    const realTld = { WEB_ORIGIN: `https://${zone}`, ENVIRONMENT: "development" };
+    expect(isTrustedOrigin(`https://${zone}`, realTld)).toBe(true);
+    expect(isTrustedOrigin(`https://auth.${zone}`, realTld)).toBe(false);
   });
 
-  it("rejects unrelated hosts outside production", () => {
+  it("rejects unrelated and non-web `.localhost` hosts outside production", () => {
     const env = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
     expect(isTrustedOrigin("https://evil.example", env)).toBe(false);
+    expect(isTrustedOrigin("https://uploads.localhost", env)).toBe(false);
+    expect(isTrustedOrigin("https://uploads.local.buildinternet.dev", env)).toBe(false);
   });
 
   it("allows extra trusted origins from env in any environment", () => {

--- a/apps/auth/src/trusted-origins.ts
+++ b/apps/auth/src/trusted-origins.ts
@@ -1,27 +1,25 @@
 /**
- * Better Auth `trustedOrigins` + CORS allow-list, pure and unit-tested (see
- * plan D1/D3). Mirrors the shape of `~/Code/releases/workers/api/src/auth/index.ts`'s
- * `authTrustedOrigins`, trimmed to what uploads.sh actually needs: no glob
- * matching (we don't have a wildcard subdomain product surface yet), just an
- * explicit uploads.sh family + portless/localhost dev origins + an env escape
- * hatch.
+ * Better Auth `trustedOrigins` allow-list, pure and unit-tested. Mirrors the
+ * shape of `~/Code/releases/workers/api/src/auth/index.ts`'s
+ * `authTrustedOrigins`, trimmed to what uploads.sh actually needs: an explicit
+ * uploads.sh family (the web origin + env escape hatch), plus a plain-loopback
+ * allowance for local dev.
+ *
+ * #731/#741: the browser only ever talks to the WEB origin — auth is reached
+ * same-origin through web's `/api/auth` proxy in every environment — so the
+ * web origin (`env.WEB_ORIGIN`, passed through in dev too, including the
+ * portless `*.localhost` and real-TLD OAuth-testing origins and any worktree
+ * prefix) is always in the static list below and needs no regex. The old
+ * portless / real-TLD parent-domain regexes existed to trust the now-retired
+ * `auth.*` dev subdomains for cross-subdomain cookie sharing, which #731
+ * removed; only the loopback convenience remains.
  */
 
-const LOCALHOST_ORIGIN_RE = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
-// Portless dev (see the `portless` skill): named `*.localhost` origins, e.g.
-// https://uploads.localhost, https://auth.uploads.localhost, a worktree-
-// prefixed https://fix-ui.uploads.localhost, or the sudo-less proxy fallback
-// http://uploads.localhost:1355. `.localhost` resolves to loopback by spec.
-const PORTLESS_ORIGIN_RE = /^https?:\/\/[a-z0-9-]+(\.[a-z0-9-]+)*\.localhost(:\d+)?$/;
-// Real-TLD portless mode for OAuth providers that reject `*.localhost`
-// redirect URIs (see the `oauth` skill): PORTLESS_TLD=dev
-// PORTLESS_NAME=uploads.local.buildinternet serves
-// https://uploads.local.buildinternet.dev + subdomains, resolved to loopback
-// via public DNS. Deliberately on the shared infra domain (matching the
-// sibling repos) rather than under uploads.sh, so prod's `Domain=.uploads.sh`
-// session cookies never overlap the local zone. Non-production only.
-const LOCAL_BUILDINTERNET_ORIGIN_RE =
-  /^https:\/\/([a-z0-9-]+\.)*uploads\.local\.buildinternet\.dev$/;
+// Non-production only: bare loopback origins on any port. Lets a developer poke
+// the auth worker directly from a scratch tool on a different loopback port
+// than the web dev server. `.localhost` and real-TLD dev origins are covered by
+// the static WEB_ORIGIN entry instead (see the module docstring).
+const LOOPBACK_ORIGIN_RE = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 
 export type TrustedOriginsEnv = {
   WEB_ORIGIN?: string;
@@ -39,10 +37,10 @@ function extraTrustedOrigins(env: TrustedOriginsEnv): string[] {
 /**
  * Static origin list for Better Auth's `trustedOrigins` option: the web
  * origin (defaults to https://uploads.sh), plus any comma-separated extras
- * from `BETTER_AUTH_TRUSTED_ORIGINS`. Dev/localhost origins are matched
- * dynamically in {@link isTrustedOrigin} (regex, not enumerable), so they are
- * intentionally NOT included here — Better Auth accepts a function too, but
- * we keep this list for callers (e.g. CORS) that want a concrete array.
+ * from `BETTER_AUTH_TRUSTED_ORIGINS`. The non-prod loopback allowance is
+ * matched dynamically in {@link isTrustedOrigin} (regex, not enumerable), so
+ * it is intentionally NOT included here — Better Auth accepts a function too,
+ * but we keep this list for the no-Origin fallback and any array consumer.
  */
 export function authTrustedOrigins(env: TrustedOriginsEnv): string[] {
   const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
@@ -53,9 +51,5 @@ export function authTrustedOrigins(env: TrustedOriginsEnv): string[] {
 export function isTrustedOrigin(origin: string, env: TrustedOriginsEnv): boolean {
   if (authTrustedOrigins(env).includes(origin)) return true;
   if (env.ENVIRONMENT === "production") return false;
-  return (
-    LOCALHOST_ORIGIN_RE.test(origin) ||
-    PORTLESS_ORIGIN_RE.test(origin) ||
-    LOCAL_BUILDINTERNET_ORIGIN_RE.test(origin)
-  );
+  return LOOPBACK_ORIGIN_RE.test(origin);
 }

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -42,7 +42,7 @@ Options:
   --scopes <list>     Comma-separated scopes (default:
                       files:read,files:write,files:delete)
   --label <text>      Token label (default: this machine's hostname)
-  --auth-url <url>    Auth base (default: https://auth.uploads.sh)
+  --auth-url <url>    Auth base (default: https://uploads.sh)
   --no-open           Don't try to open a browser automatically
   --code <code>       Fallback: use a pre-existing enrollment code instead of
                       device login (visible in shell history)
@@ -181,10 +181,10 @@ function hasEnrollmentSource(parsed: ReturnType<typeof parseCommandArgs>): boole
 }
 
 /**
- * Auth worker base URL: explicit flag > UPLOADS_AUTH_URL > swap an `api.` host
- * label for `auth.` > the production default. Local multi-worker dev (where
- * auth runs on a different loopback port than the API) needs an explicit
- * --auth-url / UPLOADS_AUTH_URL.
+ * Auth base URL: explicit flag > UPLOADS_AUTH_URL > derived from the API base
+ * (`api.<domain>` → `<domain>`, same-origin auth since #731) > the production
+ * default. Local multi-worker dev (where auth runs on a different loopback port
+ * than the API) needs an explicit --auth-url / UPLOADS_AUTH_URL.
  */
 export function resolveAuthUrl(
   parsed: ReturnType<typeof parseCommandArgs>,

--- a/packages/uploads/src/config.ts
+++ b/packages/uploads/src/config.ts
@@ -28,18 +28,25 @@ export interface UploadsClientConfig {
   token: string;
 }
 
-/** Derive auth origin from an API base (`api.` → `auth.`), else production default. */
+/**
+ * Derive the auth base URL from an API base. Since #731 the auth endpoints are
+ * served same-origin on the app origin (`<origin>/api/auth`, web proxies to the
+ * auth worker), not an `auth.` subdomain — so the canonical `api.<domain>`
+ * shape maps to its parent (`api.uploads.sh` → `uploads.sh`). Falls back to the
+ * production origin. Local multi-worker dev, where auth listens on a different
+ * loopback port, still needs an explicit `--auth-url` / `UPLOADS_AUTH_URL`.
+ */
 export function authUrlFromApi(apiUrl: string): string {
   try {
     const url = new URL(apiUrl);
     if (url.hostname.startsWith("api.")) {
-      url.hostname = `auth.${url.hostname.slice(4)}`;
+      url.hostname = url.hostname.slice(4);
       return url.origin;
     }
   } catch {
     // fall through
   }
-  return "https://auth.uploads.sh";
+  return "https://uploads.sh";
 }
 
 export const DEFAULT_API_URL = "https://api.uploads.sh";

--- a/packages/uploads/src/session-cli-version.ts
+++ b/packages/uploads/src/session-cli-version.ts
@@ -63,7 +63,7 @@ export async function syncSessionCliVersion(opts: SyncCliVersionOptions = {}): P
   const authUrl = (
     opts.authUrl ??
     process.env.UPLOADS_AUTH_URL ??
-    (apiUrl ? authUrlFromApi(apiUrl) : "https://auth.uploads.sh")
+    (apiUrl ? authUrlFromApi(apiUrl) : "https://uploads.sh")
   ).replace(/\/$/, "");
 
   const controller = new AbortController();

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -147,15 +147,15 @@ describe("resolveAuthUrl", () => {
     );
   });
 
-  it("swaps an api. host label for auth.", () => {
+  it("maps an api. host to its same-origin parent", () => {
     expect(resolveAuthUrl(parseCommandArgs([]), "https://api.uploads.sh")).toBe(
-      "https://auth.uploads.sh",
+      "https://uploads.sh",
     );
   });
 
   it("falls back to the production default for non-api hosts", () => {
     expect(resolveAuthUrl(parseCommandArgs([]), "http://localhost:8787")).toBe(
-      "https://auth.uploads.sh",
+      "https://uploads.sh",
     );
   });
 });

--- a/packages/uploads/test/session-cli-version.test.ts
+++ b/packages/uploads/test/session-cli-version.test.ts
@@ -56,7 +56,7 @@ describe("syncSessionCliVersion", () => {
     ).toBe(true);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
-    expect(call[0]).toBe("https://auth.example.test/api/auth/update-session");
+    expect(call[0]).toBe("https://example.test/api/auth/update-session");
     expect(JSON.parse(String(call[1].body))).toEqual({ cliVersion: "1.2.3" });
     expect(readFileSync(cachePath, "utf8").trim()).toBe("1.2.3");
 


### PR DESCRIPTION
The safe, behavior-preserving slice of **#731 phase E** — also completing the pruning **#741** deferred to it. The production-behavior flips are intentionally **held for the soak** (see below).

Every environment now serves auth same-origin on the web origin (`BETTER_AUTH_URL === WEB_ORIGIN` in prod, preview, and dev), which makes several legacy shapes dead code.

## Changes (all behavior-preserving / forward-compatible)

### Host-only session cookie — `deriveCookieDomain` removed
- Prod has emitted a host-only cookie since phase C (the same-origin short-circuit always fires); the `.localhost` / real-TLD / apex / label-strip body below it was unreachable in every live config.
- Removed `deriveCookieDomain` + the `cookieDomain` local; `advanced.crossSubDomainCookies` is now unconditionally `{ enabled: false }`. Device-flow comment updated.

### `trusted-origins.ts` — trimmed to the minimal dev set (#741)
- Dropped `PORTLESS_ORIGIN_RE` and the real-TLD `LOCAL_BUILDINTERNET_ORIGIN_RE`. Their justification was cross-subdomain cookie sharing with the `auth.*` dev subdomains, which #731 (and #818's stack collapse) retired.
- Same-origin dev **and** real-TLD OAuth mode reach auth as `WEB_ORIGIN`, which is always in the static list — so no regex is needed for them. A bare-loopback allowance stays for non-prod direct-poke convenience.
- Production trust is unchanged (only `WEB_ORIGIN` + `BETTER_AUTH_TRUSTED_ORIGINS`).

### CLI `--auth-url` default → same-origin app origin (changeset: `@buildinternet/uploads` patch)
- `authUrlFromApi`: `api.<domain>` now derives its parent (`api.uploads.sh` → `uploads.sh`), fallback `https://uploads.sh`. Explicit `--auth-url` / `UPLOADS_AUTH_URL` still override, and `auth.uploads.sh` keeps serving during the transition, so pinned configs are unaffected.

## Held for the soak (~Aug 28) — separate PR(s)

These change live prod behavior and need the phase-D→E soak to confirm zero legacy traffic first:
- Retire the api `/me/*` **credentialed CORS** surface (`apps/api/src/index.ts` `adminUiCors`) — browser now BFFs through web.
- Drop **MCP legacy-issuer** acceptance (`apps/mcp/src/index.ts` `LEGACY_OAUTH_ISSUER`).
- Optional **`__Host-`** cookie prefix (forces a one-time re-login).

## Verification

- `pnpm --filter @uploads/auth test` — 321 pass.
- `pnpm --filter @buildinternet/uploads test` — 1311 pass.
- Typecheck clean (auth + CLI).
- `pnpm dev:stack:raw` full smoke passes: session mint, `get-session`, `/me/*`, and the web same-origin proxies all work with the host-only cookie and pruned trusted-origins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI authentication now defaults to the main uploads app using same-origin authentication.
  * API-based configurations automatically use the corresponding web app origin.
  * Explicit authentication URL overrides and legacy authentication domains remain supported.

* **Bug Fixes**
  * Improved development-origin validation for localhost and loopback addresses.
  * Authentication cookies are now restricted to the active web host for improved isolation.
  * Updated device-flow authentication to use same-origin approval and session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->