### PR TITLE
refactor(mcp): drop legacy pre-flip OAuth issuer acceptance (#731 phase E)

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -61,19 +61,6 @@ function authOriginOf(env: Env): string {
   return (env.AUTH_ORIGIN || "https://uploads.sh").replace(/\/+$/, "");
 }
 
-/**
- * The pre-#731-phase-C issuer — tokens minted before the cookie/issuer flip
- * still carry this `iss` and remain valid until they expire naturally.
- * `oauthAuth` accepts both this and the current issuer so those tokens keep
- * working through the migration window; RFC 9728 discovery
- * (`respondProtectedResource`) advertises ONLY the current issuer — new
- * authorizations always mint against the new one. Remove this constant (and
- * the array in `oauthAuth`) once phase E confirms no live legacy-issued
- * tokens remain (they carry a bounded expiry, so this is safe to drop after
- * one token lifetime has passed since the flip).
- */
-const LEGACY_OAUTH_ISSUER = "https://auth.uploads.sh/api/auth";
-
 function bearerFrom(header: string | undefined): string {
   // RFC 9110 §11.1: auth scheme names are case-insensitive.
   return header?.match(/^Bearer +(.+)$/i)?.[1] ?? "";
@@ -103,10 +90,11 @@ async function oauthAuth(
 ): Promise<Response | null> {
   const currentIssuer = `${authOriginOf(c.env)}/api/auth`;
   const verified = await verifyOAuthJwt(token, {
-    // Accept both the current and the legacy pre-flip issuer during the
-    // #731 phase C migration window — see LEGACY_OAUTH_ISSUER's comment.
-    // De-duped for the (non-prod) case where they happen to coincide.
-    issuer: [...new Set([currentIssuer, LEGACY_OAUTH_ISSUER])],
+    // #731 phase E: the pre-flip `auth.uploads.sh/api/auth` issuer is no longer
+    // accepted. Legacy access tokens (bounded ~1h expiry) have long since aged
+    // out since the phase-C flip; a client presenting a stale one gets a 401,
+    // re-discovers the current issuer via RFC 9728, and re-authorizes.
+    issuer: currentIssuer,
     audience: OAUTH_AUDIENCES,
   });
   if (!verified) return invalidTokenChallenge(c.req.url);

--- a/apps/mcp/src/oauth.ts
+++ b/apps/mcp/src/oauth.ts
@@ -122,10 +122,9 @@ export interface VerifiedOAuthToken {
 
 export interface OAuthJwtConfig {
   /**
-   * Expected `iss` — `${AUTH_ORIGIN}/api/auth`. jose does an exact match
-   * against any of the given values when an array is passed (used during
-   * the #731 phase C migration window to accept both the current and the
-   * legacy pre-flip issuer — see `LEGACY_OAUTH_ISSUER` in index.ts).
+   * Expected `iss` — `${AUTH_ORIGIN}/api/auth`. jose does an exact match, or
+   * accepts any value when an array is passed (a general capability; the #731
+   * phase-C dual-issuer window that used it was retired in phase E).
    */
   issuer: string | string[];
   /** Acceptable `aud` values — this resource's canonical URIs. */
@@ -137,9 +136,8 @@ export interface OAuthJwtConfig {
 }
 
 /**
- * JWKS lives at the primary (current) issuer's origin — the signing key
- * material is shared regardless of which origin minted a given token, so a
- * legacy-issuer token still verifies against the current JWKS endpoint.
+ * JWKS lives at the (primary) issuer's origin. When an array is passed the
+ * first entry is treated as primary.
  */
 function defaultJwksUrl(issuer: string | string[]): string {
   const primary = Array.isArray(issuer) ? issuer[0] : issuer;

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1824,10 +1824,10 @@ describe("OAuth JWT bearer (issue #224)", () => {
     );
   });
 
-  // #731 phase C (C-1): the issuer moved from auth.uploads.sh to uploads.sh —
-  // tokens minted under the old issuer before the flip must keep working
-  // until they expire naturally.
-  it("accepts a JWT minted under the legacy pre-flip issuer (auth.uploads.sh)", async () => {
+  // #731 phase E: the pre-flip auth.uploads.sh issuer is no longer accepted —
+  // legacy tokens have aged out, so a stale one now 401s and the client
+  // re-discovers the current issuer.
+  it("401s for a JWT minted under the retired legacy issuer (auth.uploads.sh)", async () => {
     const { env } = await makeEnv();
     const jwt = await signOAuthToken(
       { sub: "user-1", workspace: "test-ws", workspaces: ["test-ws"], scope: "files:read" },
@@ -1839,7 +1839,8 @@ describe("OAuth JWT bearer (issue #224)", () => {
       jwt,
       "https://agents.uploads.sh/mcp",
     );
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain('error="invalid_token"');
   });
 
   it("still accepts a JWT minted under the current issuer (uploads.sh)", async () => {


### PR DESCRIPTION
Prod flip from **#731 phase E**. The MCP resource server accepted both the current `uploads.sh/api/auth` issuer and the pre-flip `auth.uploads.sh/api/auth` issuer, so OAuth access tokens minted before the phase-C cookie/issuer flip kept verifying. This drops the legacy acceptance.

## Why it's safe now
- OAuth access tokens use the plugin default (~1h) expiry; the phase-C flip landed **2026-08-21**, so no legacy-issued access token is still live.
- Refreshes already re-mint under the current issuer, and RFC 9728 discovery (`respondProtectedResource`) only ever advertised the current issuer.
- Worst case for a stale token: a `401` + `invalid_token` challenge → the client re-discovers the current issuer and re-authorizes once. Trivial for the current MCP user base.

## Change
- Removed `LEGACY_OAUTH_ISSUER` and the dual-issuer array in `oauthAuth`; `verifyOAuthJwt` now checks only the current issuer.
- Updated the now-stale dual-issuer comments in `oauth.ts` (the `issuer` array capability itself is retained as a general feature).
- Flipped the unit test that asserted legacy-issuer acceptance to assert a `401` + `invalid_token` challenge.

## Verification
`pnpm --filter @uploads/mcp test` — 120 pass. Typecheck clean.

Part of #731 phase E. Sibling flip (api credentialed CORS retirement) is a separate PR; `__Host-` cookie prefix remains parked.
