### PR TITLE
feat(api): make API token minting retry-safe

### DIFF
--- a/.changeset/retry-safe-token-minting.md
+++ b/.changeset/retry-safe-token-minting.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Mint workspace tokens safely on retry: `mintWorkspaceToken` now accepts an
+optional `idempotencyKey` so a retried request replays the original one-time
+token instead of minting a duplicate.

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -135,19 +135,26 @@ export async function findActiveToken(
     .first<AuthTokenRecord>();
 }
 
-export async function createToken(
-  db: D1Queryable,
-  input: {
-    workspace: string;
-    label?: string;
-    // Widened beyond FileScope so admin-scoped operator tokens (issue #257) and
-    // workspace-governance tokens (issue #262) can be minted through the same
-    // path; storage is just a JSON TEXT column.
-    scopes: (FileScope | OperatorScope | WorkspaceScope)[];
-    expiresAt?: Date;
-    mintedByUserId?: string | null;
-    now?: Date;
-  },
+export interface CreateTokenInput {
+  workspace: string;
+  label?: string;
+  // Widened beyond FileScope so admin-scoped operator tokens (issue #257) and
+  // workspace-governance tokens (issue #262) can be minted through the same
+  // path; storage is just a JSON TEXT column.
+  scopes: (FileScope | OperatorScope | WorkspaceScope)[];
+  expiresAt?: Date;
+  mintedByUserId?: string | null;
+  now?: Date;
+}
+
+/**
+ * Mint a fresh secret and its row *without writing it*. The plaintext `token`
+ * is returned once and never persisted (only its hash lives in `record`).
+ * Split out from {@link createToken} so retry-safe minting can insert the row
+ * inside a larger idempotency batch — see `token-idempotency.ts`.
+ */
+export async function buildTokenRecord(
+  input: CreateTokenInput,
 ): Promise<{ token: string; record: AuthTokenRecord }> {
   const token = randomSecret(`up_${input.workspace}_`);
   const now = input.now ?? new Date();
@@ -163,12 +170,27 @@ export async function createToken(
     minting_user_id: input.mintedByUserId ?? null,
     last_used_at: null,
   };
-  await db
+  return { token, record };
+}
+
+/**
+ * Build the `auth_tokens` insert, optionally gated by another row (e.g. an
+ * owned idempotency claim). Uses `INSERT … SELECT … WHERE` so the guard is
+ * evaluated atomically with the insert. `revoked_at`/`last_used_at` are always
+ * NULL at creation. `meta.changes > 0` means the row was written.
+ */
+export function prepareTokenInsert(
+  db: D1Queryable,
+  record: AuthTokenRecord,
+  condition?: { sql: string; values: unknown[] },
+): D1PreparedStatement {
+  return db
     .prepare(
       `INSERT INTO auth_tokens
        (id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
         minting_user_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
+       SELECT ?, ?, ?, ?, ?, ?, ?, NULL, ?
+       ${condition ? `WHERE (${condition.sql})` : ""}`,
     )
     .bind(
       record.id,
@@ -179,9 +201,17 @@ export async function createToken(
       record.created_at,
       record.expires_at,
       record.minting_user_id,
-    )
-    .run();
-  return { token, record };
+      ...(condition?.values ?? []),
+    );
+}
+
+export async function createToken(
+  db: D1Queryable,
+  input: CreateTokenInput,
+): Promise<{ token: string; record: AuthTokenRecord }> {
+  const built = await buildTokenRecord(input);
+  await prepareTokenInsert(db, built.record).run();
+  return built;
 }
 
 export async function createEnrollment(

--- a/apps/api/src/gallery-idempotency.ts
+++ b/apps/api/src/gallery-idempotency.ts
@@ -1,44 +1,23 @@
-import { ConflictError, ValidationError } from "@uploads/errors";
 import { MAX_GALLERIES_PER_WORKSPACE, prepareGalleryInsert, type GalleryRecord } from "./galleries";
 import { sha256Hex } from "./workspace";
 import type { D1Queryable } from "./db-session";
 import { boundedRead, type DataReadEnv } from "./data-read-bounds";
+import {
+  conflictFor,
+  IDEMPOTENCY_RETENTION_HOURS,
+  validateIdempotencyKey,
+  type StoredRequest,
+} from "./idempotency-core";
 
-export const IDEMPOTENCY_RETENTION_HOURS = 24;
+// Re-exported so existing importers (index.ts cron, tests) keep their paths.
+export { IDEMPOTENCY_RETENTION_HOURS, validateIdempotencyKey } from "./idempotency-core";
+export { purgeExpiredIdempotencyRequests } from "./idempotency-core";
+
 const GALLERY_CREATE_OPERATION = "gallery.create.v1";
-const IDEMPOTENCY_KEY_RE = /^[\x21-\x7e]{1,255}$/;
-
-interface StoredRequest {
-  fingerprint: string;
-  owner_nonce: string | null;
-  state: "pending" | "completed";
-  response_status: number | null;
-  response_body: string | null;
-  expires_at: string;
-}
 
 export type IdempotentGalleryResult<T> =
   | { status: "ok"; value: T; replayed: boolean }
   | { status: "limit"; limit: number };
-
-export function validateIdempotencyKey(value: string): void {
-  if (!IDEMPOTENCY_KEY_RE.test(value)) {
-    throw new ValidationError("Idempotency-Key must contain 1 to 255 visible ASCII characters.", {
-      code: "idempotency_key_invalid",
-    });
-  }
-}
-
-function conflictFor(row: StoredRequest, fingerprint: string): never {
-  if (row.fingerprint !== fingerprint) {
-    throw new ConflictError("Idempotency-Key was already used for a different request.", {
-      code: "idempotency_key_reused",
-    });
-  }
-  throw new ConflictError("A request with this Idempotency-Key is still in progress.", {
-    code: "idempotency_request_in_progress",
-  });
-}
 
 /**
  * Atomically claims a key, creates the gallery, and stores the exact 201 JSON.
@@ -141,29 +120,4 @@ export async function createGalleryIdempotently<T>(
     return conflictFor(row, fingerprint);
   }
   return { status: "ok", value: JSON.parse(row.response_body) as T, replayed: true };
-}
-
-/** Bounded daily cleanup. Expiry is also enforced when a key is claimed. */
-export async function purgeExpiredIdempotencyRequests(
-  db: D1Queryable,
-  now = new Date(),
-): Promise<{ deleted: number; truncated: boolean }> {
-  const batchSize = 500;
-  const maxBatches = 20;
-  let deleted = 0;
-  for (let batch = 0; batch < maxBatches; batch++) {
-    const result = await db
-      .prepare(
-        `DELETE FROM idempotency_requests
-         WHERE rowid IN (
-           SELECT rowid FROM idempotency_requests WHERE expires_at <= ? LIMIT ?
-         )`,
-      )
-      .bind(now.toISOString(), batchSize)
-      .run();
-    const changes = result.meta.changes ?? 0;
-    deleted += changes;
-    if (changes < batchSize) return { deleted, truncated: false };
-  }
-  return { deleted, truncated: true };
 }

--- a/apps/api/src/idempotency-core.ts
+++ b/apps/api/src/idempotency-core.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared primitives for `Idempotency-Key` support across operations.
+ *
+ * The per-operation modules (`gallery-idempotency.ts`, `token-idempotency.ts`)
+ * own their transaction shape and response projection; this module owns the
+ * pieces that must stay identical between them: key validation, the stored-row
+ * type, the conflict semantics, and the retention sweep. All records live in
+ * one `idempotency_requests` table keyed by
+ * `(workspace, principal, operation, key_hash)`, so a single cron sweep and a
+ * single key format cover every operation.
+ */
+import { ConflictError, ValidationError } from "@uploads/errors";
+import type { D1Queryable } from "./db-session";
+
+/** Successful replay records are retained this long, then swept. */
+export const IDEMPOTENCY_RETENTION_HOURS = 24;
+
+/** 1–255 visible ASCII characters, matching the documented contract. */
+export const IDEMPOTENCY_KEY_RE = /^[\x21-\x7e]{1,255}$/;
+
+/** One row of `idempotency_requests`. `response_body` may be ciphertext. */
+export interface StoredRequest {
+  fingerprint: string;
+  owner_nonce: string | null;
+  state: "pending" | "completed";
+  response_status: number | null;
+  response_body: string | null;
+  expires_at: string;
+}
+
+export function validateIdempotencyKey(value: string): void {
+  if (!IDEMPOTENCY_KEY_RE.test(value)) {
+    throw new ValidationError("Idempotency-Key must contain 1 to 255 visible ASCII characters.", {
+      code: "idempotency_key_invalid",
+    });
+  }
+}
+
+/**
+ * Turns a losing/mismatched claim into the caller-facing 409. A different
+ * fingerprint means the key was reused for a different request; anything else
+ * (still pending, or missing the stored body) means a concurrent request holds
+ * the claim. Never distinguishes another user's/workspace's key — the lookup is
+ * already scoped to the caller, so a foreign key simply looks absent.
+ */
+export function conflictFor(row: StoredRequest, fingerprint: string): never {
+  if (row.fingerprint !== fingerprint) {
+    throw new ConflictError("Idempotency-Key was already used for a different request.", {
+      code: "idempotency_key_reused",
+    });
+  }
+  throw new ConflictError("A request with this Idempotency-Key is still in progress.", {
+    code: "idempotency_request_in_progress",
+  });
+}
+
+/**
+ * Bounded daily cleanup for every operation's records. Expiry is also enforced
+ * when a key is re-claimed, so this only reclaims space. D1 writes stay
+ * unbounded (no per-statement deadline); the batch cap keeps a single cron
+ * tick from running away.
+ */
+export async function purgeExpiredIdempotencyRequests(
+  db: D1Queryable,
+  now = new Date(),
+): Promise<{ deleted: number; truncated: boolean }> {
+  const batchSize = 500;
+  const maxBatches = 20;
+  let deleted = 0;
+  for (let batch = 0; batch < maxBatches; batch++) {
+    const result = await db
+      .prepare(
+        `DELETE FROM idempotency_requests
+         WHERE rowid IN (
+           SELECT rowid FROM idempotency_requests WHERE expires_at <= ? LIMIT ?
+         )`,
+      )
+      .bind(now.toISOString(), batchSize)
+      .run();
+    const changes = result.meta.changes ?? 0;
+    deleted += changes;
+    if (changes < batchSize) return { deleted, truncated: false };
+  }
+  return { deleted, truncated: true };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,7 +20,7 @@ import { workspaceSettings } from "./routes/workspace-settings";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { runObservabilityRetention } from "./observability-retention";
-import { purgeExpiredIdempotencyRequests } from "./gallery-idempotency";
+import { purgeExpiredIdempotencyRequests } from "./idempotency-core";
 import { galleries } from "./routes/galleries";
 import { publicGalleries } from "./routes/public-galleries";
 import { publicFiles } from "./routes/public-files";

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { respondError } from "../error-response";
 import { tokens } from "./tokens";
+import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
 
 const USER = { id: "u-1", email: "a@b.com", name: "Ada", role: "user" };
 const ORG = { id: "org-acme", slug: "acme", name: "Acme" };
@@ -625,5 +626,120 @@ describe("DELETE /v1/tokens/:id", () => {
     );
     expect(res.status).toBe(429);
     expect(rows[0].revoked_at).toBeNull();
+  });
+});
+
+function countTokens(sqlite: SqliteD1): number {
+  return (sqlite.db.prepare("SELECT COUNT(*) AS c FROM auth_tokens").get() as { c: number }).c;
+}
+
+describe("POST /v1/tokens idempotency", () => {
+  const SECRET = "idempotency-master-key-0123456789";
+  const IDEMPOTENCY_MIGRATIONS = [
+    "migrations/20260710120000_auth.sql",
+    "migrations/20260712230000_token_minting_user.sql",
+    "migrations/20260817180000_token_last_used.sql",
+    "migrations/20260824120000_idempotency_requests.sql",
+  ];
+
+  function sqliteEnv(sqlite: SqliteD1, overrides: Parameters<typeof stubEnv>[0] = {}): Env {
+    return {
+      ...stubEnv({ db: database(sqlite), ...overrides }),
+      WORKSPACE_SECRETS_KEY: SECRET,
+    } as unknown as Env;
+  }
+
+  interface MintBody {
+    token: string;
+    workspace: string;
+    scopes: string[];
+    expiresAt: string | null;
+  }
+
+  it("replays the original token on an identical retry and mints once", async () => {
+    const sqlite = new SqliteD1(IDEMPOTENCY_MIGRATIONS);
+    try {
+      const env = sqliteEnv(sqlite);
+      const first = await post(env, oneGrant, { "Idempotency-Key": "route-mint-1" });
+      const retry = await post(env, oneGrant, { "Idempotency-Key": "route-mint-1" });
+      expect(first.status).toBe(201);
+      expect(retry.status).toBe(201);
+      expect(retry.headers.get("Idempotency-Replayed")).toBe("true");
+      const a = (await first.json()) as MintBody;
+      const b = (await retry.json()) as MintBody;
+      expect(b.token).toBe(a.token);
+      expect(countTokens(sqlite)).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("409s idempotency_key_reused when the same key carries a changed body", async () => {
+    const sqlite = new SqliteD1(IDEMPOTENCY_MIGRATIONS);
+    try {
+      const env = sqliteEnv(sqlite);
+      await post(env, oneGrant, { "Idempotency-Key": "route-mint-2" });
+      const changed = await post(
+        env,
+        { grants: [{ workspace: "acme", scopes: ["files:read"] }] },
+        { "Idempotency-Key": "route-mint-2" },
+      );
+      expect(changed.status).toBe(409);
+      expect((await changed.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "idempotency_key_reused" },
+      });
+      expect(countTokens(sqlite)).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("fails closed with 503 when no encryption key is configured", async () => {
+    const sqlite = new SqliteD1(IDEMPOTENCY_MIGRATIONS);
+    try {
+      const env = { ...stubEnv({ db: database(sqlite) }) } as unknown as Env;
+      const res = await post(env, oneGrant, { "Idempotency-Key": "route-nokey" });
+      expect(res.status).toBe(503);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "secrets_key_unconfigured" },
+      });
+      expect(countTokens(sqlite)).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not let a de-membered user recover a token by replaying a key", async () => {
+    const sqlite = new SqliteD1(IDEMPOTENCY_MIGRATIONS);
+    try {
+      const first = await post(sqliteEnv(sqlite), oneGrant, { "Idempotency-Key": "route-revoked" });
+      expect(first.status).toBe(201);
+      // The caller loses membership, then retries the same key.
+      const revoked = await post(sqliteEnv(sqlite, { memberships: [] }), oneGrant, {
+        "Idempotency-Key": "route-revoked",
+      });
+      expect(revoked.status).toBe(403);
+      expect((await revoked.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "workspace_forbidden" },
+      });
+      expect(countTokens(sqlite)).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("preserves one-shot behavior when no Idempotency-Key is sent", async () => {
+    const sqlite = new SqliteD1(IDEMPOTENCY_MIGRATIONS);
+    try {
+      const env = sqliteEnv(sqlite);
+      const a = await post(env, oneGrant);
+      const b = await post(env, oneGrant);
+      expect(a.status).toBe(201);
+      expect(b.status).toBe(201);
+      expect(a.headers.get("Idempotency-Replayed")).toBeNull();
+      expect(countTokens(sqlite)).toBe(2);
+    } finally {
+      sqlite.close();
+    }
   });
 });

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -24,7 +24,7 @@ import {
 import { Hono } from "hono";
 import {
   buildTokenRecord,
-  createToken,
+  prepareTokenInsert,
   isFileScope,
   isOperatorScope,
   isWorkspaceScope,
@@ -250,33 +250,8 @@ export const tokens = new Hono<SessionVars>()
 
     const expiresAt = ttlSeconds === null ? undefined : new Date(Date.now() + ttlSeconds * 1000);
 
-    // Retry-safe minting (#829): with an Idempotency-Key, claim the key, mint,
-    // and store the *encrypted* 201 body in one batch so an identical retry
-    // replays the original plaintext token instead of minting a second one or
-    // losing the only copy. Runs AFTER every gate above, so a revoked or
-    // downgraded caller is rejected before any replay. Absent the header, the
-    // original one-shot mint is preserved exactly.
-    const idempotencyKey = c.req.header("Idempotency-Key");
-    if (idempotencyKey === undefined) {
-      const { token, record: tokenRecord } = await createToken(dbFor(c.env), {
-        workspace: grant.workspace,
-        label,
-        scopes,
-        expiresAt,
-        mintedByUserId: user.id,
-      });
-      return c.json(
-        {
-          token,
-          workspace: grant.workspace,
-          scopes,
-          label: tokenRecord.label,
-          expiresAt: tokenRecord.expires_at,
-        },
-        201,
-      );
-    }
-
+    // Build the row and its one-time response once; the two mint paths differ
+    // only in how the row is persisted.
     const { token, record: tokenRecord } = await buildTokenRecord({
       workspace: grant.workspace,
       label,
@@ -291,6 +266,20 @@ export const tokens = new Hono<SessionVars>()
       label: tokenRecord.label,
       expiresAt: tokenRecord.expires_at,
     };
+
+    // Without an Idempotency-Key, the original one-shot mint is preserved
+    // exactly: a single unconditional insert.
+    const idempotencyKey = c.req.header("Idempotency-Key");
+    if (idempotencyKey === undefined) {
+      await prepareTokenInsert(dbFor(c.env), tokenRecord).run();
+      return c.json(response, 201);
+    }
+
+    // Retry-safe minting (#829): claim the key, insert the row, and store the
+    // *encrypted* 201 body in one batch so an identical retry replays the
+    // original plaintext token instead of minting a second one or losing the
+    // only copy. Runs AFTER every gate above, so a revoked or downgraded caller
+    // is rejected before any replay.
     let result;
     try {
       result = await createTokenIdempotently(primaryDbFor(c.env), {

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -14,9 +14,16 @@
  * the request carries a `grants` array, but v1 accepts exactly one grant and
  * rejects >1 with a clear "not yet supported".
  */
-import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  RateLimitedError,
+  ValidationError,
+} from "@uploads/errors";
 import { Hono } from "hono";
 import {
+  buildTokenRecord,
   createToken,
   isFileScope,
   isOperatorScope,
@@ -37,9 +44,11 @@ import {
   userHasAdminRole,
   type SessionVars,
 } from "../session-auth";
+import { secretsKeyRingFromEnv } from "../secrets";
+import { createTokenIdempotently } from "../token-idempotency";
 import { loadWorkspaceRecord, WS_NAME_RE } from "../workspace";
 import { suggestWorkspaceName } from "../workspace-suggestion";
-import { dbFor } from "../db-session";
+import { dbFor, primaryDbFor } from "../db-session";
 
 /** Redacted scope list for the issued-token surface — never garbage entries. */
 function parseIssuedScopes(value: string): string[] {
@@ -240,24 +249,69 @@ export const tokens = new Hono<SessionVars>()
     }
 
     const expiresAt = ttlSeconds === null ? undefined : new Date(Date.now() + ttlSeconds * 1000);
-    const { token, record: tokenRecord } = await createToken(dbFor(c.env), {
+
+    // Retry-safe minting (#829): with an Idempotency-Key, claim the key, mint,
+    // and store the *encrypted* 201 body in one batch so an identical retry
+    // replays the original plaintext token instead of minting a second one or
+    // losing the only copy. Runs AFTER every gate above, so a revoked or
+    // downgraded caller is rejected before any replay. Absent the header, the
+    // original one-shot mint is preserved exactly.
+    const idempotencyKey = c.req.header("Idempotency-Key");
+    if (idempotencyKey === undefined) {
+      const { token, record: tokenRecord } = await createToken(dbFor(c.env), {
+        workspace: grant.workspace,
+        label,
+        scopes,
+        expiresAt,
+        mintedByUserId: user.id,
+      });
+      return c.json(
+        {
+          token,
+          workspace: grant.workspace,
+          scopes,
+          label: tokenRecord.label,
+          expiresAt: tokenRecord.expires_at,
+        },
+        201,
+      );
+    }
+
+    const { token, record: tokenRecord } = await buildTokenRecord({
       workspace: grant.workspace,
       label,
       scopes,
       expiresAt,
       mintedByUserId: user.id,
     });
-
-    return c.json(
-      {
-        token,
+    const response = {
+      token,
+      workspace: grant.workspace,
+      scopes,
+      label: tokenRecord.label,
+      expiresAt: tokenRecord.expires_at,
+    };
+    let result;
+    try {
+      result = await createTokenIdempotently(primaryDbFor(c.env), {
         workspace: grant.workspace,
-        scopes,
-        label: tokenRecord.label,
-        expiresAt: tokenRecord.expires_at,
-      },
-      201,
-    );
+        principal: user.id,
+        key: idempotencyKey,
+        record: tokenRecord,
+        fingerprint: { scopes, label: tokenRecord.label, ttlSeconds },
+        response,
+        masterSecret: c.env.WORKSPACE_SECRETS_KEY,
+        ring: secretsKeyRingFromEnv(c.env),
+        readEnv: c.env,
+      });
+    } catch (error) {
+      if (error instanceof ConflictError && error.code === "idempotency_request_in_progress") {
+        c.header("Retry-After", "1");
+      }
+      throw error;
+    }
+    if (result.replayed) c.header("Idempotency-Replayed", "true");
+    return c.json(result.value, 201);
   })
   // Tokens this session user minted. Distinct from GET / (workspace picker)
   // and from GET /v1/workspaces/:name/tokens (workspace-admin list of every

--- a/apps/api/src/token-idempotency.ts
+++ b/apps/api/src/token-idempotency.ts
@@ -1,0 +1,195 @@
+/**
+ * Retry-safe `POST /v1/tokens` (issue #829).
+ *
+ * A workspace token is shown exactly once: the `auth_tokens` row keeps only a
+ * hash, so a naive retry either mints a second token or — worse — loses the
+ * only plaintext copy when the response never reaches the client. This claims
+ * an `Idempotency-Key`, mints the token, and stores the *encrypted* 201 body in
+ * one D1 batch, so an identical retry replays the original plaintext token.
+ *
+ * The replay body carries the plaintext token, so unlike gallery idempotency it
+ * is sealed with AES-GCM via the workspace secrets key ring (`secrets.ts`)
+ * before it touches D1, and minting fails closed (`secrets_key_unconfigured`,
+ * 503) when no key is configured — no token row, no replay row.
+ *
+ * Authorization is *not* re-checked here: the route runs full session +
+ * membership + role + scope gating before calling this, on every request
+ * including retries, so a revoked or downgraded caller is rejected before any
+ * replay can occur. See routes/tokens.ts.
+ */
+import { ServiceUnavailableError } from "@uploads/errors";
+import { type AuthTokenRecord, prepareTokenInsert } from "./auth-db";
+import { boundedRead, type DataReadEnv } from "./data-read-bounds";
+import type { D1Queryable } from "./db-session";
+import {
+  conflictFor,
+  IDEMPOTENCY_RETENTION_HOURS,
+  validateIdempotencyKey,
+  type StoredRequest,
+} from "./idempotency-core";
+import { decryptSecret, encryptSecret, type SecretsKeyRing } from "./secrets";
+import { sha256Hex } from "./workspace";
+
+export const TOKEN_CREATE_OPERATION = "token.create.v1";
+
+/** Request fields that must match for a retry to replay rather than conflict. */
+export interface TokenFingerprintInput {
+  scopes: readonly string[];
+  label: string | null;
+  /** `null` = never expires; a number = the requested TTL in seconds. */
+  ttlSeconds: number | null;
+}
+
+export type IdempotentTokenResult<T> = { value: T; replayed: boolean };
+
+/**
+ * Normalize the effective request into a stable fingerprint. Scopes are sorted
+ * so caller ordering never changes the result; the computed absolute expiry is
+ * deliberately excluded (it drifts by wall-clock between retries) — the
+ * requested `ttlSeconds` is what the caller controls.
+ */
+function fingerprintFor(input: TokenFingerprintInput): Promise<string> {
+  return sha256Hex(
+    JSON.stringify({
+      operation: TOKEN_CREATE_OPERATION,
+      scopes: [...input.scopes].sort(),
+      label: input.label,
+      ttlSeconds: input.ttlSeconds,
+    }),
+  );
+}
+
+/**
+ * Atomically claim `key`, insert `record`, and store the encrypted `response`.
+ * `db` must be primary-constrained (see `primaryDbFor`) so the claim observes
+ * concurrent writers. Returns the (decrypted) original response on replay.
+ *
+ * @throws ServiceUnavailableError `secrets_key_unconfigured` when no encryption
+ *   key is configured — before any row is written.
+ * @throws ConflictError `idempotency_key_reused` / `idempotency_request_in_progress`.
+ */
+export async function createTokenIdempotently<T>(
+  db: D1Queryable,
+  input: {
+    workspace: string;
+    principal: string;
+    key: string;
+    record: AuthTokenRecord;
+    fingerprint: TokenFingerprintInput;
+    response: T;
+    masterSecret: string | undefined;
+    ring: SecretsKeyRing;
+    readEnv?: DataReadEnv;
+    now?: Date;
+  },
+): Promise<IdempotentTokenResult<T>> {
+  validateIdempotencyKey(input.key);
+
+  // Fail closed BEFORE any write: without a key we can neither seal the replay
+  // body nor honor a future retry, and a plaintext token must never hit D1.
+  if (!input.masterSecret) {
+    throw new ServiceUnavailableError(
+      "WORKSPACE_SECRETS_KEY is not configured; tokens cannot be minted idempotently",
+      { code: "secrets_key_unconfigured" },
+    );
+  }
+
+  const now = input.now ?? new Date();
+  const createdAt = now.toISOString();
+  const expiresAt = new Date(
+    now.getTime() + IDEMPOTENCY_RETENTION_HOURS * 60 * 60 * 1000,
+  ).toISOString();
+  const keyHash = await sha256Hex(input.key);
+  const fingerprint = await fingerprintFor(input.fingerprint);
+  const ownerNonce = crypto.randomUUID();
+  // Sealed here, before the batch: an encryption failure means nothing is
+  // written (fail closed), and the stored row never contains the raw token.
+  const responseBody = await encryptSecret(input.masterSecret, JSON.stringify(input.response));
+  const scope = [input.workspace, input.principal, TOKEN_CREATE_OPERATION, keyHash] as const;
+
+  const claim = db
+    .prepare(
+      `INSERT INTO idempotency_requests
+       (workspace, principal, operation, key_hash, fingerprint, owner_nonce, state,
+        response_status, response_body, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, 'pending', NULL, NULL, ?, ?)
+       ON CONFLICT (workspace, principal, operation, key_hash) DO UPDATE SET
+         fingerprint = excluded.fingerprint,
+         owner_nonce = excluded.owner_nonce,
+         state = 'pending',
+         response_status = NULL,
+         response_body = NULL,
+         created_at = excluded.created_at,
+         expires_at = excluded.expires_at
+       WHERE idempotency_requests.expires_at <= excluded.created_at`,
+    )
+    .bind(...scope, fingerprint, ownerNonce, createdAt, expiresAt);
+
+  const ownsClaim = {
+    sql: `EXISTS (
+      SELECT 1 FROM idempotency_requests
+      WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?
+        AND owner_nonce = ? AND state = 'pending'
+    )`,
+    values: [...scope, ownerNonce],
+  };
+  const insertToken = prepareTokenInsert(db, input.record, ownsClaim);
+  const complete = db
+    .prepare(
+      `UPDATE idempotency_requests
+       SET state = 'completed', owner_nonce = NULL, response_status = 201, response_body = ?
+       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?
+         AND owner_nonce = ? AND state = 'pending'
+         AND EXISTS (SELECT 1 FROM auth_tokens WHERE id = ? AND workspace = ?)`,
+    )
+    .bind(responseBody, ...scope, ownerNonce, input.record.id, input.workspace);
+  // If we lost the claim race the token was not inserted; drop our pending
+  // claim so it can never mask the winner's completed row.
+  const releaseFailedClaim = db
+    .prepare(
+      `DELETE FROM idempotency_requests
+       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?
+         AND owner_nonce = ? AND state = 'pending'
+         AND NOT EXISTS (SELECT 1 FROM auth_tokens WHERE id = ? AND workspace = ?)`,
+    )
+    .bind(...scope, ownerNonce, input.record.id, input.workspace);
+
+  const results = await db.batch([claim, insertToken, complete, releaseFailedClaim]);
+  if ((results[1]?.meta.changes ?? 0) > 0) {
+    return { value: input.response, replayed: false };
+  }
+
+  // We did not mint — either a completed row already exists (replay) or another
+  // request holds a pending claim (conflict). Bound only this standalone read;
+  // the write batch above is never deadline-raced.
+  const replayLookup = db
+    .prepare(
+      `SELECT fingerprint, owner_nonce, state, response_status, response_body, expires_at
+       FROM idempotency_requests
+       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?`,
+    )
+    .bind(...scope);
+  const row = await boundedRead(input.readEnv ?? {}, () => replayLookup.first<StoredRequest>(), {
+    name: "d1_token_idempotency_replay",
+  });
+
+  // A missing row means the winner's claim is still settling; a pending
+  // synthetic row makes `conflictFor` raise `idempotency_request_in_progress`.
+  const settled: StoredRequest = row ?? {
+    fingerprint,
+    owner_nonce: null,
+    state: "pending",
+    response_status: null,
+    response_body: null,
+    expires_at: expiresAt,
+  };
+  if (
+    settled.fingerprint !== fingerprint ||
+    settled.state !== "completed" ||
+    !settled.response_body
+  ) {
+    conflictFor(settled, fingerprint);
+  }
+  const opened = await decryptSecret(input.ring, settled.response_body);
+  return { value: JSON.parse(opened.plaintext) as T, replayed: true };
+}

--- a/apps/api/test/token-idempotency.test.ts
+++ b/apps/api/test/token-idempotency.test.ts
@@ -1,0 +1,377 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { ServiceUnavailableError, ValidationError } from "@uploads/errors";
+import { buildTokenRecord } from "../src/auth-db";
+import { createTokenIdempotently } from "../src/token-idempotency";
+import { secretsKeyRingFromEnv } from "../src/secrets";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
+  "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
+  "migrations/20260824120000_idempotency_requests.sql",
+];
+
+const KEY = "0123456789abcdef0123456789abcdef"; // >= 16 chars
+const RING = secretsKeyRingFromEnv({ WORKSPACE_SECRETS_KEY: KEY });
+
+async function mintInput(
+  workspace: string,
+  opts: { scopes?: string[]; label?: string | null; ttlSeconds?: number | null } = {},
+) {
+  const scopes = (opts.scopes ?? ["files:read", "files:write"]) as ("files:read" | "files:write")[];
+  const ttlSeconds = opts.ttlSeconds ?? 3600;
+  const { record } = await buildTokenRecord({
+    workspace,
+    label: opts.label ?? undefined,
+    scopes,
+    expiresAt: ttlSeconds === null ? undefined : new Date("2026-08-24T13:00:00Z"),
+    mintedByUserId: "u-1",
+  });
+  const response = {
+    token: `up_${workspace}_` + record.id,
+    workspace,
+    scopes,
+    label: record.label,
+    expiresAt: record.expires_at,
+  };
+  return {
+    record,
+    response,
+    fingerprint: { scopes, label: record.label, ttlSeconds } as const,
+  };
+}
+
+function countTokens(sqlite: SqliteD1): number {
+  const row = sqlite.db.prepare("SELECT COUNT(*) AS c FROM auth_tokens").get() as { c: number };
+  return row.c;
+}
+
+describe("token creation idempotency", () => {
+  it("replays the exact original plaintext token and mints one row", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-08-24T12:00:00Z");
+      const first = await mintInput("alpha");
+      const firstResult = await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-1",
+        key: "mint-1",
+        record: first.record,
+        fingerprint: first.fingerprint,
+        response: first.response,
+        masterSecret: KEY,
+        ring: RING,
+        now,
+      });
+
+      // A retry supplies a fresh token/record (client re-generates), same key.
+      const retry = await mintInput("alpha");
+      const retryResult = await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-1",
+        key: "mint-1",
+        record: retry.record,
+        fingerprint: retry.fingerprint,
+        response: retry.response,
+        masterSecret: KEY,
+        ring: RING,
+        now: new Date("2026-08-24T12:00:05Z"),
+      });
+
+      expect(firstResult).toEqual({ value: first.response, replayed: false });
+      expect(retryResult.replayed).toBe(true);
+      expect(retryResult.value).toEqual(first.response);
+      // The retry's freshly-minted token is discarded; the original replays.
+      expect(retryResult.value.token).toBe(first.response.token);
+      expect(retryResult.value.token).not.toBe(retry.response.token);
+      expect(countTokens(sqlite)).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("never stores the plaintext token in the replay row", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const first = await mintInput("alpha");
+      await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-1",
+        key: "mint-secret",
+        record: first.record,
+        fingerprint: first.fingerprint,
+        response: first.response,
+        masterSecret: KEY,
+        ring: RING,
+      });
+      const row = sqlite.db.prepare("SELECT response_body FROM idempotency_requests").get() as {
+        response_body: string;
+      };
+      expect(row.response_body.startsWith("enc:v1:")).toBe(true);
+      expect(row.response_body).not.toContain(first.response.token);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("conflicts when the same key is reused with a changed request", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const first = await mintInput("alpha", { scopes: ["files:read"] });
+      await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-1",
+        key: "mint-2",
+        record: first.record,
+        fingerprint: first.fingerprint,
+        response: first.response,
+        masterSecret: KEY,
+        ring: RING,
+      });
+      const changed = await mintInput("alpha", { scopes: ["files:read", "files:write"] });
+      await expect(
+        createTokenIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "u-1",
+          key: "mint-2",
+          record: changed.record,
+          fingerprint: changed.fingerprint,
+          response: changed.response,
+          masterSecret: KEY,
+          ring: RING,
+        }),
+      ).rejects.toMatchObject({ code: "idempotency_key_reused" });
+      expect(countTokens(sqlite)).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("isolates replay records by principal and by workspace", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const a = await mintInput("alpha");
+      const b = await mintInput("alpha");
+      const c = await mintInput("beta");
+      const ra = await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-1",
+        key: "shared",
+        record: a.record,
+        fingerprint: a.fingerprint,
+        response: a.response,
+        masterSecret: KEY,
+        ring: RING,
+      });
+      // Same key, different user → its own mint, not u-1's replay.
+      const rb = await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-2",
+        key: "shared",
+        record: b.record,
+        fingerprint: b.fingerprint,
+        response: b.response,
+        masterSecret: KEY,
+        ring: RING,
+      });
+      // Same key, same user, different workspace → its own mint.
+      const rc = await createTokenIdempotently(database(sqlite), {
+        workspace: "beta",
+        principal: "u-1",
+        key: "shared",
+        record: c.record,
+        fingerprint: c.fingerprint,
+        response: c.response,
+        masterSecret: KEY,
+        ring: RING,
+      });
+      expect(ra.replayed).toBe(false);
+      expect(rb.replayed).toBe(false);
+      expect(rc.replayed).toBe(false);
+      expect(rb.value.token).not.toBe(ra.value.token);
+      expect(rc.value.token).not.toBe(ra.value.token);
+      expect(countTokens(sqlite)).toBe(3);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("fails closed with no encryption key: no token, no replay row", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const first = await mintInput("alpha");
+      await expect(
+        createTokenIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "u-1",
+          key: "mint-nokey",
+          record: first.record,
+          fingerprint: first.fingerprint,
+          response: first.response,
+          masterSecret: undefined,
+          ring: {},
+        }),
+      ).rejects.toBeInstanceOf(ServiceUnavailableError);
+      expect(countTokens(sqlite)).toBe(0);
+      const rows = sqlite.db.prepare("SELECT COUNT(*) AS c FROM idempotency_requests").get() as {
+        c: number;
+      };
+      expect(rows.c).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rejects an invalid Idempotency-Key before any write", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const first = await mintInput("alpha");
+      await expect(
+        createTokenIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "u-1",
+          key: "bad key with space",
+          record: first.record,
+          fingerprint: first.fingerprint,
+          response: first.response,
+          masterSecret: KEY,
+          ring: RING,
+        }),
+      ).rejects.toBeInstanceOf(ValidationError);
+      expect(countTokens(sqlite)).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("lets an expired key be reused for a new mint", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const first = await mintInput("alpha");
+      const r1 = await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-1",
+        key: "mint-exp",
+        record: first.record,
+        fingerprint: first.fingerprint,
+        response: first.response,
+        masterSecret: KEY,
+        ring: RING,
+        now: new Date("2026-08-24T12:00:00Z"),
+      });
+      // 25h later the first claim has expired; the same key starts fresh.
+      const second = await mintInput("alpha");
+      const r2 = await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-1",
+        key: "mint-exp",
+        record: second.record,
+        fingerprint: second.fingerprint,
+        response: second.response,
+        masterSecret: KEY,
+        ring: RING,
+        now: new Date("2026-08-25T13:00:00Z"),
+      });
+      expect(r1.replayed).toBe(false);
+      expect(r2.replayed).toBe(false);
+      expect(r2.value.token).not.toBe(r1.value.token);
+      expect(countTokens(sqlite)).toBe(2);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("replays after the encryption key rotates (previous key still decrypts)", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const oldKey = "old-master-key-0123456789";
+      const newKey = "new-master-key-9876543210";
+      const first = await mintInput("alpha");
+      await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-1",
+        key: "mint-rotate",
+        record: first.record,
+        fingerprint: first.fingerprint,
+        response: first.response,
+        masterSecret: oldKey,
+        ring: { current: oldKey },
+      });
+      const retry = await mintInput("alpha");
+      const result = await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-1",
+        key: "mint-rotate",
+        record: retry.record,
+        fingerprint: retry.fingerprint,
+        response: retry.response,
+        masterSecret: newKey,
+        ring: { current: newKey, previous: oldKey },
+      });
+      expect(result.replayed).toBe(true);
+      expect(result.value.token).toBe(first.response.token);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("bounds the replay lookup without racing the write batch", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const first = await mintInput("alpha");
+      await createTokenIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "u-1",
+        key: "stalled",
+        record: first.record,
+        fingerprint: first.fingerprint,
+        response: first.response,
+        masterSecret: KEY,
+        ring: RING,
+      });
+
+      const underlying = database(sqlite);
+      let batchCompleted = false;
+      const stalledDb = {
+        async batch(statements: D1PreparedStatement[]) {
+          const results = await underlying.batch(statements);
+          batchCompleted = true;
+          return results;
+        },
+        prepare(sql: string) {
+          const stmt = underlying.prepare(sql);
+          if (sql.includes("SELECT fingerprint")) {
+            return {
+              bind: (...v: unknown[]) => {
+                stmt.bind(...v);
+                return { first: () => new Promise(() => {}) };
+              },
+            } as unknown as D1PreparedStatement;
+          }
+          return stmt;
+        },
+      } as unknown as Parameters<typeof createTokenIdempotently>[0];
+
+      const retry = await mintInput("alpha");
+      await expect(
+        createTokenIdempotently(stalledDb, {
+          workspace: "alpha",
+          principal: "u-1",
+          key: "stalled",
+          record: retry.record,
+          fingerprint: retry.fingerprint,
+          response: retry.response,
+          masterSecret: KEY,
+          ring: RING,
+          readEnv: { DATA_READ_TIMEOUT_MS: "20" },
+        }),
+      ).rejects.toMatchObject({ code: "data_unavailable" });
+      expect(batchCompleted).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,6 +29,17 @@ The JavaScript client generates a key for `createGallery`. Pass
 `idempotencyKey` in the options when separate client calls must share a key.
 After 24 hours, the same key starts a new operation.
 
+`POST /v1/tokens` (workspace token minting) accepts the same header. A token is
+shown only once, so a retried mint would otherwise either create a second token
+or lose the only plaintext copy. With an `Idempotency-Key`, an identical retry
+replays the original `201` — including the original one-time token — and mints
+exactly one token; a changed request returns `409 idempotency_key_reused`. The
+replay body is encrypted at rest, so minting requires the server's encryption
+key to be configured and fails closed (`503`) otherwise. Authorization is
+re-checked on every attempt: a caller who has lost workspace access cannot
+recover a token by replaying a key. The client's `mintWorkspaceToken` accepts an
+optional `idempotencyKey`.
+
 ## Errors
 
 Every non-2xx response uses one nested envelope (same shape as either/releases):

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -903,11 +903,22 @@ export function mintWorkspaceToken(
     scopes?: Array<TokenScope>;
     label?: string;
     ttlSeconds?: number | null;
+    /**
+     * Optional retry key. Reusing it (same effective request, within 24h)
+     * replays the original response — including the one-time plaintext token —
+     * instead of minting a second token. A changed request with the same key
+     * returns 409.
+     */
+    idempotencyKey?: string;
   },
 ): Promise<MintTokenResult> {
   return jsonRequest(`${apiUrl.replace(/\/$/, "")}/v1/tokens`, {
     method: "POST",
-    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      ...(input.idempotencyKey ? { "Idempotency-Key": input.idempotencyKey } : {}),
+    },
     body: JSON.stringify({
       grants: [{ workspace: input.workspace, ...(input.scopes ? { scopes: input.scopes } : {}) }],
       ...(input.label ? { label: input.label } : {}),

--- a/packages/uploads/test/mint-token.test.ts
+++ b/packages/uploads/test/mint-token.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mintWorkspaceToken } from "../src/client.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function okFetch() {
+  return vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify({
+          token: "up_acme_x",
+          workspace: "acme",
+          scopes: ["files:read", "files:write"],
+          label: null,
+          expiresAt: null,
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+  );
+}
+
+describe("mintWorkspaceToken idempotency", () => {
+  it("sends Idempotency-Key when provided", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    await mintWorkspaceToken("https://api.test", "sess", {
+      workspace: "acme",
+      idempotencyKey: "mint-retry-1",
+    });
+    const init = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1];
+    expect(new Headers(init.headers).get("Idempotency-Key")).toBe("mint-retry-1");
+  });
+
+  it("omits Idempotency-Key when not provided", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    await mintWorkspaceToken("https://api.test", "sess", { workspace: "acme" });
+    const init = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1];
+    expect(new Headers(init.headers).has("Idempotency-Key")).toBe(false);
+  });
+});


### PR DESCRIPTION
## In plain terms

Minting an API token is a one-shot: the server stores only a hash, so the
plaintext token is shown exactly once. If a mint request times out or the
connection drops on the way back, a naive client retry either creates a second
token or — worse — the caller never sees the token at all and has to start over.
This makes `POST /v1/tokens` retry-safe: send an `Idempotency-Key` and an
identical retry replays the original response, including the original one-time
token, while minting exactly one token.

## What it does / what it is not

- **Opt-in.** Without an `Idempotency-Key` header, behavior is unchanged — the
  original one-shot mint.
- Identical retry (same key, same effective request) within 24h replays the
  original `201` with `Idempotency-Replayed: true` and the original plaintext
  token. Only one `auth_tokens` row is ever created.
- Same key + a changed request → `409 idempotency_key_reused`. A concurrent
  in-flight request → `409 idempotency_request_in_progress` with `Retry-After: 1`.
- **Encrypted at rest.** The replay body carries the plaintext token, so it is
  sealed with AES-GCM via the existing workspace secrets key ring
  (`apps/api/src/secrets.ts`) before it touches D1. Nothing stores the token in
  the clear.
- **Fails closed.** If no encryption key is configured, an idempotent mint
  returns `503 secrets_key_unconfigured` and writes neither a token nor a replay
  record. The existing secrets model is unchanged; no secrets added to source.
- **Authorization is re-checked on every attempt.** The idempotency step runs
  after the full session + membership + role + scope + rate-limit gate, so a
  caller who lost workspace access cannot recover a token by replaying a key.
- Keys are scoped by `(workspace, session user, token.create.v1)`, so users and
  workspaces never share replay records.
- **No migration required.** Reuses the existing `idempotency_requests` table
  (`operation = token.create.v1`) and its daily retention sweep. Shared
  primitives were pulled into `idempotency-core.ts`.
- **Deferred:** upload idempotency (needs coordinated D1/R2 recovery).

## How to try it

```bash
KEY=$(uuidgen)
# First call mints; an identical retry with the same key replays the same token.
uploads api POST /v1/tokens --header "Idempotency-Key: $KEY" \
  --data '{"grants":[{"workspace":"acme","scopes":["files:read","files:write"]}]}'
```

The JS client's `mintWorkspaceToken` now accepts an optional `idempotencyKey`.

## Technical notes

- Claim key → insert token (gated on owning the claim) → store encrypted 201 →
  release-on-failure, all in one `db.batch` on a primary-constrained session
  (`primaryDbFor`). D1 writes stay unbounded; only the standalone replay lookup
  is `boundedRead`, so the write batch is never deadline-raced.
- The fingerprint normalizes `{scopes (sorted), label, ttlSeconds}`; the computed
  absolute expiry is excluded so retries within the window still match.
- All D1 access goes through `dbFor`/`primaryDbFor`; `env.DB` is never touched
  directly. `createToken` was split into `buildTokenRecord` + `prepareTokenInsert`
  (behavior unchanged) so the row can be inserted inside the idempotency batch.
- Migration deliberately not run (file-only policy) — none was needed here.

## Test plan

- [x] `pnpm test:api` — full API suite (2255 passed)
- [x] `apps/api/test/token-idempotency.test.ts` (9) — replay, no-plaintext-at-rest,
  reused conflict, principal/workspace isolation, fail-closed (no key), invalid
  key, expired-key reuse, key rotation (previous key decrypts), bounded stalled
  replay without racing the write batch
- [x] `apps/api/src/routes/tokens.test.ts` idempotency block (5) — identical
  retry replays + one row, changed-body 409, 503 fail-closed, de-membered user
  cannot replay, one-shot preserved without a key
- [x] `packages/uploads` client suite (1313) incl. new `mint-token.test.ts` header
- [x] `pnpm --filter @uploads/api typecheck` and `@buildinternet/uploads typecheck`
- [x] oxlint + oxfmt on changed files; `git diff --check` clean
- [ ] Full monorepo typecheck not run here (Node 24 engine unmet locally for
  `apps/web`/`@astrojs/check`); API + client checks above are green.

Refs #829
