### PR TITLE
feat(api): add per-workspace read limits and consistent 429 metadata (#829)

### DIFF
--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -81,6 +81,16 @@ interface Env {
    */
   WRITE_LIMITER?: RateLimit;
   RENDER_LIMITER?: RateLimit;
+  /**
+   * Read-side limiters (issue #829 §3), keyed by workspace and entirely
+   * separate from the write/render/poster/intake budgets above.
+   * `HEAVY_READ_LIMITER` covers search, facets, by-path, and
+   * metadata-hydrated listings; `READ_LIMITER` covers the cheaper reads
+   * (including a listing the caller opted out of hydrating). See
+   * `read-limits.ts`.
+   */
+  READ_LIMITER?: RateLimit;
+  HEAVY_READ_LIMITER?: RateLimit;
   WS_CREATE_LIMITER?: RateLimit;
   INVITE_LIMITER?: RateLimit;
   /**

--- a/apps/api/src/error-response.ts
+++ b/apps/api/src/error-response.ts
@@ -25,5 +25,36 @@ export function respondError(c: Context, err: unknown): Response {
       }),
     );
   }
+  applyRetryAfter(c, appErr);
   return c.json(appErr.toWire(), appErr.status as ContentfulStatusCode);
+}
+
+/**
+ * Retry metadata on a refused request (issue #829 §3).
+ *
+ * `Retry-After` (RFC 9110, seconds) is the standard header and is emitted
+ * whenever the error carries a `retry_after` figure we actually know — from
+ * `RateLimitedError`'s `retryAfterSeconds`, which the rate-limit guards set
+ * from their configured window. `X-Retry-After` is emitted alongside it for
+ * compatibility: Better Auth uses that spelling, the shipped client reads
+ * both, and dropping it would break callers pinned to the old header.
+ *
+ * Errors that carry no figure emit neither header. The `Retry-After: 1` a
+ * route sets by hand for an in-progress idempotent replay is a 409, not a
+ * rate limit, and is left exactly as that route wrote it.
+ *
+ * Deliberately absent: `RateLimit-Limit`/`-Remaining`/`-Reset`. A Cloudflare
+ * `RateLimit` binding's `limit()` returns `{ success }` and nothing more, so
+ * there is no accurate quota or reset instant to report. Inventing one would
+ * be worse than omitting it, and a client that trusted a fabricated
+ * `Remaining` would back off at the wrong time.
+ */
+function applyRetryAfter(c: Context, err: AppError): void {
+  const details = err.details as { retry_after?: unknown } | undefined;
+  const retryAfter = details?.retry_after;
+  if (typeof retryAfter !== "number" || !Number.isFinite(retryAfter) || retryAfter <= 0) return;
+  const seconds = String(Math.max(1, Math.ceil(retryAfter)));
+  // `c.header` merges into the response `c.json` builds below.
+  c.header("Retry-After", seconds);
+  c.header("X-Retry-After", seconds);
 }

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -259,13 +259,22 @@ export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadIn
  * binding is absent (some local/dev setups, tests) — the window/quota
  * themselves are fixed per-binding in wrangler.jsonc (fixed sliding windows,
  * per-colo rather than globally exact — enough to blunt abuse, not billing).
+ *
+ * `opts.windowSeconds` is the binding's configured `simple.period`, mirrored
+ * here purely so the 429 can carry an honest `Retry-After`: the window length
+ * is the only recovery figure a Cloudflare `RateLimit` binding makes knowable
+ * — `limit()` returns `{ success }` and nothing else, so limit/remaining/reset
+ * are deliberately never emitted (see `respondError`). Waiting out one full
+ * window is always sufficient, which is exactly what `Retry-After` promises.
  */
-function makeRateLimitGuard<BindingKey extends string>(
+export function makeRateLimitGuard<BindingKey extends string>(
   bindingKey: BindingKey,
   message: string,
+  opts: { windowSeconds?: number; code?: string } = {},
 ): {
   middleware: MiddlewareHandler<WorkspaceVars>;
   allow: (env: Partial<Record<BindingKey, RateLimit>>, workspaceName: string) => Promise<boolean>;
+  reject: () => never;
 } {
   const allow = async (
     env: Partial<Record<BindingKey, RateLimit>>,
@@ -277,24 +286,31 @@ function makeRateLimitGuard<BindingKey extends string>(
     return success;
   };
 
+  const reject = (): never => {
+    throw new RateLimitedError(message, {
+      ...(opts.code ? { code: opts.code } : {}),
+      ...(opts.windowSeconds !== undefined ? { retryAfterSeconds: opts.windowSeconds } : {}),
+    });
+  };
+
   const middleware: MiddlewareHandler<WorkspaceVars> = async (c, next) => {
     // `c.env` is the worker's full Env; narrowed here since this guard only
     // ever reads the single `bindingKey` binding off of it.
     const env = c.env as unknown as Partial<Record<BindingKey, RateLimit>>;
-    if (!(await allow(env, c.get("workspaceName")))) {
-      throw new RateLimitedError(message);
-    }
+    if (!(await allow(env, c.get("workspaceName")))) reject();
     await next();
   };
 
-  return { middleware, allow };
+  return { middleware, allow, reject };
 }
 
 /**
  * Per-workspace rate limit for mutating requests (`WRITE_LIMITER`), used by
  * the file put/delete routes and the MCP worker's put/delete tools.
  */
-const writeRateLimitGuard = makeRateLimitGuard("WRITE_LIMITER", "rate limit exceeded");
+const writeRateLimitGuard = makeRateLimitGuard("WRITE_LIMITER", "rate limit exceeded", {
+  windowSeconds: 60,
+});
 export const writeRateLimit = writeRateLimitGuard.middleware;
 export const allowWrite = writeRateLimitGuard.allow;
 
@@ -304,7 +320,9 @@ export const allowWrite = writeRateLimitGuard.allow;
  * endpoint independent of the monthly upload-budget check (`checkPutBudget`,
  * reused for renders in routes/render.ts).
  */
-const renderRateLimitGuard = makeRateLimitGuard("RENDER_LIMITER", "render rate limit exceeded");
+const renderRateLimitGuard = makeRateLimitGuard("RENDER_LIMITER", "render rate limit exceeded", {
+  windowSeconds: 60,
+});
 export const renderRateLimit = renderRateLimitGuard.middleware;
 export const allowRender = renderRateLimitGuard.allow;
 

--- a/apps/api/src/read-limits.test.ts
+++ b/apps/api/src/read-limits.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Per-workspace read limiter (issue #829 §3): tier classification, keying,
+ * and the 429 contract (body `retry_after` plus the `Retry-After` /
+ * `X-Retry-After` header pair).
+ */
+import { Hono, type MiddlewareHandler } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "./error-response";
+import {
+  classifyLegacyListingRead,
+  classifyListingRead,
+  heavyReadRateLimit,
+  listingIsHydrated,
+  listingReadRateLimit,
+  legacyListingReadRateLimit,
+  readRateLimit,
+  READ_LIMIT_WINDOW_SECONDS,
+} from "./read-limits";
+import type { WorkspaceVars } from "./workspace";
+
+/** Records every key it is asked about; `allow` decides the verdict. */
+function fakeLimiter(allow: boolean) {
+  const keys: string[] = [];
+  return {
+    keys,
+    binding: {
+      limit: async ({ key }: { key: string }) => {
+        keys.push(key);
+        return { success: allow };
+      },
+    },
+  };
+}
+
+/**
+ * Minimal router that mounts one of the read limiters behind a stand-in for
+ * the auth middleware that normally sets `workspaceName`.
+ */
+function harness(middleware: MiddlewareHandler<WorkspaceVars>, workspace = "acme") {
+  return new Hono<WorkspaceVars>()
+    .use("*", async (c, next) => {
+      c.set("workspaceName", workspace);
+      await next();
+    })
+    .get("/probe", middleware, (c) => c.json({ ok: true }))
+    .onError((err, c) => respondError(c, err));
+}
+
+describe("read tier classification", () => {
+  it("treats a canonical listing as hydrated unless the caller opts out", () => {
+    expect(listingIsHydrated(undefined)).toBe(true);
+    expect(listingIsHydrated("1")).toBe(true);
+    expect(listingIsHydrated("0")).toBe(false);
+    expect(listingIsHydrated("false")).toBe(false);
+  });
+
+  it("charges a hydrated listing the tight tier and an unhydrated one the normal tier", () => {
+    expect(classifyListingRead(undefined)).toBe("tight");
+    expect(classifyListingRead("0")).toBe("normal");
+    expect(classifyListingRead("false")).toBe("normal");
+  });
+
+  it("classifies the legacy listing by its own inverted metadata contract", () => {
+    // Bare prefix list: object storage only.
+    expect(classifyLegacyListingRead({})).toBe("normal");
+    expect(classifyLegacyListingRead({ prefix: "f/" })).toBe("normal");
+    // Opt-in hydration, and the two shapes that switch to the D1 search path.
+    expect(classifyLegacyListingRead({ metadata: "1" })).toBe("tight");
+    expect(classifyLegacyListingRead({ name: "shot" })).toBe("tight");
+    expect(classifyLegacyListingRead({ "meta.path": "web/home" })).toBe("tight");
+  });
+});
+
+describe("read limiter keying", () => {
+  it("keys the normal limiter by workspace", async () => {
+    const limiter = fakeLimiter(true);
+    const res = await harness(readRateLimit, "acme").request("/probe", {}, {
+      READ_LIMITER: limiter.binding,
+    } as never);
+    expect(res.status).toBe(200);
+    expect(limiter.keys).toEqual(["acme"]);
+  });
+
+  it("keys the tight limiter by workspace and never spends the normal budget", async () => {
+    const normal = fakeLimiter(true);
+    const tight = fakeLimiter(true);
+    const res = await harness(heavyReadRateLimit, "beta").request("/probe", {}, {
+      READ_LIMITER: normal.binding,
+      HEAVY_READ_LIMITER: tight.binding,
+    } as never);
+    expect(res.status).toBe(200);
+    expect(tight.keys).toEqual(["beta"]);
+    expect(normal.keys).toEqual([]);
+  });
+
+  it("gives each workspace its own bucket", async () => {
+    const limiter = fakeLimiter(true);
+    const env = { HEAVY_READ_LIMITER: limiter.binding } as never;
+    await harness(heavyReadRateLimit, "acme").request("/probe", {}, env);
+    await harness(heavyReadRateLimit, "beta").request("/probe", {}, env);
+    expect(limiter.keys).toEqual(["acme", "beta"]);
+  });
+
+  it("fails open when the binding is absent", async () => {
+    const res = await harness(heavyReadRateLimit).request("/probe", {}, {} as never);
+    expect(res.status).toBe(200);
+  });
+
+  it("leaves the write limiter untouched", async () => {
+    const write = fakeLimiter(false);
+    const res = await harness(heavyReadRateLimit).request("/probe", {}, {
+      WRITE_LIMITER: write.binding,
+      HEAVY_READ_LIMITER: fakeLimiter(true).binding,
+    } as never);
+    expect(res.status).toBe(200);
+    expect(write.keys).toEqual([]);
+  });
+});
+
+describe("hydrated vs metadata=0 listing routing", () => {
+  it("charges a hydrated listing to the tight limiter", async () => {
+    const normal = fakeLimiter(true);
+    const tight = fakeLimiter(true);
+    const env = { READ_LIMITER: normal.binding, HEAVY_READ_LIMITER: tight.binding } as never;
+    await harness(listingReadRateLimit).request("/probe", {}, env);
+    expect(tight.keys).toEqual(["acme"]);
+    expect(normal.keys).toEqual([]);
+  });
+
+  it("charges a `metadata=0` listing to the normal limiter", async () => {
+    const normal = fakeLimiter(true);
+    const tight = fakeLimiter(true);
+    const env = { READ_LIMITER: normal.binding, HEAVY_READ_LIMITER: tight.binding } as never;
+    await harness(listingReadRateLimit).request("/probe?metadata=0", {}, env);
+    expect(normal.keys).toEqual(["acme"]);
+    expect(tight.keys).toEqual([]);
+  });
+
+  it("still serves a `metadata=0` listing when only the tight limiter is exhausted", async () => {
+    const env = {
+      READ_LIMITER: fakeLimiter(true).binding,
+      HEAVY_READ_LIMITER: fakeLimiter(false).binding,
+    } as never;
+    const res = await harness(listingReadRateLimit).request("/probe?metadata=0", {}, env);
+    expect(res.status).toBe(200);
+  });
+
+  it("routes the legacy listing by its own contract", async () => {
+    const normal = fakeLimiter(true);
+    const tight = fakeLimiter(true);
+    const env = { READ_LIMITER: normal.binding, HEAVY_READ_LIMITER: tight.binding } as never;
+    await harness(legacyListingReadRateLimit).request("/probe", {}, env);
+    await harness(legacyListingReadRateLimit).request("/probe?metadata=1", {}, env);
+    expect(normal.keys).toEqual(["acme"]);
+    expect(tight.keys).toEqual(["acme"]);
+  });
+});
+
+describe("429 contract", () => {
+  it("returns a rate_limited envelope with retry_after and both headers", async () => {
+    const res = await harness(heavyReadRateLimit).request("/probe", {}, {
+      HEAVY_READ_LIMITER: fakeLimiter(false).binding,
+    } as never);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe(String(READ_LIMIT_WINDOW_SECONDS));
+    // Compat spelling the shipped client also reads (packages/uploads).
+    expect(res.headers.get("X-Retry-After")).toBe(String(READ_LIMIT_WINDOW_SECONDS));
+    const body = (await res.json()) as {
+      error: { type: string; code: string; details?: { retry_after?: number } };
+    };
+    expect(body.error.type).toBe("rate_limited");
+    expect(body.error.code).toBe("read_rate_limited");
+    expect(body.error.details?.retry_after).toBe(READ_LIMIT_WINDOW_SECONDS);
+  });
+
+  it("emits no ratelimit limit/remaining/reset headers", async () => {
+    // A Cloudflare `RateLimit` binding reports only `{ success }`, so there is
+    // no accurate quota or reset instant to publish. Asserted so a future
+    // change has to decide deliberately rather than fabricate numbers.
+    const res = await harness(heavyReadRateLimit).request("/probe", {}, {
+      HEAVY_READ_LIMITER: fakeLimiter(false).binding,
+    } as never);
+    for (const header of [
+      "RateLimit-Limit",
+      "RateLimit-Remaining",
+      "RateLimit-Reset",
+      "RateLimit",
+    ]) {
+      expect(res.headers.get(header)).toBeNull();
+    }
+  });
+
+  it("emits no retry headers for an error that carries no figure", async () => {
+    const app = new Hono()
+      .get("/boom", () => {
+        throw new Error("nope");
+      })
+      .onError((err, c) => respondError(c, err));
+    const res = await app.request("/boom", {}, {} as never);
+    expect(res.status).toBe(500);
+    expect(res.headers.get("Retry-After")).toBeNull();
+    expect(res.headers.get("X-Retry-After")).toBeNull();
+  });
+});

--- a/apps/api/src/read-limits.test.ts
+++ b/apps/api/src/read-limits.test.ts
@@ -66,8 +66,19 @@ describe("read tier classification", () => {
     expect(classifyLegacyListingRead({ prefix: "f/" })).toBe("normal");
     // Opt-in hydration, and the two shapes that switch to the D1 search path.
     expect(classifyLegacyListingRead({ metadata: "1" })).toBe("tight");
+    expect(classifyLegacyListingRead({ metadata: "true" })).toBe("tight");
     expect(classifyLegacyListingRead({ name: "shot" })).toBe("tight");
     expect(classifyLegacyListingRead({ "meta.path": "web/home" })).toBe("tight");
+  });
+
+  it("does not charge the tight tier for a metadata value the legacy route ignores", () => {
+    // `routes/files.ts` hydrates only on "1"/"true". Anything else leaves the
+    // response unhydrated, so it must not pay the hydrated limit.
+    expect(classifyLegacyListingRead({ metadata: "yes" })).toBe("normal");
+    expect(classifyLegacyListingRead({ metadata: "2" })).toBe("normal");
+    expect(classifyLegacyListingRead({ metadata: "" })).toBe("normal");
+    expect(classifyLegacyListingRead({ metadata: "0" })).toBe("normal");
+    expect(classifyLegacyListingRead({ metadata: "false" })).toBe("normal");
   });
 });
 

--- a/apps/api/src/read-limits.ts
+++ b/apps/api/src/read-limits.ts
@@ -104,16 +104,22 @@ export const listingReadRateLimit: MiddlewareHandler<WorkspaceVars> = async (c, 
 /**
  * Tier for the legacy bearer listing (`GET /v1/:workspace/files`), whose
  * metadata parameter runs the other way: that route lists from object storage
- * and hydrates only on `?metadata=1`, and switches to the D1 search path
- * entirely once any `meta.*` filter or `?name=` is present. Both of those are
- * the expensive shapes, so both pay the tight limit; a bare prefix list does
- * not.
+ * and hydrates only on `?metadata=1` or `?metadata=true`, and switches to the
+ * D1 search path entirely once any `meta.*` filter or `?name=` is present.
+ * Both of those are the expensive shapes, so both pay the tight limit; a bare
+ * prefix list does not.
+ *
+ * The hydration test is deliberately positive, matching `routes/files.ts`
+ * exactly. A negative test ("anything but 0/false opts in") would charge the
+ * tight limit for an unrecognized value like `?metadata=yes`, which that route
+ * ignores — the caller would pay the tighter bound without the work ever
+ * happening.
  */
 export function classifyLegacyListingRead(query: Record<string, string>): ReadTier {
   if (query.name !== undefined) return "tight";
   if (Object.keys(query).some((key) => key.startsWith("meta."))) return "tight";
   const metadata = query.metadata;
-  return metadata !== undefined && metadata !== "0" && metadata !== "false" ? "tight" : "normal";
+  return metadata === "1" || metadata === "true" ? "tight" : "normal";
 }
 
 export const legacyListingReadRateLimit: MiddlewareHandler<WorkspaceVars> = async (c, next) => {

--- a/apps/api/src/read-limits.ts
+++ b/apps/api/src/read-limits.ts
@@ -1,0 +1,122 @@
+/**
+ * Per-workspace read limiter (issue #829 §3).
+ *
+ * Authenticated reads previously had no rate limit of their own: the only
+ * per-workspace limiters were for mutations (`WRITE_LIMITER`), renders,
+ * poster generation, and public intake. Those quotas are untouched here — a
+ * read never consumes them, and a write never consumes a read budget.
+ *
+ * Two tiers, because the cost of a read varies by an order of magnitude:
+ *
+ *  - **normal** (`READ_LIMITER`): an object-store listing the caller asked
+ *    not to hydrate (`?metadata=0`), plus the cheap point reads on the files
+ *    vertical (`file-url`). One R2 list or one narrow lookup.
+ *  - **tight** (`HEAVY_READ_LIMITER`): metadata search, facet discovery, the
+ *    by-path grouping, and a metadata-hydrated listing. Each of these fans
+ *    out into D1 with per-row work proportional to the page, so they are the
+ *    shapes worth bounding separately.
+ *
+ * Classification is derived from the request, never from a caller-supplied
+ * hint: `?metadata=0`/`false` is the same opt-out `routes/workspace-files.ts`
+ * already honors for hydration (issue #829 §5), so an unhydrated listing pays
+ * the normal limit and a hydrated one pays the tight limit — the parameter
+ * that removes the work also removes the tighter bound.
+ *
+ * Both fail open when their binding is absent, matching every other limiter
+ * in `guards.ts` (a self-hoster may drop the block entirely).
+ */
+import type { MiddlewareHandler } from "hono";
+import { makeRateLimitGuard } from "./guards";
+import type { WorkspaceVars } from "./workspace";
+
+/**
+ * Window length of both read limiters, mirrored from their `simple.period` in
+ * `wrangler.jsonc`. Sizing lives there (the same mechanism every other
+ * limiter is configured through); this constant only feeds `Retry-After`.
+ */
+export const READ_LIMIT_WINDOW_SECONDS = 60;
+
+const normalGuard = makeRateLimitGuard("READ_LIMITER", "read rate limit exceeded", {
+  windowSeconds: READ_LIMIT_WINDOW_SECONDS,
+  code: "read_rate_limited",
+});
+
+const tightGuard = makeRateLimitGuard("HEAVY_READ_LIMITER", "read rate limit exceeded", {
+  windowSeconds: READ_LIMIT_WINDOW_SECONDS,
+  code: "read_rate_limited",
+});
+
+export const allowRead = normalGuard.allow;
+export const allowHeavyRead = tightGuard.allow;
+
+export type ReadTier = "normal" | "tight";
+
+/**
+ * Whether a canonical listing request asked for D1 metadata hydration.
+ * Mirrors the `metadata=0`/`metadata=false` opt-out in
+ * `routes/workspace-files.ts` exactly — the two must not drift, or a caller
+ * could pay the tight limit for work the handler skipped.
+ */
+export function listingIsHydrated(metadataParam: string | undefined): boolean {
+  return !(metadataParam === "0" || metadataParam === "false");
+}
+
+/** Which tier a canonical listing request falls into. */
+export function classifyListingRead(metadataParam: string | undefined): ReadTier {
+  return listingIsHydrated(metadataParam) ? "tight" : "normal";
+}
+
+function enforce(tier: ReadTier): MiddlewareHandler<WorkspaceVars> {
+  const guard = tier === "tight" ? tightGuard : normalGuard;
+  return async (c, next) => {
+    const env = c.env as never;
+    if (!(await guard.allow(env, c.get("workspaceName")))) guard.reject();
+    await next();
+  };
+}
+
+const normalMiddleware = enforce("normal");
+const tightMiddleware = enforce("tight");
+
+/**
+ * Cheap authenticated reads: point lookups on the files vertical. Mount after
+ * the auth middleware that sets `workspaceName`, so the bucket is
+ * per-workspace rather than global.
+ */
+export const readRateLimit: MiddlewareHandler<WorkspaceVars> = normalMiddleware;
+
+/**
+ * Always-expensive reads: search, facets, by-path grouping. Tier is fixed by
+ * the route, never inferred from the URL.
+ */
+export const heavyReadRateLimit: MiddlewareHandler<WorkspaceVars> = tightMiddleware;
+
+/**
+ * Canonical listing, whose tier depends on whether the caller asked for
+ * metadata hydration. `?metadata=0` drops it to the normal tier because the
+ * handler genuinely skips the D1 pass in that case.
+ */
+export const listingReadRateLimit: MiddlewareHandler<WorkspaceVars> = async (c, next) => {
+  const tier = classifyListingRead(c.req.query("metadata"));
+  return (tier === "tight" ? tightMiddleware : normalMiddleware)(c, next);
+};
+
+/**
+ * Tier for the legacy bearer listing (`GET /v1/:workspace/files`), whose
+ * metadata parameter runs the other way: that route lists from object storage
+ * and hydrates only on `?metadata=1`, and switches to the D1 search path
+ * entirely once any `meta.*` filter or `?name=` is present. Both of those are
+ * the expensive shapes, so both pay the tight limit; a bare prefix list does
+ * not.
+ */
+export function classifyLegacyListingRead(query: Record<string, string>): ReadTier {
+  if (query.name !== undefined) return "tight";
+  if (Object.keys(query).some((key) => key.startsWith("meta."))) return "tight";
+  const metadata = query.metadata;
+  return metadata !== undefined && metadata !== "0" && metadata !== "false" ? "tight" : "normal";
+}
+
+export const legacyListingReadRateLimit: MiddlewareHandler<WorkspaceVars> = async (c, next) => {
+  const tier = classifyLegacyListingRead(c.req.query());
+  return (tier === "tight" ? tightMiddleware : normalMiddleware)(c, next);
+};

--- a/apps/api/src/routes/abuse.ts
+++ b/apps/api/src/routes/abuse.ts
@@ -52,8 +52,10 @@ abuse.post("/", async (c) => {
     const ip = c.req.header("cf-connecting-ip") ?? "unknown";
     const { success } = await limiter.limit({ key: `abuse-report:${ip}` });
     if (!success) {
-      c.header("Retry-After", "60");
-      throw new RateLimitedError("too many reports; retry shortly");
+      // INVITE_LIMITER's window. `respondError` turns this into both
+      // `Retry-After` and the compat `X-Retry-After`, plus `retry_after` on
+      // the error body (issue #829 §3).
+      throw new RateLimitedError("too many reports; retry shortly", { retryAfterSeconds: 60 });
     }
   }
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -308,7 +308,11 @@ export const admin = new Hono<{ Bindings: Env }>()
       const limiter = c.env.INVITE_LIMITER;
       if (limiter) {
         const { success } = await limiter.limit({ key: `invite:email:${email.toLowerCase()}` });
-        if (!success) throw new RateLimitedError("invitation email rate limit exceeded");
+        if (!success) {
+          throw new RateLimitedError("invitation email rate limit exceeded", {
+            retryAfterSeconds: 60,
+          });
+        }
       }
     }
 

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -14,7 +14,9 @@ export const auth = new Hono<{ Bindings: Env }>()
       const address = c.req.header("CF-Connecting-IP") ?? "unknown";
       const operation = c.req.path.endsWith("/exchange") ? "exchange" : "lookup";
       const { success } = await limiter.limit({ key: `invite:${operation}:${address}` });
-      if (!success) throw new RateLimitedError("invitation rate limit exceeded");
+      if (!success) {
+        throw new RateLimitedError("invitation rate limit exceeded", { retryAfterSeconds: 60 });
+      }
     }
     await next();
   })

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -10,6 +10,7 @@ import {
 import { objectPublicUrls, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { writeRateLimit } from "../guards";
+import { heavyReadRateLimit, legacyListingReadRateLimit, readRateLimit } from "../read-limits";
 import {
   getFileHandler,
   patchFileHandler,
@@ -37,7 +38,7 @@ export const files = new Hono<WorkspaceVars>()
   // result to hydrate); callers needing the private marker must HEAD the
   // object. Meta-only responses omit `truncated` (pre-#528 shape); name
   // searches include it.
-  .get("/", requireScope("files:read"), async (c) => {
+  .get("/", legacyListingReadRateLimit, requireScope("files:read"), async (c) => {
     const query = c.req.query();
     const rawName = c.req.query("name");
     const nameTerm = rawName === undefined ? undefined : normalizeSearchName(rawName);
@@ -112,7 +113,7 @@ export const files = new Hono<WorkspaceVars>()
   // agents need this to discover what is filterable before calling find_files.
   // Static path must register before `/:key{.+}` so "facets" is not treated
   // as an object key.
-  .get("/facets", requireScope("files:read"), async (c) => {
+  .get("/facets", heavyReadRateLimit, requireScope("files:read"), async (c) => {
     return c.json(
       await boundedDataRead(
         c,
@@ -132,7 +133,7 @@ export const files = new Hono<WorkspaceVars>()
   // the deployed worker 404s on any real key. `?metadata=1` on GET and a bare
   // PATCH (which has no other meaning on this route) avoid the fragile
   // suffix pattern entirely.
-  .get("/:key{.+}", requireScope("files:read"), getFileHandler)
+  .get("/:key{.+}", readRateLimit, requireScope("files:read"), getFileHandler)
 
   .patch("/:key{.+}", writeRateLimit, requireScope("files:write"), patchFileHandler)
 

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -3215,3 +3215,65 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
     });
   });
 });
+
+describe("read rate limits on the canonical files vertical (issue #829 §3)", () => {
+  const R2 = {
+    provider: "r2",
+    bucket: "shared",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "acme/",
+    publicBaseUrl: "https://storage.uploads.sh",
+  };
+
+  function readEnv(overrides: Record<string, unknown>): Env {
+    const bucket = new FakeR2Bucket();
+    return {
+      ...memberEnv({ workspace: "acme", db: new UsageFakeD1(), bucket, record: R2 }),
+      ...overrides,
+    } as unknown as Env;
+  }
+
+  const refuse = { limit: async () => ({ success: false }) };
+  const allow = { limit: async () => ({ success: true }) };
+
+  it("429s a hydrated listing when the tight read limiter is over budget", async () => {
+    const env = readEnv({ HEAVY_READ_LIMITER: refuse, READ_LIMITER: allow });
+    const res = await app().request("/me/workspaces/acme/files", {}, env);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    expect(res.headers.get("X-Retry-After")).toBe("60");
+  });
+
+  it("serves the same listing with `metadata=0` — it pays the normal limit", async () => {
+    const env = readEnv({ HEAVY_READ_LIMITER: refuse, READ_LIMITER: allow });
+    const res = await app().request("/me/workspaces/acme/files?metadata=0", {}, env);
+    expect(res.status).toBe(200);
+  });
+
+  it("429s search, facets, and by-path on the tight limiter", async () => {
+    const env = readEnv({ HEAVY_READ_LIMITER: refuse, READ_LIMITER: allow });
+    for (const path of [
+      "/me/workspaces/acme/files/search?name=shot",
+      "/me/workspaces/acme/files/facets",
+      "/me/workspaces/acme/files/by-path",
+    ]) {
+      const res = await app().request(path, {}, env);
+      expect(res.status).toBe(429);
+    }
+  });
+
+  it("does not consume the write limiter on a read", async () => {
+    const seen: string[] = [];
+    const env = readEnv({
+      WRITE_LIMITER: {
+        limit: async ({ key }: { key: string }) => {
+          seen.push(key);
+          return { success: true };
+        },
+      },
+    });
+    const res = await app().request("/me/workspaces/acme/files", {}, env);
+    expect(res.status).toBe(200);
+    expect(seen).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -45,8 +45,7 @@ reports.post("/", async (c) => {
     const ip = c.req.header("cf-connecting-ip") ?? "unknown";
     const { success } = await limiter.limit({ key: `cli-report:${ip}` });
     if (!success) {
-      c.header("Retry-After", "60");
-      throw new RateLimitedError("too many reports; retry shortly");
+      throw new RateLimitedError("too many reports; retry shortly", { retryAfterSeconds: 60 });
     }
   }
 

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -45,8 +45,9 @@ telemetry.post("/", async (c) => {
     const ip = c.req.header("cf-connecting-ip") ?? "unknown";
     const { success } = await limiter.limit({ key: `cli-telemetry:${ip}` });
     if (!success) {
-      c.header("Retry-After", "60");
-      throw new RateLimitedError("too many telemetry events; retry shortly");
+      throw new RateLimitedError("too many telemetry events; retry shortly", {
+        retryAfterSeconds: 60,
+      });
     }
   }
 

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -52,6 +52,7 @@ import {
   searchFilesByNameAndMeta,
 } from "../file-search";
 import { writeRateLimit } from "../guards";
+import { heavyReadRateLimit, listingReadRateLimit, readRateLimit } from "../read-limits";
 import { memberWorkspaceOr404 } from "../org-workspaces";
 import type { SessionVars } from "../session-auth";
 import { objectPublicUrls, publicUrl, resolveObjectLane, storage, storageConfig } from "../storage";
@@ -73,6 +74,11 @@ function scoped(scope: Parameters<typeof requireScope>[0]): MiddlewareHandler<Du
   return requireScope(scope) as unknown as MiddlewareHandler<DualAuthVars>;
 }
 const rateLimited = writeRateLimit as unknown as MiddlewareHandler<DualAuthVars>;
+// Read-side limiters (issue #829 §3), cast for the same reason as `scoped`
+// above. `listingRead` picks its tier from `?metadata`; `heavyRead` is fixed.
+const listingRead = listingReadRateLimit as unknown as MiddlewareHandler<DualAuthVars>;
+const heavyRead = heavyReadRateLimit as unknown as MiddlewareHandler<DualAuthVars>;
+const pointRead = readRateLimit as unknown as MiddlewareHandler<DualAuthVars>;
 function shared(handler: SharedFilesHandler): Handler<DualAuthVars> {
   return handler as unknown as Handler<DualAuthVars>;
 }
@@ -114,7 +120,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // default. Response shape is unchanged either way: `metadata` is simply
   // `undefined` per item when hydration is skipped, same as it already is
   // for any key with no D1 metadata row.
-  .get("/:workspace/files", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
+  .get("/:workspace/files", dualWorkspaceAuth(), listingRead, scoped("files:read"), async (c) => {
     const record = c.get("workspace");
     const name = c.get("workspaceName");
     const { prefix, delimiter, cursor } = c.req.query();
@@ -150,90 +156,102 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // Metadata + filename search — AND-of-equality `meta.*` filters and/or a
   // `name` substring term. Results carry no `visibility` (not in the D1
   // index — accepted caveat, same as the pre-#613 session route).
-  .get("/:workspace/files/search", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
-    const record = c.get("workspace");
-    const name = c.get("workspaceName");
-    const query = c.req.query();
-    const rawName = c.req.query("name");
-    const nameTerm = rawName === undefined ? undefined : normalizeSearchName(rawName);
-    const filters = parseMetaQueryFilters(query, (param) => c.req.queries(param));
-    const hasMeta = Object.keys(filters).length > 0;
+  .get(
+    "/:workspace/files/search",
+    dualWorkspaceAuth(),
+    heavyRead,
+    scoped("files:read"),
+    async (c) => {
+      const record = c.get("workspace");
+      const name = c.get("workspaceName");
+      const query = c.req.query();
+      const rawName = c.req.query("name");
+      const nameTerm = rawName === undefined ? undefined : normalizeSearchName(rawName);
+      const filters = parseMetaQueryFilters(query, (param) => c.req.queries(param));
+      const hasMeta = Object.keys(filters).length > 0;
 
-    if (!hasMeta && nameTerm === undefined) {
-      throw new ValidationError("at least one meta.* filter or name is required", {
-        code: "file_metadata_invalid_key",
-      });
-    }
+      if (!hasMeta && nameTerm === undefined) {
+        throw new ValidationError("at least one meta.* filter or name is required", {
+          code: "file_metadata_invalid_key",
+        });
+      }
 
-    // `limit` narrows the page below the server cap (never raises it) — added
-    // for the bearer-find migration (#613), whose callers pass `--limit`.
-    const SEARCH_LIMIT = 100;
-    const rawLimit = Number(c.req.query("limit") ?? SEARCH_LIMIT) || SEARCH_LIMIT;
-    const pageSize = Math.min(Math.max(1, Math.floor(rawLimit)), SEARCH_LIMIT);
-    const cfg = await storageConfig(c.env, record);
-    // `collapse=promoted` drops promoted branch originals so the screenshots
-    // drill-in (?path=…) doesn't list a shot twice — once from its `branch/<b>/`
-    // key and once from the promoted `pull/<n>/` copy. Opt-in: a bare search
-    // (and the `find_files` tool) still returns every matching object.
-    const collapsePromotedShadows = c.req.query("collapse") === "promoted";
-    const { matches, truncated, cursor } = await boundedDataRead(
-      c,
-      () =>
-        searchFilesByNameAndMeta(c.env, record, name, {
-          filters: hasMeta ? filters : undefined,
-          nameTerm,
-          prefix: query.prefix,
-          pageSize,
-          collapsePromotedShadows,
-          ...(query.cursor ? { cursor: query.cursor } : {}),
+      // `limit` narrows the page below the server cap (never raises it) — added
+      // for the bearer-find migration (#613), whose callers pass `--limit`.
+      const SEARCH_LIMIT = 100;
+      const rawLimit = Number(c.req.query("limit") ?? SEARCH_LIMIT) || SEARCH_LIMIT;
+      const pageSize = Math.min(Math.max(1, Math.floor(rawLimit)), SEARCH_LIMIT);
+      const cfg = await storageConfig(c.env, record);
+      // `collapse=promoted` drops promoted branch originals so the screenshots
+      // drill-in (?path=…) doesn't list a shot twice — once from its `branch/<b>/`
+      // key and once from the promoted `pull/<n>/` copy. Opt-in: a bare search
+      // (and the `find_files` tool) still returns every matching object.
+      const collapsePromotedShadows = c.req.query("collapse") === "promoted";
+      const { matches, truncated, cursor } = await boundedDataRead(
+        c,
+        () =>
+          searchFilesByNameAndMeta(c.env, record, name, {
+            filters: hasMeta ? filters : undefined,
+            nameTerm,
+            prefix: query.prefix,
+            pageSize,
+            collapsePromotedShadows,
+            ...(query.cursor ? { cursor: query.cursor } : {}),
+          }),
+        { name: "d1_files_search" },
+      );
+      // Upload time per match so the screenshots drill-in pop-over can show it
+      // (the grouped by-path route surfaces the same via `updatedAt`).
+      const updatedByKey = await boundedDataRead(
+        c,
+        () =>
+          getObjectUpdatedAt(
+            dbFor(c.env),
+            name,
+            matches.map((m) => m.key),
+          ),
+        { name: "d1_files_updated_at" },
+      );
+
+      return c.json({
+        items: matches.map((match) => {
+          const urls = objectPublicUrls(c.env, cfg, match.key);
+          const updatedAt = updatedByKey.get(match.key);
+          return {
+            key: match.key,
+            url: urls.url,
+            embedUrl: urls.embedUrl,
+            metadata: match.metadata,
+            ...(updatedAt !== undefined ? { updatedAt } : {}),
+          };
         }),
-      { name: "d1_files_search" },
-    );
-    // Upload time per match so the screenshots drill-in pop-over can show it
-    // (the grouped by-path route surfaces the same via `updatedAt`).
-    const updatedByKey = await boundedDataRead(
-      c,
-      () =>
-        getObjectUpdatedAt(
-          dbFor(c.env),
-          name,
-          matches.map((m) => m.key),
-        ),
-      { name: "d1_files_updated_at" },
-    );
-
-    return c.json({
-      items: matches.map((match) => {
-        const urls = objectPublicUrls(c.env, cfg, match.key);
-        const updatedAt = updatedByKey.get(match.key);
-        return {
-          key: match.key,
-          url: urls.url,
-          embedUrl: urls.embedUrl,
-          metadata: match.metadata,
-          ...(updatedAt !== undefined ? { updatedAt } : {}),
-        };
-      }),
-      truncated,
-      // Additive continuation (issue #829 §4): opaque, non-null exactly when
-      // `truncated` is true. Hand it back as `?cursor=` for the next page.
-      cursor,
-    });
-  })
+        truncated,
+        // Additive continuation (issue #829 §4): opaque, non-null exactly when
+        // `truncated` is true. Hand it back as `?cursor=` for the next page.
+        cursor,
+      });
+    },
+  )
 
   // Facet discovery for the files filter bar: which metadata keys this
   // workspace actually contains, and (with `?key=`) that key's values.
-  .get("/:workspace/files/facets", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
-    return c.json(
-      await boundedDataRead(
-        c,
-        () => listFacets(dbFor(c.env), c.get("workspaceName"), c.req.query("key")),
-        {
-          name: "d1_files_facets",
-        },
-      ),
-    );
-  })
+  .get(
+    "/:workspace/files/facets",
+    dualWorkspaceAuth(),
+    heavyRead,
+    scoped("files:read"),
+    async (c) => {
+      return c.json(
+        await boundedDataRead(
+          c,
+          () => listFacets(dbFor(c.env), c.get("workspaceName"), c.req.query("key")),
+          {
+            name: "d1_files_facets",
+          },
+        ),
+      );
+    },
+  )
 
   // Recent uploads grouped by their `path` metadata value — the screenshots
   // page's single overview query (spec: docs/superpowers/specs/
@@ -247,90 +265,96 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // leaks into the payload. Enrichment stays scoped to the thumbed groups'
   // keys plus `latest`, so the catalog's growth never widens the two D1
   // enrichment queries; catalog-only strips carry key/url/embedUrl alone.
-  .get("/:workspace/files/by-path", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
-    const record = c.get("workspace");
-    const name = c.get("workspaceName");
-    // Opt-in "Merged only" filter (Screenshots page toggle) — leaves the
-    // default (unfiltered) overview and general `meta.gh.merged=` search
-    // semantics untouched.
-    const mergedOnly = c.req.query("merged") === "1";
-    const { groups, catalog, projects, latest, truncated, catalogTruncated } =
-      await boundedDataRead(c, () => groupObjectsByPath(dbFor(c.env), name, { mergedOnly }), {
-        name: "d1_screenshots_by_path",
-      });
-    const shotKeys = [
-      ...groups.flatMap((group) => group.recent),
-      ...latest.map((item) => item.key),
-    ];
-    // `gh.ref` lets the pop-over resolve live PR/issue status via /github/titles;
-    // `updatedAt` gives it the shot's upload time (the `latest` feed already
-    // carries `uploadedAt`, this brings the same to the grouped `recent` strips).
-    const metaByKey = await boundedDataRead(
-      c,
-      () =>
-        getMetadataForKeys(dbFor(c.env), name, shotKeys, {
-          metaKeys: ["state", "gh.kind", "gh.number", "gh.ref"],
-        }),
-      { name: "d1_files_meta" },
-    );
-    const updatedByKey = await boundedDataRead(
-      c,
-      () => getObjectUpdatedAt(dbFor(c.env), name, shotKeys),
-      { name: "d1_files_updated_at" },
-    );
-    const cfg = await storageConfig(c.env, record);
-    const shotItem = (key: string) => {
-      const urls = objectPublicUrls(c.env, cfg, key);
-      const meta = metaByKey.get(key);
-      const state = meta?.state;
-      const ghKind = meta?.["gh.kind"];
-      const ghNumber = meta?.["gh.number"];
-      const ghRef = meta?.["gh.ref"];
-      const updatedAt = updatedByKey.get(key);
-      return {
-        key,
-        url: urls.url,
-        embedUrl: urls.embedUrl,
-        ...(state !== undefined ? { state } : {}),
-        ...(ghKind !== undefined ? { ghKind } : {}),
-        ...(ghNumber !== undefined ? { ghNumber } : {}),
-        ...(ghRef !== undefined ? { ghRef } : {}),
-        ...(updatedAt !== undefined ? { updatedAt } : {}),
+  .get(
+    "/:workspace/files/by-path",
+    dualWorkspaceAuth(),
+    heavyRead,
+    scoped("files:read"),
+    async (c) => {
+      const record = c.get("workspace");
+      const name = c.get("workspaceName");
+      // Opt-in "Merged only" filter (Screenshots page toggle) — leaves the
+      // default (unfiltered) overview and general `meta.gh.merged=` search
+      // semantics untouched.
+      const mergedOnly = c.req.query("merged") === "1";
+      const { groups, catalog, projects, latest, truncated, catalogTruncated } =
+        await boundedDataRead(c, () => groupObjectsByPath(dbFor(c.env), name, { mergedOnly }), {
+          name: "d1_screenshots_by_path",
+        });
+      const shotKeys = [
+        ...groups.flatMap((group) => group.recent),
+        ...latest.map((item) => item.key),
+      ];
+      // `gh.ref` lets the pop-over resolve live PR/issue status via /github/titles;
+      // `updatedAt` gives it the shot's upload time (the `latest` feed already
+      // carries `uploadedAt`, this brings the same to the grouped `recent` strips).
+      const metaByKey = await boundedDataRead(
+        c,
+        () =>
+          getMetadataForKeys(dbFor(c.env), name, shotKeys, {
+            metaKeys: ["state", "gh.kind", "gh.number", "gh.ref"],
+          }),
+        { name: "d1_files_meta" },
+      );
+      const updatedByKey = await boundedDataRead(
+        c,
+        () => getObjectUpdatedAt(dbFor(c.env), name, shotKeys),
+        { name: "d1_files_updated_at" },
+      );
+      const cfg = await storageConfig(c.env, record);
+      const shotItem = (key: string) => {
+        const urls = objectPublicUrls(c.env, cfg, key);
+        const meta = metaByKey.get(key);
+        const state = meta?.state;
+        const ghKind = meta?.["gh.kind"];
+        const ghNumber = meta?.["gh.number"];
+        const ghRef = meta?.["gh.ref"];
+        const updatedAt = updatedByKey.get(key);
+        return {
+          key,
+          url: urls.url,
+          embedUrl: urls.embedUrl,
+          ...(state !== undefined ? { state } : {}),
+          ...(ghKind !== undefined ? { ghKind } : {}),
+          ...(ghNumber !== undefined ? { ghNumber } : {}),
+          ...(ghRef !== undefined ? { ghRef } : {}),
+          ...(updatedAt !== undefined ? { updatedAt } : {}),
+        };
       };
-    };
 
-    return c.json({
-      groups: groups.map((group) => ({
-        project: group.project,
-        path: group.path,
-        count: group.count,
-        lastUpdated: group.lastUpdated,
-        recent: group.recent.map(shotItem),
-      })),
-      // Every catalog entry carries its own (shorter) strip, so the page can
-      // render thumbs for groups past the thumbed cap without fetching one
-      // search per group. Those keys are NOT metadata-enriched (see above):
-      // `objectPublicUrls` is pure computation, so this costs no extra D1.
-      catalog: catalog.map((entry) => ({
-        project: entry.project,
-        path: entry.path,
-        count: entry.count,
-        lastUpdated: entry.lastUpdated,
-        recent: entry.recent.map(shotItem),
-      })),
-      projects,
-      // Flat newest-first feed (the "Recent" view) — same item shape as
-      // `recent`, plus which (project, path) each shot belongs to.
-      latest: latest.map((item) => ({
-        ...shotItem(item.key),
-        project: item.project,
-        path: item.path,
-        uploadedAt: item.uploadedAt,
-      })),
-      truncated,
-      catalogTruncated,
-    });
-  })
+      return c.json({
+        groups: groups.map((group) => ({
+          project: group.project,
+          path: group.path,
+          count: group.count,
+          lastUpdated: group.lastUpdated,
+          recent: group.recent.map(shotItem),
+        })),
+        // Every catalog entry carries its own (shorter) strip, so the page can
+        // render thumbs for groups past the thumbed cap without fetching one
+        // search per group. Those keys are NOT metadata-enriched (see above):
+        // `objectPublicUrls` is pure computation, so this costs no extra D1.
+        catalog: catalog.map((entry) => ({
+          project: entry.project,
+          path: entry.path,
+          count: entry.count,
+          lastUpdated: entry.lastUpdated,
+          recent: entry.recent.map(shotItem),
+        })),
+        projects,
+        // Flat newest-first feed (the "Recent" view) — same item shape as
+        // `recent`, plus which (project, path) each shot belongs to.
+        latest: latest.map((item) => ({
+          ...shotItem(item.key),
+          project: item.project,
+          path: item.path,
+          uploadedAt: item.uploadedAt,
+        })),
+        truncated,
+        catalogTruncated,
+      });
+    },
+  )
 
   // Resolve a selected file to a usable URL (issue #613 wart fix: this used
   // to live outside `files/`, at `/me/workspaces/:name/file-url`). Public URL
@@ -342,24 +366,30 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // before a storage switch) still gets a usable URL — the public URL, or the
   // signed URL, is minted against the lane that actually holds the object,
   // not the workspace's current active lane.
-  .get("/:workspace/files/file-url", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
-    const record = c.get("workspace");
-    const key = c.req.query("key") ?? "";
-    if (badKey(key)) throw new NotFoundError();
-    const lane = await resolveObjectLane(c.env, record, key);
-    if (!lane) throw new NotFoundError();
+  .get(
+    "/:workspace/files/file-url",
+    dualWorkspaceAuth(),
+    pointRead,
+    scoped("files:read"),
+    async (c) => {
+      const record = c.get("workspace");
+      const key = c.req.query("key") ?? "";
+      if (badKey(key)) throw new NotFoundError();
+      const lane = await resolveObjectLane(c.env, record, key);
+      if (!lane) throw new NotFoundError();
 
-    const url = publicUrl(lane.config, key);
-    if (url) return c.json({ url });
+      const url = publicUrl(lane.config, key);
+      if (url) return c.json({ url });
 
-    const signed = await signedDownloadUrl(lane.store, key);
-    if (signed) return c.json({ url: signed });
+      const signed = await signedDownloadUrl(lane.store, key);
+      if (signed) return c.json({ url: signed });
 
-    throw new ValidationError(
-      "no public or signed URL available for this workspace's storage configuration",
-      { code: "file_url_unavailable" },
-    );
-  })
+      throw new ValidationError(
+        "no public or signed URL available for this workspace's storage configuration",
+        { code: "file_url_unavailable" },
+      );
+    },
+  )
 
   // Toggle a file's `visibility` custom-metadata flag. See the module
   // docblock above for why the key stays a query param here.
@@ -436,6 +466,7 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   .get(
     "/:workspace/files/:key{.+}",
     dualWorkspaceAuth(),
+    pointRead,
     scoped("files:read"),
     shared(getFileHandler),
   )

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -170,7 +170,9 @@ export const workspaces = new Hono<SessionVars>().post(
     // create cap) rather than the shared WRITE_LIMITER — that keeps
     // concurrent requests from racing past the per-user cap check below.
     if (!(await allowWorkspaceCreate(c.env, user.id))) {
-      throw new RateLimitedError("workspace creation rate limit exceeded");
+      throw new RateLimitedError("workspace creation rate limit exceeded", {
+        retryAfterSeconds: 60,
+      });
     }
 
     if (!(await isGithubLinked(c.env, user.id))) {
@@ -443,7 +445,9 @@ workspaces.post("/:name/invites", dualGovernanceAuth("workspace:invite"), async 
   const limiter = c.env.INVITE_LIMITER;
   if (limiter) {
     const { success } = await limiter.limit({ key: `invite:email:${email}` });
-    if (!success) throw new RateLimitedError("invite rate limit exceeded");
+    if (!success) {
+      throw new RateLimitedError("invite rate limit exceeded", { retryAfterSeconds: 60 });
+    }
   }
 
   const response = await c.env.AUTH.fetch("https://auth.internal/internal/invite", {

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -227,6 +227,37 @@
           "period": 60,
         },
       },
+      {
+        // Authenticated reads, keyed by workspace (issue #829 §3). Entirely
+        // separate from WRITE_LIMITER so a read burst can never spend a
+        // workspace's write budget or vice versa. Sized well above what the
+        // signed-in web app and the CLI produce — a workspace page load is a
+        // handful of reads, and this allows dozens of full page loads per
+        // second before anything is refused. The bound exists to stop a
+        // scripted loop, not to pace the product.
+        "name": "READ_LIMITER",
+        "type": "ratelimit",
+        "namespace_id": "1006",
+        "simple": {
+          "limit": 2400,
+          "period": 60,
+        },
+      },
+      {
+        // Expensive read shapes only: search, facets, by-path grouping, and
+        // metadata-hydrated listings (see read-limits.ts). Tighter than
+        // READ_LIMITER because each of these fans out into D1 with per-row
+        // work; still generous enough that the screenshots page, the file
+        // table, and `uploads find` paging through a large result set all sit
+        // far below it.
+        "name": "HEAVY_READ_LIMITER",
+        "type": "ratelimit",
+        "namespace_id": "1007",
+        "simple": {
+          "limit": 600,
+          "period": 60,
+        },
+      },
     ],
   },
   // Transactional email (Cloudflare Email Sending). uploads.sh is onboarded for
@@ -402,6 +433,22 @@
         "namespace_id": "1005",
         "simple": {
           "limit": 30,
+          "period": 60,
+        },
+      },
+      {
+        "name": "READ_LIMITER",
+        "namespace_id": "1006",
+        "simple": {
+          "limit": 2400,
+          "period": 60,
+        },
+      },
+      {
+        "name": "HEAVY_READ_LIMITER",
+        "namespace_id": "1007",
+        "simple": {
+          "limit": 600,
           "period": 60,
         },
       },

--- a/docs/api.md
+++ b/docs/api.md
@@ -289,9 +289,8 @@ policy checks; presign uses the same finalization as put.
 
 ### Rate limits
 
-Bursts are bounded per workspace, in separate budgets that never draw from one
-another — a read cannot exhaust a write allowance, and vice versa. Reads have
-two tiers:
+Bursts are bounded per workspace. Each budget is separate and never draws from
+another, so a read cannot exhaust a write allowance. Reads have two tiers:
 
 | Tier   | Applies to                                                                      |
 | ------ | ------------------------------------------------------------------------------- |
@@ -299,25 +298,32 @@ two tiers:
 | tight  | `files/search`, `files/facets`, `files/by-path`, a metadata-hydrated listing    |
 
 The tight tier exists because those shapes fan out with per-row work. A listing
-that skips hydration also skips the tighter bound, so a caller that discards
-metadata pays neither cost. Writes, renders, poster generation, and the public
-intake endpoints keep their own separate budgets, unchanged.
+that skips hydration also skips the tighter bound. A caller that discards
+metadata therefore pays neither cost. Writes, renders, poster generation, and
+the public intake endpoints keep their own separate budgets, unchanged.
 
-Both tiers are sized well above normal application and CLI traffic — they exist
+Both tiers are sized well above normal application and CLI traffic. They exist
 to stop a runaway loop, not to pace ordinary use.
 
-A refused request answers `429` with `type: rate_limited` and:
+A request refused by one of these burst limiters answers `429` with
+`type: rate_limited` and:
 
 - `Retry-After` — seconds to wait, the standard header.
 - `X-Retry-After` — the same value, kept for compatibility with callers that
   read the older spelling.
 - `error.details.retry_after` — the same value on the body.
 
-Waiting that long is always sufficient. No `RateLimit-Limit`,
-`RateLimit-Remaining`, or `RateLimit-Reset` header is sent: the underlying
-limiter reports only whether a request was allowed, so there is no accurate
-quota or reset instant to publish, and a fabricated one would make clients back
-off at the wrong time.
+Waiting that long is always sufficient.
+
+Not every `429` carries that metadata. `upload_budget_exceeded` reports a
+monthly budget rather than a burst, and it recovers at the start of the next
+UTC calendar month rather than after a countable delay. It therefore omits both
+headers and `retry_after` instead of publishing a figure it cannot compute.
+
+No `RateLimit-Limit`, `RateLimit-Remaining`, or `RateLimit-Reset` header is sent
+on any response. The underlying limiter reports only whether a request was
+allowed, so there is no accurate quota or reset instant to publish. A fabricated
+one would make clients back off at the wrong time.
 
 ### Maintenance operations
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -252,6 +252,38 @@ Configure limits with `pnpm workspace:limits <name> …` (see
 [workspaces](workspaces.md)). Bare keys are rewritten to `f/<id>/<name>` before
 policy checks; presign uses the same finalization as put.
 
+### Rate limits
+
+Bursts are bounded per workspace, in separate budgets that never draw from one
+another — a read cannot exhaust a write allowance, and vice versa. Reads have
+two tiers:
+
+| Tier   | Applies to                                                                      |
+| ------ | ------------------------------------------------------------------------------- |
+| normal | A listing you asked not to hydrate (`?metadata=0`), `file-url`, a single object |
+| tight  | `files/search`, `files/facets`, `files/by-path`, a metadata-hydrated listing    |
+
+The tight tier exists because those shapes fan out with per-row work. A listing
+that skips hydration also skips the tighter bound, so a caller that discards
+metadata pays neither cost. Writes, renders, poster generation, and the public
+intake endpoints keep their own separate budgets, unchanged.
+
+Both tiers are sized well above normal application and CLI traffic — they exist
+to stop a runaway loop, not to pace ordinary use.
+
+A refused request answers `429` with `type: rate_limited` and:
+
+- `Retry-After` — seconds to wait, the standard header.
+- `X-Retry-After` — the same value, kept for compatibility with callers that
+  read the older spelling.
+- `error.details.retry_after` — the same value on the body.
+
+Waiting that long is always sufficient. No `RateLimit-Limit`,
+`RateLimit-Remaining`, or `RateLimit-Reset` header is sent: the underlying
+limiter reports only whether a request was allowed, so there is no accurate
+quota or reset instant to publish, and a fabricated one would make clients back
+off at the wrong time.
+
 ### Maintenance operations
 
 **Reconcile (potentially expensive).** This operation scans every object under


### PR DESCRIPTION
Implements §3 of #829, "Bound expensive reads and improve 429s".

## Read limiter

Authenticated reads had no rate limit of their own — the only per-workspace
limiters covered mutations, renders, poster generation, and public intake.
This adds a read-side limiter in two tiers, keyed by workspace, entirely
separate from those budgets: a read never spends a write allowance and a write
never spends a read allowance.

| Tier                          | Applies to                                                                     |
| ----------------------------- | ------------------------------------------------------------------------------ |
| `READ_LIMITER` (2400/60s)     | A listing the caller opted out of hydrating (`?metadata=0`), `file-url`, a single object read |
| `HEAVY_READ_LIMITER` (600/60s) | `files/search`, `files/facets`, `files/by-path`, a metadata-hydrated listing   |

The tight tier is the set of shapes that fan out into D1 with per-row work.
Classification is derived from the request, never from a caller-supplied hint:
`?metadata=0` is the same opt-out the canonical listing already honors for
hydration (#837), so the parameter that removes the work also removes the
tighter bound — an unhydrated list does not pay the hydrated limit. The legacy
bearer listing is classified by its own inverted contract (`?metadata=1`
opts *in*, and any `meta.*` filter or `?name=` switches it to the D1 search
path), so both of its expensive shapes land in the tight tier and a bare prefix
list does not.

Limits live in `wrangler.jsonc` alongside every other limiter (production
`unsafe.bindings` and the previews `ratelimits` block), which is the existing
mechanism for changing them. Both fail open when the binding is absent, matching
`WRITE_LIMITER`/`RENDER_LIMITER`.

### Why these numbers are safe for current traffic

Sized well above observed legitimate use, because the point is bounding a
runaway loop rather than pacing the product:

- The signed-in web app's heaviest page (screenshots) is one `by-path` fetch
  plus facet lookups per load — a handful of tight-tier reads. 600/60s leaves
  room for many simultaneous members reloading continuously. The internal
  fan-out that tripped auth limits in #797 was removed there (by-path strips
  replaced the per-group search fan-out), so no page issues a per-item read
  burst today.
- The CLI's paged search (`uploads find`, cursor pagination from §4) tops out at
  100 results per request; 600 requests/minute is far more paging than any
  interactive or scripted use produces.
- The normal tier at 2400/60s is 40 reads/second sustained for one workspace.
- Every write, render, poster, and public-intake quota is unchanged.

## 429 semantics

Retry metadata is now emitted from one place — the API's error boundary — for
every rate-limit error, instead of a handful of routes setting a header by hand:

- `Retry-After` — the standard header (RFC 9110), in seconds.
- `X-Retry-After` — the same value, kept for compatibility. Better Auth uses
  this spelling and the shipped client reads both (`packages/uploads/src/client.ts`
  already falls back across the pair — verified, unchanged).
- `error.details.retry_after` — the same value on the body.

The value is the limiter's configured window, which is honest: waiting one full
window is always sufficient. Rate-limit errors that genuinely have no figure
(the monthly upload budget) emit no header rather than a guess.

**No `RateLimit-Limit` / `-Remaining` / `-Reset`.** A Cloudflare `RateLimit`
binding's `limit()` returns `{ success }` and nothing else, so there is no
accurate quota, remaining count, or reset instant available to report. Emitting
a fabricated one would make clients back off at the wrong time; a test asserts
the headers stay absent so a future change has to make that call deliberately.

## Tests

`pnpm test` from root: 343 files, 5155 tests passing. New coverage:

- `apps/api/src/read-limits.test.ts` — tier classification (canonical and
  legacy listings), per-workspace keying, tight-vs-normal routing, fail-open,
  write limiter untouched by reads, and the full 429 contract including the
  absence of limit/remaining/reset headers.
- `apps/api/src/routes/me.test.ts` — end-to-end through the real routes: a
  hydrated listing 429s with both headers while the same listing with
  `?metadata=0` succeeds; search, facets, and by-path 429 on the tight limiter;
  a read consumes no write budget.

`apps/api` typechecks; oxfmt clean.

## Not included

- No `packages/uploads` change, so no changeset: the client already read both
  header spellings and its behavior is unaffected.
- The MCP worker's read tools are not wired to the new limiter — it has its own
  binding set and reaches storage through a different path. Worth a follow-up if
  it should share the budget.
- OpenAPI is untouched here to avoid colliding with the §1 contract work; the
  narrative reference (`docs/api.md`) gains a "Rate limits" section.

Refs #829 §3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-workspace rate limits for standard and resource-intensive read operations.
  - Added retry guidance to rate-limit responses through response headers and error details.
  - Applied read limits to listings, searches, facets, grouped views, file retrieval, and related endpoints.

- **Documentation**
  - Documented read-limit tiers, affected operations, and the 429 response format.

- **Bug Fixes**
  - Standardized rate-limit responses with consistent 60-second retry information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->