### PR TITLE
refactor(api): retire credentialed cross-origin CORS, token-only at the edge (#731 phase E)

### DIFF
--- a/apps/api/src/cors.test.ts
+++ b/apps/api/src/cors.test.ts
@@ -1,25 +1,26 @@
 /**
- * CORS mounting on the root app. The subtle ones are `/v1/workspaces` and
- * `/v1/tokens`: both are authenticated by session COOKIE (self-serve creation
- * and developer token mint from the signed-in console at WEB_ORIGIN), so
- * their preflight must be credentialed — without
- * `Access-Control-Allow-Credentials` the browser drops the request entirely
- * ("Failed to fetch"). The rest of `/v1/*` is bearer-token-authenticated and
- * deliberately stays uncredentialed.
+ * CORS mounting on the root app. #731 phase E: the api exposes a single
+ * UNCREDENTIALED browser CORS surface. Every cookie-authenticated route
+ * (`/me`, `/admin-ui`, and the cookie-authed `/v1/workspaces`+`/v1/tokens`
+ * self-serve/mint surfaces) is reached by the browser same-origin through web's
+ * `/api` proxy over the service binding, so none of them advertise
+ * `Access-Control-Allow-Credentials` any more. The web origin (and, outside
+ * production, dev loopback) is still reflected for token-authenticated
+ * cross-origin calls; PATCH/DELETE stay allowed.
  */
 import { describe, expect, it } from "vitest";
 import { app } from "./index";
 
 const env = {} as unknown as Env;
 
-function preflight(path: string) {
+function preflight(path: string, method = "POST") {
   return app.request(
     `https://api.uploads.sh${path}`,
     {
       method: "OPTIONS",
       headers: {
         Origin: "https://uploads.sh",
-        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Method": method,
         "Access-Control-Request-Headers": "content-type",
       },
     },
@@ -28,103 +29,77 @@ function preflight(path: string) {
 }
 
 describe("CORS preflights from the web origin", () => {
-  it("credentials the cookie-authenticated /v1/workspaces route", async () => {
+  it("reflects the web origin, uncredentialed, on the /v1/workspaces route", async () => {
     const res = await preflight("/v1/workspaces");
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
 
-  it("credentials the #249 lifecycle subroutes, DELETE included", async () => {
-    const del = await app.request(
-      "https://api.uploads.sh/v1/workspaces/acme",
-      {
-        method: "OPTIONS",
-        headers: {
-          Origin: "https://uploads.sh",
-          "Access-Control-Request-Method": "DELETE",
-        },
-      },
-      env,
-    );
-    expect(del.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  it("keeps DELETE on the #249 lifecycle subroutes, uncredentialed", async () => {
+    const del = await preflight("/v1/workspaces/acme", "DELETE");
+    expect(del.headers.get("Access-Control-Allow-Credentials")).toBeNull();
     expect(del.headers.get("Access-Control-Allow-Methods")).toContain("DELETE");
 
     const restore = await preflight("/v1/workspaces/acme/restore");
-    expect(restore.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(restore.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
+    expect(restore.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
 
-  it("credentials the cookie-authenticated /v1/tokens mint surface", async () => {
+  it("reflects the /v1/tokens mint surface, uncredentialed", async () => {
     const res = await preflight("/v1/tokens");
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
 
-    const issued = await app.request(
-      "https://api.uploads.sh/v1/tokens/issued",
-      {
-        method: "OPTIONS",
-        headers: {
-          Origin: "https://uploads.sh",
-          "Access-Control-Request-Method": "GET",
-        },
-      },
-      env,
-    );
-    expect(issued.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    const issued = await preflight("/v1/tokens/issued", "GET");
+    expect(issued.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
 
-  it("keeps bearer-token /v1 routes uncredentialed", async () => {
+  it("keeps bearer-token /v1 routes reflected and uncredentialed", async () => {
     const res = await preflight("/v1/acme/files");
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
     expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
 
-  it("keeps the cookie-authenticated /me surface credentialed", async () => {
-    const res = await preflight("/me/workspaces");
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
-  });
-
-  it("allows PATCH on admin-ui (workspace limits + oauth client edits)", async () => {
-    const res = await app.request(
-      "https://api.uploads.sh/admin-ui/workspaces/ryan/limits",
-      {
-        method: "OPTIONS",
-        headers: {
-          Origin: "https://uploads.sh",
-          "Access-Control-Request-Method": "PATCH",
-          "Access-Control-Request-Headers": "content-type",
-        },
-      },
-      env,
-    );
+  it("reflects the /me surface, uncredentialed", async () => {
+    const res = await preflight("/me/workspaces", "GET");
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+  });
+
+  it("allows PATCH on admin-ui (workspace limits + oauth client edits), uncredentialed", async () => {
+    const res = await preflight("/admin-ui/workspaces/ryan/limits", "PATCH");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
     expect(res.headers.get("Access-Control-Allow-Methods")).toContain("PATCH");
   });
 
-  it("allows PATCH on /me (member role + file visibility)", async () => {
+  it("allows PATCH on /me (member role + file visibility), uncredentialed", async () => {
+    const res = await preflight("/me/workspaces/acme/members/user_1", "PATCH");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("PATCH");
+  });
+
+  it("rejects a non-web origin", async () => {
     const res = await app.request(
-      "https://api.uploads.sh/me/workspaces/acme/members/user_1",
+      "https://api.uploads.sh/me/workspaces",
       {
         method: "OPTIONS",
         headers: {
-          Origin: "https://uploads.sh",
-          "Access-Control-Request-Method": "PATCH",
-          "Access-Control-Request-Headers": "content-type",
+          Origin: "https://evil.example",
+          "Access-Control-Request-Method": "GET",
         },
       },
       env,
     );
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
-    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("PATCH");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 });
 
 // Loopback origins (http://localhost[:port], http://127.0.0.1[:port]) are
-// reflected on credentialed CORS for local dev convenience, but that
-// reflection must not survive in production. A local page
-// loading a victim's uploads.sh session cookie could otherwise make
-// credentialed cross-origin reads against /admin-ui, /me, and the
-// session-cookie-authenticated /v1/workspaces surface.
+// reflected outside production for local dev convenience, but never in
+// production — a local page holding a victim's uploads.sh session cookie must
+// not be reflected. (With credentialed CORS now retired the cookie can't ride
+// a cross-origin request at all, but keep the origin gate as defense in depth.)
 describe("loopback origin reflection is gated by ENVIRONMENT", () => {
   function loopbackPreflight(path: string, env: Record<string, unknown>) {
     return app.request(
@@ -140,39 +115,24 @@ describe("loopback origin reflection is gated by ENVIRONMENT", () => {
     );
   }
 
-  it("does not reflect localhost on /me in production", async () => {
-    const res = await loopbackPreflight("/me/workspaces", { ENVIRONMENT: "production" });
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
-  });
+  it.each(["/me/workspaces", "/v1/workspaces", "/v1/tokens"])(
+    "does not reflect localhost on %s in production",
+    async (path) => {
+      const res = await loopbackPreflight(path, { ENVIRONMENT: "production" });
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    },
+  );
 
-  it("still allows the configured WEB_ORIGIN on /me in production", async () => {
-    const res = await app.request(
-      "https://api.uploads.sh/me/workspaces",
-      {
-        method: "OPTIONS",
-        headers: {
-          Origin: "https://uploads.sh",
-          "Access-Control-Request-Method": "GET",
-        },
-      },
-      { ENVIRONMENT: "production" } as unknown as Env,
-    );
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
-  });
+  it.each(["/me/workspaces", "/v1/workspaces", "/v1/tokens"])(
+    "reflects localhost on %s (uncredentialed) when ENVIRONMENT is unset (dev)",
+    async (path) => {
+      const res = await loopbackPreflight(path, {});
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
+      expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+    },
+  );
 
-  it("reflects localhost on /me when ENVIRONMENT is unset (dev)", async () => {
-    const res = await loopbackPreflight("/me/workspaces", {});
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
-  });
-
-  it("does not reflect localhost on /v1/workspaces in production", async () => {
-    const res = await loopbackPreflight("/v1/workspaces", { ENVIRONMENT: "production" });
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
-  });
-
-  it("still allows the configured WEB_ORIGIN on /v1/workspaces in production", async () => {
+  it("still reflects the configured WEB_ORIGIN in production", async () => {
     const res = await app.request(
       "https://api.uploads.sh/v1/workspaces",
       {
@@ -185,23 +145,6 @@ describe("loopback origin reflection is gated by ENVIRONMENT", () => {
       { ENVIRONMENT: "production" } as unknown as Env,
     );
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
-  });
-
-  it("reflects localhost on /v1/workspaces when ENVIRONMENT is unset (dev)", async () => {
-    const res = await loopbackPreflight("/v1/workspaces", {});
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
-  });
-
-  it("does not reflect localhost on /v1/tokens in production", async () => {
-    const res = await loopbackPreflight("/v1/tokens", { ENVIRONMENT: "production" });
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
-  });
-
-  it("reflects localhost on /v1/tokens when ENVIRONMENT is unset (dev)", async () => {
-    const res = await loopbackPreflight("/v1/tokens", {});
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -47,41 +47,30 @@ function devOriginAllowed(origin: string, env: { ENVIRONMENT?: string }): boolea
   return /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
 }
 
-// Lets the browser console on the web origin (and local dev) call the token-
-// authenticated endpoints. CORS is not the security boundary — bearer tokens
-// are — but without these headers the preflight for Authorization fails.
+// The single browser CORS surface for the api. Reflects the web origin (and
+// dev loopback) for token-authenticated cross-origin calls. CORS is not the
+// security boundary — bearer tokens are — but without these headers a
+// preflight for Authorization fails.
+//
+// #731 phase E: this is UNCREDENTIALED (no `Access-Control-Allow-Credentials`).
+// Since the same-origin migration (phases B–D) the browser reaches every
+// cookie-authenticated surface (`/me`, `/admin-ui`, and the cookie-authed
+// `/v1/workspaces`+`/v1/tokens`) through the web origin's `/api` proxy over the
+// service binding — never a credentialed cross-origin request to api directly.
+// So api no longer advertises credentialed CORS: it is token-only at the edge,
+// which also removes the localhost-cookie-theft vector the old credentialed
+// reflection had to guard against. Non-browser callers (the CLI) send
+// `Authorization: Bearer` and are unaffected — CORS does not apply to them.
 const consoleCors = cors({
   origin: (origin, c) => {
     if (origin === (c.env.WEB_ORIGIN || "https://uploads.sh")) return origin;
     if (devOriginAllowed(origin, c.env)) return origin;
     return null;
   },
-  // PATCH is used by browser console clients for file metadata + galleries.
+  // PATCH: file metadata + galleries, admin workspace limits / OAuth client
+  // edits, /me member role + file-visibility updates.
   allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
   allowHeaders: ["Authorization", "Content-Type"],
-  maxAge: 86400,
-});
-
-// /admin-ui/* and /me/* are both session-cookie-authenticated (see
-// src/session-auth.ts — requireAdminUser for /admin-ui, requireSessionUser
-// only for /me), so unlike consoleCors above they must be credentialed —
-// same treatment as apps/auth's authCors for the web origin's cross-origin
-// browser calls (uploads.sh -> api.uploads.sh). The `/admin/*` surface is
-// bearer-token-only and deliberately untouched by CORS credentials — it
-// accepts either the static ADMIN_TOKEN break-glass secret or a D1-backed
-// operator token minted via POST /v1/tokens with an admin:* scope (#257).
-const adminUiCors = cors({
-  origin: (origin, c) => {
-    if (origin === (c.env.WEB_ORIGIN || "https://uploads.sh")) return origin;
-    if (devOriginAllowed(origin, c.env)) return origin;
-    return null;
-  },
-  credentials: true,
-  // PATCH: admin workspace limits, OAuth client edits, /me member role +
-  // file-visibility updates. Omitting it fails the browser preflight with
-  // "Method PATCH is not allowed by Access-Control-Allow-Methods".
-  allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
-  allowHeaders: ["Content-Type"],
   maxAge: 86400,
 });
 
@@ -123,24 +112,15 @@ export const app = new Hono<WorkspaceVars>()
       { "Cache-Control": "public, max-age=300", "Access-Control-Allow-Origin": "*" },
     ),
   )
+  // One uncredentialed CORS surface across the api (#731 phase E). The
+  // cookie-authenticated routes (`/admin-ui/*`, `/me/*`, and the
+  // `/v1/workspaces`+`/v1/tokens` self-serve/mint surfaces) are reached by the
+  // browser same-origin through web's `/api` proxy over the service binding, so
+  // they no longer need — and no longer get — credentialed cross-origin CORS.
   .use("/admin/*", consoleCors)
-  .use("/admin-ui/*", adminUiCors)
-  .use("/me/*", adminUiCors)
-  // `/v1/workspaces` (lifecycle) and `/v1/tokens` (mint / issued list /
-  // own-token revoke) are the `/v1/*` surfaces authenticated by session
-  // COOKIE, so their CORS must be credentialed like /me/* — the uncredentialed
-  // consoleCors preflight makes the browser drop the request entirely
-  // ("Failed to fetch"). Everything else under /v1/* stays uncredentialed:
-  // bearer tokens are the boundary there. CLI callers of `/v1/tokens` still
-  // send `Authorization: Bearer <session>`; CORS does not apply to them.
-  .use("/v1/*", (c, next) =>
-    (c.req.path === "/v1/workspaces" ||
-      c.req.path.startsWith("/v1/workspaces/") ||
-      c.req.path === "/v1/tokens" ||
-      c.req.path.startsWith("/v1/tokens/")
-      ? adminUiCors
-      : consoleCors)(c, next),
-  )
+  .use("/admin-ui/*", consoleCors)
+  .use("/me/*", consoleCors)
+  .use("/v1/*", consoleCors)
   .route("/admin", admin)
   .route("/admin-ui", adminUi)
   .route("/me", me)


### PR DESCRIPTION
The api-side prod flip from **#731 phase E**: api becomes **token-only at the browser edge**. It no longer advertises credentialed cross-origin CORS (`Access-Control-Allow-Credentials`); one uncredentialed `consoleCors` surface now fronts every route.

## ⚠️ Merge gate
Merging deploys to prod. Before merging, glance at Analytics/dashboard for any **credentialed cross-origin** requests to `api.uploads.sh` on `/me/*`, `/admin-ui/*`, `/v1/workspaces*`, `/v1/tokens*` (i.e. a browser `Origin` header + cookie, not `Authorization: Bearer`). Expected: ~zero. If clean, safe to merge; the only thing this can affect is a stale, pre-phase-D browser tab still calling api cross-origin with a cookie.

## Why it's safe
Traced every browser credentialed call:
- The account/admin shell **and** the `/f/` file page make their `credentials:"include"` calls to **same-origin `/api/*`** (`resolveSignedInOrigins().apiOrigin === "/api"`), which web proxies to api over the service binding — **no CORS involved**.
- `console.astro` hits absolute `api.uploads.sh` but with **uncredentialed** `Authorization: Bearer` → served by the uncredentialed surface, unaffected.
- `invite.astro` uses `credentials:"omit"`.
- The CLI is a non-browser client (`Authorization: Bearer`); CORS never applied to it.

So no live browser code makes a credentialed cross-origin call to api. Retiring the credentialed reflection also **removes the localhost-cookie-theft vector** the old CORS tests guarded against (a local page holding a victim's `uploads.sh` cookie can no longer ride a credentialed cross-origin read).

## Change
- Deleted the credentialed `adminUiCors`; `/admin-ui/*`, `/me/*`, and `/v1/*` now use the one uncredentialed `consoleCors` (which already allows `Authorization` + `PATCH`/`DELETE`). The `/v1/*` conditional collapses.
- Rewrote `cors.test.ts` to the new contract: web origin still reflected (uncredentialed), loopback still gated to non-prod, no `Allow-Credentials` anywhere.

## Verification
- `pnpm --filter @uploads/api test` — 2207 pass.
- Raw dev-stack smoke passes: session mint, `/me/*`, and the web same-origin `/api` proxies all work with the credentialed CORS retired.

Part of #731 phase E (sibling: #821 MCP legacy-issuer drop). `__Host-` cookie prefix remains parked.
