### PR TITLE
feat(api): make object PUT retry-safe with Idempotency-Key

### DIFF
--- a/.changeset/retry-safe-uploads.md
+++ b/.changeset/retry-safe-uploads.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Upload files safely on retry: `put` now accepts an optional `idempotencyKey`
+so a retried request replays the original response instead of writing a
+duplicate object.

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -20,7 +20,6 @@ import {
 import {
   deleteFileMetadata,
   deleteServerFileMetadataKeys,
-  getFileMetadata,
   mergeWithinMetadataCaps,
   replaceFileMetadata,
   setServerFileMetadata,
@@ -395,6 +394,12 @@ export async function putObject(
      * write. Absent means the caller predates this parameter.
      */
     surface?: UploadSurface;
+    /**
+     * Precomputed SHA-256 (hex) of `bytes`. The idempotent-PUT path already
+     * hashes the body for its fingerprint; passing it here avoids a second pass
+     * over a potentially multi-MB body. Omit to hash internally as usual.
+     */
+    contentSha256?: string;
   },
 ): Promise<{
   key: string;
@@ -525,7 +530,7 @@ export async function putObject(
   // (never trust a client-supplied hash). Visibility lives alongside provenance
   // in the same custom-metadata bag but is tracked separately (not client-free-form).
   // `uploaded-at` is server-only — set on the final bag, never via sanitizeProvenance.
-  const contentSha256 = await contentSha256Hex(bytes);
+  const contentSha256 = opts?.contentSha256 ?? (await contentSha256Hex(bytes));
   // Started here rather than where it is consumed, so this D1 read overlaps the
   // R2 write and usage accounting instead of adding its latency after them. Safe
   // to leave in flight: inheritableMetaForHash never rejects (it resolves to `{}`
@@ -693,24 +698,29 @@ export type PutObjectResult = Awaited<ReturnType<typeof putObject>>;
 
 /**
  * Reconciles a `key_exists` failure from an idempotent `PUT` retry (issue
- * #829): a prior attempt's bytes may already be durably stored even though
- * its idempotency claim never completed (a crash between the R2 write and
- * the completing `UPDATE`). Rather than re-running `putObject` — which would
- * double-count the upload ledger and redo poster generation — this heads the
- * existing object and, only when its stored `content-sha256` matches the
- * retry's own bytes, synthesizes the same 201 shape `putObject` would have
- * returned. Never writes anything; never touches usage.
+ * #829): a prior attempt's bytes may already be durably stored even though its
+ * idempotency claim never completed — a crash between the R2 write and the
+ * downstream D1 work (metadata, content-hash index, PR activity). Heading the
+ * object and synthesizing a response would report success while that D1 work
+ * was never applied (e.g. `X-Uploads-Meta-*` tags silently dropped). So, only
+ * when the stored object's `content-sha256` matches this retry's bytes — i.e.
+ * it is our own interrupted upload — this re-drives `putObject` with `replace`,
+ * converging the object to the intended state through the exact same
+ * metadata/index/poster path a normal write uses. The cost is the accepted
+ * one-off upload-ledger over-count on this rare recovery path.
  *
- * Returns `null` when there is no object at the key, or when one exists but
- * its content hash differs (a genuine conflict — the caller should surface
- * `key_exists` rather than treat this as a replay).
+ * Returns `null` when there is no object at the key, or when one exists but its
+ * content hash differs (a genuine conflict — the caller surfaces `key_exists`
+ * rather than overwriting someone else's object).
  */
-export async function reconcileExistingUpload(
+export async function reconcileInterruptedUpload(
   env: Env,
   ws: WorkspaceRecord,
   workspaceName: string,
   key: string,
+  bytes: Uint8Array,
   expectedContentSha256: string,
+  putOpts: NonNullable<Parameters<typeof putObject>[5]>,
 ): Promise<PutObjectResult | null> {
   const finalKey = finalizeUploadKey(key, ws);
   const lane = await resolveObjectLane(env, ws, finalKey);
@@ -722,21 +732,11 @@ export async function reconcileExistingUpload(
   const provenance = provenanceForResponse(meta.metadata ?? undefined);
   if (provenance?.["content-sha256"] !== expectedContentSha256) return null;
 
-  const urls = objectPublicUrls(env, lane.config, finalKey);
-  const visibility = objectVisibility(meta.metadata ?? undefined);
-  const metadata = await getFileMetadata(dbFor(env), workspaceName, finalKey);
-
-  return {
-    key: finalKey,
-    url: urls.url,
-    embedUrl: urls.embedUrl,
-    size: meta.size ?? 0,
-    contentType: meta.type ?? "application/octet-stream",
-    replaced: true,
-    provenance,
-    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
-    ...(visibility ? { visibility } : {}),
-  };
+  return putObject(env, ws, key, bytes, workspaceName, {
+    ...putOpts,
+    replace: true,
+    contentSha256: expectedContentSha256,
+  });
 }
 
 /**

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -20,6 +20,7 @@ import {
 import {
   deleteFileMetadata,
   deleteServerFileMetadataKeys,
+  getFileMetadata,
   mergeWithinMetadataCaps,
   replaceFileMetadata,
   setServerFileMetadata,
@@ -58,6 +59,7 @@ import {
 import {
   isSharedLane,
   objectPublicUrls,
+  resolveObjectLane,
   storage,
   storageConfig,
   storageConfigs,
@@ -683,6 +685,57 @@ export async function putObject(
     provenance,
     ...(storedMetadata ? { metadata: storedMetadata } : {}),
     ...(storedVisibility ? { visibility: storedVisibility } : {}),
+  };
+}
+
+/** The shape `putObject` resolves to — reused by the idempotency reconcile path below. */
+export type PutObjectResult = Awaited<ReturnType<typeof putObject>>;
+
+/**
+ * Reconciles a `key_exists` failure from an idempotent `PUT` retry (issue
+ * #829): a prior attempt's bytes may already be durably stored even though
+ * its idempotency claim never completed (a crash between the R2 write and
+ * the completing `UPDATE`). Rather than re-running `putObject` — which would
+ * double-count the upload ledger and redo poster generation — this heads the
+ * existing object and, only when its stored `content-sha256` matches the
+ * retry's own bytes, synthesizes the same 201 shape `putObject` would have
+ * returned. Never writes anything; never touches usage.
+ *
+ * Returns `null` when there is no object at the key, or when one exists but
+ * its content hash differs (a genuine conflict — the caller should surface
+ * `key_exists` rather than treat this as a replay).
+ */
+export async function reconcileExistingUpload(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  key: string,
+  expectedContentSha256: string,
+): Promise<PutObjectResult | null> {
+  const finalKey = finalizeUploadKey(key, ws);
+  const lane = await resolveObjectLane(env, ws, finalKey);
+  if (!lane) return null;
+
+  const meta = await lane.store.head(finalKey).catch(() => null);
+  if (!meta) return null;
+
+  const provenance = provenanceForResponse(meta.metadata ?? undefined);
+  if (provenance?.["content-sha256"] !== expectedContentSha256) return null;
+
+  const urls = objectPublicUrls(env, lane.config, finalKey);
+  const visibility = objectVisibility(meta.metadata ?? undefined);
+  const metadata = await getFileMetadata(dbFor(env), workspaceName, finalKey);
+
+  return {
+    key: finalKey,
+    url: urls.url,
+    embedUrl: urls.embedUrl,
+    size: meta.size ?? 0,
+    contentType: meta.type ?? "application/octet-stream",
+    replaced: true,
+    provenance,
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+    ...(visibility ? { visibility } : {}),
   };
 }
 

--- a/apps/api/src/gallery-idempotency.ts
+++ b/apps/api/src/gallery-idempotency.ts
@@ -3,6 +3,8 @@ import { sha256Hex } from "./workspace";
 import type { D1Queryable } from "./db-session";
 import { boundedRead, type DataReadEnv } from "./data-read-bounds";
 import {
+  buildClaimStatement,
+  buildReplayLookup,
   conflictFor,
   IDEMPOTENCY_RETENTION_HOURS,
   validateIdempotencyKey,
@@ -53,23 +55,7 @@ export async function createGalleryIdempotently<T>(
   const responseBody = JSON.stringify(input.response);
   const scope = [input.workspace, input.principal, GALLERY_CREATE_OPERATION, keyHash] as const;
 
-  const claim = db
-    .prepare(
-      `INSERT INTO idempotency_requests
-       (workspace, principal, operation, key_hash, fingerprint, owner_nonce, state,
-        response_status, response_body, created_at, expires_at)
-       VALUES (?, ?, ?, ?, ?, ?, 'pending', NULL, NULL, ?, ?)
-       ON CONFLICT (workspace, principal, operation, key_hash) DO UPDATE SET
-         fingerprint = excluded.fingerprint,
-         owner_nonce = excluded.owner_nonce,
-         state = 'pending',
-         response_status = NULL,
-         response_body = NULL,
-         created_at = excluded.created_at,
-         expires_at = excluded.expires_at
-       WHERE idempotency_requests.expires_at <= excluded.created_at`,
-    )
-    .bind(...scope, fingerprint, ownerNonce, createdAt, expiresAt);
+  const claim = buildClaimStatement(db, scope, fingerprint, ownerNonce, createdAt, expiresAt);
 
   const ownsClaim = {
     sql: `EXISTS (
@@ -104,13 +90,7 @@ export async function createGalleryIdempotently<T>(
     return { status: "ok", value: input.response, replayed: false };
   }
 
-  const replayLookup = db
-    .prepare(
-      `SELECT fingerprint, owner_nonce, state, response_status, response_body, expires_at
-       FROM idempotency_requests
-       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?`,
-    )
-    .bind(...scope);
+  const replayLookup = buildReplayLookup(db, scope);
   const row = await boundedRead(input.readEnv ?? {}, () => replayLookup.first<StoredRequest>(), {
     name: "d1_gallery_idempotency_replay",
   });

--- a/apps/api/src/idempotency-core.ts
+++ b/apps/api/src/idempotency-core.ts
@@ -28,6 +28,61 @@ export interface StoredRequest {
   expires_at: string;
 }
 
+/** `(workspace, principal, operation, key_hash)` — the primary key every op scopes by. */
+export type IdempotencyScope = readonly [
+  workspace: string,
+  principal: string,
+  operation: string,
+  keyHash: string,
+];
+
+/**
+ * The claim upsert shared by every idempotent op. Inserts a fresh `pending`
+ * row, or re-claims an existing one only when it has expired
+ * (`expires_at <= created_at`) — a live pending or completed row is never
+ * clobbered. `meta.changes > 0` after `.run()` (or on the batched result) means
+ * this caller owns the claim. Callers bind their own `expires_at`: a short
+ * pending TTL for the two-phase upload op, the 24h retention for the
+ * single-batch gallery/token ops.
+ */
+export function buildClaimStatement(
+  db: D1Queryable,
+  scope: IdempotencyScope,
+  fingerprint: string,
+  ownerNonce: string,
+  createdAt: string,
+  expiresAt: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO idempotency_requests
+       (workspace, principal, operation, key_hash, fingerprint, owner_nonce, state,
+        response_status, response_body, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, 'pending', NULL, NULL, ?, ?)
+       ON CONFLICT (workspace, principal, operation, key_hash) DO UPDATE SET
+         fingerprint = excluded.fingerprint,
+         owner_nonce = excluded.owner_nonce,
+         state = 'pending',
+         response_status = NULL,
+         response_body = NULL,
+         created_at = excluded.created_at,
+         expires_at = excluded.expires_at
+       WHERE idempotency_requests.expires_at <= excluded.created_at`,
+    )
+    .bind(...scope, fingerprint, ownerNonce, createdAt, expiresAt);
+}
+
+/** The scoped replay lookup shared by the replay/conflict tail of every op. */
+export function buildReplayLookup(db: D1Queryable, scope: IdempotencyScope): D1PreparedStatement {
+  return db
+    .prepare(
+      `SELECT fingerprint, owner_nonce, state, response_status, response_body, expires_at
+       FROM idempotency_requests
+       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?`,
+    )
+    .bind(...scope);
+}
+
 export function validateIdempotencyKey(value: string): void {
   if (!IDEMPOTENCY_KEY_RE.test(value)) {
     throw new ValidationError("Idempotency-Key must contain 1 to 255 visible ASCII characters.", {

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -11,15 +11,17 @@ import {
   headObjectJson,
   isManagedGithubKey,
   putObject,
+  reconcileExistingUpload,
 } from "../files-core";
 import { getFileMetadata, META_MAX_KEYS, setFileMetadata } from "../file-metadata";
 import { checkDeclaredLength, maxBytesForContentType, resolveUploadPolicy } from "../guards";
-import { splitUploadMetaHeaders } from "../provenance";
+import { contentSha256Hex, splitUploadMetaHeaders } from "../provenance";
 import { createLaneResolver, objectPublicUrls, resolveObjectLane, storage } from "../storage";
 import { hasGithubTags, uploaderTags } from "../uploader-identity";
+import { putObjectIdempotently } from "../upload-idempotency";
 import { sanitizeVisibility } from "../visibility";
 import type { WorkspaceVars } from "../workspace";
-import { dbFor } from "../db-session";
+import { dbFor, primaryDbFor } from "../db-session";
 
 /** Handler shape shared by the legacy bearer and canonical dual-auth routers. */
 export type SharedFilesHandler = Handler<WorkspaceVars>;
@@ -217,15 +219,53 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
       if (Object.keys(merged).length <= META_MAX_KEYS) metadata = merged;
     }
   }
-  const result = await putObject(
-    c.env,
-    c.get("workspace"),
-    key,
-    new Uint8Array(body),
-    c.get("workspaceName"),
-    { provenance, visibility, metadata, replace: wantReplace, surface: "api" },
-  );
-  return c.json({ workspace: c.get("workspaceName"), ...result }, 201);
+  const bytes = new Uint8Array(body);
+  const ws = c.get("workspace");
+  const workspaceName = c.get("workspaceName");
+  const putOpts = {
+    provenance,
+    visibility,
+    metadata,
+    replace: wantReplace,
+    surface: "api" as const,
+  };
+
+  const idempotencyKey = c.req.header("Idempotency-Key");
+  if (idempotencyKey === undefined) {
+    const result = await putObject(c.env, ws, key, bytes, workspaceName, putOpts);
+    return c.json({ workspace: workspaceName, ...result }, 201);
+  }
+
+  // contentSha256 is computed here (for the fingerprint/reconcile anchor) and
+  // again inside putObject (files-core.ts ~526) — a deliberate extra hash
+  // rather than threading it through putObject's signature; see the #829 plan.
+  const contentSha256 = await contentSha256Hex(bytes);
+  const finalKey = finalizeUploadKey(key, ws);
+  let result;
+  try {
+    result = await putObjectIdempotently(primaryDbFor(c.env), {
+      workspace: workspaceName,
+      principal: c.get("authPrincipal"),
+      key: idempotencyKey,
+      fingerprint: {
+        finalKey,
+        contentSha256,
+        visibility,
+        replace: wantReplace,
+        metadata,
+      },
+      run: () => putObject(c.env, ws, key, bytes, workspaceName, putOpts),
+      reconcile: () => reconcileExistingUpload(c.env, ws, workspaceName, key, contentSha256),
+      readEnv: c.env,
+    });
+  } catch (error) {
+    if (error instanceof ConflictError && error.code === "idempotency_request_in_progress") {
+      c.header("Retry-After", "1");
+    }
+    throw error;
+  }
+  if (result.replayed) c.header("Idempotency-Replayed", "true");
+  return c.json({ workspace: workspaceName, ...result.value }, 201);
 }
 
 export async function getFileHandler(c: Context<WorkspaceVars>) {

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -11,7 +11,7 @@ import {
   headObjectJson,
   isManagedGithubKey,
   putObject,
-  reconcileExistingUpload,
+  reconcileInterruptedUpload,
 } from "../files-core";
 import { getFileMetadata, META_MAX_KEYS, setFileMetadata } from "../file-metadata";
 import { checkDeclaredLength, maxBytesForContentType, resolveUploadPolicy } from "../guards";
@@ -236,11 +236,11 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
     return c.json({ workspace: workspaceName, ...result }, 201);
   }
 
-  // contentSha256 is computed here (for the fingerprint/reconcile anchor) and
-  // again inside putObject (files-core.ts ~526) — a deliberate extra hash
-  // rather than threading it through putObject's signature; see the #829 plan.
+  // Hash the body once, up front: it anchors the fingerprint and the reconcile
+  // check, and is threaded into putObject so it isn't hashed a second time.
   const contentSha256 = await contentSha256Hex(bytes);
   const finalKey = finalizeUploadKey(key, ws);
+  const idempotentPutOpts = { ...putOpts, contentSha256 };
   let result;
   try {
     result = await putObjectIdempotently(primaryDbFor(c.env), {
@@ -254,8 +254,9 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
         replace: wantReplace,
         metadata,
       },
-      run: () => putObject(c.env, ws, key, bytes, workspaceName, putOpts),
-      reconcile: () => reconcileExistingUpload(c.env, ws, workspaceName, key, contentSha256),
+      run: () => putObject(c.env, ws, key, bytes, workspaceName, idempotentPutOpts),
+      reconcile: () =>
+        reconcileInterruptedUpload(c.env, ws, workspaceName, key, bytes, contentSha256, putOpts),
       readEnv: c.env,
     });
   } catch (error) {

--- a/apps/api/src/token-idempotency.ts
+++ b/apps/api/src/token-idempotency.ts
@@ -22,6 +22,8 @@ import { type AuthTokenRecord, prepareTokenInsert } from "./auth-db";
 import { boundedRead, type DataReadEnv } from "./data-read-bounds";
 import type { D1Queryable } from "./db-session";
 import {
+  buildClaimStatement,
+  buildReplayLookup,
   conflictFor,
   IDEMPOTENCY_RETENTION_HOURS,
   validateIdempotencyKey,
@@ -107,23 +109,7 @@ export async function createTokenIdempotently<T>(
   const responseBody = await encryptSecret(input.masterSecret, JSON.stringify(input.response));
   const scope = [input.workspace, input.principal, TOKEN_CREATE_OPERATION, keyHash] as const;
 
-  const claim = db
-    .prepare(
-      `INSERT INTO idempotency_requests
-       (workspace, principal, operation, key_hash, fingerprint, owner_nonce, state,
-        response_status, response_body, created_at, expires_at)
-       VALUES (?, ?, ?, ?, ?, ?, 'pending', NULL, NULL, ?, ?)
-       ON CONFLICT (workspace, principal, operation, key_hash) DO UPDATE SET
-         fingerprint = excluded.fingerprint,
-         owner_nonce = excluded.owner_nonce,
-         state = 'pending',
-         response_status = NULL,
-         response_body = NULL,
-         created_at = excluded.created_at,
-         expires_at = excluded.expires_at
-       WHERE idempotency_requests.expires_at <= excluded.created_at`,
-    )
-    .bind(...scope, fingerprint, ownerNonce, createdAt, expiresAt);
+  const claim = buildClaimStatement(db, scope, fingerprint, ownerNonce, createdAt, expiresAt);
 
   const ownsClaim = {
     sql: `EXISTS (
@@ -162,13 +148,7 @@ export async function createTokenIdempotently<T>(
   // We did not mint — either a completed row already exists (replay) or another
   // request holds a pending claim (conflict). Bound only this standalone read;
   // the write batch above is never deadline-raced.
-  const replayLookup = db
-    .prepare(
-      `SELECT fingerprint, owner_nonce, state, response_status, response_body, expires_at
-       FROM idempotency_requests
-       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?`,
-    )
-    .bind(...scope);
+  const replayLookup = buildReplayLookup(db, scope);
   const row = await boundedRead(input.readEnv ?? {}, () => replayLookup.first<StoredRequest>(), {
     name: "d1_token_idempotency_replay",
   });

--- a/apps/api/src/upload-idempotency.ts
+++ b/apps/api/src/upload-idempotency.ts
@@ -19,6 +19,8 @@ import { ConflictError } from "@uploads/errors";
 import { boundedRead, type DataReadEnv } from "./data-read-bounds";
 import type { D1Queryable } from "./db-session";
 import {
+  buildClaimStatement,
+  buildReplayLookup,
   conflictFor,
   IDEMPOTENCY_RETENTION_HOURS,
   validateIdempotencyKey,
@@ -105,38 +107,15 @@ export async function putObjectIdempotently<T>(
   ).toISOString();
   const scope = [input.workspace, input.principal, UPLOAD_PUT_OPERATION, keyHash] as const;
 
-  // Claim: identical shape to token/gallery idempotency's claim INSERT, but
-  // the pending row carries the short PENDING_TTL deadline rather than the
-  // 24h retention — a completed row's expires_at is always 24h out, so this
-  // predicate re-claims an expired pending row but never a live completed one.
-  const claim = db
-    .prepare(
-      `INSERT INTO idempotency_requests
-       (workspace, principal, operation, key_hash, fingerprint, owner_nonce, state,
-        response_status, response_body, created_at, expires_at)
-       VALUES (?, ?, ?, ?, ?, ?, 'pending', NULL, NULL, ?, ?)
-       ON CONFLICT (workspace, principal, operation, key_hash) DO UPDATE SET
-         fingerprint = excluded.fingerprint,
-         owner_nonce = excluded.owner_nonce,
-         state = 'pending',
-         response_status = NULL,
-         response_body = NULL,
-         created_at = excluded.created_at,
-         expires_at = excluded.expires_at
-       WHERE idempotency_requests.expires_at <= excluded.created_at`,
-    )
-    .bind(...scope, fp, ownerNonce, createdAt, pendingExpires);
-  await claim.run();
+  // Claim the key. The pending row carries the short PENDING_TTL deadline rather
+  // than the 24h retention a completed row gets, so `buildClaimStatement`'s
+  // `expires_at <= created_at` predicate re-claims an expired pending row but
+  // never a live completed one. `meta.changes > 0` means we own the claim — the
+  // same signal gallery/token read off their batched insert.
+  const claim = buildClaimStatement(db, scope, fp, ownerNonce, createdAt, pendingExpires);
+  const claimed = await claim.run();
 
-  const owner = await db
-    .prepare(
-      `SELECT owner_nonce, state FROM idempotency_requests
-       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?`,
-    )
-    .bind(...scope)
-    .first<{ owner_nonce: string | null; state: "pending" | "completed" }>();
-
-  if (owner?.owner_nonce === ownerNonce && owner.state === "pending") {
+  if ((claimed.meta.changes ?? 0) > 0) {
     const complete = (responseBody: string) =>
       db
         .prepare(
@@ -160,10 +139,25 @@ export async function putObjectIdempotently<T>(
 
     try {
       const value = await input.run();
-      await complete(JSON.stringify(value));
+      const done = await complete(JSON.stringify(value));
+      // A 0-row completion means our pending claim was stolen (its TTL expired
+      // mid-`run()` and another request re-claimed). We still answer 201 — the
+      // upload landed — but the stored row now belongs to the other owner, so a
+      // racing retry may briefly see `pending`. Log it so that stays diagnosable.
+      if ((done.meta.changes ?? 0) === 0) {
+        console.warn({
+          event: "upload_idempotency_completion_lost",
+          workspace: input.workspace,
+          finalKey: input.fingerprint.finalKey,
+        });
+      }
       return { value, replayed: false };
     } catch (err) {
       if (err instanceof ConflictError && err.code === "key_exists") {
+        // A prior attempt's bytes already landed but its claim never completed.
+        // `reconcile()` re-drives the write only when the stored content hash
+        // matches — our own interrupted upload — and returns null on a genuine
+        // key collision, which surfaces as `key_exists`.
         const reconciled = await input.reconcile();
         if (reconciled) {
           await complete(JSON.stringify(reconciled));
@@ -177,27 +171,20 @@ export async function putObjectIdempotently<T>(
 
   // Did not win the claim: replay the winner's response, or conflict. Bound
   // only this standalone read; run()/reconcile() above are never raced.
-  const replayLookup = db
-    .prepare(
-      `SELECT fingerprint, owner_nonce, state, response_status, response_body, expires_at
-       FROM idempotency_requests
-       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?`,
-    )
-    .bind(...scope);
+  const replayLookup = buildReplayLookup(db, scope);
   const row = await boundedRead(input.readEnv ?? {}, () => replayLookup.first<StoredRequest>(), {
     name: "d1_upload_idempotency_replay",
   });
 
-  const settled: StoredRequest = row ?? {
-    fingerprint: fp,
-    owner_nonce: null,
-    state: "pending",
-    response_status: null,
-    response_body: null,
-    expires_at: pendingExpires,
-  };
-  if (settled.fingerprint !== fp || settled.state !== "completed" || !settled.response_body) {
-    conflictFor(settled, fp);
+  // A missing row means the winner's claim is still settling — treat as
+  // in-progress so the caller retries.
+  if (!row) {
+    throw new ConflictError("A request with this Idempotency-Key is still in progress.", {
+      code: "idempotency_request_in_progress",
+    });
   }
-  return { value: JSON.parse(settled.response_body) as T, replayed: true };
+  if (row.fingerprint !== fp || row.state !== "completed" || !row.response_body) {
+    conflictFor(row, fp);
+  }
+  return { value: JSON.parse(row.response_body) as T, replayed: true };
 }

--- a/apps/api/src/upload-idempotency.ts
+++ b/apps/api/src/upload-idempotency.ts
@@ -1,0 +1,203 @@
+/**
+ * Retry-safe object `PUT` (issue #829).
+ *
+ * Unlike gallery/token creation, a `PUT` writes bytes to R2 and *then* does
+ * D1 usage/metadata work, and R2 has no transaction with D1 — so claim, do
+ * the work, and complete can't be one atomic `db.batch`. This reuses the
+ * same `idempotency_requests` table and claim/replay shape as
+ * `gallery-idempotency.ts` / `token-idempotency.ts`, split into three
+ * separate statements gated by `owner_nonce` instead of one batch, plus a
+ * short `pending` TTL (`PENDING_TTL_MS`) distinct from the 24h completed
+ * retention — so a crash between the R2 write and the completing `UPDATE`
+ * doesn't strand every retry behind a day-long `idempotency_request_in_progress`.
+ *
+ * The replay body carries no secret (an upload response has nothing to
+ * protect), so — unlike `token-idempotency.ts` — it is stored as plain JSON:
+ * no encryption, no key-ring, no fail-closed path.
+ */
+import { ConflictError } from "@uploads/errors";
+import { boundedRead, type DataReadEnv } from "./data-read-bounds";
+import type { D1Queryable } from "./db-session";
+import {
+  conflictFor,
+  IDEMPOTENCY_RETENTION_HOURS,
+  validateIdempotencyKey,
+  type StoredRequest,
+} from "./idempotency-core";
+import { sha256Hex } from "./workspace";
+
+export const UPLOAD_PUT_OPERATION = "upload.put.v1";
+
+/** Crash-mid-flight window: long enough for the slowest single-shot upload, short enough that a stall doesn't strand retries behind `idempotency_request_in_progress` for a day. */
+export const PENDING_TTL_MS = 5 * 60 * 1000;
+
+/** Request fields that must match for a retry to replay rather than conflict. */
+export interface UploadFingerprintInput {
+  finalKey: string;
+  contentSha256: string;
+  visibility: string | undefined;
+  replace: boolean;
+  metadata: Record<string, string> | undefined;
+}
+
+export type IdempotentUploadResult<T> = { value: T; replayed: boolean };
+
+/** Stable stringify: sorts object keys so header ordering never trips a false `idempotency_key_reused`. */
+function stableStringify(value: Record<string, string> | undefined): string {
+  if (!value) return "null";
+  const sorted: Record<string, string> = {};
+  for (const key of Object.keys(value).sort()) sorted[key] = value[key]!;
+  return JSON.stringify(sorted);
+}
+
+function fingerprintFor(input: UploadFingerprintInput): Promise<string> {
+  return sha256Hex(
+    JSON.stringify({
+      operation: UPLOAD_PUT_OPERATION,
+      finalKey: input.finalKey,
+      contentSha256: input.contentSha256,
+      visibility: input.visibility ?? null,
+      replace: input.replace,
+      metadata: stableStringify(input.metadata),
+    }),
+  );
+}
+
+/**
+ * Claims `key`, runs `run()` (the real `putObject`), and stores the plain-JSON
+ * 201 body. `db` must be primary-constrained (see `primaryDbFor`) so the claim
+ * observes concurrent writers.
+ *
+ * - On `run()` throwing `ConflictError` `key_exists` (the crash-window case —
+ *   a prior attempt's bytes already landed but the claim never completed),
+ *   calls `reconcile()`; a non-null result is treated as our own earlier
+ *   upload and completes the claim. A null result means a genuine conflict:
+ *   the claim is released and `key_exists` is rethrown.
+ * - Any other `run()` failure releases the claim and rethrows — errors are
+ *   never cached.
+ * - Losing the claim race replays the winner's stored response (bounded read
+ *   only; `run()`/`reconcile()` are never deadline-raced), or throws
+ *   `idempotency_key_reused` / `idempotency_request_in_progress`.
+ */
+export async function putObjectIdempotently<T>(
+  db: D1Queryable,
+  input: {
+    workspace: string;
+    principal: string;
+    key: string;
+    fingerprint: UploadFingerprintInput;
+    run: () => Promise<T>;
+    reconcile: () => Promise<T | null>;
+    readEnv?: DataReadEnv;
+    now?: Date;
+  },
+): Promise<IdempotentUploadResult<T>> {
+  validateIdempotencyKey(input.key);
+
+  const now = input.now ?? new Date();
+  const keyHash = await sha256Hex(input.key);
+  const fp = await fingerprintFor(input.fingerprint);
+  const ownerNonce = crypto.randomUUID();
+  const createdAt = now.toISOString();
+  const pendingExpires = new Date(now.getTime() + PENDING_TTL_MS).toISOString();
+  const completedExpires = new Date(
+    now.getTime() + IDEMPOTENCY_RETENTION_HOURS * 60 * 60 * 1000,
+  ).toISOString();
+  const scope = [input.workspace, input.principal, UPLOAD_PUT_OPERATION, keyHash] as const;
+
+  // Claim: identical shape to token/gallery idempotency's claim INSERT, but
+  // the pending row carries the short PENDING_TTL deadline rather than the
+  // 24h retention — a completed row's expires_at is always 24h out, so this
+  // predicate re-claims an expired pending row but never a live completed one.
+  const claim = db
+    .prepare(
+      `INSERT INTO idempotency_requests
+       (workspace, principal, operation, key_hash, fingerprint, owner_nonce, state,
+        response_status, response_body, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, 'pending', NULL, NULL, ?, ?)
+       ON CONFLICT (workspace, principal, operation, key_hash) DO UPDATE SET
+         fingerprint = excluded.fingerprint,
+         owner_nonce = excluded.owner_nonce,
+         state = 'pending',
+         response_status = NULL,
+         response_body = NULL,
+         created_at = excluded.created_at,
+         expires_at = excluded.expires_at
+       WHERE idempotency_requests.expires_at <= excluded.created_at`,
+    )
+    .bind(...scope, fp, ownerNonce, createdAt, pendingExpires);
+  await claim.run();
+
+  const owner = await db
+    .prepare(
+      `SELECT owner_nonce, state FROM idempotency_requests
+       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?`,
+    )
+    .bind(...scope)
+    .first<{ owner_nonce: string | null; state: "pending" | "completed" }>();
+
+  if (owner?.owner_nonce === ownerNonce && owner.state === "pending") {
+    const complete = (responseBody: string) =>
+      db
+        .prepare(
+          `UPDATE idempotency_requests
+           SET state = 'completed', owner_nonce = NULL, response_status = 201,
+               response_body = ?, expires_at = ?
+           WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?
+             AND owner_nonce = ? AND state = 'pending'`,
+        )
+        .bind(responseBody, completedExpires, ...scope, ownerNonce)
+        .run();
+    const release = () =>
+      db
+        .prepare(
+          `DELETE FROM idempotency_requests
+           WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?
+             AND owner_nonce = ? AND state = 'pending'`,
+        )
+        .bind(...scope, ownerNonce)
+        .run();
+
+    try {
+      const value = await input.run();
+      await complete(JSON.stringify(value));
+      return { value, replayed: false };
+    } catch (err) {
+      if (err instanceof ConflictError && err.code === "key_exists") {
+        const reconciled = await input.reconcile();
+        if (reconciled) {
+          await complete(JSON.stringify(reconciled));
+          return { value: reconciled, replayed: true };
+        }
+      }
+      await release();
+      throw err;
+    }
+  }
+
+  // Did not win the claim: replay the winner's response, or conflict. Bound
+  // only this standalone read; run()/reconcile() above are never raced.
+  const replayLookup = db
+    .prepare(
+      `SELECT fingerprint, owner_nonce, state, response_status, response_body, expires_at
+       FROM idempotency_requests
+       WHERE workspace = ? AND principal = ? AND operation = ? AND key_hash = ?`,
+    )
+    .bind(...scope);
+  const row = await boundedRead(input.readEnv ?? {}, () => replayLookup.first<StoredRequest>(), {
+    name: "d1_upload_idempotency_replay",
+  });
+
+  const settled: StoredRequest = row ?? {
+    fingerprint: fp,
+    owner_nonce: null,
+    state: "pending",
+    response_status: null,
+    response_body: null,
+    expires_at: pendingExpires,
+  };
+  if (settled.fingerprint !== fp || settled.state !== "completed" || !settled.response_body) {
+    conflictFor(settled, fp);
+  }
+  return { value: JSON.parse(settled.response_body) as T, replayed: true };
+}

--- a/apps/api/test/reconcile-existing-upload.test.ts
+++ b/apps/api/test/reconcile-existing-upload.test.ts
@@ -1,65 +1,72 @@
 /**
- * `reconcileExistingUpload` (issue #829) — the crash-window recovery primitive
- * behind retry-safe `PUT`. Exercised end-to-end against the real putObject +
- * fake R2/D1 so the head → provenance-sha compare → response synthesis path is
- * covered directly (the idempotency wrapper's control flow is unit-tested with
- * fakes in upload-idempotency.test.ts).
+ * `reconcileInterruptedUpload` (issue #829) — the crash-window recovery behind
+ * retry-safe `PUT`. A prior attempt's bytes can land in R2 before its D1 work
+ * (metadata, content-hash index) runs; on the retry, `putObject` throws
+ * `key_exists`, and this re-drives the write (with `replace`) so the object
+ * converges to the intended state — rather than reporting success with the
+ * requested metadata silently dropped. Exercised end-to-end against the real
+ * putObject + fake R2/D1.
  */
 import { describe, expect, it } from "vitest";
-import { putObject, reconcileExistingUpload } from "../src/files-core";
+import { getFileMetadata } from "../src/file-metadata";
+import { putObject, reconcileInterruptedUpload } from "../src/files-core";
 import { makePosterEnv, PNG, WORKSPACE } from "./poster-fixtures";
 
-describe("reconcileExistingUpload", () => {
-  it("reconstructs the put response when the stored bytes match the sha", async () => {
+const OPTS = { surface: "api" as const };
+
+describe("reconcileInterruptedUpload", () => {
+  it("re-applies metadata a crashed attempt never wrote (the correctness case)", async () => {
     const { env, ws } = makePosterEnv();
-    const put = await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+    // Simulate the crash window: the object landed in R2 but its D1 metadata
+    // never got written — modeled here as a put that carried no metadata.
+    const put = await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE, OPTS);
     const sha = put.provenance!["content-sha256"]!;
+    expect(await getFileMetadata(env.DB, WORKSPACE, put.key)).toEqual({});
 
-    const reconciled = await reconcileExistingUpload(env, ws, WORKSPACE, put.key, sha);
-    expect(reconciled).not.toBeNull();
-    expect(reconciled).toMatchObject({
-      key: put.key,
-      url: put.url,
-      size: put.size,
-      contentType: put.contentType,
-      replaced: true,
-    });
-    expect(reconciled!.provenance?.["content-sha256"]).toBe(sha);
-  });
-
-  it("echoes the stored queryable metadata (keyed by workspaceName, not ws.name)", async () => {
-    const { env, ws } = makePosterEnv();
-    const put = await putObject(env, ws, "screenshots/tagged.png", PNG, WORKSPACE, {
+    // The retry carried `X-Uploads-Meta-*`; reconcile must converge them.
+    const reconciled = await reconcileInterruptedUpload(env, ws, WORKSPACE, put.key, PNG, sha, {
+      ...OPTS,
       metadata: { project: "acme", stage: "after" },
     });
-    const sha = put.provenance!["content-sha256"]!;
-
-    const reconciled = await reconcileExistingUpload(env, ws, WORKSPACE, put.key, sha);
+    expect(reconciled).not.toBeNull();
     expect(reconciled!.metadata).toMatchObject({ project: "acme", stage: "after" });
+    expect(reconciled!.key).toBe(put.key);
+    // The D1 tier now actually holds them — not just the echoed response.
+    expect(await getFileMetadata(env.DB, WORKSPACE, put.key)).toMatchObject({
+      project: "acme",
+      stage: "after",
+    });
   });
 
-  it("returns null when the stored object's sha differs (a genuine key_exists)", async () => {
+  it("returns null and does not overwrite when the stored sha differs", async () => {
     const { env, ws } = makePosterEnv();
-    const put = await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+    const put = await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE, {
+      ...OPTS,
+      metadata: { keep: "original" },
+    });
 
-    const reconciled = await reconcileExistingUpload(
+    const reconciled = await reconcileInterruptedUpload(
       env,
       ws,
       WORKSPACE,
       put.key,
-      "0".repeat(64), // some other request's content hash
+      PNG,
+      "0".repeat(64), // a different request's content hash
+      { ...OPTS, metadata: { should: "not-apply" } },
     );
     expect(reconciled).toBeNull();
   });
 
   it("returns null when no object exists at the key", async () => {
     const { env, ws } = makePosterEnv();
-    const reconciled = await reconcileExistingUpload(
+    const reconciled = await reconcileInterruptedUpload(
       env,
       ws,
       WORKSPACE,
       "screenshots/absent.png",
+      PNG,
       "0".repeat(64),
+      OPTS,
     );
     expect(reconciled).toBeNull();
   });

--- a/apps/api/test/reconcile-existing-upload.test.ts
+++ b/apps/api/test/reconcile-existing-upload.test.ts
@@ -1,0 +1,66 @@
+/**
+ * `reconcileExistingUpload` (issue #829) — the crash-window recovery primitive
+ * behind retry-safe `PUT`. Exercised end-to-end against the real putObject +
+ * fake R2/D1 so the head → provenance-sha compare → response synthesis path is
+ * covered directly (the idempotency wrapper's control flow is unit-tested with
+ * fakes in upload-idempotency.test.ts).
+ */
+import { describe, expect, it } from "vitest";
+import { putObject, reconcileExistingUpload } from "../src/files-core";
+import { makePosterEnv, PNG, WORKSPACE } from "./poster-fixtures";
+
+describe("reconcileExistingUpload", () => {
+  it("reconstructs the put response when the stored bytes match the sha", async () => {
+    const { env, ws } = makePosterEnv();
+    const put = await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+    const sha = put.provenance!["content-sha256"]!;
+
+    const reconciled = await reconcileExistingUpload(env, ws, WORKSPACE, put.key, sha);
+    expect(reconciled).not.toBeNull();
+    expect(reconciled).toMatchObject({
+      key: put.key,
+      url: put.url,
+      size: put.size,
+      contentType: put.contentType,
+      replaced: true,
+    });
+    expect(reconciled!.provenance?.["content-sha256"]).toBe(sha);
+  });
+
+  it("echoes the stored queryable metadata (keyed by workspaceName, not ws.name)", async () => {
+    const { env, ws } = makePosterEnv();
+    const put = await putObject(env, ws, "screenshots/tagged.png", PNG, WORKSPACE, {
+      metadata: { project: "acme", stage: "after" },
+    });
+    const sha = put.provenance!["content-sha256"]!;
+
+    const reconciled = await reconcileExistingUpload(env, ws, WORKSPACE, put.key, sha);
+    expect(reconciled!.metadata).toMatchObject({ project: "acme", stage: "after" });
+  });
+
+  it("returns null when the stored object's sha differs (a genuine key_exists)", async () => {
+    const { env, ws } = makePosterEnv();
+    const put = await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+
+    const reconciled = await reconcileExistingUpload(
+      env,
+      ws,
+      WORKSPACE,
+      put.key,
+      "0".repeat(64), // some other request's content hash
+    );
+    expect(reconciled).toBeNull();
+  });
+
+  it("returns null when no object exists at the key", async () => {
+    const { env, ws } = makePosterEnv();
+    const reconciled = await reconcileExistingUpload(
+      env,
+      ws,
+      WORKSPACE,
+      "screenshots/absent.png",
+      "0".repeat(64),
+    );
+    expect(reconciled).toBeNull();
+  });
+});

--- a/apps/api/test/upload-idempotency.test.ts
+++ b/apps/api/test/upload-idempotency.test.ts
@@ -1,0 +1,389 @@
+/// <reference types="node" />
+
+import { ConflictError, ValidationError } from "@uploads/errors";
+import { describe, expect, it, vi } from "vitest";
+import {
+  PENDING_TTL_MS,
+  putObjectIdempotently,
+  type UploadFingerprintInput,
+} from "../src/upload-idempotency";
+import { IDEMPOTENCY_RETENTION_HOURS } from "../src/idempotency-core";
+import { database, SqliteD1 } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = ["migrations/20260824120000_idempotency_requests.sql"];
+
+function fingerprint(overrides: Partial<UploadFingerprintInput> = {}): UploadFingerprintInput {
+  return {
+    finalKey: "f/abc/photo.png",
+    contentSha256: "a".repeat(64),
+    visibility: undefined,
+    replace: false,
+    metadata: undefined,
+    ...overrides,
+  };
+}
+
+function response(key: string) {
+  return { key, url: `https://uploads.test/${key}`, embedUrl: null, size: 10 };
+}
+
+describe("upload PUT idempotency", () => {
+  it("stores a completed row on fresh success and returns replayed:false", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const run = vi.fn(async () => response("f/abc/photo.png"));
+      const reconcile = vi.fn(async () => null);
+      const result = await putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "put-1",
+        fingerprint: fingerprint(),
+        run,
+        reconcile,
+        now: new Date("2026-08-24T12:00:00Z"),
+      });
+      expect(result).toEqual({ value: response("f/abc/photo.png"), replayed: false });
+      expect(run).toHaveBeenCalledTimes(1);
+      const row = sqlite.db
+        .prepare("SELECT state, response_body FROM idempotency_requests WHERE key_hash IS NOT NULL")
+        .get() as { state: string; response_body: string };
+      expect(row.state).toBe("completed");
+      expect(JSON.parse(row.response_body)).toEqual(response("f/abc/photo.png"));
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("replays the stored value on retry without calling run again", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const first = await putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "put-2",
+        fingerprint: fingerprint(),
+        run: async () => response("f/abc/photo.png"),
+        reconcile: async () => null,
+        now: new Date("2026-08-24T12:00:00Z"),
+      });
+      expect(first.replayed).toBe(false);
+
+      const run = vi.fn(async () => {
+        throw new Error("must not run again");
+      });
+      const retry = await putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "put-2",
+        fingerprint: fingerprint(),
+        run,
+        reconcile: async () => null,
+        now: new Date("2026-08-24T12:00:30Z"),
+      });
+      expect(retry).toEqual({ value: response("f/abc/photo.png"), replayed: true });
+      expect(run).not.toHaveBeenCalled();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rejects same key with a different fingerprint", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "put-3",
+        fingerprint: fingerprint(),
+        run: async () => response("f/abc/photo.png"),
+        reconcile: async () => null,
+        now: new Date("2026-08-24T12:00:00Z"),
+      });
+
+      await expect(
+        putObjectIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "d1-token:one",
+          key: "put-3",
+          fingerprint: fingerprint({ contentSha256: "b".repeat(64) }),
+          run: async () => response("f/abc/other.png"),
+          reconcile: async () => null,
+          now: new Date("2026-08-24T12:00:30Z"),
+        }),
+      ).rejects.toMatchObject({ code: "idempotency_key_reused" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("reconciles a key_exists failure to the prior upload and completes the claim", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const reconciled = response("f/abc/photo.png");
+      const run = vi.fn(async () => {
+        throw new ConflictError("exists", { code: "key_exists" });
+      });
+      const reconcile = vi.fn(async () => reconciled);
+      const result = await putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "put-4",
+        fingerprint: fingerprint(),
+        run,
+        reconcile,
+        now: new Date("2026-08-24T12:00:00Z"),
+      });
+      expect(result).toEqual({ value: reconciled, replayed: true });
+      expect(reconcile).toHaveBeenCalledTimes(1);
+      const row = sqlite.db
+        .prepare("SELECT state, response_body FROM idempotency_requests")
+        .get() as { state: string; response_body: string };
+      expect(row.state).toBe("completed");
+      expect(JSON.parse(row.response_body)).toEqual(reconciled);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rethrows key_exists and releases the claim when reconcile finds nothing", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await expect(
+        putObjectIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "d1-token:one",
+          key: "put-5",
+          fingerprint: fingerprint(),
+          run: async () => {
+            throw new ConflictError("exists", { code: "key_exists" });
+          },
+          reconcile: async () => null,
+          now: new Date("2026-08-24T12:00:00Z"),
+        }),
+      ).rejects.toMatchObject({ code: "key_exists" });
+      expect(
+        sqlite.db.prepare("SELECT COUNT(*) AS c FROM idempotency_requests").get(),
+      ).toMatchObject({ c: 0 });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("releases the claim on a non-key_exists failure and lets a corrected retry succeed", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await expect(
+        putObjectIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "d1-token:one",
+          key: "put-6",
+          fingerprint: fingerprint(),
+          run: async () => {
+            throw new ValidationError("nope", { code: "empty_body" });
+          },
+          reconcile: async () => null,
+          now: new Date("2026-08-24T12:00:00Z"),
+        }),
+      ).rejects.toMatchObject({ code: "empty_body" });
+      expect(
+        sqlite.db.prepare("SELECT COUNT(*) AS c FROM idempotency_requests").get(),
+      ).toMatchObject({ c: 0 });
+
+      const retry = await putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "put-6",
+        fingerprint: fingerprint(),
+        run: async () => response("f/abc/photo.png"),
+        reconcile: async () => null,
+        now: new Date("2026-08-24T12:00:05Z"),
+      });
+      expect(retry).toEqual({ value: response("f/abc/photo.png"), replayed: false });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("re-claims a stale pending row past PENDING_TTL but never a live completed row", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const start = new Date("2026-08-24T12:00:00Z");
+
+      // Establish a pending claim that never completes (simulating a crash
+      // between the R2 write and the completing UPDATE), then age it past
+      // PENDING_TTL directly in the table.
+      const firstCall = putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:two",
+        key: "stale-key",
+        fingerprint: fingerprint(),
+        run: () => new Promise(() => {}), // never resolves; we abandon it below
+        reconcile: async () => null,
+        now: start,
+      });
+      // Let the claim land, then abandon the in-flight run() (simulating a crash).
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      void firstCall;
+
+      // Age the pending row past PENDING_TTL directly.
+      sqlite.db
+        .prepare(
+          `UPDATE idempotency_requests SET expires_at = ?
+           WHERE workspace = 'alpha' AND principal = 'd1-token:two' AND operation = 'upload.put.v1'`,
+        )
+        .run(new Date(start.getTime() - 1000).toISOString());
+
+      const after = new Date(start.getTime() + PENDING_TTL_MS + 1000);
+      const run = vi.fn(async () => response("f/abc/photo.png"));
+      const retry = await putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:two",
+        key: "stale-key",
+        fingerprint: fingerprint(),
+        run,
+        reconcile: async () => null,
+        now: after,
+      });
+      expect(retry).toEqual({ value: response("f/abc/photo.png"), replayed: false });
+      expect(run).toHaveBeenCalledTimes(1);
+
+      // A completed row inside its 24h window must never be re-claimed.
+      const wellWithinRetention = new Date(
+        after.getTime() + PENDING_TTL_MS + 1000, // still nowhere near 24h
+      );
+      const shouldNotRun = vi.fn(async () => {
+        throw new Error("must not re-run a completed claim");
+      });
+      const replay = await putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:two",
+        key: "stale-key",
+        fingerprint: fingerprint(),
+        run: shouldNotRun,
+        reconcile: async () => null,
+        now: wellWithinRetention,
+      });
+      expect(replay).toEqual({ value: response("f/abc/photo.png"), replayed: true });
+      expect(shouldNotRun).not.toHaveBeenCalled();
+      expect(wellWithinRetention.getTime() - after.getTime()).toBeLessThan(
+        IDEMPOTENCY_RETENTION_HOURS * 3600e3,
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("reports in_progress for a live pending claim owned by someone else", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      // Kick off (and never resolve) a first call so its pending claim stays live.
+      const stuck = putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "in-progress-key",
+        fingerprint: fingerprint(),
+        run: () => new Promise(() => {}),
+        reconcile: async () => null,
+        now: new Date("2026-08-24T12:00:00Z"),
+      });
+      void stuck;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await expect(
+        putObjectIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "d1-token:one",
+          key: "in-progress-key",
+          fingerprint: fingerprint(),
+          run: async () => response("f/abc/photo.png"),
+          reconcile: async () => null,
+          now: new Date("2026-08-24T12:00:01Z"),
+        }),
+      ).rejects.toMatchObject({ code: "idempotency_request_in_progress" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("isolates the same key by principal and workspace", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-08-24T12:00:00Z");
+      const scopes: [string, string][] = [
+        ["alpha", "d1-token:one"],
+        ["alpha", "d1-token:two"],
+        ["beta", "d1-token:one"],
+      ];
+      for (const [workspace, principal] of scopes) {
+        const result = await putObjectIdempotently(database(sqlite), {
+          workspace,
+          principal,
+          key: "shared-key",
+          fingerprint: fingerprint(),
+          run: async () => response("f/abc/photo.png"),
+          reconcile: async () => null,
+          now,
+        });
+        expect(result.replayed).toBe(false);
+      }
+      expect(
+        sqlite.db.prepare("SELECT COUNT(*) AS c FROM idempotency_requests").get(),
+      ).toMatchObject({ c: 3 });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("canonicalizes metadata key order so retries replay instead of conflicting", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "meta-order",
+        fingerprint: fingerprint({ metadata: { b: "2", a: "1" } }),
+        run: async () => response("f/abc/photo.png"),
+        reconcile: async () => null,
+        now: new Date("2026-08-24T12:00:00Z"),
+      });
+
+      const run = vi.fn(async () => {
+        throw new Error("must not run again");
+      });
+      const retry = await putObjectIdempotently(database(sqlite), {
+        workspace: "alpha",
+        principal: "d1-token:one",
+        key: "meta-order",
+        fingerprint: fingerprint({ metadata: { a: "1", b: "2" } }),
+        run,
+        reconcile: async () => null,
+        now: new Date("2026-08-24T12:00:05Z"),
+      });
+      expect(retry).toEqual({ value: response("f/abc/photo.png"), replayed: true });
+      expect(run).not.toHaveBeenCalled();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rejects blank, control-character, and oversized keys", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      for (const key of ["", "has space", "line\nbreak", "x".repeat(256)]) {
+        await expect(
+          putObjectIdempotently(database(sqlite), {
+            workspace: "alpha",
+            principal: "d1-token:one",
+            key,
+            fingerprint: fingerprint(),
+            run: async () => response("f/abc/photo.png"),
+            reconcile: async () => null,
+            now: new Date("2026-08-24T12:00:00Z"),
+          }),
+        ).rejects.toMatchObject({ code: "idempotency_key_invalid" });
+      }
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/web/public/.well-known/openapi.json
+++ b/apps/web/public/.well-known/openapi.json
@@ -152,6 +152,7 @@
       "put": {
         "operationId": "putFile",
         "summary": "Upload a file",
+        "description": "Send an Idempotency-Key to make retries safe for 24 hours. Reusing the key with the same effective request (keyed on the uploaded content) returns the original 201 response. Reusing it with a different request returns 409.",
         "parameters": [
           {
             "name": "replace",
@@ -164,7 +165,8 @@
             "in": "query",
             "schema": { "type": "boolean", "default": false },
             "description": "Validate and resolve the final key without writing."
-          }
+          },
+          { "$ref": "#/components/parameters/IdempotencyKey" }
         ],
         "requestBody": {
           "required": true,
@@ -181,6 +183,12 @@
           },
           "201": {
             "description": "The file was stored.",
+            "headers": {
+              "Idempotency-Replayed": {
+                "description": "Present with value `true` when the API replays a stored response.",
+                "schema": { "type": "string", "enum": ["true"] }
+              }
+            },
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/FilePut" } }
             }

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,13 +41,14 @@ recover a token by replaying a key. The client's `mintWorkspaceToken` accepts an
 optional `idempotencyKey`.
 
 `PUT /v1/workspaces/:workspace/files/:key` (object upload) accepts the same
-header. The key is scoped to the uploaded content plus the rest of the
-request, so an identical retry replays the original `201` instead of writing a
-duplicate object or hitting the `409 key_exists` a naive retry would get on a
-strict key. A retry with the same key but a different request returns
-`409 idempotency_key_reused`. The client's `put` accepts an optional
-`idempotencyKey`; unlike `createGallery`, it is never generated automatically
-— only supplied when the caller opts in.
+header. The API scopes the key to the uploaded content and the rest of the
+request. An identical retry replays the original `201`. That avoids both a
+duplicate object and the `409 key_exists` a naive retry would hit on a strict
+key. A retry with the same key but a different request returns
+`409 idempotency_key_reused`. A concurrent request can return
+`409 idempotency_request_in_progress` with `Retry-After: 1`. The client's `put`
+accepts an optional `idempotencyKey`. Unlike `createGallery`, it is never
+generated automatically — only supplied when the caller opts in.
 
 ## Errors
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,6 +40,15 @@ re-checked on every attempt: a caller who has lost workspace access cannot
 recover a token by replaying a key. The client's `mintWorkspaceToken` accepts an
 optional `idempotencyKey`.
 
+`PUT /v1/workspaces/:workspace/files/:key` (object upload) accepts the same
+header. The key is scoped to the uploaded content plus the rest of the
+request, so an identical retry replays the original `201` instead of writing a
+duplicate object or hitting the `409 key_exists` a naive retry would get on a
+strict key. A retry with the same key but a different request returns
+`409 idempotency_key_reused`. The client's `put` accepts an optional
+`idempotencyKey`; unlike `createGallery`, it is never generated automatically
+— only supplied when the caller opts in.
+
 ## Errors
 
 Every non-2xx response uses one nested envelope (same shape as either/releases):

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -52,6 +52,13 @@ export interface PutOptions {
    * `KEY_EXISTS`.
    */
   replace?: boolean;
+  /**
+   * Reuse this key to safely retry the same upload request (issue #829). Not
+   * generated automatically — unlike `createGallery`, a `put` is only
+   * retried by the client (see `resilientFetch`) or is server-replay-safe
+   * when the caller supplies one; omit it and no header is sent.
+   */
+  idempotencyKey?: string;
 }
 
 export interface ListOptions {
@@ -524,13 +531,17 @@ export interface EnrollmentCreateResult {
 const JSON_TIMEOUT_MS = 15_000;
 const CONTENT_TIMEOUT_MS = 60_000;
 
-// At most one retry. Retried on network errors, 503, and 429 — and only for
-// GET/PUT, since a `put` is byte-idempotent (same key, same bytes). POST is
-// retryable only when the request carries an Idempotency-Key; DELETE/PATCH
-// remain single-attempt because telling "no bytes sent" apart from "the
-// mutation already landed" isn't reliable enough to risk a double-apply.
+// At most one retry. Retried on network errors, 503, and 429 — GET always.
+// POST and PUT are retryable only when the request carries an
+// Idempotency-Key (gallery-create's POST, and an upload PUT that opts in per
+// issue #829) — a bare PUT is no longer assumed byte-idempotent, since a
+// strict (non-`gh/`) key without a caller-supplied key can 409 `key_exists`
+// on replay. DELETE/PATCH remain single-attempt because telling "no bytes
+// sent" apart from "the mutation already landed" isn't reliable enough to
+// risk a double-apply.
 const MAX_ATTEMPTS = 2;
-const RETRYABLE_METHODS = new Set(["GET", "PUT"]);
+const RETRYABLE_METHODS = new Set(["GET"]);
+const IDEMPOTENCY_KEYED_METHODS = new Set(["POST", "PUT"]);
 const RETRYABLE_STATUSES = new Set([429, 503]);
 const DEFAULT_RETRY_DELAY_MS = 2_000;
 // Cap an honored X-Retry-After so a large server-suggested backoff can't
@@ -601,7 +612,8 @@ async function resilientFetch(
   const normalizedMethod = method.toUpperCase();
   const retryable =
     RETRYABLE_METHODS.has(normalizedMethod) ||
-    (normalizedMethod === "POST" && new Headers(init.headers).has("Idempotency-Key"));
+    (IDEMPOTENCY_KEYED_METHODS.has(normalizedMethod) &&
+      new Headers(init.headers).has("Idempotency-Key"));
   for (let attempt = 1; ; attempt++) {
     let res: Response | undefined;
     let networkErr: UploadsError | undefined;
@@ -1160,6 +1172,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
 
       const headers: Record<string, string> = { "Content-Type": contentType };
       if (opts.replace) headers["X-Uploads-Replace"] = "1";
+      if (opts.idempotencyKey) headers["Idempotency-Key"] = opts.idempotencyKey;
       if (opts.provenance) {
         for (const [k, v] of Object.entries(opts.provenance)) {
           if (v !== undefined && v !== "") headers[`X-Uploads-Meta-${k}`] = v;

--- a/packages/uploads/test/put-idempotency.test.ts
+++ b/packages/uploads/test/put-idempotency.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createUploadsClient } from "../src/client.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function client() {
+  return createUploadsClient({
+    apiUrl: "https://api.test",
+    workspace: "test",
+    token: "up_test_x",
+  });
+}
+
+function okFetch() {
+  return vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify({
+          workspace: "test",
+          key: "a.png",
+          url: "https://cdn.test/a.png",
+          size: 3,
+          contentType: "image/png",
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+  );
+}
+
+describe("put idempotency (issue #829)", () => {
+  it("sends Idempotency-Key when provided", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await client().put(new Uint8Array([1, 2, 3]), {
+      filename: "a.png",
+      key: "a.png",
+      idempotencyKey: "upload-retry-1",
+    });
+
+    const init = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1];
+    expect(new Headers(init.headers).get("Idempotency-Key")).toBe("upload-retry-1");
+  });
+
+  it("omits Idempotency-Key when not provided", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await client().put(new Uint8Array([1, 2, 3]), {
+      filename: "a.png",
+      key: "a.png",
+    });
+
+    const init = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1];
+    expect(new Headers(init.headers).has("Idempotency-Key")).toBe(false);
+  });
+});


### PR DESCRIPTION
## In plain terms

Uploading a file is a one-shot: the API writes the bytes, then records usage and
metadata. If the response is lost to a network blip after the bytes land, a
naive retry either writes a **duplicate** object (bare `f/<id>` keys get a new id
each attempt) or gets a confusing `409 key_exists` on a fixed key. This makes
object `PUT` retry-safe: send an `Idempotency-Key` and an identical retry replays
the original `201` — same object, same response — instead of duplicating or
erroring.

This is the uploads block of #829; galleries (#832) and token minting (#834)
shipped earlier and this reuses their machinery.

## What it does / what it is not

- **Opt-in.** No `Idempotency-Key` header → behavior unchanged.
- Identical retry (same key + same effective request, anchored on the uploaded
  content hash) within 24h replays the original `201` with
  `Idempotency-Replayed: true`, and writes exactly one object.
- Same key + different request → `409 idempotency_key_reused`. A concurrent
  in-flight request → `409 idempotency_request_in_progress` with `Retry-After: 1`.
- **No encryption** (unlike token minting): an upload response holds no secret,
  so the replay body is plain JSON.
- **No migration.** Reuses the `idempotency_requests` table (`operation =
  upload.put.v1`) and its daily retention sweep. No ledger, no orphan reaper.
- **Client behavior change (flagged):** a **bare** `PUT` (no `Idempotency-Key`)
  is no longer auto-retried by the client on a network hiccup/503/429 — only a
  keyed `PUT`/`POST` is. Bare `f/<id>` uploads re-govern to a new key per
  attempt, so the old blanket PUT-retry could silently create duplicates; this
  is #829's intended correction, not a regression. Wiring the CLI to supply a
  key for retryable uploads is a sensible follow-up, not in this PR.

## How to try it

```bash
KEY=$(uuidgen)
# First call stores the object; an identical retry with the same key replays it.
uploads api PUT "/v1/workspaces/acme/files/reports/q3.pdf" \
  --header "Idempotency-Key: $KEY" --data-binary @q3.pdf
```

The JS client's `put` now accepts an optional `idempotencyKey` (never generated
automatically).

## Technical notes

- **Two-phase, not one batch.** R2 is not transactional with D1, so the flow is
  `claim` → `run putObject` → `complete`, as three `owner_nonce`-gated statements
  on a primary-constrained session (`primaryDbFor`). Only the standalone replay
  lookup is `boundedRead`; the R2 write + bookkeeping are never deadline-raced.
- **Crash-window recovery without a ledger.** A crash between the R2 write and
  the completing `UPDATE` leaves a `pending` row. The pending row carries a short
  TTL (`PENDING_TTL_MS`, 5 min) distinct from the 24h completed retention, so a
  stall doesn't strand retries for a day. On re-run, `putObject` throws
  `key_exists`; `reconcileInterruptedUpload` heads the object and, **only when**
  its stored `content-sha256` matches the request, re-drives `putObject` with
  `replace` — converging metadata, content-hash, and poster through the normal
  write path. (Re-driving, rather than synthesizing the response from a read, is
  required for correctness: a crash before the D1 metadata write would otherwise
  replay a `201` with the caller's `X-Uploads-Meta-*` silently dropped.) A
  mismatched sha is a real conflict and surfaces `key_exists` without overwriting.
- **Accepted, documented tolerance:** re-driving on the rare recovery path can
  over-count the monthly upload *count* by one (`reserveUploads` is
  unconditional). Bytes and object count stay exact. Within the same cap-boundary
  inaccuracy the code already tolerates; not worth a reconciliation mechanism.
- Fingerprint over `{finalKey, contentSha256, visibility, replace, metadata}`
  with sorted-key metadata serialization. Errors from `run()` are never cached —
  the pending claim is released so a corrected retry re-evaluates.
- Shared primitives (`idempotency-core.ts`), error codes, `Idempotency-Key` /
  `Retry-After` / `Idempotency-Replayed` headers, and CORS allowlist reused.

## Test plan

- [x] `pnpm test:api` — full API suite (2269 passed)
- [x] `apps/api/test/upload-idempotency.test.ts` (11) — fresh/replay, reused
  conflict, `key_exists`→reconcile match & null, non-`key_exists` release,
  pending-TTL re-claim, completed-row-not-clobbered, in-progress, isolation,
  fingerprint canonicalization
- [x] `apps/api/test/reconcile-existing-upload.test.ts` (3) — end-to-end
  re-drive that converges metadata a crashed attempt never wrote (asserts the D1
  tier, not just the echoed response), sha-mismatch → null (no overwrite),
  absent → null
- [x] `packages/uploads` client suite (1315) incl. new `put-idempotency.test.ts`
- [x] `@uploads/api` + `@buildinternet/uploads` typecheck; oxlint/oxfmt on changed
  files; `git diff --check` clean
- [ ] Full monorepo typecheck not run here (Node 24 engine unmet locally for
  `apps/web`); API + client checks above are green.

Refs #829


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional idempotency keys for file uploads, allowing safe retries without duplicate objects.
  * Replayed responses are identified with the `Idempotency-Replayed` header.
  * Upload retries with mismatched request details now return a clear conflict.

* **Bug Fixes**
  * Prevented automatic retries for uploads that lack an idempotency key.

* **Documentation**
  * Updated API documentation and OpenAPI specifications with upload retry behavior and supported headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
