### PR TITLE
feat(api): make gallery creation retry-safe

### DIFF
--- a/.changeset/safe-gallery-retries.md
+++ b/.changeset/safe-gallery-retries.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Retry gallery creation safely with caller-scoped idempotency keys.

--- a/apps/api/migrations/20260824120000_idempotency_requests.sql
+++ b/apps/api/migrations/20260824120000_idempotency_requests.sql
@@ -1,0 +1,17 @@
+CREATE TABLE idempotency_requests (
+  workspace TEXT NOT NULL,
+  principal TEXT NOT NULL,
+  operation TEXT NOT NULL,
+  key_hash TEXT NOT NULL,
+  fingerprint TEXT NOT NULL,
+  owner_nonce TEXT,
+  state TEXT NOT NULL CHECK (state IN ('pending', 'completed')),
+  response_status INTEGER,
+  response_body TEXT,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  PRIMARY KEY (workspace, principal, operation, key_hash)
+);
+
+CREATE INDEX idempotency_requests_expires_idx
+  ON idempotency_requests (expires_at);

--- a/apps/api/src/db-session.ts
+++ b/apps/api/src/db-session.ts
@@ -56,3 +56,12 @@ export function createDbSession(db: D1Database): D1DatabaseSession {
 export function dbFor(env: Env): D1Queryable {
   return env.DB_SESSION ?? env.DB;
 }
+
+/**
+ * Idempotency decisions must observe the latest claim from another request.
+ * Use a primary-constrained session even when ordinary reads may start on a
+ * replica. Test doubles without the Sessions API fall back to the raw binding.
+ */
+export function primaryDbFor(env: Env): D1Queryable {
+  return typeof env.DB.withSession === "function" ? env.DB.withSession("first-primary") : env.DB;
+}

--- a/apps/api/src/dual-workspace-auth.ts
+++ b/apps/api/src/dual-workspace-auth.ts
@@ -150,6 +150,7 @@ export function dualWorkspaceAuth(): MiddlewareHandler<DualAuthVars> {
     c.set("workspaceName", name);
     c.set("authScopes", [...FILE_SCOPES]);
     c.set("authSource", "session");
+    c.set("authPrincipal", `session-user:${userId}`);
     // A bearer token's `mintingUserId` names the Better Auth user whose
     // linked GitHub identity `isEntitledToClaimRepo` checks (see
     // `github-claim-authz.ts`) — for a session caller, that's simply the

--- a/apps/api/src/galleries.ts
+++ b/apps/api/src/galleries.ts
@@ -153,51 +153,74 @@ async function classifyVersion(
   return { status: "conflict", currentVersion: current.version };
 }
 
-export async function createGallery(
-  db: D1Queryable,
-  input: { workspace: string; title: string; description?: string | null; now?: Date },
-): Promise<MutationResult<GalleryRecord>> {
+export function buildGallery(input: {
+  workspace: string;
+  title: string;
+  description?: string | null;
+  now?: Date;
+}): MutationResult<GalleryRecord> {
   const titleError = validateTitle(input.title);
   if (titleError) return titleError;
   const descriptionError = plainText(input.description, "description", 2000);
   if (descriptionError) return descriptionError;
   const now = (input.now ?? new Date()).toISOString();
-  const record: GalleryRecord = {
-    id: randomGalleryId(),
-    workspace: input.workspace,
-    title: input.title.trim(),
-    description: input.description ?? null,
-    visibility: "public",
-    cover_item_id: null,
-    version: 1,
-    created_at: now,
-    updated_at: now,
-    deleted_at: null,
+  return {
+    status: "ok",
+    value: {
+      id: randomGalleryId(),
+      workspace: input.workspace,
+      title: input.title.trim(),
+      description: input.description ?? null,
+      visibility: "public",
+      cover_item_id: null,
+      version: 1,
+      created_at: now,
+      updated_at: now,
+      deleted_at: null,
+    },
   };
+}
+
+/** Build the quota-guarded gallery insert, optionally gated by another row. */
+export function prepareGalleryInsert(
+  db: D1Queryable,
+  record: GalleryRecord,
+  condition?: { sql: string; values: unknown[] },
+): D1PreparedStatement {
   // The count check lives in the INSERT so concurrent creates cannot exceed the
   // tenant quota. Soft-deleted galleries deliberately do not consume a slot.
-  const result = await db
+  return db
     .prepare(
       `INSERT INTO galleries
       (id, workspace, title, description, visibility, cover_item_id, version, created_at, updated_at, deleted_at)
      SELECT ?, ?, ?, ?, 'public', NULL, 1, ?, ?, NULL
-     WHERE (SELECT COUNT(*) FROM galleries WHERE workspace = ? AND deleted_at IS NULL) < ?`,
+     WHERE (SELECT COUNT(*) FROM galleries WHERE workspace = ? AND deleted_at IS NULL) < ?
+       ${condition ? `AND (${condition.sql})` : ""}`,
     )
     .bind(
       record.id,
       record.workspace,
       record.title,
       record.description,
-      now,
-      now,
+      record.created_at,
+      record.updated_at,
       record.workspace,
       MAX_GALLERIES_PER_WORKSPACE,
-    )
-    .run();
+      ...(condition?.values ?? []),
+    );
+}
+
+export async function createGallery(
+  db: D1Queryable,
+  input: { workspace: string; title: string; description?: string | null; now?: Date },
+): Promise<MutationResult<GalleryRecord>> {
+  const built = buildGallery(input);
+  if (built.status !== "ok") return built;
+  const result = await prepareGalleryInsert(db, built.value).run();
   if ((result.meta.changes ?? 0) === 0) {
     return { status: "limit", limit: MAX_GALLERIES_PER_WORKSPACE };
   }
-  return { status: "ok", value: record };
+  return built;
 }
 
 export async function getGallery(

--- a/apps/api/src/gallery-idempotency.ts
+++ b/apps/api/src/gallery-idempotency.ts
@@ -1,0 +1,165 @@
+import { ConflictError, ValidationError } from "@uploads/errors";
+import { MAX_GALLERIES_PER_WORKSPACE, prepareGalleryInsert, type GalleryRecord } from "./galleries";
+import { sha256Hex } from "./workspace";
+import type { D1Queryable } from "./db-session";
+
+export const IDEMPOTENCY_RETENTION_HOURS = 24;
+const GALLERY_CREATE_OPERATION = "gallery.create.v1";
+const IDEMPOTENCY_KEY_RE = /^[\x21-\x7e]{1,255}$/;
+
+interface StoredRequest {
+  fingerprint: string;
+  owner_nonce: string | null;
+  state: "pending" | "completed";
+  response_status: number | null;
+  response_body: string | null;
+  expires_at: string;
+}
+
+export type IdempotentGalleryResult<T> =
+  | { status: "ok"; value: T; replayed: boolean }
+  | { status: "limit"; limit: number };
+
+export function validateIdempotencyKey(value: string): void {
+  if (!IDEMPOTENCY_KEY_RE.test(value)) {
+    throw new ValidationError("Idempotency-Key must contain 1 to 255 visible ASCII characters.", {
+      code: "idempotency_key_invalid",
+    });
+  }
+}
+
+function conflictFor(row: StoredRequest, fingerprint: string): never {
+  if (row.fingerprint !== fingerprint) {
+    throw new ConflictError("Idempotency-Key was already used for a different request.", {
+      code: "idempotency_key_reused",
+    });
+  }
+  throw new ConflictError("A request with this Idempotency-Key is still in progress.", {
+    code: "idempotency_request_in_progress",
+  });
+}
+
+/**
+ * Atomically claims a key, creates the gallery, and stores the exact 201 JSON.
+ * The canonical and compatibility routes both use the same logical operation.
+ */
+export async function createGalleryIdempotently<T>(
+  db: D1Queryable,
+  input: {
+    workspace: string;
+    principal: string;
+    key: string;
+    record: GalleryRecord;
+    response: T;
+    now?: Date;
+  },
+): Promise<IdempotentGalleryResult<T>> {
+  validateIdempotencyKey(input.key);
+  const now = input.now ?? new Date();
+  const createdAt = now.toISOString();
+  const expiresAt = new Date(
+    now.getTime() + IDEMPOTENCY_RETENTION_HOURS * 60 * 60 * 1000,
+  ).toISOString();
+  const keyHash = await sha256Hex(input.key);
+  const fingerprint = await sha256Hex(
+    JSON.stringify({
+      operation: GALLERY_CREATE_OPERATION,
+      title: input.record.title,
+      description: input.record.description,
+    }),
+  );
+  const ownerNonce = crypto.randomUUID();
+  const responseBody = JSON.stringify(input.response);
+  const scope = [input.workspace, input.principal, GALLERY_CREATE_OPERATION, keyHash] as const;
+
+  const claim = db
+    .prepare(
+      `INSERT INTO idempotency_requests
+       (workspace, principal, operation, key_hash, fingerprint, owner_nonce, state,
+        response_status, response_body, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, 'pending', NULL, NULL, ?, ?)
+       ON CONFLICT (workspace, principal, operation, key_hash) DO UPDATE SET
+         fingerprint = excluded.fingerprint,
+         owner_nonce = excluded.owner_nonce,
+         state = 'pending',
+         response_status = NULL,
+         response_body = NULL,
+         created_at = excluded.created_at,
+         expires_at = excluded.expires_at
+       WHERE idempotency_requests.expires_at <= excluded.created_at`,
+    )
+    .bind(...scope, fingerprint, ownerNonce, createdAt, expiresAt);
+
+  const ownsClaim = {
+    sql: `EXISTS (
+      SELECT 1 FROM idempotency_requests
+      WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?
+        AND owner_nonce = ? AND state = 'pending'
+    )`,
+    values: [...scope, ownerNonce],
+  };
+  const insertGallery = prepareGalleryInsert(db, input.record, ownsClaim);
+  const complete = db
+    .prepare(
+      `UPDATE idempotency_requests
+       SET state = 'completed', owner_nonce = NULL, response_status = 201, response_body = ?
+       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?
+         AND owner_nonce = ? AND state = 'pending'
+         AND EXISTS (SELECT 1 FROM galleries WHERE id = ? AND workspace = ?)`,
+    )
+    .bind(responseBody, ...scope, ownerNonce, input.record.id, input.workspace);
+  // A quota refusal is not cached and must not leave a pending claim behind.
+  const releaseFailedClaim = db
+    .prepare(
+      `DELETE FROM idempotency_requests
+       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?
+         AND owner_nonce = ? AND state = 'pending'
+         AND NOT EXISTS (SELECT 1 FROM galleries WHERE id = ? AND workspace = ?)`,
+    )
+    .bind(...scope, ownerNonce, input.record.id, input.workspace);
+
+  const results = await db.batch([claim, insertGallery, complete, releaseFailedClaim]);
+  if ((results[1]?.meta.changes ?? 0) > 0) {
+    return { status: "ok", value: input.response, replayed: false };
+  }
+
+  const row = await db
+    .prepare(
+      `SELECT fingerprint, owner_nonce, state, response_status, response_body, expires_at
+       FROM idempotency_requests
+       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?`,
+    )
+    .bind(...scope)
+    .first<StoredRequest>();
+
+  if (!row) return { status: "limit", limit: MAX_GALLERIES_PER_WORKSPACE };
+  if (row.fingerprint !== fingerprint || row.state !== "completed" || !row.response_body) {
+    return conflictFor(row, fingerprint);
+  }
+  return { status: "ok", value: JSON.parse(row.response_body) as T, replayed: true };
+}
+
+/** Bounded daily cleanup. Expiry is also enforced when a key is claimed. */
+export async function purgeExpiredIdempotencyRequests(
+  db: D1Queryable,
+  now = new Date(),
+): Promise<{ deleted: number; truncated: boolean }> {
+  const batchSize = 500;
+  const maxBatches = 20;
+  let deleted = 0;
+  for (let batch = 0; batch < maxBatches; batch++) {
+    const result = await db
+      .prepare(
+        `DELETE FROM idempotency_requests
+         WHERE rowid IN (
+           SELECT rowid FROM idempotency_requests WHERE expires_at <= ? LIMIT ?
+         )`,
+      )
+      .bind(now.toISOString(), batchSize)
+      .run();
+    const changes = result.meta.changes ?? 0;
+    deleted += changes;
+    if (changes < batchSize) return { deleted, truncated: false };
+  }
+  return { deleted, truncated: true };
+}

--- a/apps/api/src/gallery-idempotency.ts
+++ b/apps/api/src/gallery-idempotency.ts
@@ -2,6 +2,7 @@ import { ConflictError, ValidationError } from "@uploads/errors";
 import { MAX_GALLERIES_PER_WORKSPACE, prepareGalleryInsert, type GalleryRecord } from "./galleries";
 import { sha256Hex } from "./workspace";
 import type { D1Queryable } from "./db-session";
+import { boundedRead, type DataReadEnv } from "./data-read-bounds";
 
 export const IDEMPOTENCY_RETENTION_HOURS = 24;
 const GALLERY_CREATE_OPERATION = "gallery.create.v1";
@@ -51,6 +52,7 @@ export async function createGalleryIdempotently<T>(
     key: string;
     record: GalleryRecord;
     response: T;
+    readEnv?: DataReadEnv;
     now?: Date;
   },
 ): Promise<IdempotentGalleryResult<T>> {
@@ -123,14 +125,16 @@ export async function createGalleryIdempotently<T>(
     return { status: "ok", value: input.response, replayed: false };
   }
 
-  const row = await db
+  const replayLookup = db
     .prepare(
       `SELECT fingerprint, owner_nonce, state, response_status, response_body, expires_at
        FROM idempotency_requests
        WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?`,
     )
-    .bind(...scope)
-    .first<StoredRequest>();
+    .bind(...scope);
+  const row = await boundedRead(input.readEnv ?? {}, () => replayLookup.first<StoredRequest>(), {
+    name: "d1_gallery_idempotency_replay",
+  });
 
   if (!row) return { status: "limit", limit: MAX_GALLERIES_PER_WORKSPACE };
   if (row.fingerprint !== fingerprint || row.state !== "completed" || !row.response_body) {

--- a/apps/api/src/gallery-service.ts
+++ b/apps/api/src/gallery-service.ts
@@ -472,6 +472,19 @@ export async function hydrateOwnerGallery(
   items: GalleryItemRecord[],
 ): Promise<GalleryDto> {
   return {
+    ...emptyOwnerGallery(env, record),
+    items: (await hydrateGalleryItems(env, workspace, items, { audience: "owner" })).map(
+      (item) => ({
+        ...item,
+        pageUrl: galleryItemUrl(env, record.id, item.id),
+      }),
+    ),
+  };
+}
+
+/** A newly created gallery has no items, so projecting it must not touch storage. */
+export function emptyOwnerGallery(env: Env, record: GalleryRecord): GalleryDto {
+  return {
     id: record.id,
     url: galleryUrl(env, record.id),
     workspace: record.workspace,
@@ -482,12 +495,7 @@ export async function hydrateOwnerGallery(
     version: record.version,
     createdAt: record.created_at,
     updatedAt: record.updated_at,
-    items: (await hydrateGalleryItems(env, workspace, items, { audience: "owner" })).map(
-      (item) => ({
-        ...item,
-        pageUrl: galleryItemUrl(env, record.id, item.id),
-      }),
-    ),
+    items: [],
   };
 }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,6 +20,7 @@ import { workspaceSettings } from "./routes/workspace-settings";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { runObservabilityRetention } from "./observability-retention";
+import { purgeExpiredIdempotencyRequests } from "./gallery-idempotency";
 import { galleries } from "./routes/galleries";
 import { publicGalleries } from "./routes/public-galleries";
 import { publicFiles } from "./routes/public-files";
@@ -70,7 +71,7 @@ const consoleCors = cors({
   // PATCH: file metadata + galleries, admin workspace limits / OAuth client
   // edits, /me member role + file-visibility updates.
   allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
-  allowHeaders: ["Authorization", "Content-Type"],
+  allowHeaders: ["Authorization", "Content-Type", "Idempotency-Key"],
   maxAge: 86400,
 });
 
@@ -249,6 +250,18 @@ export default {
         console.error(
           JSON.stringify({
             message: "observability_retention_failed",
+            error: appErr.message,
+            code: appErr.code,
+          }),
+        );
+      }),
+    );
+    ctx.waitUntil(
+      purgeExpiredIdempotencyRequests(env.DB).catch((err) => {
+        const appErr = AppError.from(err);
+        console.error(
+          JSON.stringify({
+            message: "idempotency_retention_failed",
             error: appErr.message,
             code: appErr.code,
           }),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,7 +1,7 @@
 import { AppError, NotFoundError } from "@uploads/errors";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { createDbSession } from "./db-session";
+import { createDbSession, dbFor } from "./db-session";
 import { respondError } from "./error-response";
 import { workspaceAuth, type WorkspaceVars } from "./workspace";
 import { files } from "./routes/files";
@@ -257,7 +257,7 @@ export default {
       }),
     );
     ctx.waitUntil(
-      purgeExpiredIdempotencyRequests(env.DB).catch((err) => {
+      purgeExpiredIdempotencyRequests(dbFor(env)).catch((err) => {
         const appErr = AppError.from(err);
         console.error(
           JSON.stringify({

--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -91,6 +91,7 @@ export async function createGalleryHandler(c: Context<WorkspaceVars>) {
       key: idempotencyKey,
       record,
       response,
+      readEnv: c.env,
     });
   } catch (error) {
     if (error instanceof ConflictError && error.code === "idempotency_request_in_progress") {

--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -10,6 +10,7 @@ import { badKey } from "../files-core";
 import {
   addGalleryItem,
   addExternalReference,
+  buildGallery,
   createGallery,
   getGallery,
   listGalleries,
@@ -24,6 +25,7 @@ import {
 } from "../galleries";
 import {
   decodeGalleryCursor,
+  emptyOwnerGallery,
   encodeGalleryCursor,
   gallerySummary,
   hydrateOwnerGallery,
@@ -38,7 +40,9 @@ import { publicUrl, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { jsonBody } from "./json-body";
 import { dbFor } from "../db-session";
+import { primaryDbFor } from "../db-session";
 import { boundedDataRead } from "../data-read-bounds";
+import { createGalleryIdempotently } from "../gallery-idempotency";
 
 async function ownerGallery(c: Context<WorkspaceVars>, id: string) {
   const record = await getGallery(dbFor(c.env), c.get("workspaceName"), id);
@@ -59,21 +63,50 @@ async function ownerGallery(c: Context<WorkspaceVars>, id: string) {
  */
 export async function createGalleryHandler(c: Context<WorkspaceVars>) {
   const body = await jsonBody(c);
-  const result = unwrapMutation(
-    await createGallery(dbFor(c.env), {
-      workspace: c.get("workspaceName"),
-      title: typeof body.title === "string" ? body.title : "",
-      description:
-        body.description === null || typeof body.description === "string"
-          ? body.description
-          : undefined,
-    }),
-  );
-  await recordAdoptionSafe(c.env, {
-    metric: "gallery_created",
+  const input = {
     workspace: c.get("workspaceName"),
-  });
-  return c.json(await ownerGallery(c, result.value.id), 201);
+    title: typeof body.title === "string" ? body.title : "",
+    description:
+      body.description === null || typeof body.description === "string"
+        ? body.description
+        : undefined,
+  };
+  const idempotencyKey = c.req.header("Idempotency-Key");
+  if (idempotencyKey === undefined) {
+    const result = unwrapMutation(await createGallery(dbFor(c.env), input));
+    await recordAdoptionSafe(c.env, {
+      metric: "gallery_created",
+      workspace: c.get("workspaceName"),
+    });
+    return c.json(await ownerGallery(c, result.value.id), 201);
+  }
+
+  const record = unwrapMutation(buildGallery(input)).value;
+  const response = emptyOwnerGallery(c.env, record);
+  let result;
+  try {
+    result = await createGalleryIdempotently(primaryDbFor(c.env), {
+      workspace: c.get("workspaceName"),
+      principal: c.get("authPrincipal"),
+      key: idempotencyKey,
+      record,
+      response,
+    });
+  } catch (error) {
+    if (error instanceof ConflictError && error.code === "idempotency_request_in_progress") {
+      c.header("Retry-After", "1");
+    }
+    throw error;
+  }
+  if (result.status === "limit") mutationError(result);
+  if (result.replayed) c.header("Idempotency-Replayed", "true");
+  if (!result.replayed) {
+    await recordAdoptionSafe(c.env, {
+      metric: "gallery_created",
+      workspace: c.get("workspaceName"),
+    });
+  }
+  return c.json(result.value, 201);
 }
 
 export async function listGalleriesHandler(c: Context<WorkspaceVars>) {

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -365,6 +365,8 @@ export type WorkspaceVars = {
     authScopes: FileScope[];
     /** "session" is set only by `dualWorkspaceAuth` (see dual-workspace-auth.ts). */
     authSource: "d1" | "legacy" | "session";
+    /** Stable opaque credential identity used to isolate idempotency keys. */
+    authPrincipal: string;
     /** Better Auth user behind the bearer token (issue #340), or null. */
     mintingUserId: string | null;
   };
@@ -578,6 +580,7 @@ function workspaceAuthWith(
     c.set("workspaceName", name);
     c.set("authScopes", d1Token ? parseScopes(d1Token.scopes) : [...FILE_SCOPES]);
     c.set("authSource", d1Token ? "d1" : "legacy");
+    c.set("authPrincipal", d1Token ? `d1-token:${d1Token.id}` : `legacy-token:${providedHash}`);
     // Uploader attribution (issue #340) — null for legacy/enrollment tokens.
     c.set("mintingUserId", d1Token?.minting_user_id ?? null);
     if (d1Token) {

--- a/apps/api/test/gallery-idempotency.test.ts
+++ b/apps/api/test/gallery-idempotency.test.ts
@@ -1,0 +1,245 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { buildGallery } from "../src/galleries";
+import { emptyOwnerGallery } from "../src/gallery-service";
+import {
+  createGalleryIdempotently,
+  purgeExpiredIdempotencyRequests,
+} from "../src/gallery-idempotency";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260711180000_galleries.sql",
+  "migrations/20260824120000_idempotency_requests.sql",
+];
+
+function gallery(workspace: string, title: string, now: Date) {
+  const result = buildGallery({ workspace, title, now });
+  if (result.status !== "ok") throw new Error(`build failed: ${result.status}`);
+  return result.value;
+}
+
+describe("gallery creation idempotency", () => {
+  it("projects an empty response without resolving workspace storage", () => {
+    const record = gallery("alpha", "Shots", new Date("2026-08-24T12:00:00Z"));
+    const response = emptyOwnerGallery(
+      { WEB_ORIGIN: "https://uploads.test" } as unknown as Env,
+      record,
+    );
+    expect(response).toMatchObject({ id: record.id, title: "Shots", items: [] });
+  });
+
+  it("replays the exact response and creates one gallery", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-08-24T12:00:00Z");
+      const firstRecord = gallery("alpha", "Shots", now);
+      const firstResponse = { id: firstRecord.id, title: firstRecord.title, items: [] };
+      const first = await createGalleryIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "gallery-create-1",
+        record: firstRecord,
+        response: firstResponse,
+        now,
+      });
+      const retryRecord = gallery("alpha", "Shots", new Date("2026-08-24T12:01:00Z"));
+      const retry = await createGalleryIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "gallery-create-1",
+        record: retryRecord,
+        response: { id: retryRecord.id, title: retryRecord.title, items: [] },
+        now: new Date("2026-08-24T12:01:00Z"),
+      });
+
+      expect(first).toEqual({ status: "ok", value: firstResponse, replayed: false });
+      expect(retry).toEqual({ status: "ok", value: firstResponse, replayed: true });
+      expect(sqlite.db.prepare("SELECT COUNT(*) AS count FROM galleries").get()).toMatchObject({
+        count: 1,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("lets concurrent callers create once and replay once", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-08-24T12:00:00Z");
+      const records = [gallery("alpha", "Shots", now), gallery("alpha", "Shots", now)];
+      const results = await Promise.all(
+        records.map((record) =>
+          createGalleryIdempotently(database(sqlite), {
+            workspace: "alpha",
+            principal: "d1-token:one",
+            key: "concurrent-key",
+            record,
+            response: { id: record.id },
+            now,
+          }),
+        ),
+      );
+
+      expect(results.map((result) => result.status === "ok" && result.replayed).sort()).toEqual([
+        false,
+        true,
+      ]);
+      expect(sqlite.db.prepare("SELECT COUNT(*) AS count FROM galleries").get()).toMatchObject({
+        count: 1,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rolls back the claim when the gallery insert fails", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-08-24T12:00:00Z");
+      const record = gallery("alpha", "Shots", now);
+      sqlite.db
+        .prepare(
+          `INSERT INTO galleries
+           (id, workspace, title, description, visibility, cover_item_id, version, created_at, updated_at, deleted_at)
+           VALUES (?, ?, ?, NULL, 'public', NULL, 1, ?, ?, NULL)`,
+        )
+        .run(record.id, record.workspace, record.title, record.created_at, record.updated_at);
+
+      await expect(
+        createGalleryIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "d1-token:one",
+          key: "failing-key",
+          record,
+          response: { id: record.id },
+          now,
+        }),
+      ).rejects.toThrow();
+      expect(
+        sqlite.db.prepare("SELECT COUNT(*) AS count FROM idempotency_requests").get(),
+      ).toMatchObject({ count: 0 });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rejects reuse with a different effective request", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-08-24T12:00:00Z");
+      const first = gallery("alpha", "Shots", now);
+      await createGalleryIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "session-user:one",
+        key: "same-key",
+        record: first,
+        response: { id: first.id },
+        now,
+      });
+      const changed = gallery("alpha", "Changed", now);
+      await expect(
+        createGalleryIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "session-user:one",
+          key: "same-key",
+          record: changed,
+          response: { id: changed.id },
+          now,
+        }),
+      ).rejects.toMatchObject({ code: "idempotency_key_reused" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("isolates the same key by principal and workspace", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-08-24T12:00:00Z");
+      for (const [workspace, principal] of [
+        ["alpha", "d1-token:one"],
+        ["alpha", "d1-token:two"],
+        ["beta", "d1-token:one"],
+      ] as const) {
+        const record = gallery(workspace, "Shots", now);
+        await expect(
+          createGalleryIdempotently(database(sqlite), {
+            workspace,
+            principal,
+            key: "shared-key",
+            record,
+            response: { id: record.id },
+            now,
+          }),
+        ).resolves.toMatchObject({ status: "ok", replayed: false });
+      }
+      expect(sqlite.db.prepare("SELECT COUNT(*) AS count FROM galleries").get()).toMatchObject({
+        count: 3,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("allows a fresh create after expiry and purges expired rows", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const start = new Date("2026-08-24T12:00:00Z");
+      const first = gallery("alpha", "First", start);
+      await createGalleryIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "legacy-token:one",
+        key: "expiring-key",
+        record: first,
+        response: { id: first.id },
+        now: start,
+      });
+
+      const afterExpiry = new Date("2026-08-25T12:00:01Z");
+      const second = gallery("alpha", "Second", afterExpiry);
+      await expect(
+        createGalleryIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "legacy-token:one",
+          key: "expiring-key",
+          record: second,
+          response: { id: second.id },
+          now: afterExpiry,
+        }),
+      ).resolves.toMatchObject({ status: "ok", replayed: false });
+
+      await expect(
+        purgeExpiredIdempotencyRequests(database(sqlite), new Date("2026-08-26T12:00:02Z")),
+      ).resolves.toEqual({ deleted: 1, truncated: false });
+      expect(sqlite.db.prepare("SELECT COUNT(*) AS count FROM galleries").get()).toMatchObject({
+        count: 2,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rejects blank, control-character, and oversized keys", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-08-24T12:00:00Z");
+      for (const key of ["", "has space", "line\nbreak", "x".repeat(256)]) {
+        const record = gallery("alpha", "Shots", now);
+        await expect(
+          createGalleryIdempotently(database(sqlite), {
+            workspace: "alpha",
+            principal: "d1-token:one",
+            key,
+            record,
+            response: { id: record.id },
+            now,
+          }),
+        ).rejects.toMatchObject({ code: "idempotency_key_invalid" });
+      }
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/gallery-idempotency.test.ts
+++ b/apps/api/test/gallery-idempotency.test.ts
@@ -64,6 +64,59 @@ describe("gallery creation idempotency", () => {
     }
   });
 
+  it("bounds the replay lookup without racing the write batch", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-08-24T12:00:00Z");
+      const firstRecord = gallery("alpha", "Shots", now);
+      await createGalleryIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "stalled-replay",
+        record: firstRecord,
+        response: { id: firstRecord.id },
+        now,
+      });
+
+      const underlying = database(sqlite);
+      let batchCompleted = false;
+      const stalledReplayDb = {
+        async batch(statements: D1PreparedStatement[]) {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          const results = await underlying.batch(statements);
+          batchCompleted = true;
+          return results;
+        },
+        prepare(sql: string) {
+          const statement = underlying.prepare(sql);
+          if (!sql.includes("SELECT fingerprint, owner_nonce")) return statement;
+          return {
+            bind() {
+              return this;
+            },
+            first: () => new Promise<never>(() => {}),
+          } as unknown as D1PreparedStatement;
+        },
+      } as unknown as D1Database;
+      const retryRecord = gallery("alpha", "Shots", new Date("2026-08-24T12:01:00Z"));
+
+      await expect(
+        createGalleryIdempotently(stalledReplayDb, {
+          workspace: "alpha",
+          principal: "d1-token:one",
+          key: "stalled-replay",
+          record: retryRecord,
+          response: { id: retryRecord.id },
+          readEnv: { DATA_READ_TIMEOUT_MS: "5" },
+          now: new Date("2026-08-24T12:01:00Z"),
+        }),
+      ).rejects.toMatchObject({ code: "data_unavailable" });
+      expect(batchCompleted).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+
   it("lets concurrent callers create once and replay once", async () => {
     const sqlite = new SqliteD1(MIGRATIONS);
     try {

--- a/apps/api/test/index-scheduled.test.ts
+++ b/apps/api/test/index-scheduled.test.ts
@@ -19,6 +19,7 @@ const MIGRATIONS = [
   "migrations/20260713210559_file_metadata.sql",
   "migrations/20260710140000_workspace_usage.sql",
   "migrations/20260822120100_workspace_usage_shared_subset.sql",
+  "migrations/20260824120000_idempotency_requests.sql",
 ];
 
 const WS = "acme";
@@ -106,6 +107,21 @@ describe("scheduled handler — no staging reaper (#421)", () => {
         "gh.staged-at": daysAgo(400),
       });
 
+      const insertIdempotency = sqlite.db.prepare(
+        `INSERT INTO idempotency_requests
+         (workspace, principal, operation, key_hash, fingerprint, owner_nonce, state,
+          response_status, response_body, created_at, expires_at)
+         VALUES (?, 'd1-token:test', 'gallery.create.v1', ?, 'fingerprint', NULL,
+                 'completed', 201, '{}', ?, ?)`,
+      );
+      insertIdempotency.run(WS, "expired", daysAgo(2), daysAgo(1));
+      insertIdempotency.run(
+        WS,
+        "current",
+        new Date().toISOString(),
+        new Date(Date.now() + MS_PER_DAY).toISOString(),
+      );
+
       const { ctx, settle } = fakeExecutionContext();
       await worker.scheduled({} as ScheduledController, env, ctx);
       await settle();
@@ -118,6 +134,9 @@ describe("scheduled handler — no staging reaper (#421)", () => {
       expect(await getFileMetadata(database(sqlite), WS, abandonedKey)).toMatchObject({
         "gh.kind": "branch",
       });
+      expect(
+        sqlite.db.prepare("SELECT key_hash FROM idempotency_requests ORDER BY key_hash").all(),
+      ).toEqual([{ key_hash: "current" }]);
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -122,6 +122,14 @@ beforeEach(async () => {
       "utf8",
     ),
   );
+  db.exec(
+    readFileSync(
+      fileURLToPath(
+        new NodeURL("../migrations/20260824120000_idempotency_requests.sql", import.meta.url),
+      ),
+      "utf8",
+    ),
+  );
   // Phase 4: adds auth_tokens.minting_user_id, which findActiveToken (used by
   // workspaceAuth on these routes) now selects.
   db.exec(

--- a/apps/api/test/routes-workspace-galleries.test.ts
+++ b/apps/api/test/routes-workspace-galleries.test.ts
@@ -143,6 +143,7 @@ beforeEach(async () => {
   db.exec(migration("20260710140000_workspace_usage.sql"));
   db.exec(migration("20260822120100_workspace_usage_shared_subset.sql"));
   db.exec(migration("20260711180000_galleries.sql"));
+  db.exec(migration("20260824120000_idempotency_requests.sql"));
   db.exec(migration("20260712230000_token_minting_user.sql"));
   db.exec(migration("20260817180000_token_last_used.sql"));
   db.exec(migration("20260713210559_file_metadata.sql"));
@@ -184,6 +185,31 @@ async function createViaCanonical(env: Parameters<typeof app.request>[2]) {
 }
 
 describe("POST/GET/PATCH/DELETE /v1/workspaces/:workspace/galleries (bearer, canonical CRUD)", () => {
+  it("replays one logical create across canonical and compatibility routes", async () => {
+    const env = await makeEnv();
+    const headers = {
+      Authorization: `Bearer ${TOKEN}`,
+      "Content-Type": "application/json",
+      "Idempotency-Key": "canonical-legacy-create",
+    };
+    const first = await app.request(
+      "/v1/workspaces/acme/galleries",
+      { method: "POST", headers, body: JSON.stringify({ title: "Launch media" }) },
+      env,
+    );
+    const replay = await app.request(
+      "/v1/acme/galleries",
+      { method: "POST", headers, body: JSON.stringify({ title: "Launch media" }) },
+      env,
+    );
+
+    expect(first.status).toBe(201);
+    expect(replay.status).toBe(201);
+    expect(replay.headers.get("Idempotency-Replayed")).toBe("true");
+    expect(await replay.json()).toEqual(await first.json());
+    expect(db.prepare("SELECT COUNT(*) AS count FROM galleries").get()).toMatchObject({ count: 1 });
+  });
+
   it("creates, reads, updates, and deletes a gallery", async () => {
     const env = await makeEnv();
     const gallery = await createViaCanonical(env);
@@ -283,6 +309,44 @@ describe("POST/GET/PATCH/DELETE /v1/workspaces/:workspace/galleries (bearer, can
 });
 
 describe("GET /v1/workspaces/:workspace/galleries (session auth)", () => {
+  it("isolates the same idempotency key between a bearer credential and a session user", async () => {
+    const env = await makeEnv();
+    const body = JSON.stringify({ title: "Independent creates" });
+    const bearer = await app.request(
+      "/v1/workspaces/acme/galleries",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${TOKEN}`,
+          "Content-Type": "application/json",
+          "Idempotency-Key": "shared-across-auth",
+        },
+        body,
+      },
+      env,
+    );
+    const session = await app.request(
+      "/v1/workspaces/acme/galleries",
+      {
+        method: "POST",
+        headers: {
+          cookie: "session=x",
+          "Content-Type": "application/json",
+          "Idempotency-Key": "shared-across-auth",
+        },
+        body,
+      },
+      env,
+    );
+
+    expect(bearer.status).toBe(201);
+    expect(session.status).toBe(201);
+    const bearerGallery = (await bearer.json()) as { id: string };
+    const sessionGallery = (await session.json()) as { id: string };
+    expect(bearerGallery.id).not.toBe(sessionGallery.id);
+    expect(db.prepare("SELECT COUNT(*) AS count FROM galleries").get()).toMatchObject({ count: 2 });
+  });
+
   it("a member reaches the same handler as a bearer caller (200, identical list shape)", async () => {
     const env = await makeEnv();
     await createViaCanonical(env);

--- a/apps/web/public/.well-known/openapi.json
+++ b/apps/web/public/.well-known/openapi.json
@@ -316,6 +316,8 @@
       "post": {
         "operationId": "createGallery",
         "summary": "Create a gallery",
+        "description": "Send an Idempotency-Key to make retries safe for 24 hours. Reusing the key with the same effective body returns the original 201 response. Reusing it with a different body returns 409.",
+        "parameters": [{ "$ref": "#/components/parameters/IdempotencyKey" }],
         "requestBody": {
           "required": true,
           "content": {
@@ -325,6 +327,12 @@
         "responses": {
           "201": {
             "description": "The gallery was created.",
+            "headers": {
+              "Idempotency-Replayed": {
+                "description": "Present with value `true` when the API replays a stored response.",
+                "schema": { "type": "string", "enum": ["true"] }
+              }
+            },
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/Gallery" } }
             }
@@ -332,6 +340,7 @@
           "400": { "$ref": "#/components/responses/Validation" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "403": { "$ref": "#/components/responses/Forbidden" },
+          "409": { "$ref": "#/components/responses/Conflict" },
           "429": { "$ref": "#/components/responses/RateLimited" }
         }
       },
@@ -639,6 +648,13 @@
         "in": "path",
         "required": true,
         "schema": { "type": "string", "pattern": "^gal_" }
+      },
+      "IdempotencyKey": {
+        "name": "Idempotency-Key",
+        "in": "header",
+        "required": false,
+        "description": "A caller-scoped retry key retained for 24 hours. Use 1 to 255 visible ASCII characters.",
+        "schema": { "type": "string", "minLength": 1, "maxLength": 255 }
       },
       "Prefix": { "name": "prefix", "in": "query", "schema": { "type": "string" } },
       "Cursor": {

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,23 @@ application. API integrations should use a workspace token.
 
 Unknown workspaces and bad tokens are indistinguishable (both 401).
 
+## Idempotency
+
+`POST /v1/workspaces/:workspace/galleries` accepts an optional
+`Idempotency-Key` header. `POST /v1/:workspace/galleries` accepts the same
+header and shares the same logical operation.
+
+Use 1 to 255 visible ASCII characters. The API scopes the key to the workspace
+and the current credential. It retains a successful response for 24 hours.
+The same key and effective JSON body replay the original `201` response with
+`Idempotency-Replayed: true`. The same key with a different effective body
+returns `409 idempotency_key_reused`. A concurrent request can return
+`409 idempotency_request_in_progress` with `Retry-After: 1`.
+
+The JavaScript client generates a key for `createGallery`. Pass
+`idempotencyKey` in the options when separate client calls must share a key.
+After 24 hours, the same key starts a new operation.
+
 ## Errors
 
 Every non-2xx response uses one nested envelope (same shape as either/releases):
@@ -53,7 +70,7 @@ Throw `AppError` subclasses from `@uploads/errors` in route code; the API's
 | `GET /v1/workspaces/:workspace/usage`                                           | Read workspace usage, limits, token scopes, and plan; requires `files:read`                                                                                                                                                     |
 | `POST /v1/workspaces/:workspace/usage/reconcile`                                | Maintenance operation. Potentially expensive: scans storage and rebuilds `bytes` and `objects`; bearer token only; requires `files:write`                                                                                       |
 | `POST /v1/workspaces/:workspace/usage/purge-expired`                            | Destructive maintenance operation. Permanently deletes objects older than `retentionDays`, then reconciles; bearer token only; requires `files:delete`                                                                          |
-| `POST /v1/workspaces/:workspace/galleries`                                      | Create an empty public gallery; requires `files:write`                                                                                                                                                                          |
+| `POST /v1/workspaces/:workspace/galleries`                                      | Create an empty public gallery; requires `files:write`; accepts `Idempotency-Key` for safe retries                                                                                                                              |
 | `GET /v1/workspaces/:workspace/galleries?limit=&cursor=`                        | List enriched gallery summaries with opaque cursor pagination; requires `files:read`                                                                                                                                            |
 | `GET /v1/workspaces/:workspace/galleries/:id`                                   | Read one owned gallery; requires `files:read`                                                                                                                                                                                   |
 | `PATCH/DELETE /v1/workspaces/:workspace/galleries/:id`                          | Update or soft-delete gallery metadata; requires `files:write`                                                                                                                                                                  |

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -44,6 +44,11 @@ export const ERROR_CODES = [
   // Auth / enrollment
   "invalid_enrollment",
 
+  // Idempotency
+  "idempotency_key_invalid",
+  "idempotency_key_reused",
+  "idempotency_request_in_progress",
+
   // External integrations (GitHub App, OAuth providers, …)
   "integration_authorization_required",
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -229,6 +229,8 @@ export interface GalleryListResult {
 export interface CreateGalleryOptions {
   title: string;
   description?: string | null;
+  /** Reuse this key to safely retry the same create request. Generated when omitted. */
+  idempotencyKey?: string;
 }
 
 export interface AddGalleryItemOptions {
@@ -523,8 +525,9 @@ const JSON_TIMEOUT_MS = 15_000;
 const CONTENT_TIMEOUT_MS = 60_000;
 
 // At most one retry. Retried on network errors, 503, and 429 — and only for
-// GET/PUT, since a `put` is byte-idempotent (same key, same bytes) but a
-// POST/DELETE/PATCH might not be, and telling "no bytes sent" apart from "the
+// GET/PUT, since a `put` is byte-idempotent (same key, same bytes). POST is
+// retryable only when the request carries an Idempotency-Key; DELETE/PATCH
+// remain single-attempt because telling "no bytes sent" apart from "the
 // mutation already landed" isn't reliable enough to risk a double-apply.
 const MAX_ATTEMPTS = 2;
 const RETRYABLE_METHODS = new Set(["GET", "PUT"]);
@@ -595,7 +598,10 @@ async function resilientFetch(
   init: RequestInit,
   timeoutMs: number,
 ): Promise<Response> {
-  const retryable = RETRYABLE_METHODS.has(method.toUpperCase());
+  const normalizedMethod = method.toUpperCase();
+  const retryable =
+    RETRYABLE_METHODS.has(normalizedMethod) ||
+    (normalizedMethod === "POST" && new Headers(init.headers).has("Idempotency-Key"));
   for (let attempt = 1; ; attempt++) {
     let res: Response | undefined;
     let networkErr: UploadsError | undefined;
@@ -1274,9 +1280,13 @@ export function createUploadsClient(config: UploadsClientConfig) {
     },
 
     async createGallery(opts: CreateGalleryOptions): Promise<Gallery> {
+      const { idempotencyKey = crypto.randomUUID(), ...body } = opts;
       return request<Gallery>("POST", galleriesBase(config), {
-        body: new TextEncoder().encode(JSON.stringify(opts)),
-        headers: { "Content-Type": "application/json" },
+        body: new TextEncoder().encode(JSON.stringify(body)),
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": idempotencyKey,
+        },
       });
     },
 

--- a/packages/uploads/test/client-resilience.test.ts
+++ b/packages/uploads/test/client-resilience.test.ts
@@ -35,7 +35,7 @@ describe("request timeouts", () => {
     vi.stubGlobal("fetch", stallingFetch());
 
     const promise = client()
-      .createGallery({ title: "t" })
+      .deleteGallery("gal_1", { expectedVersion: 1 })
       .then(
         () => null,
         (e: unknown) => e,
@@ -177,19 +177,29 @@ describe("bounded retry", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("does not retry a non-idempotent POST on 503", async () => {
-    const fetchMock = vi.fn(async () => new Response(null, { status: 503 }));
+  it("retries gallery creation with the same idempotency key", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls++;
+      if (calls === 1) return new Response(null, { status: 503 });
+      return new Response(JSON.stringify({ id: "gal_1", title: "t" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
     vi.stubGlobal("fetch", fetchMock);
 
-    const err = await client()
-      .createGallery({ title: "t" })
-      .then(
-        () => null,
-        (e: unknown) => e,
-      );
+    const promise = client().createGallery({ title: "t", idempotencyKey: "create-gallery-1" });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await promise;
 
-    expect(err).toBeInstanceOf(UploadsError);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const requestCalls = fetchMock.mock.calls as unknown as Array<[string, RequestInit]>;
+    const firstHeaders = new Headers(requestCalls[0]?.[1].headers);
+    const secondHeaders = new Headers(requestCalls[1]?.[1].headers);
+    expect(firstHeaders.get("Idempotency-Key")).toBe("create-gallery-1");
+    expect(secondHeaders.get("Idempotency-Key")).toBe("create-gallery-1");
   });
 
   it("does not retry DELETE on 503", async () => {


### PR DESCRIPTION
## In plain terms

Gallery creation can now survive a timeout or dropped response without creating a duplicate gallery. The API replays the original successful result when the caller retries with the same idempotency key.

Refs #829.

## What it does / what it is not

- Adds optional Idempotency-Key support to canonical and compatibility gallery-create routes.
- Scopes each key to the workspace, logical operation, and authenticated credential.
- Rejects a reused key when the effective request body changes.
- Generates an idempotency key in the JavaScript client and retries that POST once on network, 429, or 503 failures.
- Retains successful responses for 24 hours and removes expired records through the daily cleanup task.
- Documents the contract in the public OpenAPI document and API guide.
- Does not add token-mint or upload idempotency. Token replay needs encrypted secret storage. Upload replay needs recovery across D1 and object storage.

## How to try it

Send the same gallery body and Idempotency-Key twice:

```bash
curl -X POST "https://api.uploads.sh/v1/workspaces/$UPLOADS_WORKSPACE/galleries" \
  -H "Authorization: Bearer $UPLOADS_TOKEN" \
  -H "Content-Type: application/json" \
  -H "Idempotency-Key: gallery-demo-1" \
  -d '{"title":"Launch media"}'
```

The second response keeps status 201, returns the original gallery, and includes Idempotency-Replayed: true.

## Technical notes

- One transactional D1 batch claims the key, inserts the gallery, and stores the response.
- Idempotency reads use a primary-constrained D1 session so a retry cannot observe a stale replica.
- The database stores a SHA-256 digest of the raw key, not the key itself.
- The new migration is included in the branch. I did not apply migrations manually.

## Test plan

- [x] API test suite: 161 files, 2,240 tests
- [x] Client test suite: 74 files, 1,311 tests
- [x] Web test suite: 58 files, 883 tests
- [x] API, client, and errors TypeScript checks
- [x] Changed-file oxlint and oxfmt checks
- [ ] Full monorepo typecheck in this worktree; unrelated workspace dependencies were unavailable offline. CI will run the complete gate.
