### PR TITLE
feat(api): make canonical list metadata hydration optional (#829)

### DIFF
--- a/.changeset/skip-list-metadata-hydration.md
+++ b/.changeset/skip-list-metadata-hydration.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`list`/`listAll` now skip the server's per-key metadata hydration when the
+caller didn't request `metadata: true`, instead of fetching it and throwing
+it away.

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -104,10 +104,16 @@ function sessionFileBrowserGate(): MiddlewareHandler<DualAuthVars> {
 
 export const workspaceFiles = new Hono<DualAuthVars>()
 
-  // Folder-aware listing, D1 `gh.*` metadata always hydrated. Query params:
+  // Folder-aware listing, D1 `gh.*` metadata hydrated by default. Query params:
   // `prefix`/`cursor` pass straight through, `limit` defaults to 100
   // (clamped inside `listObjects`), `delimiter` enables S3-style "folder"
-  // navigation via `listObjects`'s `prefixes`.
+  // navigation via `listObjects`'s `prefixes`. `metadata=0`/`false` skips the
+  // D1 metadata hydration pass for callers that discard it anyway (issue
+  // #829 §5) — same param name as the legacy `?metadata=1` opt-in on
+  // `files.ts`'s plain listing, inverted here since this route hydrates by
+  // default. Response shape is unchanged either way: `metadata` is simply
+  // `undefined` per item when hydration is skipped, same as it already is
+  // for any key with no D1 metadata row.
   .get("/:workspace/files", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
     const record = c.get("workspace");
     const name = c.get("workspaceName");
@@ -119,17 +125,24 @@ export const workspaceFiles = new Hono<DualAuthVars>()
       prefixes,
     } = await listObjects(c.env, record, { prefix, delimiter, limit, cursor });
 
-    const metaByKey = await boundedDataRead(
-      c,
-      () =>
-        getMetadataForKeys(
-          dbFor(c.env),
-          name,
-          items.map((item) => item.key),
-        ),
-      { name: "d1_files_meta" },
-    );
-    const files = items.map((item) => ({ ...item, metadata: metaByKey.get(item.key) }));
+    const metadataParam = c.req.query("metadata");
+    const skipMetadata = metadataParam === "0" || metadataParam === "false";
+
+    const files = skipMetadata
+      ? items
+      : await (async () => {
+          const metaByKey = await boundedDataRead(
+            c,
+            () =>
+              getMetadataForKeys(
+                dbFor(c.env),
+                name,
+                items.map((item) => item.key),
+              ),
+            { name: "d1_files_meta" },
+          );
+          return items.map((item) => ({ ...item, metadata: metaByKey.get(item.key) }));
+        })();
 
     return c.json({ files, prefixes, cursor: nextCursor });
   })

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -207,6 +207,44 @@ describe("GET /v1/workspaces/:workspace/files (dual auth)", () => {
     const res = await app.request("/v1/workspaces/acme/files", {}, env);
     expect(res.status).toBe(401);
   });
+
+  // Issue #829 §5: hydrating each row's D1 metadata is the expensive part of
+  // this route; `?metadata=0` opts out for callers that discard it anyway.
+  // Default behavior (no param) must stay exactly as before.
+  it("hydrates D1 metadata by default", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    (env as unknown as { DB: { metadata: Map<string, Map<string, string>> } }).DB.metadata.set(
+      "acme shots/a.png",
+      new Map([["app", "web"]]),
+    );
+    const res = await app.request(
+      "/v1/workspaces/acme/files",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { files: { key: string; metadata?: unknown }[] };
+    expect(body.files).toMatchObject([{ key: "shots/a.png", metadata: { app: "web" } }]);
+  });
+
+  it.each(["0", "false"])("?metadata=%s skips D1 metadata hydration", async (value) => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    (env as unknown as { DB: { metadata: Map<string, Map<string, string>> } }).DB.metadata.set(
+      "acme shots/a.png",
+      new Map([["app", "web"]]),
+    );
+    const res = await app.request(
+      `/v1/workspaces/acme/files?metadata=${value}`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { files: { key: string; metadata?: unknown }[] };
+    expect(body.files).toMatchObject([{ key: "shots/a.png" }]);
+    expect(body.files[0]).not.toHaveProperty("metadata");
+  });
 });
 
 describe("GET /v1/workspaces/:workspace/files/file-url (dual auth)", () => {

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -1096,13 +1096,17 @@ export function createUploadsClient(config: UploadsClientConfig) {
     if (opts.prefix) params.set("prefix", opts.prefix);
     if (opts.limit != null) params.set("limit", String(opts.limit));
     if (opts.cursor) params.set("cursor", opts.cursor);
-    if (opts.metadata) params.set("metadata", "1");
+    // The canonical route hydrates D1 metadata by default (issue #613 — the
+    // session shape won the reconciliation); when the caller didn't ask for
+    // `opts.metadata` this client discards it anyway below, so `metadata=0`
+    // opts out of the hydration pass server-side instead of paying for work
+    // whose result is thrown away (issue #829 §5).
+    params.set("metadata", opts.metadata ? "1" : "0");
     const qs = params.toString();
-    // Canonical list envelope is `{files, prefixes, cursor}` with queryable
-    // metadata always hydrated (issue #613 — the session shape won the
-    // reconciliation). This client keeps its historical `{items, cursor}`
-    // contract: rename the array and honor `opts.metadata` by stripping the
-    // hydrated maps when the caller didn't ask for them.
+    // Canonical list envelope is `{files, prefixes, cursor}`. This client
+    // keeps its historical `{items, cursor}` contract: rename the array and
+    // honor `opts.metadata` by stripping the hydrated maps when the caller
+    // didn't ask for them.
     const page = await request<{ files: ListItem[]; cursor: string | null }>(
       "GET",
       `${canonicalFilesBase(config)}${qs ? `?${qs}` : ""}`,

--- a/packages/uploads/test/client-metadata.test.ts
+++ b/packages/uploads/test/client-metadata.test.ts
@@ -238,7 +238,10 @@ describe("list metadata hydration", () => {
     expect(items[0].metadata).toEqual({ path: "/settings", state: "before" });
   });
 
-  it("omits the param when metadata is not requested", async () => {
+  // Issue #829 §5: the caller discards the hydrated map when it didn't ask
+  // for `metadata: true`, so the client opts out of the server's D1
+  // hydration pass rather than paying for it and throwing the result away.
+  it("sends metadata=0 to skip D1 hydration when metadata is not requested", async () => {
     let seenUrl = "";
     const fetch = vi.fn(async (input: string | URL | Request) => {
       seenUrl = String(input);
@@ -253,6 +256,6 @@ describe("list metadata hydration", () => {
 
     await client.listAll({ prefix: "gh/" });
 
-    expect(seenUrl).not.toContain("metadata");
+    expect(seenUrl).toContain("metadata=0");
   });
 });


### PR DESCRIPTION
Implements issue #829 §5 ("Make expensive enrichment optional") for the canonical file listing.

## What changed

- `GET /v1/workspaces/:workspace/files` (and its legacy `/me/workspaces/:name/files` alias, which forwards the query string unchanged) now accepts `?metadata=0` / `?metadata=false` to skip the D1 metadata hydration pass. Default behavior is unchanged — no param, or any other value, still hydrates and returns `metadata` per row exactly as before. No response fields were removed or renamed.
- `packages/uploads`'s client (`list`/`listAll`) now sends `metadata=0` whenever the caller didn't pass `metadata: true`. Previously the client always paid for the server's hydration pass and then discarded the `metadata` map client-side when the caller hadn't asked for it — this closes that gap. Callers that do pass `metadata: true` are unaffected (client still sends `metadata=1` and surfaces the map).

## Param naming

`files.ts`'s legacy bearer listing route already uses `?metadata=1`/`true` as an *opt-in* (that route doesn't hydrate by default). The canonical route hydrates by default, so this reuses the same `metadata` param name with inverted polarity (`0`/`false` opts out) rather than introducing a second param — same spelling callers already know, consistent with how each route's default behaves.

## Left out of scope

Evaluated gallery preview enrichment (`workspace-galleries.ts`'s `itemCount`/`references`/`previewUrl` hydration on `GET /:workspace/galleries`) for the same opt-out pattern. That enrichment is structurally different — it isn't a single D1 read but a per-row storage resolve for the cover thumbnail — so making it optional is a larger change than this PR's scope. Noting it here rather than doing it as part of §5.

## Tests

- `apps/api/test/routes-workspace-files.test.ts`: default hydration is unchanged; `?metadata=0` and `?metadata=false` both skip hydration (no `metadata` key on returned rows).
- `packages/uploads/test/client-metadata.test.ts`: client still requests `metadata=1` when `metadata: true` is passed; now asserts it sends `metadata=0` when it isn't.
- `pnpm test` (root, full suite): all passing.
- Typecheck: `apps/api` (`pnpm --filter @uploads/api run typecheck`) and `packages/uploads` (`pnpm run typecheck` in that package) both clean.

## Changeset

Added a `minor` changeset for `@buildinternet/uploads` — additive client behavior change (fewer bytes/less server work on `list`/`listAll` calls that don't request metadata).

Refs #829 §5.
