### PR TITLE
feat(storage): surface broken BYO-bucket credentials, with a prompted hosted-storage fallback

### DIFF
--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -31,6 +31,7 @@ import {
   recordContentHash,
 } from "./content-hash";
 import { recordPrActivityFromMetadata } from "./github-pr-activity";
+import { noteStorageFailure, noteStorageSuccess } from "./storage-health";
 import { DEFAULT_MAX_UPLOAD_BYTES, inspectUpload, resolveUploadPolicy } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
 import {
@@ -557,6 +558,11 @@ export async function putObject(
     // Settle the in-flight donor lookup so no D1 read outlives the request. It
     // resolves to `{}` rather than rejecting, so this only discards a result.
     await inheritedPromise;
+    // Credential-shaped failures flag the active BYO lane unhealthy (issue
+    // #826) so the settings page and the signed-in banner can say so before
+    // the next person notices a broken upload. Filters non-credential
+    // failures and shared lanes itself, and never throws.
+    await noteStorageFailure(env, workspaceName, ws, err);
     // Nothing was stored — return both reservations to the budget.
     await releaseUploadsSafe(dbFor(env), workspaceName, 1);
     await releaseStorageBytesSafe(dbFor(env), workspaceName, reservedBytes, undefined, {
@@ -564,6 +570,11 @@ export async function putObject(
     });
     throw err;
   }
+
+  // The write landed, so whatever flagged this lane unhealthy is over —
+  // clear it (issue #826). Returns without touching KV when nothing is
+  // flagged, which is every upload on a working workspace.
+  await noteStorageSuccess(env, workspaceName, ws);
 
   // Usage accounting first: the object is already durably stored above, so
   // the ledger must be updated regardless of whether the metadata batch

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -883,6 +883,7 @@ describe("workspace storage admin panel (issue #583 Task 3.3)", () => {
       verifiedAt: undefined,
       configuredBy: null,
       lanes: [],
+      health: { ok: true },
     });
   });
 

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -2743,6 +2743,7 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
         byoBucketEnabled: false,
         bucket: "uploads-default",
         lanes: [],
+        health: { ok: true },
       });
     });
 
@@ -2770,6 +2771,7 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
         configuredAt: "2026-01-01T00:00:00.000Z",
         verifiedAt: "2026-01-01T00:00:00.000Z",
         lanes: [],
+        health: { ok: true },
       });
     });
   });

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -85,6 +85,7 @@ import { resolveRepoCommentOptions, workspaceCommentDefaults } from "../repo-com
 import { sealCredentialFieldsStrict } from "../secrets";
 import { selfServeWorkspaceRecord } from "../self-serve-defaults";
 import type { SessionVars } from "../session-auth";
+import { clearStorageHealthFields } from "../storage-health";
 import { isSharedLane, storageConfig as laneConfig } from "../storage";
 import { getWorkspaceUsage } from "../usage";
 import {
@@ -593,6 +594,11 @@ export async function storagePutHandler(c: Context<SettingsVars>) {
         next.storageConfiguredAt = nowIso;
         next.storageConfiguredBy = userId;
         next.storageAccessKeyIdLast4 = accessKeyIdLast4;
+        // The rotation just passed the full verify pipeline against these
+        // exact credentials, so whatever flagged this lane unhealthy (issue
+        // #826) is demonstrably fixed — clear the badge and the banner now
+        // rather than waiting for the next upload to prove it again.
+        clearStorageHealthFields(next);
         return next;
       }
 
@@ -669,7 +675,11 @@ export async function storageActivateHandler(c: Context<SettingsVars>) {
 
   const nowIso = new Date().toISOString();
   let verifiedAt = target.verifiedAt;
-  if (!isSharedLane(target) && isLaneVerifyStale(target.verifiedAt)) {
+  // A lane carrying a health flag (issue #826) is re-verified however fresh
+  // its `verifiedAt` looks: the flag is later evidence than the stamp, and
+  // `promoteLane` clears the flag unconditionally — so without this a broken
+  // lane could be switched back to and silently read as healthy again.
+  if (!isSharedLane(target) && (isLaneVerifyStale(target.verifiedAt) || target.unhealthyAt)) {
     const result = await verifyLaneForActivate(c.env, target);
     if (!result.ok) {
       return c.json(result, 422);

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -18,7 +18,7 @@ import {
   type StorageVerifyResult,
 } from "../storage-verify";
 import { storageBudgetApplies } from "../budget";
-import { storageHealth, type StorageHealth } from "../storage-health";
+import { healthFromFields, storageHealth, type StorageHealth } from "../storage-health";
 import { reconcileWorkspaceUsage } from "../reconcile";
 import { isSharedLane, storageConfig } from "../storage";
 import type { StorageLane, WorkspaceRecord } from "../workspace";
@@ -56,6 +56,14 @@ export interface StorageLaneStatus {
   accessKeyIdLast4?: string;
   /** Set when this lane was demoted while flagged unhealthy (issue #826). */
   unhealthyAt?: string;
+  /**
+   * The same normalized health the active lane reports, for a lane that was
+   * demoted while flagged (issue #826). Carries the validated code and its
+   * sentence, so a client can say *what* broke on a fallback lane rather than
+   * only that something did. Absent on a healthy lane — no `{ ok: true }`
+   * noise on every entry.
+   */
+  health?: StorageHealth;
 }
 
 export interface StorageStatusResponse {
@@ -82,7 +90,10 @@ export interface StorageStatusResponse {
 
 /** Masked projection of one `StorageLane` for `storageStatusResponse` — never a credential value. */
 function laneStatus(lane: StorageLane): StorageLaneStatus {
+  const health = healthFromFields(lane.unhealthyAt, lane.unhealthyCode);
   return {
+    // Only present on an actually-flagged lane; see `StorageLaneStatus.health`.
+    ...(health.ok ? {} : { health }),
     laneId: lane.id,
     role: lane.lastActiveAt ? "fallback" : "standby",
     mode: isSharedLane(lane) ? "shared" : "byo",

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -18,6 +18,7 @@ import {
   type StorageVerifyResult,
 } from "../storage-verify";
 import { storageBudgetApplies } from "../budget";
+import { storageHealth, type StorageHealth } from "../storage-health";
 import { reconcileWorkspaceUsage } from "../reconcile";
 import { isSharedLane, storageConfig } from "../storage";
 import type { StorageLane, WorkspaceRecord } from "../workspace";
@@ -53,6 +54,8 @@ export interface StorageLaneStatus {
   lastActiveAt?: string;
   accountIdMasked?: string;
   accessKeyIdLast4?: string;
+  /** Set when this lane was demoted while flagged unhealthy (issue #826). */
+  unhealthyAt?: string;
 }
 
 export interface StorageStatusResponse {
@@ -69,6 +72,12 @@ export interface StorageStatusResponse {
   activeLaneId?: string;
   /** Every other configured lane: saved-but-never-used configs and demoted former actives. */
   lanes: StorageLaneStatus[];
+  /**
+   * Whether the *active* lane's storage is currently working (issue #826).
+   * Always `{ ok: true }` in shared mode — a platform-binding failure is not
+   * a workspace-level state and never asks a workspace to fix anything.
+   */
+  health: StorageHealth;
 }
 
 /** Masked projection of one `StorageLane` for `storageStatusResponse` — never a credential value. */
@@ -83,6 +92,7 @@ function laneStatus(lane: StorageLane): StorageLaneStatus {
     lastActiveAt: lane.lastActiveAt,
     accountIdMasked: maskTrailing(lane.accountId),
     accessKeyIdLast4: lane.storageAccessKeyIdLast4,
+    unhealthyAt: lane.unhealthyAt,
   };
 }
 
@@ -116,6 +126,7 @@ export function storageStatusResponse(
     jurisdiction: byo ? record.jurisdiction : undefined,
     activeLaneId: record.storageLaneId,
     lanes: (record.storageLanes ?? []).map(laneStatus),
+    health: byo ? storageHealth(record) : { ok: true },
   };
 }
 

--- a/apps/api/src/storage-health.test.ts
+++ b/apps/api/src/storage-health.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import { fakeRegistry } from "../test/fake-kv";
+import {
+  classifyStorageFailure,
+  clearStorageHealthFields,
+  noteStorageFailure,
+  noteStorageSuccess,
+  STORAGE_HEALTH_MESSAGES,
+  storageHealth,
+} from "./storage-health";
+import { demoteActiveLane, promoteLane } from "./workspace-lanes";
+import type { WorkspaceRecord } from "./workspace";
+import { storageStatusResponse } from "./routes/workspace-storage";
+
+/** A BYO (HTTP-credential, no binding) active-lane record. */
+function byoRecord(extra: Partial<WorkspaceRecord> = {}): WorkspaceRecord {
+  return {
+    provider: "r2",
+    bucket: "acme-media",
+    accountId: "a".repeat(32),
+    accessKeyId: "enc:v1:key",
+    secretAccessKey: "enc:v1:secret",
+    storageLaneId: "lane_0000beef",
+    ...extra,
+  } as WorkspaceRecord;
+}
+
+/** A shared (platform binding) active-lane record. */
+function sharedRecord(extra: Partial<WorkspaceRecord> = {}): WorkspaceRecord {
+  return {
+    provider: "r2",
+    bucket: "uploads-shared",
+    binding: "BUCKET",
+    prefix: "acme/",
+    ...extra,
+  } as WorkspaceRecord;
+}
+
+function envWith(records: Record<string, unknown>): {
+  env: Env;
+  registry: ReturnType<typeof fakeRegistry>;
+} {
+  const registry = fakeRegistry(records);
+  return { env: { REGISTRY: registry } as unknown as Env, registry };
+}
+
+/** Shapes files-sdk raises: a `code` string, sometimes an HTTP `status`. */
+function filesError(code: string, status?: number): Error & { code: string; status?: number } {
+  return Object.assign(new Error(code), { code, status });
+}
+
+describe("classifyStorageFailure", () => {
+  it("maps rejected credentials to auth", () => {
+    expect(classifyStorageFailure(filesError("Unauthorized"))).toBe("auth");
+    expect(classifyStorageFailure(filesError("Forbidden"))).toBe("auth");
+    expect(classifyStorageFailure(filesError("SomethingElse", 403))).toBe("auth");
+  });
+
+  it("maps a missing bucket to bucket_missing", () => {
+    expect(classifyStorageFailure(filesError("NotFound"))).toBe("bucket_missing");
+  });
+
+  it("ignores failures a credential rotation could not fix", () => {
+    expect(classifyStorageFailure(filesError("InternalError", 500))).toBeUndefined();
+    expect(classifyStorageFailure(filesError("EntityTooLarge", 413))).toBeUndefined();
+    expect(classifyStorageFailure(new Error("network"))).toBeUndefined();
+    expect(classifyStorageFailure(undefined)).toBeUndefined();
+  });
+});
+
+describe("storageHealth", () => {
+  it("reports healthy when nothing is flagged", () => {
+    expect(storageHealth(byoRecord())).toEqual({ ok: true });
+  });
+
+  it("projects the plain-language sentence and the first-failure timestamp", () => {
+    const health = storageHealth(
+      byoRecord({ storageUnhealthyAt: "2026-08-24T10:00:00.000Z", storageUnhealthyCode: "auth" }),
+    );
+    expect(health).toEqual({
+      ok: false,
+      code: "auth",
+      message: STORAGE_HEALTH_MESSAGES.auth,
+      since: "2026-08-24T10:00:00.000Z",
+    });
+  });
+
+  it("still reports unhealthy for an unrecognized code", () => {
+    const health = storageHealth(
+      byoRecord({ storageUnhealthyAt: "2026-08-24T10:00:00.000Z", storageUnhealthyCode: "wat" }),
+    );
+    expect(health.ok).toBe(false);
+    expect(health.code).toBe("unreachable");
+  });
+});
+
+describe("noteStorageFailure", () => {
+  it("flags the active BYO lane on an auth failure", async () => {
+    const { env, registry } = envWith({ acme: byoRecord() });
+    await noteStorageFailure(env, "acme", byoRecord(), filesError("Unauthorized"));
+    const stored = registry.record<WorkspaceRecord>("acme")!;
+    expect(stored.storageUnhealthyCode).toBe("auth");
+    expect(typeof stored.storageUnhealthyAt).toBe("string");
+  });
+
+  it("never flags a shared lane — a platform failure is not the workspace's to fix", async () => {
+    const { env, registry } = envWith({ acme: sharedRecord() });
+    await noteStorageFailure(env, "acme", sharedRecord(), filesError("Unauthorized"));
+    expect(registry.puts).toHaveLength(0);
+  });
+
+  it("ignores failures that say nothing about credentials", async () => {
+    const { env, registry } = envWith({ acme: byoRecord() });
+    await noteStorageFailure(env, "acme", byoRecord(), filesError("InternalError", 500));
+    expect(registry.puts).toHaveLength(0);
+  });
+
+  it("keeps the first failure timestamp and writes nothing when already flagged the same way", async () => {
+    const flagged = byoRecord({
+      storageUnhealthyAt: "2026-08-01T00:00:00.000Z",
+      storageUnhealthyCode: "auth",
+    });
+    const { env, registry } = envWith({ acme: flagged });
+    await noteStorageFailure(env, "acme", flagged, filesError("Unauthorized"));
+    expect(registry.puts).toHaveLength(0);
+    expect(registry.record<WorkspaceRecord>("acme")!.storageUnhealthyAt).toBe(
+      "2026-08-01T00:00:00.000Z",
+    );
+  });
+
+  it("updates the code without moving `since` when the failure kind changes", async () => {
+    const flagged = byoRecord({
+      storageUnhealthyAt: "2026-08-01T00:00:00.000Z",
+      storageUnhealthyCode: "auth",
+    });
+    const { env, registry } = envWith({ acme: flagged });
+    await noteStorageFailure(env, "acme", flagged, filesError("NotFound"));
+    const stored = registry.record<WorkspaceRecord>("acme")!;
+    expect(stored.storageUnhealthyCode).toBe("bucket_missing");
+    expect(stored.storageUnhealthyAt).toBe("2026-08-01T00:00:00.000Z");
+  });
+
+  it("does not flag a lane the workspace has since switched away from", async () => {
+    // The stored record moved on to another lane while the failing upload was
+    // in flight — flagging now would describe the wrong lane.
+    const { env, registry } = envWith({ acme: byoRecord({ storageLaneId: "lane_11111111" }) });
+    await noteStorageFailure(env, "acme", byoRecord(), filesError("Unauthorized"));
+    expect(registry.puts).toHaveLength(0);
+  });
+
+  it("never throws when the workspace record is gone", async () => {
+    const { env } = envWith({});
+    await expect(
+      noteStorageFailure(env, "acme", byoRecord(), filesError("Unauthorized")),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("noteStorageSuccess", () => {
+  it("clears the flag after a write lands again", async () => {
+    const flagged = byoRecord({
+      storageUnhealthyAt: "2026-08-01T00:00:00.000Z",
+      storageUnhealthyCode: "auth",
+    });
+    const { env, registry } = envWith({ acme: flagged });
+    await noteStorageSuccess(env, "acme", flagged);
+    const stored = registry.record<WorkspaceRecord>("acme")!;
+    expect(stored.storageUnhealthyAt).toBeUndefined();
+    expect(stored.storageUnhealthyCode).toBeUndefined();
+  });
+
+  it("costs no KV write on a healthy workspace", async () => {
+    const { env, registry } = envWith({ acme: byoRecord() });
+    await noteStorageSuccess(env, "acme", byoRecord());
+    expect(registry.puts).toHaveLength(0);
+  });
+});
+
+describe("lane transitions carry health", () => {
+  it("demoting a flagged active lane keeps it flagged in the lane list", () => {
+    const record = byoRecord({
+      storageUnhealthyAt: "2026-08-01T00:00:00.000Z",
+      storageUnhealthyCode: "auth",
+    });
+    const lane = demoteActiveLane(record, "2026-08-24T00:00:00.000Z");
+    expect(lane.unhealthyAt).toBe("2026-08-01T00:00:00.000Z");
+    expect(lane.unhealthyCode).toBe("auth");
+  });
+
+  it("promoting a lane clears the active-lane flag", () => {
+    const next = byoRecord({
+      storageUnhealthyAt: "2026-08-01T00:00:00.000Z",
+      storageUnhealthyCode: "auth",
+    });
+    promoteLane(
+      next,
+      { provider: "r2", bucket: "uploads-shared", binding: "BUCKET", prefix: "acme/" },
+      undefined,
+    );
+    expect(next.storageUnhealthyAt).toBeUndefined();
+    expect(next.storageUnhealthyCode).toBeUndefined();
+  });
+
+  it("clearStorageHealthFields removes both fields", () => {
+    const next = byoRecord({ storageUnhealthyAt: "x", storageUnhealthyCode: "auth" });
+    clearStorageHealthFields(next);
+    expect(next.storageUnhealthyAt).toBeUndefined();
+    expect(next.storageUnhealthyCode).toBeUndefined();
+  });
+});
+
+describe("storageStatusResponse health projection", () => {
+  it("reports the unhealthy active lane", () => {
+    const response = storageStatusResponse(
+      byoRecord({ storageUnhealthyAt: "2026-08-01T00:00:00.000Z", storageUnhealthyCode: "auth" }),
+      true,
+    );
+    expect(response.health).toEqual({
+      ok: false,
+      code: "auth",
+      message: STORAGE_HEALTH_MESSAGES.auth,
+      since: "2026-08-01T00:00:00.000Z",
+    });
+  });
+
+  it("always reports healthy in shared mode", () => {
+    const response = storageStatusResponse(
+      sharedRecord({ storageUnhealthyAt: "2026-08-01T00:00:00.000Z" }),
+      true,
+    );
+    expect(response.health).toEqual({ ok: true });
+  });
+
+  it("surfaces a demoted lane's flag in the lane list", () => {
+    const response = storageStatusResponse(
+      sharedRecord({
+        storageLanes: [
+          {
+            id: "lane_0000beef",
+            provider: "r2",
+            bucket: "acme-media",
+            accountId: "a".repeat(32),
+            accessKeyId: "enc:v1:key",
+            secretAccessKey: "enc:v1:secret",
+            lastActiveAt: "2026-08-24T00:00:00.000Z",
+            unhealthyAt: "2026-08-01T00:00:00.000Z",
+            unhealthyCode: "auth",
+          },
+        ],
+      }),
+      true,
+    );
+    expect(response.lanes[0]?.unhealthyAt).toBe("2026-08-01T00:00:00.000Z");
+  });
+});

--- a/apps/api/src/storage-health.test.ts
+++ b/apps/api/src/storage-health.test.ts
@@ -66,6 +66,28 @@ describe("classifyStorageFailure", () => {
     expect(classifyStorageFailure(new Error("network"))).toBeUndefined();
     expect(classifyStorageFailure(undefined)).toBeUndefined();
   });
+
+  it("leaves files-sdk's transport/outage code unflagged", () => {
+    // files-sdk normalizes network blips, timeouts, and provider outages to a
+    // single `Provider` code and retries them itself. Nothing in that shape
+    // separates a dead bucket from a hiccup, so it must never tell a workspace
+    // its credentials are broken.
+    expect(classifyStorageFailure(filesError("Provider"))).toBeUndefined();
+    expect(classifyStorageFailure(filesError("Provider", 503))).toBeUndefined();
+    expect(
+      classifyStorageFailure(
+        Object.assign(filesError("Provider"), { cause: new Error("fetch failed") }),
+      ),
+    ).toBeUndefined();
+    expect(
+      classifyStorageFailure(Object.assign(filesError("Provider"), { aborted: true })),
+    ).toBeUndefined();
+  });
+
+  it("still classifies auth when a Provider-coded error carries a 401/403", () => {
+    expect(classifyStorageFailure(filesError("Provider", 401))).toBe("auth");
+    expect(classifyStorageFailure(filesError("Provider", 403))).toBe("auth");
+  });
 });
 
 describe("storageHealth", () => {
@@ -251,5 +273,58 @@ describe("storageStatusResponse health projection", () => {
       true,
     );
     expect(response.lanes[0]?.unhealthyAt).toBe("2026-08-01T00:00:00.000Z");
+    // The normalized block too — a client showing "this fallback is broken"
+    // must be able to say *what* broke, not just that something did.
+    expect(response.lanes[0]?.health).toEqual({
+      ok: false,
+      code: "auth",
+      message: STORAGE_HEALTH_MESSAGES.auth,
+      since: "2026-08-01T00:00:00.000Z",
+    });
+  });
+
+  it("normalizes an unrecognized stored code on a demoted lane", () => {
+    const response = storageStatusResponse(
+      sharedRecord({
+        storageLanes: [
+          {
+            id: "lane_0000beef",
+            provider: "r2",
+            bucket: "acme-media",
+            accountId: "a".repeat(32),
+            accessKeyId: "enc:v1:key",
+            secretAccessKey: "enc:v1:secret",
+            lastActiveAt: "2026-08-24T00:00:00.000Z",
+            unhealthyAt: "2026-08-01T00:00:00.000Z",
+            unhealthyCode: "wat",
+          },
+        ],
+      }),
+      true,
+    );
+    expect(response.lanes[0]?.health).toMatchObject({
+      ok: false,
+      code: "unreachable",
+      message: STORAGE_HEALTH_MESSAGES.unreachable,
+    });
+  });
+
+  it("omits `health` entirely on a healthy lane", () => {
+    const response = storageStatusResponse(
+      sharedRecord({
+        storageLanes: [
+          {
+            id: "lane_0000beef",
+            provider: "r2",
+            bucket: "acme-media",
+            accountId: "a".repeat(32),
+            accessKeyId: "enc:v1:key",
+            secretAccessKey: "enc:v1:secret",
+          },
+        ],
+      }),
+      true,
+    );
+    expect(response.lanes[0]).not.toHaveProperty("health");
   });
 });

--- a/apps/api/src/storage-health.ts
+++ b/apps/api/src/storage-health.ts
@@ -90,9 +90,15 @@ function errorStatus(err: unknown): number | undefined {
  * (a too-large object, a bad key) and a transient 5xx both return
  * `undefined`: flagging on those would light the banner for problems a
  * credential rotation cannot fix, which is worse than saying nothing.
- * `unreachable` is reserved for the one non-auth case a rotation *can*
- * fix — a bucket whose endpoint no longer answers at all — and is
- * deliberately conservative for the same reason.
+ *
+ * Note what is deliberately absent. files-sdk normalizes network blips,
+ * connection timeouts, and provider outages to a single `Provider` code, and
+ * retries them itself as transient. Nothing in that shape separates "this
+ * bucket is gone for good" from "the network hiccuped". So this function
+ * never returns `unreachable`: a transport failure leaves the lane unflagged
+ * rather than telling a workspace to rotate keys that are probably fine.
+ * `unreachable` exists only as `healthCodeOf`'s fallback wording for a stored
+ * code this version does not recognize.
  */
 export function classifyStorageFailure(err: unknown): StorageHealthCode | undefined {
   const code = errorCode(err);
@@ -116,8 +122,7 @@ export interface StorageHealth {
 
 const HEALTH_CODES = new Set<string>(["auth", "bucket_missing", "unreachable"]);
 
-function healthCodeOf(record: Pick<WorkspaceRecord, "storageUnhealthyCode">): StorageHealthCode {
-  const code = record.storageUnhealthyCode;
+function healthCodeOf(code: string | undefined): StorageHealthCode {
   // A record hand-edited (or written by a future version) with an unknown
   // code still reports *unhealthy* — the flag is the signal, the code only
   // picks the sentence. Falling back to `unreachable` keeps the vaguest,
@@ -125,18 +130,28 @@ function healthCodeOf(record: Pick<WorkspaceRecord, "storageUnhealthyCode">): St
   return code && HEALTH_CODES.has(code) ? (code as StorageHealthCode) : "unreachable";
 }
 
-/** Reads the stored flag into the projected shape. Healthy when nothing is flagged. */
+/**
+ * Normalizes a stored (timestamp, code) pair into the projected shape. The
+ * single place a stored code becomes a validated code plus its sentence, so
+ * the active lane and the saved-lane list can never disagree about what a
+ * given stored value means.
+ */
+export function healthFromFields(at: string | undefined, code: string | undefined): StorageHealth {
+  if (!at) return { ok: true };
+  const validated = healthCodeOf(code);
+  return {
+    ok: false,
+    code: validated,
+    message: STORAGE_HEALTH_MESSAGES[validated],
+    since: at,
+  };
+}
+
+/** Reads the *active* lane's flag into the projected shape. Healthy when nothing is flagged. */
 export function storageHealth(
   record: Pick<WorkspaceRecord, "storageUnhealthyAt" | "storageUnhealthyCode">,
 ): StorageHealth {
-  if (!record.storageUnhealthyAt) return { ok: true };
-  const code = healthCodeOf(record);
-  return {
-    ok: false,
-    code,
-    message: STORAGE_HEALTH_MESSAGES[code],
-    since: record.storageUnhealthyAt,
-  };
+  return healthFromFields(record.storageUnhealthyAt, record.storageUnhealthyCode);
 }
 
 /**
@@ -176,7 +191,7 @@ export async function noteStorageFailure(
   const code = classifyStorageFailure(err);
   if (!code) return;
   if (!isByoRecord(ws)) return;
-  if (ws.storageUnhealthyAt && healthCodeOf(ws) === code) return;
+  if (ws.storageUnhealthyAt && healthCodeOf(ws.storageUnhealthyCode) === code) return;
 
   const nowIso = new Date().toISOString();
   const laneId = ws.storageLaneId;
@@ -187,7 +202,8 @@ export async function noteStorageFailure(
       // started; if the workspace has switched since, that lane is no longer
       // the one this flag would describe.
       if ((current.storageLaneId ?? null) !== (laneId ?? null)) return null;
-      if (current.storageUnhealthyAt && healthCodeOf(current) === code) return null;
+      if (current.storageUnhealthyAt && healthCodeOf(current.storageUnhealthyCode) === code)
+        return null;
       return {
         ...current,
         // First failure wins: `since` is "failing since", not "last failed".

--- a/apps/api/src/storage-health.ts
+++ b/apps/api/src/storage-health.ts
@@ -1,0 +1,244 @@
+/**
+ * Health state for the active BYO (customer-credential) storage lane — issue
+ * #826.
+ *
+ * Verification (`storage-verify.ts`) is a point-in-time stamp: it runs at
+ * connect, at rotate, and before a stale lane is activated. Nothing between
+ * those moments notices when a previously-working R2 token is revoked, the
+ * bucket is deleted, or the account is detached — the workspace just starts
+ * failing uploads. This module closes that gap from the cheapest possible
+ * signal: the storage operations the workspace is *already* running. When a
+ * write fails with an auth-shaped error, the active lane is flagged unhealthy
+ * on the workspace record; when one succeeds again, the flag clears itself.
+ *
+ * Deliberately not a scheduled prober. A cron sweep would cost a live
+ * round-trip against every BYO bucket on a fixed interval whether or not the
+ * workspace is being used, and it would still learn nothing sooner than the
+ * first failing upload does for an active workspace. Detection here is free
+ * and exactly as timely; a sweep can be added later for idle workspaces
+ * without changing any of the state this module writes.
+ *
+ * Every write goes through `mutateWorkspaceRecord` (never a bare
+ * `REGISTRY.put`) and is a no-op unless it would actually change the record,
+ * so the common path — healthy lane, successful upload — costs zero KV
+ * writes.
+ *
+ * Never put a credential value, or any part of one, into a code, message, or
+ * log line here.
+ */
+import { storageBudgetApplies } from "./budget";
+import { mutateWorkspaceRecord } from "./workspace-mutate";
+import type { WorkspaceRecord } from "./workspace";
+
+/**
+ * True for customer-credential (BYO) storage. Identical to
+ * `isByoRecord` in `routes/workspace-storage.ts` and derived from the same
+ * single source (`storageBudgetApplies`, which returns `false` for exactly
+ * this shape) rather than importing it — that module imports *this* one for
+ * `storageHealth`, and routing a core detection path through a route module
+ * to save four lines is not worth the import cycle.
+ */
+function isByoRecord(
+  record: Pick<WorkspaceRecord, "binding" | "accountId" | "accessKeyId" | "secretAccessKey">,
+): boolean {
+  return !storageBudgetApplies(record);
+}
+
+/**
+ * Why the active lane is considered unhealthy. Deliberately coarse — these
+ * map 1:1 onto the three sentences a workspace admin can actually act on,
+ * not onto the underlying S3 error taxonomy.
+ */
+export type StorageHealthCode = "auth" | "bucket_missing" | "unreachable";
+
+/**
+ * Plain-language failure sentences, in the same voice as the verify-form
+ * failures on the storage settings page (`STORAGE_CHECK_FAILURES`): what went
+ * wrong, not which probe stage reported it. The fix is always the same one
+ * (rotate credentials), so it is not repeated in the sentence — the UI puts
+ * it on the button.
+ */
+export const STORAGE_HEALTH_MESSAGES: Record<StorageHealthCode, string> = {
+  auth: "We can no longer sign in to your bucket",
+  bucket_missing: "We can no longer find your bucket",
+  unreachable: "We can no longer reach your bucket",
+};
+
+/** Duck-types files-sdk's `FilesError` without depending on the package (apps/api doesn't declare it) — same shape check `storage-verify.ts` uses. */
+function errorCode(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code?: unknown }).code;
+    return typeof code === "string" ? code : undefined;
+  }
+  return undefined;
+}
+
+/** HTTP status carried by a files-sdk error, when it carries one. */
+function errorStatus(err: unknown): number | undefined {
+  if (err && typeof err === "object" && "status" in err) {
+    const status = (err as { status?: unknown }).status;
+    return typeof status === "number" ? status : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Maps a storage-operation failure onto a health code, or `undefined` when
+ * the failure says nothing about the lane's credentials.
+ *
+ * Only *credential-shaped* failures flag a lane. A 4xx the caller caused
+ * (a too-large object, a bad key) and a transient 5xx both return
+ * `undefined`: flagging on those would light the banner for problems a
+ * credential rotation cannot fix, which is worse than saying nothing.
+ * `unreachable` is reserved for the one non-auth case a rotation *can*
+ * fix — a bucket whose endpoint no longer answers at all — and is
+ * deliberately conservative for the same reason.
+ */
+export function classifyStorageFailure(err: unknown): StorageHealthCode | undefined {
+  const code = errorCode(err);
+  if (code === "Unauthorized" || code === "Forbidden") return "auth";
+  if (code === "NotFound") return "bucket_missing";
+  const status = errorStatus(err);
+  if (status === 401 || status === 403) return "auth";
+  return undefined;
+}
+
+/** The active lane's health, projected for the settings page and the signed-in banner. */
+export interface StorageHealth {
+  ok: boolean;
+  /** Present only when `ok` is false. */
+  code?: StorageHealthCode;
+  /** Plain-language sentence for `code`. Present only when `ok` is false. */
+  message?: string;
+  /** When the lane was first flagged (not the most recent failure) — "failing since". */
+  since?: string;
+}
+
+const HEALTH_CODES = new Set<string>(["auth", "bucket_missing", "unreachable"]);
+
+function healthCodeOf(record: Pick<WorkspaceRecord, "storageUnhealthyCode">): StorageHealthCode {
+  const code = record.storageUnhealthyCode;
+  // A record hand-edited (or written by a future version) with an unknown
+  // code still reports *unhealthy* — the flag is the signal, the code only
+  // picks the sentence. Falling back to `unreachable` keeps the vaguest,
+  // least-wrong wording.
+  return code && HEALTH_CODES.has(code) ? (code as StorageHealthCode) : "unreachable";
+}
+
+/** Reads the stored flag into the projected shape. Healthy when nothing is flagged. */
+export function storageHealth(
+  record: Pick<WorkspaceRecord, "storageUnhealthyAt" | "storageUnhealthyCode">,
+): StorageHealth {
+  if (!record.storageUnhealthyAt) return { ok: true };
+  const code = healthCodeOf(record);
+  return {
+    ok: false,
+    code,
+    message: STORAGE_HEALTH_MESSAGES[code],
+    since: record.storageUnhealthyAt,
+  };
+}
+
+/**
+ * Clears the health flag on `next` in place. Called from every path that has
+ * just *proven* the active lane works — a successful rotate, a successful
+ * activate — so a fixed lane never keeps a stale danger badge until its next
+ * upload happens to land.
+ */
+export function clearStorageHealthFields(next: WorkspaceRecord): void {
+  delete next.storageUnhealthyAt;
+  delete next.storageUnhealthyCode;
+}
+
+/**
+ * Flags the workspace's active lane unhealthy after a failed storage
+ * operation. Safe to call on any failure — it filters down to the cases
+ * worth reporting itself:
+ *
+ * - non-credential errors (`classifyStorageFailure` → `undefined`) are ignored;
+ * - shared (platform binding) lanes are ignored: a shared-lane failure is our
+ *   problem, and telling a workspace to rotate credentials it doesn't own
+ *   would be nonsense;
+ * - a lane already flagged with the same code is left alone (`since` keeps
+ *   pointing at the *first* failure, and no KV write happens);
+ * - a record whose active lane changed since the failing operation started is
+ *   left alone — the switch already re-verified whatever is active now.
+ *
+ * Never throws: detection must not be able to turn a failed upload into a
+ * differently-failed upload.
+ */
+export async function noteStorageFailure(
+  env: Env,
+  workspaceName: string,
+  ws: WorkspaceRecord,
+  err: unknown,
+): Promise<void> {
+  const code = classifyStorageFailure(err);
+  if (!code) return;
+  if (!isByoRecord(ws)) return;
+  if (ws.storageUnhealthyAt && healthCodeOf(ws) === code) return;
+
+  const nowIso = new Date().toISOString();
+  const laneId = ws.storageLaneId;
+  try {
+    await mutateWorkspaceRecord(env, workspaceName, (current) => {
+      if (!isByoRecord(current)) return null;
+      // The operation failed against the lane that was active when it
+      // started; if the workspace has switched since, that lane is no longer
+      // the one this flag would describe.
+      if ((current.storageLaneId ?? null) !== (laneId ?? null)) return null;
+      if (current.storageUnhealthyAt && healthCodeOf(current) === code) return null;
+      return {
+        ...current,
+        // First failure wins: `since` is "failing since", not "last failed".
+        storageUnhealthyAt: current.storageUnhealthyAt ?? nowIso,
+        storageUnhealthyCode: code,
+      };
+    });
+  } catch {
+    // A losing write race or a workspace deleted mid-request. The next
+    // failing operation re-attempts the flag; nothing here is worth failing
+    // the caller's request over.
+    return;
+  }
+  console.log(
+    JSON.stringify({
+      event: "workspace_storage_unhealthy",
+      workspace: workspaceName,
+      laneId,
+      code,
+    }),
+  );
+}
+
+/**
+ * Clears the flag after a storage operation succeeds. The self-healing half
+ * of {@link noteStorageFailure}: a workspace that rotates its token outside
+ * this app (or whose bucket comes back) drops the banner on its next upload
+ * without anyone visiting settings.
+ *
+ * Costs nothing on the overwhelmingly common path — a record with no flag
+ * returns before touching KV.
+ */
+export async function noteStorageSuccess(
+  env: Env,
+  workspaceName: string,
+  ws: WorkspaceRecord,
+): Promise<void> {
+  if (!ws.storageUnhealthyAt) return;
+  const laneId = ws.storageLaneId;
+  try {
+    await mutateWorkspaceRecord(env, workspaceName, (current) => {
+      if (!current.storageUnhealthyAt) return null;
+      if ((current.storageLaneId ?? null) !== (laneId ?? null)) return null;
+      const next = { ...current };
+      clearStorageHealthFields(next);
+      return next;
+    });
+  } catch {
+    return;
+  }
+  console.log(
+    JSON.stringify({ event: "workspace_storage_recovered", workspace: workspaceName, laneId }),
+  );
+}

--- a/apps/api/src/workspace-lanes.ts
+++ b/apps/api/src/workspace-lanes.ts
@@ -39,6 +39,11 @@ export function demoteActiveLane(current: WorkspaceRecord, nowIso: string): Stor
     storageConfiguredAt: current.storageConfiguredAt,
     storageConfiguredBy: current.storageConfiguredBy,
     storageAccessKeyIdLast4: current.storageAccessKeyIdLast4,
+    // Health travels with the lane (issue #826): switching away from a lane
+    // because its credentials broke must not make it look fine in the lane
+    // list the moment it stops being active.
+    unhealthyAt: current.storageUnhealthyAt,
+    unhealthyCode: current.storageUnhealthyCode,
   };
 }
 
@@ -99,6 +104,14 @@ export function promoteLane(
   else delete next.storageAccessKeyIdLast4;
   if (verifiedAt) next.storageVerifiedAt = verifiedAt;
   else delete next.storageVerifiedAt;
+  // A lane only ever becomes active after it has been proven to work — a
+  // binding-mode (shared) lane needs no proof, and an HTTP-credential lane is
+  // re-verified by `storageActivateHandler` before the swap (which forces a
+  // re-verify for a lane carrying a health flag, however fresh its
+  // `verifiedAt` looks). So promotion always clears the flag rather than
+  // carrying the demoted lane's history onto the live one.
+  delete next.storageUnhealthyAt;
+  delete next.storageUnhealthyCode;
 }
 
 /**

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -224,6 +224,23 @@ export interface WorkspaceRecord {
    * lane. Stamped into new-upload provenance (see `files-core.ts`).
    */
   storageLaneId?: string;
+  /**
+   * Set when the active BYO lane's credentials stopped working (issue #826) —
+   * the timestamp of the *first* failure in the current unhealthy stretch, so
+   * the UI can say "failing since". Absent = healthy, which is also every
+   * shared-lane record: a platform-binding failure is never a workspace's
+   * problem to fix. Written and cleared only through
+   * `storage-health.ts`.
+   */
+  storageUnhealthyAt?: string;
+  /**
+   * Which kind of failure flagged the lane — `StorageHealthCode` in
+   * `storage-health.ts` (`"auth" | "bucket_missing" | "unreachable"`),
+   * widened to `string` here so an older worker reading a newer record can't
+   * fail to parse it. Picks the plain-language sentence; the flag itself is
+   * `storageUnhealthyAt`.
+   */
+  storageUnhealthyCode?: string;
 }
 
 /**
@@ -269,6 +286,15 @@ export interface StorageLane extends StorageLaneFields {
   storageAccessKeyIdLast4?: string;
   storageConfiguredAt?: string;
   storageConfiguredBy?: string;
+  /**
+   * Health carried down from the active-lane fields when this lane was
+   * demoted (issue #826) — a lane you switched away from *because* it broke
+   * still reads as broken in the lane list. Cleared on promotion: a lane only
+   * becomes active after it verifies.
+   */
+  unhealthyAt?: string;
+  /** `StorageHealthCode`, widened to `string` — see `WorkspaceRecord.storageUnhealthyCode`. */
+  unhealthyCode?: string;
 }
 
 /** New lane id: "lane_" + 8 lowercase hex chars from crypto.getRandomValues. */

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -59,6 +59,7 @@ const {
 const hasPreview = Astro.slots.has("preview");
 
 const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`;
+const storagePath = `/account/workspaces/${encodeURIComponent(workspace)}/settings/storage`;
 ---
 
 <AccountLayout
@@ -67,6 +68,27 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
   title={workspace}
   railWide={wideRail && hasPreview}
 >
+  {
+    /* Broken-BYO-bucket notice (#826) — server-rendered hidden, revealed by
+      `initStorageHealthBanner` only for admins of a workspace whose active
+      lane is actually failing. Sits above the tab content because it is about
+      the workspace, not about this tab. */
+  }
+  <div class="ws-storage-alert" data-storage-health-banner role="alert" hidden>
+    <div class="ws-storage-alert__body">
+      <p class="ws-storage-alert__msg" data-storage-health-message></p>
+      <a class="ws-storage-alert__link" data-storage-health-link href={storagePath}
+        >Fix storage settings</a
+      >
+    </div>
+    <button
+      type="button"
+      class="ws-storage-alert__dismiss"
+      data-storage-health-dismiss
+      aria-label="Dismiss this notice">×</button
+    >
+  </div>
+
   <slot />
 
   <Fragment slot="rail">
@@ -151,6 +173,62 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
 </AccountLayout>
 
 <style>
+  /* Broken-storage notice (#826). Danger-tinted panel, one line of copy and
+     one link — deliberately not a `ul-callout`, which is a page-body element;
+     this sits in the shell above whatever the tab renders. */
+  .ws-storage-alert {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+    padding: 11px 14px;
+    border: 1px solid color-mix(in srgb, var(--red) 45%, transparent);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--red) 8%, transparent);
+  }
+  .ws-storage-alert[hidden] {
+    display: none;
+  }
+  .ws-storage-alert__body {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 10px;
+    min-width: 0;
+  }
+  .ws-storage-alert__msg {
+    margin: 0;
+    color: var(--fg);
+    font-size: var(--text-meta);
+    line-height: 1.5;
+    text-wrap: pretty;
+  }
+  .ws-storage-alert__link {
+    color: var(--red);
+    font-size: var(--text-meta);
+    font-weight: var(--weight-semibold);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    white-space: nowrap;
+  }
+  .ws-storage-alert__dismiss {
+    flex: none;
+    padding: 0 4px;
+    background: none;
+    border: 0;
+    color: var(--muted);
+    font: inherit;
+    font-size: 16px;
+    line-height: 1.2;
+    cursor: pointer;
+  }
+  .ws-storage-alert__dismiss:hover,
+  .ws-storage-alert__dismiss:focus-visible {
+    color: var(--fg);
+    outline: none;
+  }
+
   /* Section *bodies* are filled via innerHTML by workspace-rail.ts, so
      injected classes need :global() — Astro scope only lands on elements
      this component renders. Shared section chrome (`.ws-rail`, head/label/
@@ -307,6 +385,7 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
 <script>
   import { onAstroPageLoad } from "../lib/account-shell";
   import { resolveActiveWorkspace } from "../lib/workspace-browse-url";
+  import { initStorageHealthBanner } from "../lib/storage-health-banner";
   import { initWorkspaceRail } from "../lib/workspace-rail";
 
   function bootWorkspaceRail(): void {
@@ -332,6 +411,9 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
     // `initWorkspaceRail` queries `document` for rail hooks — `root`
     // here is only this function's own re-entrancy guard.
     initWorkspaceRail(apiOrigin, workspace);
+    // Same boot, same re-entrancy guard: one health check per workspace-tab
+    // page load, painting the shell banner only when it has something to say.
+    initStorageHealthBanner(apiOrigin, workspace);
   }
 
   // Eager boot for the initial load, then re-boot after every ClientRouter

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -69,10 +69,10 @@ const storagePath = `/account/workspaces/${encodeURIComponent(workspace)}/settin
   railWide={wideRail && hasPreview}
 >
   {
-    /* Broken-BYO-bucket notice (#826) — server-rendered hidden, revealed by
-      `initStorageHealthBanner` only for admins of a workspace whose active
-      lane is actually failing. Sits above the tab content because it is about
-      the workspace, not about this tab. */
+    /* Broken-BYO-bucket notice (#826).
+      Server-rendered hidden; `initStorageHealthBanner` reveals it.
+      Only admins of a workspace whose active lane is failing ever see it.
+      It sits above the tab content because it is about the workspace. */
   }
   <div class="ws-storage-alert" data-storage-health-banner role="alert" hidden>
     <div class="ws-storage-alert__body">
@@ -173,9 +173,10 @@ const storagePath = `/account/workspaces/${encodeURIComponent(workspace)}/settin
 </AccountLayout>
 
 <style>
-  /* Broken-storage notice (#826). Danger-tinted panel, one line of copy and
-     one link — deliberately not a `ul-callout`, which is a page-body element;
-     this sits in the shell above whatever the tab renders. */
+  /* Broken-storage notice (#826).
+     A danger-tinted panel with one line of copy and one link.
+     Deliberately not a `ul-callout`: that is a page-body element.
+     This sits in the shell, above whatever the tab renders. */
   .ws-storage-alert {
     display: flex;
     align-items: flex-start;

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1397,7 +1397,7 @@ describe("getWorkspaceStorageStatus", () => {
 
     await expect(getWorkspaceStorageStatus("http://127.0.0.1:8787", "acme")).resolves.toEqual({
       kind: "ok",
-      status: { mode: "shared", byoBucketEnabled: true, lanes: [] },
+      status: { mode: "shared", byoBucketEnabled: true, lanes: [], health: { ok: true } },
     });
     expect(fetchMock).toHaveBeenCalledOnce();
   });
@@ -1455,8 +1455,47 @@ describe("getWorkspaceStorageStatus", () => {
             lastActiveAt: "2026-06-01T00:00:00.000Z",
           },
         ],
+        health: { ok: true },
       },
     });
+  });
+
+  it("parses an unhealthy active lane, and fails healthy on a garbled health block", async () => {
+    const body = {
+      mode: "byo",
+      byoBucketEnabled: true,
+      bucket: "my-bucket",
+      lanes: [],
+      health: {
+        ok: false,
+        code: "auth",
+        message: "We can no longer sign in to your bucket",
+        since: "2026-08-01T00:00:00.000Z",
+      },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json(body)),
+    );
+    const unhealthy = await getWorkspaceStorageStatus("http://127.0.0.1:8787", "acme");
+    expect(unhealthy).toMatchObject({ kind: "ok", status: { health: body.health } });
+
+    // No `message` — the UI would have nothing true to say, so a partial
+    // payload must not paint a danger badge and a workspace-wide banner.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ ...body, health: { ok: false } })),
+    );
+    const partial = await getWorkspaceStorageStatus("http://127.0.0.1:8787", "acme");
+    expect(partial).toMatchObject({ kind: "ok", status: { health: { ok: true } } });
+
+    // An older API with no `health` block at all.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ mode: "byo", byoBucketEnabled: true, lanes: [] })),
+    );
+    const legacy = await getWorkspaceStorageStatus("http://127.0.0.1:8787", "acme");
+    expect(legacy).toMatchObject({ kind: "ok", status: { health: { ok: true } } });
   });
 
   it("reports 403 as forbidden — non-admin members get no panel at all", async () => {
@@ -1635,6 +1674,7 @@ describe("putWorkspaceStorage", () => {
         bucket: "my-bucket",
         accessKeyIdLast4: "1234",
         lanes: [],
+        health: { ok: true },
       },
     });
   });
@@ -1708,6 +1748,7 @@ describe("activateWorkspaceStorage", () => {
         bucket: "my-bucket",
         activeLaneId: "lane_abc12345",
         lanes: [],
+        health: { ok: true },
       },
     });
   });
@@ -1764,7 +1805,7 @@ describe("deleteWorkspaceStorage", () => {
 
     await expect(deleteWorkspaceStorage("http://127.0.0.1:8787", "acme")).resolves.toEqual({
       kind: "ok",
-      status: { mode: "shared", byoBucketEnabled: true, lanes: [] },
+      status: { mode: "shared", byoBucketEnabled: true, lanes: [], health: { ok: true } },
     });
   });
 

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1498,6 +1498,69 @@ describe("getWorkspaceStorageStatus", () => {
     expect(legacy).toMatchObject({ kind: "ok", status: { health: { ok: true } } });
   });
 
+  it("treats a blank failure message as healthy, and trims the one it keeps", async () => {
+    const base = { mode: "byo", byoBucketEnabled: true, bucket: "my-bucket", lanes: [] };
+    // An empty or whitespace-only sentence would paint a danger badge and a
+    // workspace-wide banner with nothing in them.
+    for (const message of ["", "   ", "\n\t "]) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => Response.json({ ...base, health: { ok: false, code: "auth", message } })),
+      );
+      const blank = await getWorkspaceStorageStatus("http://127.0.0.1:8787", "acme");
+      expect(blank).toMatchObject({ kind: "ok", status: { health: { ok: true } } });
+    }
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({ ...base, health: { ok: false, code: "auth", message: "  Broken.  " } }),
+      ),
+    );
+    const padded = await getWorkspaceStorageStatus("http://127.0.0.1:8787", "acme");
+    expect(padded).toMatchObject({
+      kind: "ok",
+      status: { health: { ok: false, message: "Broken." } },
+    });
+  });
+
+  it("parses a demoted lane's health block, and omits it when the lane is healthy", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          mode: "shared",
+          byoBucketEnabled: true,
+          lanes: [
+            {
+              laneId: "lane_broken1",
+              role: "fallback",
+              mode: "byo",
+              bucket: "acme-media",
+              unhealthyAt: "2026-08-01T00:00:00.000Z",
+              health: {
+                ok: false,
+                code: "auth",
+                message: "We can no longer sign in to your bucket",
+                since: "2026-08-01T00:00:00.000Z",
+              },
+            },
+            { laneId: "lane_fine1", role: "standby", mode: "byo", bucket: "acme-spare" },
+          ],
+        }),
+      ),
+    );
+    const result = await getWorkspaceStorageStatus("http://127.0.0.1:8787", "acme");
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.status.lanes[0]?.health).toEqual({
+      ok: false,
+      code: "auth",
+      message: "We can no longer sign in to your bucket",
+      since: "2026-08-01T00:00:00.000Z",
+    });
+    expect(result.status.lanes[1]).not.toHaveProperty("health");
+  });
+
   it("reports 403 as forbidden — non-admin members get no panel at all", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1774,6 +1774,12 @@ export interface WorkspaceStorageLane {
   accessKeyIdLast4?: string;
   /** Set when this lane was demoted while its credentials were failing (issue #826). */
   unhealthyAt?: string;
+  /**
+   * Normalized health for a lane demoted while flagged (issue #826) — the
+   * same shape and the same server-authored sentence the active lane reports.
+   * Absent on a healthy lane.
+   */
+  health?: WorkspaceStorageHealth;
 }
 
 /** Whether the *active* lane's storage is currently working (issue #826). Always healthy in shared mode. */
@@ -1811,7 +1817,10 @@ function toWorkspaceStorageLane(value: unknown): WorkspaceStorageLane | null {
   if (typeof v.laneId !== "string" || (v.role !== "standby" && v.role !== "fallback")) return null;
   if (v.mode !== "shared" && v.mode !== "byo") return null;
   if (typeof v.bucket !== "string") return null;
+  // Same parser (and same fail-healthy rules) as the active lane's block.
+  const health = toWorkspaceStorageHealth(v.health);
   return {
+    ...(health.ok ? {} : { health }),
     laneId: v.laneId,
     role: v.role,
     mode: v.mode,
@@ -1831,15 +1840,22 @@ function toWorkspaceStorageLane(value: unknown): WorkspaceStorageLane | null {
  * workspace-wide banner from nothing. Only an explicit `ok: false` is treated
  * as broken, and only with a `message` the server actually wrote — the UI
  * never invents failure copy.
+ *
+ * "Actually wrote" means non-blank after trimming: an empty or whitespace-only
+ * message would render a danger badge and a banner with nothing in them, which
+ * is worse than staying quiet. The trimmed value is what callers get, so no
+ * downstream surface has to re-trim before display.
  */
 function toWorkspaceStorageHealth(value: unknown): WorkspaceStorageHealth {
   if (!value || typeof value !== "object") return { ok: true };
   const v = value as Record<string, unknown>;
   if (v.ok !== false || typeof v.message !== "string") return { ok: true };
+  const message = v.message.trim();
+  if (!message) return { ok: true };
   return {
     ok: false,
     code: typeof v.code === "string" ? v.code : undefined,
-    message: v.message,
+    message,
     since: typeof v.since === "string" ? v.since : undefined,
   };
 }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1772,6 +1772,19 @@ export interface WorkspaceStorageLane {
   lastActiveAt?: string;
   accountIdMasked?: string;
   accessKeyIdLast4?: string;
+  /** Set when this lane was demoted while its credentials were failing (issue #826). */
+  unhealthyAt?: string;
+}
+
+/** Whether the *active* lane's storage is currently working (issue #826). Always healthy in shared mode. */
+export interface WorkspaceStorageHealth {
+  ok: boolean;
+  /** `"auth" | "bucket_missing" | "unreachable"` — widened, since the sentence to show ships in `message`. */
+  code?: string;
+  /** Plain-language failure sentence, server-authored. Present only when `ok` is false. */
+  message?: string;
+  /** When the lane was *first* flagged — "failing since", not "last failed". */
+  since?: string;
 }
 
 export interface WorkspaceStorageStatus {
@@ -1788,6 +1801,8 @@ export interface WorkspaceStorageStatus {
   activeLaneId?: string;
   /** Every other configured lane: saved-but-never-used configs and demoted former actives. */
   lanes: WorkspaceStorageLane[];
+  /** Health of the active lane. Defaults to healthy when an older API omits it. */
+  health: WorkspaceStorageHealth;
 }
 
 function toWorkspaceStorageLane(value: unknown): WorkspaceStorageLane | null {
@@ -1806,6 +1821,26 @@ function toWorkspaceStorageLane(value: unknown): WorkspaceStorageLane | null {
     lastActiveAt: typeof v.lastActiveAt === "string" ? v.lastActiveAt : undefined,
     accountIdMasked: typeof v.accountIdMasked === "string" ? v.accountIdMasked : undefined,
     accessKeyIdLast4: typeof v.accessKeyIdLast4 === "string" ? v.accessKeyIdLast4 : undefined,
+    unhealthyAt: typeof v.unhealthyAt === "string" ? v.unhealthyAt : undefined,
+  };
+}
+
+/**
+ * Fails *healthy* on anything unrecognized: a missing/garbled `health` block
+ * (an older API, a truncated body) must not paint a danger badge and a
+ * workspace-wide banner from nothing. Only an explicit `ok: false` is treated
+ * as broken, and only with a `message` the server actually wrote — the UI
+ * never invents failure copy.
+ */
+function toWorkspaceStorageHealth(value: unknown): WorkspaceStorageHealth {
+  if (!value || typeof value !== "object") return { ok: true };
+  const v = value as Record<string, unknown>;
+  if (v.ok !== false || typeof v.message !== "string") return { ok: true };
+  return {
+    ok: false,
+    code: typeof v.code === "string" ? v.code : undefined,
+    message: v.message,
+    since: typeof v.since === "string" ? v.since : undefined,
   };
 }
 
@@ -1825,6 +1860,7 @@ function toWorkspaceStorageStatus(body: unknown): WorkspaceStorageStatus | null 
     jurisdiction: typeof b.jurisdiction === "string" ? b.jurisdiction : undefined,
     activeLaneId: typeof b.activeLaneId === "string" ? b.activeLaneId : undefined,
     lanes: Array.isArray(b.lanes) ? b.lanes.flatMap((l) => toWorkspaceStorageLane(l) ?? []) : [],
+    health: toWorkspaceStorageHealth(b.health),
   };
 }
 

--- a/apps/web/src/lib/storage-health-banner.ts
+++ b/apps/web/src/lib/storage-health-banner.ts
@@ -1,0 +1,99 @@
+/**
+ * Signed-in banner for a broken BYO bucket (issue #826).
+ *
+ * An admin shouldn't have to open the storage settings tab to find out that
+ * uploads are failing, so every workspace tab checks the active lane's health
+ * once per page load and paints a dismissable notice pointing at the fix.
+ *
+ * Only admins ever see it: `GET /v1/workspaces/:name/storage` is admin/owner
+ * only, and a non-admin's 403 lands in the same silent no-op as any other
+ * unavailable result. Nothing is ever painted from a failed or unparseable
+ * response — `getWorkspaceStorageStatus` already fails healthy.
+ */
+import { getWorkspaceStorageStatus } from "./api-client";
+import { onSession } from "./account-shell";
+
+/** sessionStorage prefix for per-failure dismissals. */
+const DISMISS_KEY_PREFIX = "uploads:storageHealthDismissed:";
+
+/**
+ * Dismissal is scoped to the workspace *and* the failure it was dismissed
+ * for: a lane that recovers and breaks again gets a fresh `since`, and so a
+ * fresh banner. sessionStorage (not localStorage) because "I've seen it, stop
+ * following me around this session" is the actual ask — a still-broken bucket
+ * is worth re-raising next time they sign in.
+ */
+function dismissKey(workspace: string, since: string | undefined): string {
+  return `${DISMISS_KEY_PREFIX}${workspace}:${since ?? "unknown"}`;
+}
+
+function isDismissed(workspace: string, since: string | undefined): boolean {
+  try {
+    return sessionStorage.getItem(dismissKey(workspace, since)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markDismissed(workspace: string, since: string | undefined): void {
+  try {
+    sessionStorage.setItem(dismissKey(workspace, since), "1");
+  } catch {
+    // Private mode / quota — the banner just reappears on the next tab.
+  }
+}
+
+export function storageSettingsPath(workspace: string): string {
+  return `/account/workspaces/${encodeURIComponent(workspace)}/settings/storage`;
+}
+
+export interface InitStorageHealthBannerOptions {
+  /** Query root for `[data-storage-health-banner]`. Defaults to `document`. */
+  root?: Document | Element;
+  /** Current path, for the "already on the fix page" check. Defaults to `location.pathname`. */
+  pathname?: string;
+}
+
+/**
+ * Mounts the banner for one workspace-tab page load. Safe to call on every
+ * tab: it no-ops when the banner element is absent, when the caller is not an
+ * admin, when storage is healthy, when the notice was already dismissed for
+ * this failure, and when the user is already on the storage settings page
+ * (where the lane card says the same thing in more detail — a banner above it
+ * would be pure repetition).
+ */
+export function initStorageHealthBanner(
+  apiOrigin: string,
+  workspace: string,
+  opts: InitStorageHealthBannerOptions = {},
+): void {
+  const root = opts.root ?? document;
+  const banner = root.querySelector<HTMLElement>("[data-storage-health-banner]");
+  if (!banner || !workspace) return;
+  const settingsPath = storageSettingsPath(workspace);
+  const pathname = opts.pathname ?? location.pathname;
+  if (pathname === settingsPath) return;
+
+  onSession(() => {
+    void getWorkspaceStorageStatus(apiOrigin, workspace).then((result) => {
+      if (result.kind !== "ok") return;
+      const { health } = result.status;
+      if (health.ok || !health.message) return;
+      if (isDismissed(workspace, health.since)) return;
+
+      const messageEl = banner.querySelector<HTMLElement>("[data-storage-health-message]");
+      const linkEl = banner.querySelector<HTMLAnchorElement>("[data-storage-health-link]");
+      const dismissEl = banner.querySelector<HTMLButtonElement>("[data-storage-health-dismiss]");
+      // Server-authored sentence, set as text — never as markup.
+      if (messageEl) {
+        messageEl.textContent = `${health.message}. New uploads to this workspace are failing.`;
+      }
+      if (linkEl) linkEl.href = settingsPath;
+      dismissEl?.addEventListener("click", () => {
+        banner.hidden = true;
+        markDismissed(workspace, health.since);
+      });
+      banner.hidden = false;
+    });
+  });
+}

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -162,9 +162,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           <h3 class="storage-lane-heading flex items-center gap-2.5 m-0">
             Your bucket
             <span class="ul-badge ul-badge--ok" id="storage-byo-badge-ok">Active</span>
-            <!-- Unhealthy active lane (#826). Swapped for the Active badge
-                 rather than shown beside it: the lane IS still the active one,
-                 so two badges would read as two lanes. -->
+            <!-- Unhealthy active lane (#826).
+                 Swapped for the Active badge rather than shown beside it.
+                 The lane IS still the active one.
+                 Two badges would read as two lanes. -->
             <span class="ul-badge ul-badge--danger" id="storage-byo-badge-error" hidden
               >Not working</span
             >
@@ -201,11 +202,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         </div>
         <p class="settings-note muted" id="storage-byo-note">New uploads go to this bucket.</p>
 
-        <!-- Unhealthy-lane panel (#826): one plain-language sentence about
-             what stopped working, the fix as the primary button, and the
-             prompted (never automatic) fallback beside it. Replaces the
-             "New uploads go to this bucket" note while it's showing — that
-             line is no longer true. -->
+        <!-- Unhealthy-lane panel (#826).
+             One plain-language sentence about what stopped working.
+             The fix is the primary button.
+             The prompted, never automatic, fallback sits beside it.
+             This replaces the "New uploads go to this bucket" note.
+             That note is not true while uploads are failing. -->
         <div
           class="storage-unhealthy max-w-[32rem] mt-1 mb-3 flex flex-col gap-2.5 rounded-md border border-destructive/40 bg-destructive/5 px-4 py-3"
           id="storage-unhealthy"
@@ -631,14 +633,14 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       }
 
       /**
-       * Unhealthy-lane state for the active BYO card (#826). The server owns
-       * the failure sentence (`health.message`) — this only decides which
-       * badge shows and whether the fallback button is offered at all.
+       * Unhealthy-lane state for the active BYO card (#826).
+       * The server owns the failure sentence (`health.message`).
+       * This picks the badge and decides whether to offer the fallback.
        *
-       * The fallback button appears only when a shared lane has actually been
-       * recorded; without one there is no lane id to activate, and the ⋯
-       * menu's "Switch back to hosted storage…" (which falls through to the
-       * legacy detach path) remains the way out.
+       * The fallback button needs a recorded shared lane to activate.
+       * Without one there is no lane id to point it at.
+       * The ⋯ menu's "Switch back to hosted storage…" is then the way out.
+       * That item falls through to the legacy detach path.
        */
       function renderHealth(status: WorkspaceStorageStatus): void {
         const unhealthy = status.mode === "byo" && !status.health.ok;
@@ -1041,18 +1043,18 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         statusEl.dataset.state = "error";
       }
 
-      // The primary fix on the unhealthy panel. Opens the same rotate form the
-      // ⋯ menu does, prefilled from the status already on screen (no refetch —
-      // the panel is only visible because that status was just applied).
+      // The primary fix on the unhealthy panel.
+      // Opens the same rotate form the ⋯ menu does.
+      // Prefilled from the status already on screen, with no refetch.
+      // That status is current: the panel only exists because it was applied.
       storageUnhealthyRotateBtn.addEventListener("click", () => {
         if (!lastStatus) return;
         openForm("rotate", lastStatus);
       });
 
-      // Prompted fallback (#826) — never a silent reroute. Same activate
-      // primitive and the same confirmation copy as every other switch, so
-      // "existing files keep resolving from your bucket" is stated before
-      // anything moves.
+      // Prompted fallback (#826) — never a silent reroute.
+      // Same activate primitive and confirmation copy as every other switch.
+      // So "existing files keep resolving" is stated before anything moves.
       storageUnhealthyFallbackBtn.addEventListener("click", () => {
         if (!sharedFallbackLaneId) return;
         void activateLane(

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -160,7 +160,14 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       <div id="storage-byo" hidden>
         <div class="storage-lane-head flex items-center justify-between gap-3">
           <h3 class="storage-lane-heading flex items-center gap-2.5 m-0">
-            Your bucket <span class="ul-badge ul-badge--ok">Active</span>
+            Your bucket
+            <span class="ul-badge ul-badge--ok" id="storage-byo-badge-ok">Active</span>
+            <!-- Unhealthy active lane (#826). Swapped for the Active badge
+                 rather than shown beside it: the lane IS still the active one,
+                 so two badges would read as two lanes. -->
+            <span class="ul-badge ul-badge--danger" id="storage-byo-badge-error" hidden
+              >Not working</span
+            >
           </h3>
           <div class="storage-menu relative flex-none" data-storage-menu>
             <button
@@ -192,7 +199,31 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             </div>
           </div>
         </div>
-        <p class="settings-note muted">New uploads go to this bucket.</p>
+        <p class="settings-note muted" id="storage-byo-note">New uploads go to this bucket.</p>
+
+        <!-- Unhealthy-lane panel (#826): one plain-language sentence about
+             what stopped working, the fix as the primary button, and the
+             prompted (never automatic) fallback beside it. Replaces the
+             "New uploads go to this bucket" note while it's showing — that
+             line is no longer true. -->
+        <div
+          class="storage-unhealthy max-w-[32rem] mt-1 mb-3 flex flex-col gap-2.5 rounded-md border border-destructive/40 bg-destructive/5 px-4 py-3"
+          id="storage-unhealthy"
+          role="alert"
+          hidden
+        >
+          <p class="m-0 text-[13px] font-medium text-destructive" id="storage-unhealthy-msg"></p>
+          <p class="m-0 text-xs text-muted-foreground" id="storage-unhealthy-detail"></p>
+          <div class="storage-actions flex flex-wrap items-center gap-3">
+            <button type="button" class="ul-btn ul-btn--solid" id="storage-unhealthy-rotate-btn"
+              >Rotate credentials</button
+            >
+            <button type="button" class="ul-btn" id="storage-unhealthy-fallback-btn" hidden
+              >Switch to hosted storage until this is fixed</button
+            >
+          </div>
+        </div>
+
         <dl class="kv" id="storage-byo-details"></dl>
         <div
           class="storage-confirm max-w-[32rem] mt-3 flex flex-col gap-2.5 rounded-md border border-border px-4 py-3"
@@ -443,6 +474,20 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         page,
       );
       const storageActionStatus = requireElement<HTMLElement>("#storage-action-status", page);
+      const storageByoNote = requireElement<HTMLElement>("#storage-byo-note", page);
+      const storageByoBadgeOk = requireElement<HTMLElement>("#storage-byo-badge-ok", page);
+      const storageByoBadgeError = requireElement<HTMLElement>("#storage-byo-badge-error", page);
+      const storageUnhealthy = requireElement<HTMLElement>("#storage-unhealthy", page);
+      const storageUnhealthyMsg = requireElement<HTMLElement>("#storage-unhealthy-msg", page);
+      const storageUnhealthyDetail = requireElement<HTMLElement>("#storage-unhealthy-detail", page);
+      const storageUnhealthyRotateBtn = requireElement<HTMLButtonElement>(
+        "#storage-unhealthy-rotate-btn",
+        page,
+      );
+      const storageUnhealthyFallbackBtn = requireElement<HTMLButtonElement>(
+        "#storage-unhealthy-fallback-btn",
+        page,
+      );
       const storageConnect = requireElement<HTMLElement>("#storage-connect", page);
       const storageConnectHeading = requireElement<HTMLElement>("#storage-connect-heading", page);
       const storageSetupHelp = requireElement<HTMLDetailsElement>("#storage-setup-help", page);
@@ -583,6 +628,35 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         storageSavedDetails.innerHTML = rows
           .map(([label, value]) => `<dt>${escapeHtml(label)}</dt><dd>${value}</dd>`)
           .join("");
+      }
+
+      /**
+       * Unhealthy-lane state for the active BYO card (#826). The server owns
+       * the failure sentence (`health.message`) — this only decides which
+       * badge shows and whether the fallback button is offered at all.
+       *
+       * The fallback button appears only when a shared lane has actually been
+       * recorded; without one there is no lane id to activate, and the ⋯
+       * menu's "Switch back to hosted storage…" (which falls through to the
+       * legacy detach path) remains the way out.
+       */
+      function renderHealth(status: WorkspaceStorageStatus): void {
+        const unhealthy = status.mode === "byo" && !status.health.ok;
+        storageByoBadgeOk.hidden = unhealthy;
+        storageByoBadgeError.hidden = !unhealthy;
+        // "New uploads go to this bucket" is not true while uploads are failing.
+        storageByoNote.hidden = unhealthy;
+        storageUnhealthy.hidden = !unhealthy;
+        if (!unhealthy) return;
+        storageUnhealthyMsg.textContent = status.health.message ?? "";
+        const since = status.health.since
+          ? ` Uploads started failing ${formatTimestamp(status.health.since)}.`
+          : "";
+        storageUnhealthyDetail.textContent =
+          `New uploads to this bucket are failing.${since} Rotating the access keys ` +
+          `usually fixes it. Nothing already stored on your bucket is touched, and ` +
+          `existing files keep resolving.`;
+        storageUnhealthyFallbackBtn.hidden = sharedFallbackLaneId === null;
       }
 
       /** "Existing files stay where they are and keep working. New uploads go to <target>." — the switch confirmation copy from every direction (spec verbatim). */
@@ -967,6 +1041,28 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         statusEl.dataset.state = "error";
       }
 
+      // The primary fix on the unhealthy panel. Opens the same rotate form the
+      // ⋯ menu does, prefilled from the status already on screen (no refetch —
+      // the panel is only visible because that status was just applied).
+      storageUnhealthyRotateBtn.addEventListener("click", () => {
+        if (!lastStatus) return;
+        openForm("rotate", lastStatus);
+      });
+
+      // Prompted fallback (#826) — never a silent reroute. Same activate
+      // primitive and the same confirmation copy as every other switch, so
+      // "existing files keep resolving from your bucket" is stated before
+      // anything moves.
+      storageUnhealthyFallbackBtn.addEventListener("click", () => {
+        if (!sharedFallbackLaneId) return;
+        void activateLane(
+          sharedFallbackLaneId,
+          "hosted storage",
+          storageActionStatus,
+          storageByoConfirm,
+        );
+      });
+
       storageUseBtn.addEventListener("click", () => {
         if (!savedLaneId) return;
         void activateLane(
@@ -1096,6 +1192,9 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             storageSaved.hidden = true;
           }
         }
+
+        // Last: it reads `sharedFallbackLaneId`, resolved above.
+        renderHealth(status);
       }
 
       async function loadStorage(): Promise<void> {


### PR DESCRIPTION
Closes #826.

Once a BYO bucket is connected and active, nothing told the workspace when its previously-working credentials broke — a revoked R2 token or a deleted bucket just started failing uploads silently. This adds a health signal for the active BYO lane, surfaces it where an admin will actually see it, and offers a one-click way to keep working while it's fixed.

## What's implemented

**Detection (`apps/api/src/storage-health.ts`)**
- `classifyStorageFailure` maps a storage-operation error onto `auth` / `bucket_missing` / `unreachable`, and returns nothing for failures a credential rotation couldn't fix (caller-caused 4xx, transient 5xx, plain network errors).
- `noteStorageFailure` flags the active lane on the workspace record; `noteStorageSuccess` clears it. Both go through `mutateWorkspaceRecord`, never a bare `REGISTRY.put`, and both are no-ops unless they'd actually change the record — a healthy workspace's uploads cost zero extra KV writes.
- Hooked into the upload path in `files-core.ts`: the existing `store.upload` failure branch reports, the success path clears.
- New record fields `storageUnhealthyAt` (first failure in the current stretch — "failing since", not "last failed") and `storageUnhealthyCode`. Health travels with the lane: `demoteActiveLane` carries it down, `promoteLane` clears it.

**Storage settings page**
- An unhealthy active lane swaps its `Active` badge for a danger `Not working` badge and renders a panel with the server-authored failure sentence ("We can no longer sign in to your bucket"), a short "what this means" line, **Rotate credentials** as the primary button (opens the existing rotate form), and the fallback action beside it.
- The "New uploads go to this bucket" note hides while the lane is broken — it isn't true.
- Demoted lanes carry `unhealthyAt` in the lane list, so a lane you switched away from *because* it broke doesn't read as fine.

**Signed-in banner (`apps/web/src/lib/storage-health-banner.ts`)**
- Dismissable workspace-level notice in `WorkspaceLayout`, above the tab content, linking to the storage settings page. Admin-only by construction (the status route is admin/owner only; a member's 403 is a silent no-op), skipped on the storage settings page itself, and dismissal is keyed to the workspace *and* the failure timestamp so a recover-then-break-again raises a fresh notice.

**Fallback**
- "Switch to hosted storage until this is fixed" runs the existing `activate` primitive against the recorded shared fallback lane, through the same inline confirmation and the same copy as every other switch. Never automatic — the issue's "silent rerouting vs. prompted action" question is settled on the prompted side.

## Decisions

- **On-failure detection, not a scheduled prober.** A cron sweep would do a live round-trip against every BYO bucket on a fixed interval whether or not the workspace is being used, and would still learn nothing sooner than the first failing upload does for an active workspace. A sweep for idle workspaces can be added later without changing any state this writes.
- **Conservative classification.** Only credential-shaped failures flag a lane. Flagging on a transient 5xx would light a workspace-wide banner for something rotating keys can't fix.
- **Shared lanes are never flagged.** A platform-binding failure is ours; telling a workspace to rotate credentials it doesn't own would be nonsense.
- **The client fails healthy.** A missing or partial `health` block (older API, truncated body) parses as healthy — the UI never invents failure copy, and only ever renders the sentence the server wrote.
- **Activating a flagged lane always re-verifies**, however fresh its `verifiedAt` looks: the flag is later evidence than the stamp, and promotion clears the flag unconditionally.
- **Rotation clears the flag immediately** — the rotate path just proved those exact credentials work, so the badge and banner shouldn't linger until the next upload.

## Deliberately deferred

- Read-path detection: only the write path reports today. A failing read is more often a public-domain problem than a credential one, and the fallback lane resolution already covers a lot of it.
- Email notification (issue item 3's "and possibly an email").
- CLI/API parity (`uploads doctor`, upload error messages) — the state and its projection are in place for it; no CLI change here.
- A scheduled sweep for workspaces that aren't uploading.

## Test evidence

- New `apps/api/src/storage-health.test.ts` — 21 cases covering classification, the flag/clear lifecycle (first-failure timestamp preserved, no write when unchanged, shared lanes untouched, lane-switch race ignored, never throws), lane demote/promote health handoff, and the status projection.
- New api-client case for the unhealthy projection plus the two fail-healthy paths (partial block, no block).
- `pnpm test` at repo root: 336 files, 5054 tests passing.
- `pnpm typecheck` clean in `apps/api` and `apps/web`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added storage health monitoring for customer-managed storage.
  * Workspace pages now display alerts when storage credentials or buckets become unavailable.
  * Storage settings provide clearer failure details, credential rotation, and available hosted-storage fallback options.
  * Storage status now includes health information and unhealthy timestamps.

* **Bug Fixes**
  * Storage health automatically clears after successful operations or credential updates.
  * Storage lane transitions now preserve or reset health status appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->