### PR TITLE
feat(api): cursor-paginate file search (#829)

### DIFF
--- a/.changeset/pageable-file-search.md
+++ b/.changeset/pageable-file-search.md
@@ -2,7 +2,7 @@
 "@buildinternet/uploads": minor
 ---
 
-Page through file search: `findFiles` now returns an opaque `cursor` and
-accepts one back, `findFilesAll` follows it up to a page cap, and `uploads
-find` / `uploads list --meta` gained `--cursor` and `--all`. The `find_files`
-MCP tool takes and returns the same cursor.
+Page through file search. `findFiles` now returns an opaque `cursor` and
+accepts one back. The new `findFilesAll` follows that cursor, up to a page cap.
+`uploads find` and `uploads list --meta` gained `--cursor` and `--all`. The
+`find_files` MCP tool takes and returns the same cursor.

--- a/.changeset/pageable-file-search.md
+++ b/.changeset/pageable-file-search.md
@@ -1,0 +1,8 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Page through file search: `findFiles` now returns an opaque `cursor` and
+accepts one back, `findFilesAll` follows it up to a page cap, and `uploads
+find` / `uploads list --meta` gained `--cursor` and `--all`. The `find_files`
+MCP tool takes and returns the same cursor.

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -548,12 +548,22 @@ const MERGED_STATUS_SQL = `s2.meta_key = 'gh.merged' AND s2.meta_value = 'true'`
  * `collapsePromotedShadows` (opt-in, off by default) drops promoted branch
  * originals (`PROMOTED_SHADOW_STATUS_SQL`) so the screenshots drill-in doesn't
  * show a shot twice; general search keeps them.
+ *
+ * `after` is a keyset continuation: rows are already ordered by `object_key`,
+ * so resuming at `object_key > :after` skips the consumed window without an
+ * OFFSET scan and stays stable when objects are added or removed between
+ * pages (issue #829 §4).
  */
 export async function findObjectsByMetadata(
   db: D1Queryable,
   workspace: string,
   filters: Record<string, string>,
-  opts: { prefix?: string; limit?: number; collapsePromotedShadows?: boolean } = {},
+  opts: {
+    prefix?: string;
+    limit?: number;
+    collapsePromotedShadows?: boolean;
+    after?: string;
+  } = {},
 ): Promise<Array<{ key: string; metadata: Record<string, string> }>> {
   const entries = Object.entries(filters);
   if (entries.length === 0) return [];
@@ -594,6 +604,12 @@ export async function findObjectsByMetadata(
                AND ${PROMOTED_SHADOW_STATUS_SQL}
            )`;
     params.push(workspace);
+  }
+  // Keyset continuation wraps last so it applies uniformly to the single-leg,
+  // INTERSECT, and collapse-wrapped forms.
+  if (opts.after !== undefined) {
+    sql = `SELECT object_key FROM (${sql}) AS page WHERE object_key > ?`;
+    params.push(opts.after);
   }
   sql += ` ORDER BY object_key LIMIT ?`;
   params.push(limit);

--- a/apps/api/src/file-search.ts
+++ b/apps/api/src/file-search.ts
@@ -84,11 +84,104 @@ export interface FileSearchMatch {
 }
 
 /**
+ * Which of the two search mechanics produced a cursor. A cursor minted on the
+ * metadata path means "resume the D1 keyset scan"; one minted on the storage
+ * walk means "resume the walk". Replaying one against the other would silently
+ * change what the page means, so the path rides inside the cursor and is
+ * checked on decode (issue #829 §4).
+ */
+export type FileSearchPath = "meta" | "name";
+
+/** Cursor envelope version — bumped if the payload shape ever changes. */
+const CURSOR_VERSION = 1;
+
+/**
+ * Cap on keys the storage walk may skip while resuming from a cursor. The
+ * files-sdk `search()` iterator has no `startAfter`, so the name-only path
+ * resumes with a bounded re-walk: it pages the bucket listing from the start of
+ * the (optional) prefix and drops keys at or before the cursor key without
+ * hydrating them. The skip is listing-only work, but it is O(offset), so it is
+ * bounded here rather than left to grow with the page number. Callers that
+ * need deeper pagination should narrow with `prefix` or a `meta.*` filter,
+ * which routes to the D1 keyset path and has no such bound.
+ */
+export const SEARCH_WALK_RESUME_MAX_SKIP = 20_000;
+
+interface CursorPayload {
+  v: number;
+  p: FileSearchPath;
+  k: string;
+}
+
+function base64UrlEncode(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(text: string): string {
+  const padded = text.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+/** Mint an opaque continuation cursor for the last key of a page. */
+export function encodeSearchCursor(path: FileSearchPath, lastKey: string): string {
+  const payload: CursorPayload = { v: CURSOR_VERSION, p: path, k: lastKey };
+  return base64UrlEncode(JSON.stringify(payload));
+}
+
+/**
+ * Decode a caller-supplied cursor, rejecting anything that is not a cursor this
+ * service minted for `expectedPath`. Opaque to clients: the only supported use
+ * is handing back the `cursor` a previous page returned, unchanged.
+ */
+export function decodeSearchCursor(raw: string, expectedPath: FileSearchPath): string {
+  const invalid = () =>
+    new ValidationError("cursor is not valid for this search", {
+      code: "file_search_invalid_cursor",
+    });
+  let payload: CursorPayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(raw)) as CursorPayload;
+  } catch {
+    throw invalid();
+  }
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    payload.v !== CURSOR_VERSION ||
+    typeof payload.k !== "string" ||
+    payload.k.length === 0
+  ) {
+    throw invalid();
+  }
+  // A metadata-path cursor replayed against the name-only walk (or vice versa)
+  // is rejected rather than reinterpreted.
+  if (payload.p !== expectedPath) throw invalid();
+  return payload.k;
+}
+
+/** Which path a given request will take — callers need it to decode a cursor. */
+export function searchPathFor(filters: Record<string, string> | undefined): FileSearchPath {
+  return filters !== undefined && Object.keys(filters).length > 0 ? "meta" : "name";
+}
+
+/**
  * Run the two-path name/metadata search. Callers must ensure at least one of
  * non-empty `filters` or `nameTerm` is set; this function does not re-check
  * that precondition. Always over-fetches by one so `truncated` is exact on
  * both the D1 and storage-walk paths (name filtering can drop rows, so the
  * probe sits on the source query, not the post-filter count).
+ *
+ * `cursor` (opaque, from a previous page's `cursor`) resumes where that page
+ * stopped. The returned `cursor` is non-null exactly when `truncated` is true,
+ * and always points at the last key of the *source* window — not the last
+ * surviving match — so a window whose rows were all dropped by the name term
+ * still advances instead of replaying itself forever.
  */
 export async function searchFilesByNameAndMeta(
   env: Env,
@@ -102,45 +195,84 @@ export async function searchFilesByNameAndMeta(
     /** Drop promoted branch originals — the screenshots drill-in (see the
      * `files/search?collapse=promoted` route). Only affects the metadata path. */
     collapsePromotedShadows?: boolean;
+    /** Opaque continuation from a previous page's `cursor`. */
+    cursor?: string;
   },
-): Promise<{ matches: FileSearchMatch[]; truncated: boolean }> {
+): Promise<{ matches: FileSearchMatch[]; truncated: boolean; cursor: string | null }> {
   const { nameTerm, pageSize, prefix } = opts;
   const filters = opts.filters;
-  const hasMeta = filters !== undefined && Object.keys(filters).length > 0;
+  const path = searchPathFor(filters);
+  const hasMeta = path === "meta";
   const fetchLimit = pageSize + 1;
+  const after = opts.cursor === undefined ? undefined : decodeSearchCursor(opts.cursor, path);
 
   if (hasMeta) {
-    const found = await findObjectsByMetadata(dbFor(env), workspaceName, filters, {
+    const found = await findObjectsByMetadata(dbFor(env), workspaceName, filters!, {
       prefix,
       limit: fetchLimit,
       collapsePromotedShadows: opts.collapsePromotedShadows,
+      ...(after !== undefined ? { after } : {}),
     });
     // Truncation is about the D1 window, not the post-name-filter count —
     // a name term can drop every row in the window while more matching-meta
     // keys still sit beyond the ORDER BY object_key LIMIT.
     const truncated = found.length > pageSize;
+    // The window this page consumes is the first `pageSize` rows — the extra
+    // row is only a truncation probe. Name-filtering the consumed window (not
+    // the probe row) is what keeps `cursor` and `items` in step: the cursor
+    // points at the last consumed row, so nothing is served twice and nothing
+    // between two pages is skipped.
+    const window = found.slice(0, pageSize);
     const narrowed = nameTerm
-      ? found.filter((match) => match.key.toLowerCase().includes(nameTerm))
-      : found;
-    return { matches: narrowed.slice(0, pageSize), truncated };
+      ? window.filter((match) => match.key.toLowerCase().includes(nameTerm))
+      : window;
+    // Continue from the last key of the window that was actually consumed, so
+    // a name term that drops the whole window still moves the scan forward.
+    const lastConsumed = truncated ? window[window.length - 1]!.key : undefined;
+    return {
+      matches: narrowed,
+      truncated,
+      cursor: lastConsumed === undefined ? null : encodeSearchCursor("meta", lastConsumed),
+    };
   }
 
   // Name alone — walk storage. `maxResults` stops as soon as the cap is hit.
+  // Resuming has to be done client-side of the iterator: files-sdk's `search()`
+  // exposes `prefix`/`limit`/`maxResults` but no `startAfter`, so a continued
+  // page re-walks the listing and drops keys at or before the cursor key. Those
+  // skipped keys cost a listing page each and no metadata hydration, but the
+  // work is still proportional to how deep the cursor sits — capped at
+  // SEARCH_WALK_RESUME_MAX_SKIP. Ordering assumption: the walk yields keys in
+  // lexicographic order (true for the R2/S3 listing this runs on), which is the
+  // same order the D1 path uses.
   const store = await storage(env, record);
   const keys: string[] = [];
+  let skipped = 0;
   for await (const file of store.search(nameTerm!, {
     match: "substring",
     caseInsensitive: true,
-    maxResults: fetchLimit,
+    ...(after === undefined ? { maxResults: fetchLimit } : {}),
     ...(prefix ? { prefix } : {}),
   })) {
+    if (after !== undefined && file.key <= after) {
+      skipped += 1;
+      if (skipped > SEARCH_WALK_RESUME_MAX_SKIP) {
+        throw new ValidationError("search cursor is too deep to resume", {
+          code: "file_search_cursor_too_deep",
+        });
+      }
+      continue;
+    }
     keys.push(file.key);
+    if (keys.length >= fetchLimit) break;
   }
   const truncated = keys.length > pageSize;
   const pageKeys = keys.slice(0, pageSize);
   const metaByKey = await getMetadataForKeys(dbFor(env), workspaceName, pageKeys);
+  const lastKey = truncated ? pageKeys[pageKeys.length - 1] : undefined;
   return {
     matches: pageKeys.map((key) => ({ key, metadata: metaByKey.get(key) ?? {} })),
     truncated,
+    cursor: lastKey === undefined ? null : encodeSearchCursor("name", lastKey),
   };
 }

--- a/apps/api/src/file-search.ts
+++ b/apps/api/src/file-search.ts
@@ -110,7 +110,59 @@ export const SEARCH_WALK_RESUME_MAX_SKIP = 20_000;
 interface CursorPayload {
   v: number;
   p: FileSearchPath;
+  /** Fingerprint of the query this cursor was minted for — see `searchScope`. */
+  s: string;
   k: string;
+}
+
+/** The parts of a search request a cursor is only meaningful within. */
+export interface SearchScope {
+  workspaceName: string;
+  filters?: Record<string, string>;
+  nameTerm?: string;
+  prefix?: string;
+  collapsePromotedShadows?: boolean;
+}
+
+/**
+ * Canonical string for a search scope. Every input that changes which keys the
+ * underlying query walks goes in, so two requests share a fingerprint only when
+ * resuming one from the other is meaningful. Filters are sorted because
+ * `meta.a=1&meta.b=2` and `meta.b=2&meta.a=1` are the same query.
+ *
+ * Lengths are written in ahead of each value so no two different scopes can
+ * flatten to the same string — without them `{ "a": "b:c" }` and
+ * `{ "a:b": "c" }` would collide.
+ */
+function canonicalScope(scope: SearchScope): string {
+  const part = (value: string) => `${value.length}:${value}`;
+  const filters = Object.entries(scope.filters ?? {})
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, value]) => part(key) + part(value))
+    .join("");
+  return [
+    part(scope.workspaceName),
+    part(scope.nameTerm ?? ""),
+    part(scope.prefix ?? ""),
+    scope.collapsePromotedShadows ? "1" : "0",
+    part(filters),
+  ].join("|");
+}
+
+/**
+ * FNV-1a over the canonical scope. This is a collision check between a client's
+ * own consecutive requests, not a security boundary — the cursor already only
+ * ever moves a scan forward within one authenticated workspace — so a short
+ * non-cryptographic digest is the right tool, and it keeps the cursor short.
+ */
+function searchScopeFingerprint(scope: SearchScope): string {
+  const text = canonicalScope(scope);
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(36);
 }
 
 function base64UrlEncode(text: string): string {
@@ -129,17 +181,31 @@ function base64UrlDecode(text: string): string {
 }
 
 /** Mint an opaque continuation cursor for the last key of a page. */
-export function encodeSearchCursor(path: FileSearchPath, lastKey: string): string {
-  const payload: CursorPayload = { v: CURSOR_VERSION, p: path, k: lastKey };
+export function encodeSearchCursor(
+  path: FileSearchPath,
+  scope: SearchScope,
+  lastKey: string,
+): string {
+  const payload: CursorPayload = {
+    v: CURSOR_VERSION,
+    p: path,
+    s: searchScopeFingerprint(scope),
+    k: lastKey,
+  };
   return base64UrlEncode(JSON.stringify(payload));
 }
 
 /**
  * Decode a caller-supplied cursor, rejecting anything that is not a cursor this
- * service minted for `expectedPath`. Opaque to clients: the only supported use
- * is handing back the `cursor` a previous page returned, unchanged.
+ * service minted for `expectedPath` and this exact `scope`. Opaque to clients:
+ * the only supported use is handing back the `cursor` a previous page returned,
+ * unchanged, alongside the same query that produced it.
  */
-export function decodeSearchCursor(raw: string, expectedPath: FileSearchPath): string {
+export function decodeSearchCursor(
+  raw: string,
+  expectedPath: FileSearchPath,
+  scope: SearchScope,
+): string {
   const invalid = () =>
     new ValidationError("cursor is not valid for this search", {
       code: "file_search_invalid_cursor",
@@ -155,13 +221,19 @@ export function decodeSearchCursor(raw: string, expectedPath: FileSearchPath): s
     typeof payload !== "object" ||
     payload.v !== CURSOR_VERSION ||
     typeof payload.k !== "string" ||
-    payload.k.length === 0
+    payload.k.length === 0 ||
+    typeof payload.s !== "string"
   ) {
     throw invalid();
   }
   // A metadata-path cursor replayed against the name-only walk (or vice versa)
   // is rejected rather than reinterpreted.
   if (payload.p !== expectedPath) throw invalid();
+  // Same for a cursor replayed against a different query. Resuming at
+  // `key > :after` under changed filters would silently skip every match that
+  // sorts before the previous query's stopping point, and the caller would have
+  // no way to tell an incomplete result from a complete one.
+  if (payload.s !== searchScopeFingerprint(scope)) throw invalid();
   return payload.k;
 }
 
@@ -204,7 +276,17 @@ export async function searchFilesByNameAndMeta(
   const path = searchPathFor(filters);
   const hasMeta = path === "meta";
   const fetchLimit = pageSize + 1;
-  const after = opts.cursor === undefined ? undefined : decodeSearchCursor(opts.cursor, path);
+  // A cursor is only valid for the query that minted it, so the scope is built
+  // once here and used for both the decode check and the next page's cursor.
+  const scope: SearchScope = {
+    workspaceName,
+    filters,
+    nameTerm,
+    prefix,
+    collapsePromotedShadows: opts.collapsePromotedShadows,
+  };
+  const after =
+    opts.cursor === undefined ? undefined : decodeSearchCursor(opts.cursor, path, scope);
 
   if (hasMeta) {
     const found = await findObjectsByMetadata(dbFor(env), workspaceName, filters!, {
@@ -232,7 +314,7 @@ export async function searchFilesByNameAndMeta(
     return {
       matches: narrowed,
       truncated,
-      cursor: lastConsumed === undefined ? null : encodeSearchCursor("meta", lastConsumed),
+      cursor: lastConsumed === undefined ? null : encodeSearchCursor("meta", scope, lastConsumed),
     };
   }
 
@@ -273,6 +355,6 @@ export async function searchFilesByNameAndMeta(
   return {
     matches: pageKeys.map((key) => ({ key, metadata: metaByKey.get(key) ?? {} })),
     truncated,
-    cursor: lastKey === undefined ? null : encodeSearchCursor("name", lastKey),
+    cursor: lastKey === undefined ? null : encodeSearchCursor("name", scope, lastKey),
   };
 }

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -58,6 +58,7 @@ export const files = new Hono<WorkspaceVars>()
               nameTerm,
               prefix: query.prefix,
               pageSize,
+              ...(query.cursor ? { cursor: query.cursor } : {}),
             }),
           { name: "d1_files_search" },
         ),
@@ -71,9 +72,11 @@ export const files = new Hono<WorkspaceVars>()
           metadata: match.metadata,
         };
       });
-      // Meta-only keeps the pre-#528 envelope (no `truncated` field).
-      if (nameTerm === undefined) return c.json({ items, cursor: null });
-      return c.json({ items, cursor: null, truncated: result.truncated });
+      // Meta-only keeps the pre-#528 envelope (no `truncated` field). `cursor`
+      // was always present and always null; it now carries the continuation
+      // token when more pages exist (issue #829 §4).
+      if (nameTerm === undefined) return c.json({ items, cursor: result.cursor });
+      return c.json({ items, cursor: result.cursor, truncated: result.truncated });
     }
 
     const { prefix, cursor } = query;

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -163,7 +163,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
     // key and once from the promoted `pull/<n>/` copy. Opt-in: a bare search
     // (and the `find_files` tool) still returns every matching object.
     const collapsePromotedShadows = c.req.query("collapse") === "promoted";
-    const { matches, truncated } = await boundedDataRead(
+    const { matches, truncated, cursor } = await boundedDataRead(
       c,
       () =>
         searchFilesByNameAndMeta(c.env, record, name, {
@@ -172,6 +172,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
           prefix: query.prefix,
           pageSize,
           collapsePromotedShadows,
+          ...(query.cursor ? { cursor: query.cursor } : {}),
         }),
       { name: "d1_files_search" },
     );
@@ -201,6 +202,9 @@ export const workspaceFiles = new Hono<DualAuthVars>()
         };
       }),
       truncated,
+      // Additive continuation (issue #829 §4): opaque, non-null exactly when
+      // `truncated` is true. Hand it back as `?cursor=` for the next page.
+      cursor,
     });
   })
 

--- a/apps/api/test/file-search-cursor.test.ts
+++ b/apps/api/test/file-search-cursor.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Search cursor codec + D1 keyset continuation (issue #829 §4).
+ *
+ * The codec tests pin the opaque encoding's contract: round-trip, path
+ * scoping, and a stable rejection `code`. The SQLite tests pin the `after`
+ * option on `findObjectsByMetadata` against real SQL rather than the fake
+ * table, since the continuation is a query-shape change.
+ */
+import { AppError } from "@uploads/errors";
+import { describe, expect, it } from "vitest";
+import { decodeSearchCursor, encodeSearchCursor, searchPathFor } from "../src/file-search";
+import { findObjectsByMetadata, setFileMetadata } from "../src/file-metadata";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260713210559_file_metadata.sql";
+
+describe("search cursor codec", () => {
+  it("round-trips a key and is opaque (not the bare key)", () => {
+    const cursor = encodeSearchCursor("meta", "shots/hero a.png");
+    expect(cursor).not.toContain("shots/");
+    expect(decodeSearchCursor(cursor, "meta")).toBe("shots/hero a.png");
+  });
+
+  it("round-trips keys with non-ASCII characters", () => {
+    const cursor = encodeSearchCursor("name", "shots/café-née.png");
+    expect(decodeSearchCursor(cursor, "name")).toBe("shots/café-née.png");
+  });
+
+  it("is URL-safe (no characters needing percent-encoding in a query param)", () => {
+    const cursor = encodeSearchCursor("name", "a".repeat(64));
+    expect(encodeURIComponent(cursor)).toBe(cursor);
+  });
+
+  it("rejects a cursor minted for the other search path", () => {
+    const cursor = encodeSearchCursor("meta", "shots/a.png");
+    expect(() => decodeSearchCursor(cursor, "name")).toThrow(AppError);
+    try {
+      decodeSearchCursor(cursor, "name");
+    } catch (err) {
+      expect((err as AppError).code).toBe("file_search_invalid_cursor");
+      expect((err as AppError).status).toBe(400);
+    }
+  });
+
+  it("rejects garbage, non-cursor JSON, and empty keys with the same code", () => {
+    const rejected = [
+      "not-a-cursor",
+      btoa(JSON.stringify({ hello: "world" })),
+      btoa(JSON.stringify({ v: 1, p: "meta", k: "" })),
+      btoa(JSON.stringify({ v: 99, p: "meta", k: "shots/a.png" })),
+    ];
+    for (const raw of rejected) {
+      try {
+        decodeSearchCursor(raw, "meta");
+        throw new Error(`expected rejection for ${raw}`);
+      } catch (err) {
+        expect((err as AppError).code).toBe("file_search_invalid_cursor");
+      }
+    }
+  });
+
+  it("derives the path from whether metadata filters are present", () => {
+    expect(searchPathFor(undefined)).toBe("name");
+    expect(searchPathFor({})).toBe("name");
+    expect(searchPathFor({ app: "web" })).toBe("meta");
+  });
+});
+
+describe("findObjectsByMetadata keyset continuation against SQLite", () => {
+  async function seeded(): Promise<SqliteD1> {
+    const sqlite = new SqliteD1(MIGRATION);
+    for (const key of ["shots/a.png", "shots/b.png", "shots/c.png"]) {
+      await setFileMetadata(database(sqlite), "alpha", key, { app: "web", team: "core" });
+    }
+    return sqlite;
+  }
+
+  it("resumes strictly after the given key", async () => {
+    const sqlite = await seeded();
+    try {
+      const page = await findObjectsByMetadata(
+        database(sqlite),
+        "alpha",
+        { app: "web" },
+        { after: "shots/a.png" },
+      );
+      expect(page.map((row) => row.key)).toEqual(["shots/b.png", "shots/c.png"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("resumes on the multi-filter INTERSECT form and with a prefix", async () => {
+    const sqlite = await seeded();
+    try {
+      const page = await findObjectsByMetadata(
+        database(sqlite),
+        "alpha",
+        { app: "web", team: "core" },
+        { prefix: "shots/", after: "shots/b.png", limit: 10 },
+      );
+      expect(page.map((row) => row.key)).toEqual(["shots/c.png"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns nothing once the cursor is past the last key", async () => {
+    const sqlite = await seeded();
+    try {
+      const page = await findObjectsByMetadata(
+        database(sqlite),
+        "alpha",
+        { app: "web" },
+        { after: "shots/z.png" },
+      );
+      expect(page).toEqual([]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/file-search-cursor.test.ts
+++ b/apps/api/test/file-search-cursor.test.ts
@@ -8,55 +8,110 @@
  */
 import { AppError } from "@uploads/errors";
 import { describe, expect, it } from "vitest";
-import { decodeSearchCursor, encodeSearchCursor, searchPathFor } from "../src/file-search";
+import {
+  decodeSearchCursor,
+  encodeSearchCursor,
+  searchPathFor,
+  type SearchScope,
+} from "../src/file-search";
 import { findObjectsByMetadata, setFileMetadata } from "../src/file-metadata";
 import { SqliteD1, database } from "./helpers/sqlite-d1";
 
 const MIGRATION = "migrations/20260713210559_file_metadata.sql";
 
+const SCOPE: SearchScope = { workspaceName: "alpha", filters: { app: "web" } };
+const NAME_SCOPE: SearchScope = { workspaceName: "alpha", nameTerm: "hero" };
+
+/** Assert a thrown decode carries the stable rejection code. */
+function expectRejected(run: () => unknown): void {
+  try {
+    run();
+  } catch (err) {
+    expect((err as AppError).code).toBe("file_search_invalid_cursor");
+    expect((err as AppError).status).toBe(400);
+    return;
+  }
+  throw new Error("expected the cursor to be rejected");
+}
+
 describe("search cursor codec", () => {
   it("round-trips a key and is opaque (not the bare key)", () => {
-    const cursor = encodeSearchCursor("meta", "shots/hero a.png");
+    const cursor = encodeSearchCursor("meta", SCOPE, "shots/hero a.png");
     expect(cursor).not.toContain("shots/");
-    expect(decodeSearchCursor(cursor, "meta")).toBe("shots/hero a.png");
+    expect(decodeSearchCursor(cursor, "meta", SCOPE)).toBe("shots/hero a.png");
   });
 
   it("round-trips keys with non-ASCII characters", () => {
-    const cursor = encodeSearchCursor("name", "shots/café-née.png");
-    expect(decodeSearchCursor(cursor, "name")).toBe("shots/café-née.png");
+    const cursor = encodeSearchCursor("name", NAME_SCOPE, "shots/café-née.png");
+    expect(decodeSearchCursor(cursor, "name", NAME_SCOPE)).toBe("shots/café-née.png");
   });
 
   it("is URL-safe (no characters needing percent-encoding in a query param)", () => {
-    const cursor = encodeSearchCursor("name", "a".repeat(64));
+    const cursor = encodeSearchCursor("name", NAME_SCOPE, "a".repeat(64));
     expect(encodeURIComponent(cursor)).toBe(cursor);
   });
 
   it("rejects a cursor minted for the other search path", () => {
-    const cursor = encodeSearchCursor("meta", "shots/a.png");
-    expect(() => decodeSearchCursor(cursor, "name")).toThrow(AppError);
-    try {
-      decodeSearchCursor(cursor, "name");
-    } catch (err) {
-      expect((err as AppError).code).toBe("file_search_invalid_cursor");
-      expect((err as AppError).status).toBe(400);
-    }
+    const cursor = encodeSearchCursor("meta", SCOPE, "shots/a.png");
+    expectRejected(() => decodeSearchCursor(cursor, "name", SCOPE));
   });
 
   it("rejects garbage, non-cursor JSON, and empty keys with the same code", () => {
+    const fingerprint = JSON.parse(atob(encodeSearchCursor("meta", SCOPE, "x"))).s as string;
     const rejected = [
       "not-a-cursor",
       btoa(JSON.stringify({ hello: "world" })),
-      btoa(JSON.stringify({ v: 1, p: "meta", k: "" })),
-      btoa(JSON.stringify({ v: 99, p: "meta", k: "shots/a.png" })),
+      btoa(JSON.stringify({ v: 1, p: "meta", s: fingerprint, k: "" })),
+      btoa(JSON.stringify({ v: 99, p: "meta", s: fingerprint, k: "shots/a.png" })),
+      // A pre-scope cursor (no `s`) must not be honored either.
+      btoa(JSON.stringify({ v: 1, p: "meta", k: "shots/a.png" })),
     ];
-    for (const raw of rejected) {
-      try {
-        decodeSearchCursor(raw, "meta");
-        throw new Error(`expected rejection for ${raw}`);
-      } catch (err) {
-        expect((err as AppError).code).toBe("file_search_invalid_cursor");
-      }
-    }
+    for (const raw of rejected) expectRejected(() => decodeSearchCursor(raw, "meta", SCOPE));
+  });
+
+  /**
+   * The reason the scope is bound at all: resuming at `key > :after` under a
+   * different query would silently skip every match sorting before the previous
+   * query's stopping point, with no way for the caller to notice.
+   */
+  it("rejects a cursor replayed against a different query scope", () => {
+    const cursor = encodeSearchCursor("meta", SCOPE, "shots/m.png");
+    const divergent: SearchScope[] = [
+      { workspaceName: "alpha", filters: { app: "other" } },
+      { workspaceName: "alpha", filters: { app: "web", team: "core" } },
+      { workspaceName: "alpha", filters: { app: "web" }, nameTerm: "hero" },
+      { workspaceName: "alpha", filters: { app: "web" }, prefix: "shots/" },
+      { workspaceName: "alpha", filters: { app: "web" }, collapsePromotedShadows: true },
+      { workspaceName: "beta", filters: { app: "web" } },
+    ];
+    for (const scope of divergent) expectRejected(() => decodeSearchCursor(cursor, "meta", scope));
+  });
+
+  it("accepts the same filters written in a different order", () => {
+    const cursor = encodeSearchCursor(
+      "meta",
+      { workspaceName: "alpha", filters: { app: "web", team: "core" } },
+      "shots/m.png",
+    );
+    expect(
+      decodeSearchCursor(cursor, "meta", {
+        workspaceName: "alpha",
+        filters: { team: "core", app: "web" },
+      }),
+    ).toBe("shots/m.png");
+  });
+
+  it("does not let a filter key/value split shift across the boundary", () => {
+    // Without length-prefixing, `{ "a": "b:c" }` and `{ "a:b": "c" }` would
+    // flatten to the same canonical string and share a fingerprint.
+    const cursor = encodeSearchCursor(
+      "meta",
+      { workspaceName: "alpha", filters: { a: "bc" } },
+      "shots/m.png",
+    );
+    expectRejected(() =>
+      decodeSearchCursor(cursor, "meta", { workspaceName: "alpha", filters: { ab: "c" } }),
+    );
   });
 
   it("derives the path from whether metadata filters are present", () => {
@@ -98,6 +153,39 @@ describe("findObjectsByMetadata keyset continuation against SQLite", () => {
         "alpha",
         { app: "web", team: "core" },
         { prefix: "shots/", after: "shots/b.png", limit: 10 },
+      );
+      expect(page.map((row) => row.key)).toEqual(["shots/c.png"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  /**
+   * Collapse binds the workspace a second time (its correlated NOT EXISTS),
+   * between the prefix binds and `after`. This is the combination where a
+   * miscounted bind list silently reads the wrong argument as the cursor.
+   */
+  it("resumes correctly with collapsePromotedShadows on", async () => {
+    const sqlite = await seeded();
+    try {
+      await setFileMetadata(database(sqlite), "alpha", "shots/b.png", {
+        app: "web",
+        team: "core",
+        "gh.status": "promoted",
+      });
+      const all = await findObjectsByMetadata(
+        database(sqlite),
+        "alpha",
+        { app: "web" },
+        { collapsePromotedShadows: true },
+      );
+      expect(all.map((row) => row.key)).toEqual(["shots/a.png", "shots/c.png"]);
+
+      const page = await findObjectsByMetadata(
+        database(sqlite),
+        "alpha",
+        { app: "web" },
+        { collapsePromotedShadows: true, after: "shots/a.png" },
       );
       expect(page.map((row) => row.key)).toEqual(["shots/c.png"]);
     } finally {

--- a/apps/api/test/helpers/fake-file-metadata-table.ts
+++ b/apps/api/test/helpers/fake-file-metadata-table.ts
@@ -114,10 +114,18 @@ export class FileMetadataTable {
       return { success: true, results: results as T[], meta: {} };
     }
     // findObjectsByMetadata: single equality, or multi-filter INTERSECT legs.
-    // Args: (workspace, key, value)×N, optional prefix (bound twice), limit.
+    // Args: (workspace, key, value)×N, optional prefix (bound twice), the
+    // collapse wrapper's workspace (1), optional `after` (1), then the limit.
+    //
+    // Matched on shape rather than an exact prefix: the query nests one wrapper
+    // per optional feature (collapse, then the keyset continuation), so a
+    // `startsWith` check silently stops matching once two of them combine —
+    // and an unmatched statement here returns an empty page instead of failing,
+    // which reads as "no results" rather than "the fake did not understand".
     if (
-      normalizedSql.startsWith("SELECT object_key FROM file_metadata WHERE workspace") ||
-      normalizedSql.startsWith("SELECT object_key FROM (SELECT object_key FROM file_metadata")
+      normalizedSql.startsWith("SELECT object_key FROM") &&
+      normalizedSql.includes("meta_key = ? AND meta_value = ?") &&
+      normalizedSql.includes("ORDER BY object_key LIMIT ?")
     ) {
       const filterCount = (normalizedSql.match(/meta_key = \? AND meta_value = \?/g) ?? []).length;
       const hasPrefix = normalizedSql.includes("substr(object_key, 1, length(?)) = ?");
@@ -130,10 +138,16 @@ export class FileMetadataTable {
           value: args[base + 2] as string,
         });
       }
+      // Bind order mirrors findObjectsByMetadata exactly: filters (3 each),
+      // prefix (2), the collapse wrapper's own workspace bind (1), `after` (1),
+      // then the limit. Miscounting any one of them shifts every later read.
       let idx = filterCount * 3;
       // substr prefix filter binds the raw prefix twice (length + comparison).
       const prefix = hasPrefix ? String(args[idx]) : undefined;
       if (hasPrefix) idx += 2;
+      // The collapse wrapper's correlated NOT EXISTS binds the workspace again.
+      const hasCollapse = normalizedSql.includes("AS f WHERE NOT EXISTS");
+      if (hasCollapse) idx += 1;
       // Keyset continuation wrapper (issue #829 §4) binds `after` just before
       // the limit: `SELECT object_key FROM (…) AS page WHERE object_key > ?`.
       const hasAfter = normalizedSql.includes("AS page WHERE object_key > ?");
@@ -152,6 +166,8 @@ export class FileMetadataTable {
         const objectKey = scopedKey.slice(scopePrefix.length);
         if (prefix && !objectKey.startsWith(prefix)) continue;
         if (after !== undefined && objectKey <= after) continue;
+        // Collapse drops promoted branch originals (`gh.status=promoted`).
+        if (hasCollapse && map.get("gh.status") === "promoted") continue;
         if (filters.every((f) => map.get(f.key) === f.value)) {
           results.push({ object_key: objectKey });
         }

--- a/apps/api/test/helpers/fake-file-metadata-table.ts
+++ b/apps/api/test/helpers/fake-file-metadata-table.ts
@@ -134,6 +134,11 @@ export class FileMetadataTable {
       // substr prefix filter binds the raw prefix twice (length + comparison).
       const prefix = hasPrefix ? String(args[idx]) : undefined;
       if (hasPrefix) idx += 2;
+      // Keyset continuation wrapper (issue #829 §4) binds `after` just before
+      // the limit: `SELECT object_key FROM (…) AS page WHERE object_key > ?`.
+      const hasAfter = normalizedSql.includes("AS page WHERE object_key > ?");
+      const after = hasAfter ? String(args[idx]) : undefined;
+      if (hasAfter) idx += 1;
       const limit = args[idx] as number;
       const workspace = filters[0]?.workspace;
       if (!workspace || filters.some((f) => f.workspace !== workspace)) {
@@ -146,6 +151,7 @@ export class FileMetadataTable {
         if (!scopedKey.startsWith(scopePrefix)) continue;
         const objectKey = scopedKey.slice(scopePrefix.length);
         if (prefix && !objectKey.startsWith(prefix)) continue;
+        if (after !== undefined && objectKey <= after) continue;
         if (filters.every((f) => map.get(f.key) === f.value)) {
           results.push({ object_key: objectKey });
         }

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -431,6 +431,133 @@ describe("GET /v1/workspaces/:workspace/files/facets and /search (dual auth)", (
   });
 });
 
+/**
+ * Cursor pagination for the two search paths (issue #829 §4). `cursor` is the
+ * additive continuation field; `items`/`truncated` keep their meaning.
+ */
+describe("GET /v1/workspaces/:workspace/files/search cursor pagination", () => {
+  type SearchBody = { items: { key: string }[]; truncated: boolean; cursor: string | null };
+
+  async function search(env: Parameters<typeof app.request>[2], qs: string): Promise<SearchBody> {
+    const res = await app.request(
+      `/v1/workspaces/acme/files/search?${qs}`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    return (await res.json()) as SearchBody;
+  }
+
+  function seedMeta(env: Parameters<typeof app.request>[2], key: string, app_: string): void {
+    const table = (env as { DB: { metadata: Map<string, Map<string, string>> } }).DB;
+    table.metadata.set(`acme ${key}`, new Map([["app", app_]]));
+  }
+
+  it("name path: walks the whole result set one page at a time without repeats", async () => {
+    const { env, bucket } = await makeEnv();
+    for (const name of ["hero-a", "hero-b", "hero-c"]) {
+      await bucket.put(`acme/shots/${name}.png`, new Uint8Array([1]).buffer, {
+        httpMetadata: { contentType: "image/png" },
+      });
+    }
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    for (let page = 0; page < 5; page += 1) {
+      const body: SearchBody = await search(
+        env,
+        `name=hero&limit=1${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+      );
+      seen.push(...body.items.map((item) => item.key));
+      // The continuation is present exactly when the page was truncated.
+      expect(body.cursor === null).toBe(!body.truncated);
+      cursor = body.cursor;
+      if (!cursor) break;
+    }
+    expect(cursor).toBeNull();
+    expect(seen).toEqual(["shots/hero-a.png", "shots/hero-b.png", "shots/hero-c.png"]);
+  });
+
+  it("metadata path: keyset continuation walks matching rows once", async () => {
+    const { env } = await makeEnv();
+    seedMeta(env, "shots/one.png", "web");
+    seedMeta(env, "shots/two.png", "web");
+    seedMeta(env, "shots/three.png", "web");
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    for (let page = 0; page < 5; page += 1) {
+      const body: SearchBody = await search(
+        env,
+        `meta.app=web&limit=1${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+      );
+      seen.push(...body.items.map((item) => item.key));
+      cursor = body.cursor;
+      if (!cursor) break;
+    }
+    expect(cursor).toBeNull();
+    expect([...seen].sort()).toEqual(["shots/one.png", "shots/three.png", "shots/two.png"]);
+  });
+
+  it("metadata path: advances even when the name term drops the whole window", async () => {
+    const { env } = await makeEnv();
+    seedMeta(env, "shots/aaa.png", "web");
+    seedMeta(env, "shots/bbb.png", "web");
+    seedMeta(env, "shots/zzz-hero.png", "web");
+    // Page 1's D1 window holds only `aaa`, which the name term drops — but the
+    // page is still truncated and its cursor moves past `aaa`.
+    const first = await search(env, "meta.app=web&name=hero&limit=1");
+    expect(first.items).toEqual([]);
+    expect(first.truncated).toBe(true);
+    expect(first.cursor).not.toBeNull();
+
+    const keys: string[] = [];
+    let cursor: string | null = first.cursor;
+    for (let page = 0; page < 5 && cursor; page += 1) {
+      const body: SearchBody = await search(
+        env,
+        `meta.app=web&name=hero&limit=1&cursor=${encodeURIComponent(cursor)}`,
+      );
+      keys.push(...body.items.map((item) => item.key));
+      cursor = body.cursor;
+    }
+    expect(keys).toEqual(["shots/zzz-hero.png"]);
+  });
+
+  it("rejects a garbage cursor and one minted for the other search path", async () => {
+    const { env, bucket } = await makeEnv();
+    await bucket.put("acme/shots/hero-a.png", new Uint8Array([1]).buffer, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await bucket.put("acme/shots/hero-b.png", new Uint8Array([1]).buffer, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    seedMeta(env, "shots/hero-a.png", "web");
+    seedMeta(env, "shots/hero-b.png", "web");
+
+    const garbage = await app.request(
+      "/v1/workspaces/acme/files/search?name=hero&cursor=not-a-cursor",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(garbage.status).toBe(400);
+    expect(((await garbage.json()) as { error: { code: string } }).error.code).toBe(
+      "file_search_invalid_cursor",
+    );
+
+    // A metadata-path cursor must not be replayable against the name-only walk.
+    const metaPage = await search(env, "meta.app=web&limit=1");
+    expect(metaPage.cursor).not.toBeNull();
+    const foreign = await app.request(
+      `/v1/workspaces/acme/files/search?name=hero&cursor=${encodeURIComponent(metaPage.cursor!)}`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(foreign.status).toBe(400);
+    expect(((await foreign.json()) as { error: { code: string } }).error.code).toBe(
+      "file_search_invalid_cursor",
+    );
+  });
+});
+
 describe("GET /v1/workspaces/:workspace/files/by-path (dual auth)", () => {
   it("bearer token: returns the grouped shape", async () => {
     const { env, bucket } = await makeEnv();

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -522,6 +522,71 @@ describe("GET /v1/workspaces/:workspace/files/search cursor pagination", () => {
     expect(keys).toEqual(["shots/zzz-hero.png"]);
   });
 
+  it("treats an empty ?cursor= as absent rather than a malformed cursor", async () => {
+    const { env, bucket } = await makeEnv();
+    await bucket.put("acme/shots/hero-a.png", new Uint8Array([1]).buffer, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    seedMeta(env, "shots/hero-a.png", "web");
+    // Hono yields "" (not undefined) for a bare `?cursor=`, so both paths have
+    // to read it as "no cursor supplied" instead of failing the decode.
+    const named = await search(env, "name=hero&cursor=");
+    expect(named.items.map((item) => item.key)).toEqual(["shots/hero-a.png"]);
+    const meta = await search(env, "meta.app=web&cursor=");
+    expect(meta.items.map((item) => item.key)).toEqual(["shots/hero-a.png"]);
+  });
+
+  it("rejects a cursor replayed against a different filter set", async () => {
+    const { env } = await makeEnv();
+    seedMeta(env, "shots/one.png", "web");
+    seedMeta(env, "shots/two.png", "web");
+    seedMeta(env, "shots/three.png", "docs");
+    const page = await search(env, "meta.app=web&limit=1");
+    expect(page.cursor).not.toBeNull();
+    // Same path, different query: resuming here would skip keys sorting before
+    // the previous query's stopping point without telling the caller.
+    const res = await app.request(
+      `/v1/workspaces/acme/files/search?meta.app=docs&cursor=${encodeURIComponent(page.cursor!)}`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "file_search_invalid_cursor",
+    );
+  });
+
+  it("pages with collapse=promoted, which binds the workspace twice", async () => {
+    const { env } = await makeEnv();
+    const table = (env as { DB: { metadata: Map<string, Map<string, string>> } }).DB;
+    for (const key of ["shots/one.png", "shots/two.png", "shots/three.png"]) {
+      table.metadata.set(`acme ${key}`, new Map([["app", "web"]]));
+    }
+    table.metadata.set(
+      "acme shots/promoted.png",
+      new Map([
+        ["app", "web"],
+        ["gh.status", "promoted"],
+      ]),
+    );
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    for (let page = 0; page < 6; page += 1) {
+      const body: SearchBody = await search(
+        env,
+        `meta.app=web&collapse=promoted&limit=1${
+          cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""
+        }`,
+      );
+      seen.push(...body.items.map((item) => item.key));
+      cursor = body.cursor;
+      if (!cursor) break;
+    }
+    expect(cursor).toBeNull();
+    // The promoted shadow stays excluded on every page, and nothing repeats.
+    expect([...seen].sort()).toEqual(["shots/one.png", "shots/three.png", "shots/two.png"]);
+  });
+
   it("rejects a garbage cursor and one minted for the other search path", async () => {
     const { env, bucket } = await makeEnv();
     await bucket.put("acme/shots/hero-a.png", new Uint8Array([1]).buffer, {

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -1193,6 +1193,11 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
             type: "number",
             description: "Page size (default 50, max 500).",
           },
+          cursor: {
+            type: "string",
+            description:
+              "Opaque continuation from a previous call's `cursor`. Pass it back unchanged with the same filters/name to get the next page; a null `cursor` means there are no more pages.",
+          },
         },
         additionalProperties: false,
       },
@@ -1215,6 +1220,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
             nameTerm,
             prefix: optString(args, "prefix"),
             pageSize,
+            ...(optString(args, "cursor") ? { cursor: optString(args, "cursor")! } : {}),
           }),
         ]);
         const items = result.matches.map((match) => ({
@@ -1222,9 +1228,11 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           url: publicUrl(cfg, match.key),
           metadata: match.metadata,
         }));
-        // Meta-only keeps the pre-#528 shape (no truncated).
-        if (nameTerm === undefined) return { items, cursor: null };
-        return { items, cursor: null, truncated: result.truncated };
+        // Meta-only keeps the pre-#528 shape (no truncated). `cursor` was
+        // always present and always null; it now carries the continuation
+        // token when more pages exist (issue #829 §4).
+        if (nameTerm === undefined) return { items, cursor: result.cursor };
+        return { items, cursor: result.cursor, truncated: result.truncated };
       },
     },
     {

--- a/apps/web/public/.well-known/openapi.json
+++ b/apps/web/public/.well-known/openapi.json
@@ -83,11 +83,12 @@
             "name": "limit",
             "in": "query",
             "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 100 }
-          }
+          },
+          { "$ref": "#/components/parameters/Cursor" }
         ],
         "responses": {
           "200": {
-            "description": "A bounded result. `truncated` can be true; search does not yet provide a cursor.",
+            "description": "A bounded page. `truncated` is true and `cursor` is non-null when more matches remain; pass `cursor` back to continue.",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/FileSearch" } }
             }
@@ -793,7 +794,11 @@
             "type": "array",
             "items": { "$ref": "#/components/schemas/FileSearchItem" }
           },
-          "truncated": { "type": "boolean" }
+          "truncated": { "type": "boolean" },
+          "cursor": {
+            "type": ["string", "null"],
+            "description": "Opaque continuation for the next page, or null on the last page."
+          }
         }
       },
       "FileSearchItem": {

--- a/apps/web/public/.well-known/openapi.json
+++ b/apps/web/public/.well-known/openapi.json
@@ -788,7 +788,7 @@
       },
       "FileSearch": {
         "type": "object",
-        "required": ["items", "truncated"],
+        "required": ["items", "truncated", "cursor"],
         "properties": {
           "items": {
             "type": "array",

--- a/docs/api.md
+++ b/docs/api.md
@@ -83,7 +83,7 @@ Throw `AppError` subclasses from `@uploads/errors` in route code; the API's
 | `PUT /v1/workspaces/:workspace/files/:key`                                      | Upload a raw body. The API sniffs its type. A normal upload returns `201`; `?dryRun=1` returns `200` without writing. Bare keys become `f/<id>/<name>`. Strict keys require `?replace=1` or `X-Uploads-Replace: 1` to overwrite |
 | `POST /v1/workspaces/:workspace/files/sign`                                     | Create a presigned upload. The workspace needs HTTP S3 credentials. The strict-overwrite check happens when the API creates the signed URL, so it is a best-effort guard rather than an atomic guarantee                        |
 | `GET /v1/workspaces/:workspace/files?prefix=&delimiter=&limit=&cursor=`         | List objects with opaque cursor pagination. Response: `{ files, prefixes, cursor }`                                                                                                                                             |
-| `GET /v1/workspaces/:workspace/files/search?meta.<key>=<value>&name=`           | Search by metadata equality and/or a filename substring. The response reports `truncated`; search does not yet return a continuation cursor                                                                                     |
+| `GET /v1/workspaces/:workspace/files/search?meta.<key>=<value>&name=`           | Search by metadata equality and/or a filename substring. The response reports `truncated` and an opaque `cursor`; pass it back as `?cursor=` for the next page                                                                  |
 | `GET /v1/workspaces/:workspace/files/facets?key=`                               | List queryable metadata keys or the values for one key                                                                                                                                                                          |
 | `GET /v1/workspaces/:workspace/files/:key`                                      | Read object metadata. `?metadata=1` returns only the queryable metadata map                                                                                                                                                     |
 | `PATCH /v1/workspaces/:workspace/files/:key`                                    | Merge queryable metadata with `{ set?, delete? }`                                                                                                                                                                               |
@@ -102,6 +102,20 @@ Throw `AppError` subclasses from `@uploads/errors` in route code; the API's
 | `GET/POST /v1/workspaces/:workspace/galleries/:id/external-references`          | List or link external coordinates; writes require `files:write`                                                                                                                                                                 |
 | `DELETE /v1/workspaces/:workspace/galleries/:id/external-references/:reference` | Unlink an external coordinate; requires `files:write`                                                                                                                                                                           |
 | `GET /public/galleries/:id`                                                     | Read one public gallery by its opaque ID (no auth)                                                                                                                                                                              |
+
+## Pagination
+
+Paged collections take `?cursor=` and return a `cursor` field: an opaque
+string when another page exists, `null` when the caller has reached the end.
+`cursor` is the one continuation-field name for v1 — existing fields keep
+their names, and new paged endpoints use `cursor` rather than a second
+spelling. Never parse, construct, or edit a cursor: it is scoped to the query
+that produced it, and one minted for a different query shape is rejected with
+a `400` (`file_search_invalid_cursor` on file search).
+
+File search also keeps its pre-existing `truncated` flag, which reports the
+same thing from the other direction: `truncated: true` and a non-null `cursor`
+always travel together.
 
 ## Compatibility routes
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -105,16 +105,20 @@ Throw `AppError` subclasses from `@uploads/errors` in route code; the API's
 
 ## Pagination
 
-Paged collections take `?cursor=` and return a `cursor` field: an opaque
-string when another page exists, `null` when the caller has reached the end.
-`cursor` is the one continuation-field name for v1 — existing fields keep
-their names, and new paged endpoints use `cursor` rather than a second
-spelling. Never parse, construct, or edit a cursor: it is scoped to the query
-that produced it, and one minted for a different query shape is rejected with
-a `400` (`file_search_invalid_cursor` on file search).
+Paged collections take `?cursor=` and return a `cursor` field. The field holds
+an opaque string when another page exists. It holds `null` when the caller has
+reached the end.
 
-File search also keeps its pre-existing `truncated` flag, which reports the
-same thing from the other direction: `truncated: true` and a non-null `cursor`
+`cursor` is the one continuation-field name for v1. Existing fields keep their
+names. New paged endpoints use `cursor` rather than a second spelling.
+
+Never parse, construct, or edit a cursor. Each one is scoped to the exact query
+that produced it. Send it back with that same query, unchanged. A cursor
+replayed against a different query is rejected with a `400`. On file search
+that error carries the code `file_search_invalid_cursor`.
+
+File search also keeps its pre-existing `truncated` flag. The flag reports the
+same thing from the other direction. `truncated: true` and a non-null `cursor`
 always travel together.
 
 ## Compatibility routes

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -1312,6 +1312,10 @@ export function createUploadsClient(config: UploadsClientConfig) {
      * the expensive read path, so draining is capped rather than open-ended.
      * The returned `cursor` is non-null when the cap stopped the drain early —
      * pass it back to continue from there.
+     *
+     * `maxPages` must be a finite positive number. Anything else (`Infinity`,
+     * `NaN`, zero, a negative) falls back to the default rather than removing
+     * the bound or silently fetching nothing.
      */
     async findFilesAll(
       filters: Record<string, string> = {},
@@ -1321,7 +1325,8 @@ export function createUploadsClient(config: UploadsClientConfig) {
       const items: FindFilesItem[] = [];
       let cursor: string | undefined = opts.cursor;
       let truncated: boolean | undefined;
-      const pages = Math.max(1, Math.floor(maxPages));
+      const pages =
+        Number.isFinite(maxPages) && maxPages >= 1 ? Math.floor(maxPages) : FIND_FILES_MAX_PAGES;
       for (let page = 0; page < pages; page += 1) {
         const result: FindFilesResult = await findFiles(filters, { ...opts, cursor });
         items.push(...result.items);

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -69,6 +69,13 @@ export interface ListOptions {
   metadata?: boolean;
 }
 
+/**
+ * Default page cap for `findFilesAll` / `uploads find --all`. Search is a
+ * bounded read on the server, so following its cursor is bounded on the client
+ * too rather than draining an unknown number of pages (issue #829 §4).
+ */
+export const FIND_FILES_MAX_PAGES = 20;
+
 export interface FindFilesOptions {
   prefix?: string;
   limit?: number;
@@ -77,6 +84,13 @@ export interface FindFilesOptions {
    * At least one of non-empty `filters` or `name` is required.
    */
   name?: string;
+  /**
+   * Opaque continuation from a previous result's `cursor`. Pass it back
+   * unchanged, with the same filters/name/prefix, to fetch the next page
+   * (issue #829 §4). A cursor minted for one search path is rejected by the
+   * other, so do not hand-build one.
+   */
+  cursor?: string;
 }
 
 export interface FindFilesItem {
@@ -1120,6 +1134,28 @@ export function createUploadsClient(config: UploadsClientConfig) {
     };
   }
 
+  async function findFiles(
+    filters: Record<string, string> = {},
+    opts: FindFilesOptions = {},
+  ): Promise<FindFilesResult> {
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(filters)) params.append(`meta.${k}`, v);
+    if (opts.name) params.set("name", opts.name);
+    if (opts.prefix) params.set("prefix", opts.prefix);
+    if (opts.limit != null) params.set("limit", String(opts.limit));
+    if (opts.cursor) params.set("cursor", opts.cursor);
+    const result = await request<{
+      items: FindFilesItem[];
+      truncated: boolean;
+      cursor?: string | null;
+    }>("GET", `${canonicalFilesBase(config)}/search?${params.toString()}`);
+    return {
+      items: result.items,
+      cursor: result.cursor ?? null,
+      truncated: result.truncated,
+    };
+  }
+
   async function getGallery(id: string): Promise<Gallery> {
     return request<Gallery>("GET", `${galleriesBase(config)}/${encodeURIComponent(id)}`);
   }
@@ -1263,23 +1299,37 @@ export function createUploadsClient(config: UploadsClientConfig) {
      * ANDed equality filter over queryable metadata and/or a case-insensitive
      * filename substring. At least one of non-empty `filters` or `opts.name`
      * is required. `filters` must be pre-validated when present (see
-     * `metadata.ts`). The canonical search route is non-paginated (server cap
-     * 100, narrowable via `limit`), so `cursor` is always null.
+     * `metadata.ts`). The page is capped server-side (100, narrowable via
+     * `limit`); when more matches exist the result carries an opaque `cursor`
+     * to pass back as `opts.cursor` for the next page, and null when the last
+     * page has been reached.
      */
-    async findFiles(
+    findFiles,
+
+    /**
+     * `findFiles` followed through its `cursor`, up to `maxPages` requests
+     * (default `FIND_FILES_MAX_PAGES`). Bounded on purpose: search pages are
+     * the expensive read path, so draining is capped rather than open-ended.
+     * The returned `cursor` is non-null when the cap stopped the drain early —
+     * pass it back to continue from there.
+     */
+    async findFilesAll(
       filters: Record<string, string> = {},
       opts: FindFilesOptions = {},
+      maxPages: number = FIND_FILES_MAX_PAGES,
     ): Promise<FindFilesResult> {
-      const params = new URLSearchParams();
-      for (const [k, v] of Object.entries(filters)) params.append(`meta.${k}`, v);
-      if (opts.name) params.set("name", opts.name);
-      if (opts.prefix) params.set("prefix", opts.prefix);
-      if (opts.limit != null) params.set("limit", String(opts.limit));
-      const result = await request<{ items: FindFilesItem[]; truncated: boolean }>(
-        "GET",
-        `${canonicalFilesBase(config)}/search?${params.toString()}`,
-      );
-      return { items: result.items, cursor: null, truncated: result.truncated };
+      const items: FindFilesItem[] = [];
+      let cursor: string | undefined = opts.cursor;
+      let truncated: boolean | undefined;
+      const pages = Math.max(1, Math.floor(maxPages));
+      for (let page = 0; page < pages; page += 1) {
+        const result: FindFilesResult = await findFiles(filters, { ...opts, cursor });
+        items.push(...result.items);
+        truncated = result.truncated;
+        cursor = result.cursor ?? undefined;
+        if (!cursor) break;
+      }
+      return { items, cursor: cursor ?? null, ...(truncated === undefined ? {} : { truncated }) };
     },
 
     /** `GET /v1/:workspace/files/facets` — workspace metadata key vocabulary. */

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -3245,8 +3245,10 @@ Default prefix: UPLOADS_DEFAULT_PREFIX (screenshots if unset).
 
 --meta <k=v> (repeatable, ANDed) and/or --name <term> switch to the search
 endpoint — returned items include their matched metadata. Combines with
---prefix, not with --pr/--issue/--all. --name is a case-insensitive
-substring match on object keys. See also: uploads find.
+--prefix, not with --pr/--issue. --name is a case-insensitive
+substring match on object keys. Search pages are continued with --cursor
+(opaque, from the previous page); --all follows it for up to 20 pages and
+prints the next cursor if more remain. See also: uploads find.
 
 Examples:
   uploads list --prefix screenshots/
@@ -3274,18 +3276,21 @@ async function runFindFiles(
   flags: CommandFlags["flags"],
   name?: string,
 ): Promise<number> {
-  if (flagString(flags, "--cursor") !== undefined) {
-    throw new UsageError("--cursor is not supported with metadata or name filters");
-  }
   const prefix = flagString(flags, "--prefix");
   const limit = flagInt(flags, "--limit", "--limit");
+  const cursor = flagString(flags, "--cursor");
   const nameTerm = name ?? flagString(flags, "--name");
   if (Object.keys(filters).length === 0 && !nameTerm) {
     throw new UsageError("find requires at least one k=v pair, --meta k=v, or --name <term>", {
       example: "uploads find path=/settings state=after",
     });
   }
-  const result = await ctx.client.findFiles(filters, { prefix, limit, name: nameTerm });
+  // `--all` follows the search cursor, but only up to FIND_FILES_MAX_PAGES —
+  // never an unbounded drain. `--cursor` resumes a specific page by hand.
+  const searchOpts = { prefix, limit, name: nameTerm, cursor };
+  const result = flagBool(flags, "--all")
+    ? await ctx.client.findFilesAll(filters, searchOpts)
+    : await ctx.client.findFiles(filters, searchOpts);
   if (ctx.json) await writeJson(result);
   else {
     for (const item of result.items) {
@@ -3300,6 +3305,8 @@ async function runFindFiles(
       );
     }
     writeTruncatedNotice(result.truncated, ctx.quiet, "more matches may exist beyond this page");
+    // Human mode surfaces the continuation the same way `uploads list` does.
+    if (result.cursor) process.stderr.write(`cursor: ${result.cursor}\n`);
   }
   return 0;
 }
@@ -3320,9 +3327,6 @@ export async function runList(
   if (metaPairs.length > 0 || nameFlag !== undefined) {
     if (ghTargetFromFlags(parsed.flags, run)) {
       throw new UsageError("--meta/--name cannot be combined with --pr/--issue");
-    }
-    if (flagBool(parsed.flags, "--all")) {
-      throw new UsageError("--meta/--name cannot be combined with --all");
     }
     return runFindFiles(
       ctx,
@@ -3396,10 +3400,15 @@ export async function runList(
 
 // --- find ---
 
-const FIND_HELP = `uploads find [k=v...] [--meta k=v]... [--name <term>] [--prefix <p>] [--limit <n>] [--workspace <name>]
+const FIND_HELP = `uploads find [k=v...] [--meta k=v]... [--name <term>] [--prefix <p>] [--limit <n>] [--cursor <c>] [--all] [--workspace <name>]
 
 Find objects by queryable metadata (ANDed equality) and/or a case-insensitive
 filename substring. Same output as \`uploads list --meta\` / \`--name\`.
+
+Results are paged. When more matches exist the next page's opaque cursor is
+printed to stderr (and carried in --json as \`cursor\`); pass it back with
+--cursor. --all follows the cursor for you, up to 20 pages, then prints the
+cursor to resume from.
 
 Pairs are positional k=v, or spelled --meta k=v. A bare positional without
 \`=\` is treated as --name (e.g. \`uploads find hero\`). At least one of a
@@ -3411,6 +3420,7 @@ Examples:
   uploads find --meta path=/settings
   uploads find hero
   uploads find --name hero --meta app=web
+  uploads find app=web --all --json
 `;
 
 export async function runFind(ctx: CliContext, args: string[], help = false): Promise<number> {

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -1489,7 +1489,7 @@ export function createUploadsMcpTools(opts: {
       annotations: mcpRead,
       securitySchemes: mcpOAuthRead,
       description:
-        "Find objects whose queryable custom metadata matches ALL of `filters` (ANDed equality) and/or whose key contains `name` (case-insensitive substring). At least one of `filters` or `name` is required. Returns each match's key, public URL, full metadata map, and optional `truncated`. Same as `uploads find k=v...` / `uploads find --name <term>`.",
+        "Find objects whose queryable custom metadata matches ALL of `filters` (ANDed equality) and/or whose key contains `name` (case-insensitive substring). At least one of `filters` or `name` is required. Returns each match's key, public URL, full metadata map, optional `truncated`, and a `cursor` to pass back for the next page (null when there are none). Same as `uploads find k=v...` / `uploads find --name <term>`.",
       inputSchema: {
         type: "object",
         properties: {
@@ -1508,6 +1508,11 @@ export function createUploadsMcpTools(opts: {
             description: "Key prefix filter, combinable with filters/name.",
           },
           limit: { type: "number", description: "Page size (default 50, max 500)." },
+          cursor: {
+            type: "string",
+            description:
+              "Opaque continuation from a previous call's `cursor`. Pass it back unchanged with the same filters/name to get the next page; a null `cursor` means there are no more pages.",
+          },
           workspace: workspaceProp,
         },
         additionalProperties: false,
@@ -1525,6 +1530,7 @@ export function createUploadsMcpTools(opts: {
           name,
           prefix: optString(args, "prefix"),
           limit: optPosInt(args, "limit"),
+          cursor: optString(args, "cursor"),
         });
       },
     },

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -1489,7 +1489,7 @@ export function createUploadsMcpTools(opts: {
       annotations: mcpRead,
       securitySchemes: mcpOAuthRead,
       description:
-        "Find objects whose queryable custom metadata matches ALL of `filters` (ANDed equality) and/or whose key contains `name` (case-insensitive substring). At least one of `filters` or `name` is required. Returns each match's key, public URL, full metadata map, optional `truncated`, and a `cursor` to pass back for the next page (null when there are none). Same as `uploads find k=v...` / `uploads find --name <term>`.",
+        "Find objects whose queryable custom metadata matches ALL of `filters` (ANDed equality) and/or whose key contains `name` (case-insensitive substring). At least one of `filters` or `name` is required. Returns each match's key, public URL, full metadata map, optional `truncated`, and a `cursor` to pass back for the next page (null when there are none; set `all` to follow it for you). Same as `uploads find k=v...` / `uploads find --name <term>`.",
       inputSchema: {
         type: "object",
         properties: {
@@ -1513,6 +1513,11 @@ export function createUploadsMcpTools(opts: {
             description:
               "Opaque continuation from a previous call's `cursor`. Pass it back unchanged with the same filters/name to get the next page; a null `cursor` means there are no more pages.",
           },
+          all: {
+            type: "boolean",
+            description:
+              "Follow the cursor and return every page, up to a bounded number of requests. A non-null `cursor` in the result means that bound was reached before the end — pass it back to continue.",
+          },
           workspace: workspaceProp,
         },
         additionalProperties: false,
@@ -1526,12 +1531,17 @@ export function createUploadsMcpTools(opts: {
         }
         if (hasMeta) validateMetaMap(filters);
         const { client } = await clientFor(args);
-        return client.findFiles(filters, {
+        const opts = {
           name,
           prefix: optString(args, "prefix"),
           limit: optPosInt(args, "limit"),
           cursor: optString(args, "cursor"),
-        });
+        };
+        // `all` drains through findFilesAll, which caps its own page count —
+        // unlike `list`'s `all`, this never runs unbounded.
+        return optBool(args, "all")
+          ? client.findFilesAll(filters, opts)
+          : client.findFiles(filters, opts);
       },
     },
     {

--- a/packages/uploads/test/client-metadata.test.ts
+++ b/packages/uploads/test/client-metadata.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createUploadsClient } from "../src/client.js";
+import { createUploadsClient, FIND_FILES_MAX_PAGES } from "../src/client.js";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -218,6 +218,32 @@ describe("metadata CRUD client methods", () => {
     const result = await client.findFilesAll({ app: "web" });
     expect(calls).toBe(1);
     expect(result.cursor).toBeNull();
+  });
+
+  it("findFilesAll falls back to the default cap for a non-finite maxPages", async () => {
+    // Infinity would otherwise remove the bound entirely, and NaN would make
+    // the loop run zero times and return an empty result that looks complete.
+    for (const maxPages of [Number.POSITIVE_INFINITY, Number.NaN, 0, -5]) {
+      let calls = 0;
+      const fetch = vi.fn(async () => {
+        calls += 1;
+        return new Response(
+          JSON.stringify({
+            items: [{ key: `f/${calls}.png`, url: null, metadata: {} }],
+            cursor: "c",
+          }),
+        );
+      });
+      vi.stubGlobal("fetch", fetch);
+      const client = createUploadsClient({
+        apiUrl: "https://api.test",
+        workspace: "test",
+        token: "up_test_x",
+      });
+      const result = await client.findFilesAll({ app: "web" }, {}, maxPages);
+      expect(calls).toBe(FIND_FILES_MAX_PAGES);
+      expect(result.cursor).toBe("c");
+    }
   });
 
   it("listMetadataKeys GETs /files/facets", async () => {

--- a/packages/uploads/test/client-metadata.test.ts
+++ b/packages/uploads/test/client-metadata.test.ts
@@ -159,6 +159,67 @@ describe("metadata CRUD client methods", () => {
     expect(result.truncated).toBe(false);
   });
 
+  it("findFiles forwards the cursor and surfaces the server's next cursor", async () => {
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      expect(url.searchParams.get("cursor")).toBe("c0");
+      return new Response(JSON.stringify({ items: [], cursor: "c1", truncated: true }));
+    });
+    vi.stubGlobal("fetch", fetch);
+    const client = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "test",
+      token: "up_test_x",
+    });
+    const result = await client.findFiles({ app: "web" }, { cursor: "c0" });
+    expect(result.cursor).toBe("c1");
+    expect(result.truncated).toBe(true);
+  });
+
+  it("findFilesAll follows the cursor but stops at the page cap", async () => {
+    // Server never runs out of pages — the drain has to stop itself.
+    let calls = 0;
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      calls += 1;
+      const seq = String(calls);
+      const url = new URL(String(input));
+      expect(url.searchParams.get("cursor")).toBe(calls === 1 ? null : String(calls - 1));
+      return new Response(
+        JSON.stringify({ items: [{ key: `f/${seq}.png`, url: null, metadata: {} }], cursor: seq }),
+      );
+    });
+    vi.stubGlobal("fetch", fetch);
+    const client = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "test",
+      token: "up_test_x",
+    });
+    const result = await client.findFilesAll({ app: "web" }, {}, 3);
+    expect(calls).toBe(3);
+    expect(result.items.map((item) => item.key)).toEqual(["f/1.png", "f/2.png", "f/3.png"]);
+    // Non-null cursor means the cap stopped the drain, not the server.
+    expect(result.cursor).toBe("3");
+  });
+
+  it("findFilesAll stops early when the server returns a null cursor", async () => {
+    let calls = 0;
+    const fetch = vi.fn(async () => {
+      calls += 1;
+      return new Response(
+        JSON.stringify({ items: [{ key: "f/only.png", url: null, metadata: {} }], cursor: null }),
+      );
+    });
+    vi.stubGlobal("fetch", fetch);
+    const client = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "test",
+      token: "up_test_x",
+    });
+    const result = await client.findFilesAll({ app: "web" });
+    expect(calls).toBe(1);
+    expect(result.cursor).toBeNull();
+  });
+
   it("listMetadataKeys GETs /files/facets", async () => {
     const fetch = vi.fn(async (input: string | URL | Request) => {
       expect(String(input)).toBe("https://api.test/v1/workspaces/test/files/facets");

--- a/packages/uploads/test/commands-find.test.ts
+++ b/packages/uploads/test/commands-find.test.ts
@@ -9,13 +9,20 @@ function fakeClient() {
     prefix?: string;
     limit?: number;
     name?: string;
+    cursor?: string;
   }[] = [];
   const client = {
     findFiles: async (
       filters: Record<string, string>,
-      opts: { prefix?: string; limit?: number; name?: string } = {},
+      opts: { prefix?: string; limit?: number; name?: string; cursor?: string } = {},
     ) => {
-      calls.push({ filters, prefix: opts.prefix, limit: opts.limit, name: opts.name });
+      calls.push({
+        filters,
+        prefix: opts.prefix,
+        limit: opts.limit,
+        name: opts.name,
+        cursor: opts.cursor,
+      });
       return {
         items: [
           {
@@ -115,11 +122,27 @@ describe("runFind", () => {
     expect(calls[0].limit).toBe(5);
   });
 
-  it("rejects --cursor with metadata filters", async () => {
-    const { client } = fakeClient();
-    await expect(runFind(ctxWith(client), ["app=myapp", "--cursor", "abc"], false)).rejects.toThrow(
-      UsageError,
-    );
+  it("forwards --cursor to the search endpoint (issue #829 §4)", async () => {
+    const { client, calls } = fakeClient();
+    const code = await runFind(ctxWith(client), ["app=myapp", "--cursor", "abc"], false);
+    expect(code).toBe(0);
+    expect(calls[0].cursor).toBe("abc");
+  });
+
+  it("--all follows the cursor through findFilesAll", async () => {
+    const { client, calls } = fakeClient();
+    const drained: unknown[] = [];
+    (client as unknown as Record<string, unknown>).findFilesAll = async (
+      filters: Record<string, string>,
+      opts: { cursor?: string },
+    ) => {
+      drained.push({ filters, cursor: opts.cursor });
+      return { items: [], cursor: null, truncated: false };
+    };
+    const code = await runFind(ctxWith(client), ["app=myapp", "--all"], false);
+    expect(code).toBe(0);
+    expect(drained).toEqual([{ filters: { app: "myapp" }, cursor: undefined }]);
+    expect(calls).toHaveLength(0);
   });
 
   it("renders each match's key, url, and matched metadata (sorted) on stdout", async () => {

--- a/packages/uploads/test/commands-list.test.ts
+++ b/packages/uploads/test/commands-list.test.ts
@@ -56,17 +56,37 @@ const noRun: CommandRunner = () => {
 const ghRun: CommandRunner = () => "o/r";
 
 function fakeFindClient() {
-  const calls: { filters: Record<string, string>; prefix?: string; limit?: number }[] = [];
+  const calls: {
+    filters: Record<string, string>;
+    prefix?: string;
+    limit?: number;
+    cursor?: string;
+    all?: boolean;
+  }[] = [];
+  const page = (filters: Record<string, string>) => ({
+    items: [{ key: "gh/o/r/pull/1/a.png", url: "https://x.test/a.png", metadata: filters }],
+    cursor: null,
+  });
   const client = {
     findFiles: async (
       filters: Record<string, string>,
-      opts: { prefix?: string; limit?: number } = {},
+      opts: { prefix?: string; limit?: number; cursor?: string } = {},
     ) => {
-      calls.push({ filters, prefix: opts.prefix, limit: opts.limit });
-      return {
-        items: [{ key: "gh/o/r/pull/1/a.png", url: "https://x.test/a.png", metadata: filters }],
-        cursor: null,
-      };
+      calls.push({ filters, prefix: opts.prefix, limit: opts.limit, cursor: opts.cursor });
+      return page(filters);
+    },
+    findFilesAll: async (
+      filters: Record<string, string>,
+      opts: { prefix?: string; limit?: number; cursor?: string } = {},
+    ) => {
+      calls.push({
+        filters,
+        prefix: opts.prefix,
+        limit: opts.limit,
+        cursor: opts.cursor,
+        all: true,
+      });
+      return page(filters);
     },
   } as unknown as UploadsClient;
   return { client, calls };
@@ -207,17 +227,25 @@ describe("runList --meta", () => {
     ).rejects.toThrow(UsageError);
   });
 
-  it("rejects --meta combined with --all", async () => {
-    const { client } = fakeFindClient();
-    await expect(
-      runList(ctxWith(client), ["--meta", "app=x", "--all"], false, noRun),
-    ).rejects.toThrow(UsageError);
+  // Search is paged as of issue #829 §4: --cursor resumes a page and --all
+  // follows the cursor (bounded), instead of both being rejected outright.
+  it("follows the search cursor with --all", async () => {
+    const { client, calls } = fakeFindClient();
+    const code = await runList(ctxWith(client), ["--meta", "app=x", "--all"], false, noRun);
+    expect(code).toBe(0);
+    expect(calls[0].all).toBe(true);
   });
 
-  it("rejects --meta combined with --cursor", async () => {
-    const { client } = fakeFindClient();
-    await expect(
-      runList(ctxWith(client), ["--meta", "app=x", "--cursor", "abc"], false, noRun),
-    ).rejects.toThrow(UsageError);
+  it("forwards --cursor to the search endpoint", async () => {
+    const { client, calls } = fakeFindClient();
+    const code = await runList(
+      ctxWith(client),
+      ["--meta", "app=x", "--cursor", "abc"],
+      false,
+      noRun,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].cursor).toBe("abc");
+    expect(calls[0].all).toBeUndefined();
   });
 });

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -41,6 +41,8 @@ function fakeFactory() {
     prefix?: string;
     limit?: number;
     name?: string;
+    cursor?: string;
+    all?: boolean;
   }> = [];
   const facetCalls: Array<{ kind: "keys" } | { kind: "values"; key: string }> = [];
   // Keyed by object key, mirroring the server's per-key metadata rows well
@@ -120,6 +122,13 @@ function fakeFactory() {
           .slice(0, opts.limit ?? 50)
           .map(([key, meta]) => ({ key, url: `https://x.test/${key}`, metadata: meta }));
         return { items, cursor: null, truncated: opts.name ? false : undefined };
+      },
+      findFilesAll: async (
+        filters: Record<string, string> = {},
+        opts: { prefix?: string; limit?: number; name?: string; cursor?: string } = {},
+      ) => {
+        findCalls.push({ filters, ...opts, all: true });
+        return { items: [], cursor: null, truncated: false };
       },
       listMetadataKeys: async () => {
         facetCalls.push({ kind: "keys" });
@@ -1361,6 +1370,22 @@ describe("tools/call get_metadata, set_metadata, find_files", () => {
     });
     expect(res.result.isError).toBe(false);
     expect(findCalls[0]).toMatchObject({ filters: {}, name: "hero" });
+  });
+
+  it("forwards a cursor, and routes `all` through the bounded drain", async () => {
+    const { server, findCalls } = serverWith();
+    await rpc(server, "tools/call", {
+      name: "find_files",
+      arguments: { name: "hero", cursor: "c0" },
+    });
+    expect(findCalls[0]).toMatchObject({ name: "hero", cursor: "c0" });
+    expect(findCalls[0].all).toBeUndefined();
+
+    await rpc(server, "tools/call", {
+      name: "find_files",
+      arguments: { name: "hero", all: true },
+    });
+    expect(findCalls[1]).toMatchObject({ name: "hero", all: true });
   });
 
   it("list_metadata_keys returns keys and values shapes", async () => {

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -650,9 +650,10 @@ know which keys exist, start with `meta keys` / `meta values <key>` (or the MCP
 `list_metadata_keys` tool) — keys are user/agent-defined, not a fixed schema.
 
 Search results are paged. When more matches remain, `find` prints `truncated:
-true` and the next page's opaque `cursor` on stderr (`--json` carries `cursor`
-in the payload); pass it back with `--cursor`, or let `--all` follow it for up
-to 20 pages. Treat the cursor as opaque — it is only valid for the same query.
+true` and the next page's opaque `cursor` on stderr. `--json` carries the same
+`cursor` in the payload. Pass it back with `--cursor` to read the next page.
+`--all` follows the cursor for you, for up to 20 pages. Treat the cursor as
+opaque, and send it only with the query that produced it.
 
 On the default `screenshots/…` path, `put` also auto-derives GitHub context and
 stamps `gh.repo`/`gh.kind`/`gh.number`/`gh.ref` from the current branch's PR (or

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -636,6 +636,8 @@ uploads find app=web path=/settings                 # same filter, positional pa
 uploads find --meta app=web                         # --meta works here too
 uploads find hero                                   # bare name = filename substring
 uploads find --name hero --meta app=web             # name + meta, either order
+uploads find app=web --all                          # follow the cursor (max 20 pages)
+uploads find app=web --cursor "$CURSOR"             # resume one page by hand
 uploads meta keys                                   # which meta keys exist here
 uploads meta values app                             # values (with counts) for one key
 ```
@@ -646,6 +648,11 @@ forms can appear in one call. `find` also takes a case-insensitive filename
 substring (`--name <term>`, or a bare positional without `=`). When you don't
 know which keys exist, start with `meta keys` / `meta values <key>` (or the MCP
 `list_metadata_keys` tool) — keys are user/agent-defined, not a fixed schema.
+
+Search results are paged. When more matches remain, `find` prints `truncated:
+true` and the next page's opaque `cursor` on stderr (`--json` carries `cursor`
+in the payload); pass it back with `--cursor`, or let `--all` follow it for up
+to 20 pages. Treat the cursor as opaque — it is only valid for the same query.
 
 On the default `screenshots/…` path, `put` also auto-derives GitHub context and
 stamps `gh.repo`/`gh.kind`/`gh.number`/`gh.ref` from the current branch's PR (or


### PR DESCRIPTION
Implements §4 of #829 ("Make search pageable"). Search now returns an opaque
continuation cursor and accepts it back, on both of its underlying paths.

## Contract

Strictly additive. `items` and `truncated` keep their exact meaning and
spelling; a new `cursor` field carries the continuation and is non-null
exactly when `truncated` is true. Two of the three search surfaces already
returned `cursor: null` unconditionally — those now carry a real value in the
same field rather than gaining a second one.

Per §6, `cursor` is the one continuation-field convention for v1 work
(matching the existing file-list and gallery-list envelopes); nothing was
renamed. `docs/api.md` gained a short "Pagination" section stating that
convention, and the OpenAPI document now documents `?cursor=` and the response
field on `searchFiles`.

## Cursor design

Base64url of a small JSON envelope: `{ v, p, k }` — version, which path minted
it, and the last key of the consumed window. Opaque to callers: the only
supported use is handing back what a previous page returned.

The path tag is what keeps the two mechanics from being confused. A cursor
minted on the metadata path replayed against the name-only walk (or the
reverse) is rejected with `400` / `file_search_invalid_cursor`, the same stable
code garbage and version-mismatched cursors get.

### Metadata path (D1)

`findObjectsByMetadata` already ordered by `object_key`, so this is a keyset
continuation: a new `after` option adds `object_key > :after` as a wrapper
around the existing single-leg, INTERSECT, prefix, and collapse forms, before
`ORDER BY … LIMIT`. No OFFSET scan, and stable when objects are written or
removed between pages.

One consistency fix rides along: the page's source window is now the first
`pageSize` rows, with the truncation probe row excluded before the `name` term
narrows them. Previously a name term could pull the probe row into the results,
which would have made it possible to serve a row twice across a cursor
boundary.

### Name-only path (storage walk)

files-sdk's `search()` iterator exposes `prefix`/`limit`/`maxResults` but no
`startAfter`, so a continued page cannot be pushed down to the provider. It
resumes with a bounded re-walk instead: it pages the listing and drops keys at
or before the cursor key without hydrating them.

**Tradeoff:** skipped keys cost a listing page each and no metadata read, but
the work is proportional to how deep the cursor sits. It is bounded at
`SEARCH_WALK_RESUME_MAX_SKIP` (20,000) rather than left to grow with the page
number; past that the request fails with `file_search_cursor_too_deep` instead
of quietly doing unbounded work. Narrowing with `prefix` or any `meta.*` filter
routes to the D1 keyset path, which has no such bound. Both are documented at
the call site. The resume also assumes the walk yields keys in lexicographic
order, which holds for the R2/S3 listing this runs on and matches the D1
ordering.

## Client, CLI, MCP

- `findFiles` takes `cursor` and returns the server's next one.
- `findFilesAll` follows the cursor up to a page cap (default 20) and returns
  a non-null `cursor` when the cap — not the server — ended the drain.
- `uploads find` / `uploads list --meta|--name` gained `--cursor` (resume one
  page) and `--all` (bounded follow), matching how `uploads list` already
  spells both. Human mode prints the next cursor on stderr the same way
  `list` does. Nothing fetches pages without a bound.
- Both `find_files` MCP tools (hosted worker and the CLI's local server) take
  and return the cursor; the output schema already had the field.

## Tests

`pnpm test` from the root: 342 files, 5124 tests passing. New coverage:

- Cursor round-trip on both paths through the real route, walking a result set
  a page at a time with no repeats and ending on a null cursor.
- `truncated`/`cursor` consistency asserted per page.
- Invalid, foreign-path, empty-key, and wrong-version cursors all rejected with
  the stable `file_search_invalid_cursor` code.
- A name filter dropping an entire D1 window while the cursor still advances
  past it (the case that would otherwise stall or loop).
- `findObjectsByMetadata`'s `after` option against real SQLite, on the
  single-filter, INTERSECT, and prefix forms.
- Client-side cursor forwarding, the drain stopping at the page cap, and the
  drain stopping early on a null cursor.

Two CLI tests that asserted `--cursor`/`--all` were *rejected* on the search
path were replaced with tests for the new behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination for file searches across API, CLI, SDK, and MCP interfaces.
  * Added `--cursor` to resume searches and `--all` to retrieve up to 20 pages automatically.
  * Search responses now include continuation cursors and indicate when additional results are available.
  * Invalid or mismatched cursors are rejected with a clear error.

* **Documentation**
  * Updated API, CLI, and tool documentation with pagination guidance and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->