### PR TITLE
GA the BYO-bucket surface: gate on by default, unmetered-storage notes

### DIFF
--- a/.changeset/byo-usage-unmetered-note.md
+++ b/.changeset/byo-usage-unmetered-note.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads usage` is BYO-bucket aware: when a workspace's own bucket is active, the storage meter counts only hosted-storage residue (the number the quota actually enforces) and a note explains that storage in your own bucket is unmetered.

--- a/apps/api/src/budget.test.ts
+++ b/apps/api/src/budget.test.ts
@@ -171,11 +171,13 @@ describe("usageWithLimits — storage fields use the active lane's budget attrib
     });
     expect(out.maxStorageBytes).toBe(1_000);
     expect(out.storageRemainingBytes).toBe(100);
+    expect(out.storageBudgetBasis).toBe("shared");
   });
 
   it("includes maxStorageBytes/storageRemainingBytes for a shared-bucket record", () => {
     const out = usageWithLimits(usage, { maxStorageBytes: 1_000 });
     expect(out.maxStorageBytes).toBe(1_000);
     expect(out.storageRemainingBytes).toBe(100);
+    expect(out.storageBudgetBasis).toBe("total");
   });
 });

--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -226,6 +226,13 @@ export function usageWithLimits(usage: WorkspaceUsage, limits: WorkspaceBudgetLi
     uploadsInPeriod: usage.uploadsInPeriod,
     periodStart: usage.periodStart,
     updatedAt: usage.updatedAt,
+    // Which usage number the storage cap is enforced against: "total" for a
+    // shared/hosted lane, "shared" for a BYO-active workspace where only
+    // hosted-storage residue is metered (BYO bytes are the customer's own
+    // bill). Lets clients render an honest meter + "your bucket is
+    // unmetered" note instead of comparing total bytes to a cap that
+    // doesn't apply to them.
+    storageBudgetBasis: storageBudgetApplies(limits) ? "total" : "shared",
   };
 
   if (maxStorageBytes !== undefined && usageBytes !== undefined) {

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -874,7 +874,8 @@ describe("workspace storage admin panel (issue #583 Task 3.3)", () => {
     expect(await res.json()).toEqual({
       workspace: "acme",
       mode: "shared",
-      byoBucketEnabled: false,
+      // GA default-on: an absent flag reports the surface as enabled.
+      byoBucketEnabled: true,
       bucket: "uploads-default",
       publicBaseUrl: undefined,
       accountIdMasked: undefined,

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -356,6 +356,7 @@ describe("GET /me/workspaces/:name/usage", () => {
       updatedAt: "2026-07-10T00:00:00.000Z",
       maxStorageBytes: 1000,
       storageRemainingBytes: 500,
+      storageBudgetBasis: "total",
       scopes: ["files:read", "files:write", "files:delete"],
       plan: "free",
     });
@@ -2735,7 +2736,10 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
 
   describe("GET /me/workspaces/:name/storage", () => {
     it("is readable even when byoBucketEnabled is off, reporting shared mode", async () => {
-      const { env } = storageEnv({ role: "admin", record: SHARED_RECORD });
+      const { env } = storageEnv({
+        role: "admin",
+        record: { ...SHARED_RECORD, byoBucketEnabled: false },
+      });
       const res = await app().request("/me/workspaces/acme/storage", {}, env);
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({
@@ -2777,8 +2781,11 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
   });
 
   describe("POST /me/workspaces/:name/storage/verify", () => {
-    it("403s (byo_bucket_disabled) when the workspace flag is off", async () => {
-      const { env } = storageEnv({ role: "owner", record: SHARED_RECORD });
+    it("403s (byo_bucket_disabled) when the workspace flag is explicitly off", async () => {
+      const { env } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: false },
+      });
       const res = await app().request(
         "/me/workspaces/acme/storage/verify",
         {
@@ -2841,8 +2848,11 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
       secretAccessKey: "s3cr3t",
     };
 
-    it("403s (byo_bucket_disabled) when the workspace flag is off", async () => {
-      const { env } = storageEnv({ role: "owner", record: SHARED_RECORD });
+    it("403s (byo_bucket_disabled) when the workspace flag is explicitly off", async () => {
+      const { env } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: false },
+      });
       const res = await app().request(
         "/me/workspaces/acme/storage/buckets",
         {
@@ -2910,8 +2920,11 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
   });
 
   describe("PUT /me/workspaces/:name/storage", () => {
-    it("403s (byo_bucket_disabled) when the workspace flag is off", async () => {
-      const { env } = storageEnv({ role: "owner", record: SHARED_RECORD });
+    it("403s (byo_bucket_disabled) when the workspace flag is explicitly off", async () => {
+      const { env } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: false },
+      });
       const res = await app().request(
         "/me/workspaces/acme/storage",
         {
@@ -3117,8 +3130,11 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
   });
 
   describe("DELETE /me/workspaces/:name/storage", () => {
-    it("403s (byo_bucket_disabled) when the workspace flag is off", async () => {
-      const { env } = storageEnv({ role: "owner", record: SHARED_RECORD });
+    it("403s (byo_bucket_disabled) when the workspace flag is explicitly off", async () => {
+      const { env } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: false },
+      });
       const res = await app().request("/me/workspaces/acme/storage", { method: "DELETE" }, env);
       expect(res.status).toBe(403);
     });

--- a/apps/api/src/workspace.test.ts
+++ b/apps/api/src/workspace.test.ts
@@ -129,16 +129,16 @@ describe("isUnprefixedDedicatedBucket (#583 lifecycle guards)", () => {
   });
 });
 
-describe("byoBucketAllowed (#583 Task 1.3 feature gate)", () => {
-  it("is false when byoBucketEnabled is absent (fail-closed default)", () => {
-    expect(byoBucketAllowed({})).toBe(false);
+describe("byoBucketAllowed (#583 Task 1.3 feature gate, GA default-on)", () => {
+  it("is true when byoBucketEnabled is absent (GA default)", () => {
+    expect(byoBucketAllowed({})).toBe(true);
   });
 
-  it("is false when byoBucketEnabled is explicitly false", () => {
+  it("is false only when byoBucketEnabled is explicitly false (operator kill switch)", () => {
     expect(byoBucketAllowed({ byoBucketEnabled: false })).toBe(false);
   });
 
-  it("is true only when byoBucketEnabled is explicitly true", () => {
+  it("is true when byoBucketEnabled is explicitly true", () => {
     expect(byoBucketAllowed({ byoBucketEnabled: true })).toBe(true);
   });
 });

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -305,16 +305,14 @@ export function newLaneId(): string {
 }
 
 /**
- * Fail-closed gate for the self-serve BYO-bucket surface (issue #583 Task
- * 1.3): only an explicit `true` unlocks it. Undefined, false, or any other
- * value is treated as blocked — same posture as `posterGenerationAllowed`'s
- * kill switches (`apps/api/src/poster.ts`), chosen because losing access to
- * an unshipped surface costs nothing, while accidentally exposing
- * customer-credential storage config to a workspace that was never enabled
- * for it would be a real incident. Only an operator can flip this today.
+ * Gate for the self-serve BYO-bucket surface (issue #583 Task 1.3). GA'd
+ * 2026-08-24: on by default for every workspace — only an operator-set
+ * explicit `false` (the admin panel's Storage toggle) blocks it, kept as a
+ * per-workspace kill switch. Plan-level gating, if a billing decision ever
+ * wants it, goes through `planAllowsByoBucket` (@uploads/billing), not here.
  */
 export function byoBucketAllowed(record: Pick<WorkspaceRecord, "byoBucketEnabled">): boolean {
-  return record.byoBucketEnabled === true;
+  return record.byoBucketEnabled !== false;
 }
 
 /**

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -408,8 +408,11 @@ describe("storage vertical (self-serve BYO bucket)", () => {
   });
 
   describe("POST /v1/workspaces/:workspace/storage/verify", () => {
-    it("403s (byo_bucket_disabled) when the workspace flag is off", async () => {
-      const { env } = makeEnv({ role: "owner", record: SHARED_RECORD });
+    it("403s (byo_bucket_disabled) when the workspace flag is explicitly off", async () => {
+      const { env } = makeEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: false },
+      });
       const res = await app.request(
         "/v1/workspaces/acme/storage/verify",
         {

--- a/apps/web/src/content/changelog/byo-bucket.md
+++ b/apps/web/src/content/changelog/byo-bucket.md
@@ -1,0 +1,25 @@
+---
+title: "Bring your own bucket"
+date: 2026-08-24
+tags: [platform, web]
+---
+
+You can now point any workspace at your own storage bucket. Files upload
+straight to a bucket you own, serve from your own domain, and stay yours —
+uploads.sh keeps only encrypted credentials and a pointer, never a copy.
+
+We're starting with Cloudflare R2; more S3-compatible providers are on the
+roadmap. Available to every workspace, on any plan, and storage in your own
+bucket is unmetered — the plan's storage limit only counts files on hosted
+storage.
+
+Setup takes a few minutes from your workspace's **Settings → Storage** page:
+create an R2 bucket, scope an API token to it, give it a custom domain, and
+paste the three into one form. Verifying and saving never moves anything —
+your bucket sits ready until you click **Use this bucket**, and switching is
+instant and reversible either way: existing files keep serving from wherever
+they already are, only new uploads follow the active bucket.
+
+The [setup guide](/docs/byo-bucket) has the full walkthrough, the serving
+matrix (custom domain vs signed-only), and what's different on your own
+bucket. Plan limits are covered in [Plans & limits](/docs/limits).

--- a/apps/web/src/content/changelog/byo-bucket.md
+++ b/apps/web/src/content/changelog/byo-bucket.md
@@ -2,6 +2,9 @@
 title: "Bring your own bucket"
 date: 2026-08-24
 tags: [platform, web]
+image:
+  url: https://storage.uploads.sh/default/screenshots/changelog/byo-bucket.webp
+  alt: "The workspace storage settings page with a connected bucket active, showing the bucket, masked credentials, public base URL, and the note that storage in your own bucket is unmetered"
 ---
 
 You can now point any workspace at your own storage bucket. Files upload

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -155,6 +155,11 @@ export interface WorkspaceUsage {
   storageRemainingBytes?: number;
   maxUploadsPerPeriod?: number;
   uploadsRemaining?: number;
+  /** Bytes still on hosted storage (shared-lane residue). */
+  sharedBytes?: number;
+  /** "total" = cap meters all bytes; "shared" = BYO active, cap meters only
+   * hosted-storage residue and the customer's own bucket is unmetered. */
+  storageBudgetBasis?: "total" | "shared";
 }
 
 function parseWorkspaceUsage(body: unknown): WorkspaceUsage | null {

--- a/apps/web/src/lib/workspace-cache.ts
+++ b/apps/web/src/lib/workspace-cache.ts
@@ -180,6 +180,8 @@ export function toWorkspaceSnapshot(
           uploadsInPeriod: usage.uploadsInPeriod,
           maxStorageBytes: usage.maxStorageBytes,
           maxUploadsPerPeriod: usage.maxUploadsPerPeriod,
+          sharedBytes: usage.sharedBytes,
+          storageBudgetBasis: usage.storageBudgetBasis,
         }
       : undefined,
   };

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -183,6 +183,21 @@ describe("renderUsageHtml", () => {
     expect(html).toContain("3 objects");
     expect(html).not.toContain("usage-text");
   });
+
+  it("meters hosted residue and adds the unmetered note when a BYO bucket is active", () => {
+    const html = renderUsageHtml({
+      bytes: 900,
+      objects: 3,
+      uploadsInPeriod: 2,
+      maxStorageBytes: 1000,
+      sharedBytes: 250,
+      storageBudgetBasis: "shared",
+    });
+    expect(html).toContain("Hosted storage");
+    expect(html).toContain("250 B of 1 KB");
+    expect(html).toContain('aria-valuenow="25"');
+    expect(html).toContain("unmetered");
+  });
 });
 
 describe("orderOrgsOldestFirst", () => {

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -69,6 +69,11 @@ export type UsageSnapshot = {
   uploadsInPeriod: number;
   maxStorageBytes?: number;
   maxUploadsPerPeriod?: number;
+  /** Bytes still on hosted storage (shared-lane residue). */
+  sharedBytes?: number;
+  /** "shared" = BYO bucket active: the storage cap meters only hosted
+   * residue, the customer's own bucket is unmetered. */
+  storageBudgetBasis?: "total" | "shared";
 };
 
 function formatUsagePlain(usage: UsageSnapshot): string {
@@ -104,11 +109,17 @@ function progressRowHtml(label: string, detail: string, pct: number): string {
 
 export function renderUsageHtml(usage: UsageSnapshot): string {
   const meters: { label: string; detail: string; pct: number }[] = [];
-  const storagePct = usagePct(usage.bytes, usage.maxStorageBytes);
+  // BYO-active workspaces (`storageBudgetBasis: "shared"`) meter only the
+  // residue still on hosted storage — bytes in the customer's own bucket are
+  // unmetered, so a total-bytes meter would overstate usage against a cap
+  // that doesn't apply to it.
+  const byoActive = usage.storageBudgetBasis === "shared";
+  const meteredBytes = byoActive ? (usage.sharedBytes ?? 0) : usage.bytes;
+  const storagePct = usagePct(meteredBytes, usage.maxStorageBytes);
   if (storagePct !== null && usage.maxStorageBytes) {
     meters.push({
-      label: "Storage",
-      detail: `${formatBytes(usage.bytes)} of ${formatBytes(usage.maxStorageBytes)}`,
+      label: byoActive ? "Hosted storage" : "Storage",
+      detail: `${formatBytes(meteredBytes)} of ${formatBytes(usage.maxStorageBytes)}`,
       pct: storagePct,
     });
   }
@@ -120,11 +131,14 @@ export function renderUsageHtml(usage: UsageSnapshot): string {
       pct: uploadsPct,
     });
   }
+  const byoNote = byoActive
+    ? `<div class="usage-meta">Storage on your own bucket is unmetered — the plan limit only counts files on hosted storage.</div>`
+    : "";
   if (!meters.length) {
-    return `<div class="usage-text">${escapeHtml(formatUsagePlain(usage))}</div>`;
+    return `<div class="usage-text">${escapeHtml(formatUsagePlain(usage))}</div>${byoNote}`;
   }
   const objects = `${usage.objects} object${usage.objects === 1 ? "" : "s"}`;
-  return `<div class="ul-progress">${meters.map((m) => progressRowHtml(m.label, m.detail, m.pct)).join("")}</div><div class="usage-meta">${escapeHtml(objects)}</div>`;
+  return `<div class="ul-progress">${meters.map((m) => progressRowHtml(m.label, m.detail, m.pct)).join("")}</div><div class="usage-meta">${escapeHtml(objects)}</div>${byoNote}`;
 }
 
 /** Minimal member shape `renderMembersHtml` needs — api-client's `WorkspaceMember` satisfies it. */

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -76,7 +76,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
               >
                 Uploads go to hosted storage at <code>storage.uploads.sh</code> — no setup, and links
                 just work. Prefer to own the data? Point this workspace at your own Cloudflare R2 bucket.
-                Nothing moves until you switch.
+                Nothing moves until you switch, and storage in your own bucket is unmetered — the plan's
+                storage limit doesn't apply to it.
               </div>
             </div>
             <div
@@ -200,7 +201,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             </div>
           </div>
         </div>
-        <p class="settings-note muted" id="storage-byo-note">New uploads go to this bucket.</p>
+        <p class="settings-note muted" id="storage-byo-note">
+          New uploads go to this bucket. Storage here is unmetered — the plan's storage limit only
+          counts files still on hosted storage.
+        </p>
 
         <!-- Unhealthy-lane panel (#826).
              One plain-language sentence about what stopped working.

--- a/apps/web/src/pages/account/workspaces/new.astro
+++ b/apps/web/src/pages/account/workspaces/new.astro
@@ -31,7 +31,7 @@ export const prerender = false;
         </div>
         <p class="ws-hint muted">2–63 chars · lowercase letters, digits, hyphens</p>
 
-        <label class="storage-byo-option muted" id="byo-option" hidden>
+        <label class="storage-byo-option muted" id="byo-option">
           <input type="checkbox" id="byo-checkbox" />
           Bring your own storage bucket
           <span class="muted">— set up after the workspace is created.</span>
@@ -146,19 +146,12 @@ export const prerender = false;
       // workspace-less user can create one mid-authorization and resume.
       const nextPath = safeSameOriginPath(new URLSearchParams(location.search).get("next"));
 
-      // "Bring your own storage bucket" (issue #583 Task 2.1). There's no
-      // pre-creation capability signal to check — `byoBucketEnabled` is a
-      // per-workspace record flag that only exists once a workspace exists,
-      // and it's off by default for everyone. Rather than always showing an
-      // option that 403s for virtually every user, or inventing a new
-      // capability endpoint, this reveals the checkbox only for `?byo=1`
-      // (shared out-of-band with early-access workspaces/orgs) — an honest
-      // client-side gate the settings page's own `byoBucketEnabled` check
-      // still enforces for real: an unflagged workspace just lands on a
-      // normal settings page after creation.
-      const byoOption = requireElement<HTMLElement>("#byo-option", page);
+      // "Bring your own storage bucket" (issue #583 Task 2.1). Since the
+      // BYO-bucket GA the surface is on by default for every workspace, so
+      // the checkbox is always visible (the old `?byo=1` early-access reveal
+      // is gone). The settings page's own `byoBucketEnabled` check still
+      // enforces the operator kill switch for real.
       const byoCheckbox = requireElement<HTMLInputElement>("#byo-checkbox", page);
-      if (new URLSearchParams(location.search).get("byo") === "1") byoOption.hidden = false;
 
       void listAccounts(authOrigin).then((accounts) => {
         if (accounts && !accounts.some((a) => a.providerId === "github")) githubEl.hidden = false;
@@ -221,7 +214,7 @@ export const prerender = false;
           githubEl.hidden = true;
           successEl.hidden = true;
           const name = input.value.trim();
-          const wantsByo = !byoOption.hidden && byoCheckbox.checked;
+          const wantsByo = byoCheckbox.checked;
           if (submit) submit.disabled = true;
           // Creation itself stays one unchanged transaction — shared-bucket
           // record, normal path — regardless of the BYO checkbox. BYO is

--- a/apps/web/src/pages/docs/byo-bucket.astro
+++ b/apps/web/src/pages/docs/byo-bucket.astro
@@ -6,7 +6,6 @@
 import DocsLayout from "../../layouts/DocsLayout.astro";
 
 const TOC = [
-  { id: "status", label: "Current status" },
   { id: "setup", label: "Set up your bucket" },
   { id: "serving", label: "Serving: custom domain vs signed-only" },
   { id: "degraded", label: "What's different" },
@@ -23,10 +22,9 @@ const TOC = [
   active="byo-bucket"
   toc={TOC}
 >
-  <div class="callout" id="status">
-    <strong>In preview.</strong> Bring-your-own-bucket is available to a small set of workspaces while
-    we finish testing. If your workspace doesn't show "Connect your own bucket" on its settings page,
-    it isn't in the preview yet.
+  <div class="callout">
+    Available to every workspace, on any plan. Storage in your own bucket is unmetered — the plan's
+    storage limit only counts files on hosted storage.
   </div>
 
   <section class="lead" id="setup">

--- a/apps/web/src/pages/docs/limits.astro
+++ b/apps/web/src/pages/docs/limits.astro
@@ -85,6 +85,11 @@ const TOC = [
       Both plans also carry internal rate guards against automated abuse. Normal use — even heavy
       agent-driven use — does not reach them.
     </p>
+    <p class="note">
+      The storage cap only counts files on hosted storage. If your workspace <a
+        href="/docs/byo-bucket">brings its own bucket</a
+      >, storage there is unmetered — file-size and video-size caps still apply.
+    </p>
   </section>
 
   <section id="at-the-cap">

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -769,6 +769,13 @@ Source (and where to look if something breaks): https://github.com/buildinternet
               whole set that shows linked issues and pull requests.
             </p>
           </div>
+          <div class="feature">
+            <h3>Bring your own bucket</h3>
+            <p>
+              <a href="/docs/byo-bucket">Connect your own bucket</a> to unlock custom domains and unmetered
+              storage — hosted storage works out of the box, your bucket is there when you want it.
+            </p>
+          </div>
         </div>
       </section>
 

--- a/packages/billing/src/byo-bucket.ts
+++ b/packages/billing/src/byo-bucket.ts
@@ -6,9 +6,10 @@
  * Ships dark: `PLANS.*.byoBucket` is `true` for every plan today, and
  * nothing calls this predicate for enforcement yet. The live gate is the
  * per-workspace `byoBucketEnabled` record flag
- * (`apps/api/src/workspace.ts`'s `byoBucketAllowed`), off by default and
- * operator-set only. This predicate exists so that when a future billing
- * decision restricts BYO to a paid plan, that's a one-line flip on
+ * (`apps/api/src/workspace.ts`'s `byoBucketAllowed`) — since the 2026-08-24
+ * GA it is on by default, with an operator-set explicit `false` as the
+ * per-workspace kill switch. This predicate exists so that when a future
+ * billing decision restricts BYO to a paid plan, that's a one-line flip on
  * `PLANS` plus wiring this predicate into the gate check — not new
  * plumbing. Callers read this predicate, never switch on plan id
  * (precedent: `marketsMemberCap`).
@@ -25,9 +26,9 @@ export interface ByoBucketPlanRecord {
 
 /**
  * Whether this workspace's plan permits the BYO-bucket surface. Currently
- * always `true` (every plan's `byoBucket` capability is `true`) — the real
- * gate today is `byoBucketAllowed` in `apps/api/src/workspace.ts`, not this
- * predicate. `getPlan` fails open to `free` for an unrecognized/absent plan
+ * always `true` (every plan's `byoBucket` capability is `true`) — the only
+ * live restriction is `byoBucketAllowed`'s per-workspace kill switch in
+ * `apps/api/src/workspace.ts`, not this predicate. `getPlan` fails open to `free` for an unrecognized/absent plan
  * string, same as every other plan-capability read in this package.
  */
 export function planAllowsByoBucket(record: ByoBucketPlanRecord): boolean {

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -43,7 +43,8 @@ export interface PlanDefinition {
    * Task 1.3). Ships dark: `true` on every plan today, and nothing reads it
    * for enforcement yet — the short-term gate is the per-workspace
    * `byoBucketEnabled` record flag (`apps/api/src/workspace.ts`'s
-   * `byoBucketAllowed`), off by default and operator-set only. This field
+   * `byoBucketAllowed`), on by default since the 2026-08-24 GA with an
+   * operator-set explicit `false` as the kill switch. This field
    * exists so a future billing decision (e.g. Pro-only) is a one-line flip
    * here rather than new plumbing. See `packages/billing/src/byo-bucket.ts`
    * — callers read that predicate, never switch on plan id (precedent:

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -482,6 +482,11 @@ export interface UsageResult {
   storageRemainingBytes?: number;
   maxUploadsPerPeriod?: number;
   uploadsRemaining?: number;
+  /** Bytes still on hosted storage (shared-lane residue). */
+  sharedBytes?: number;
+  /** "shared" = BYO bucket active: the storage cap meters only hosted
+   * residue; the customer's own bucket is unmetered. */
+  storageBudgetBasis?: "total" | "shared";
   /** File scopes of the presented token (servers ≥ this field's release). */
   scopes?: Array<TokenScope>;
   /**

--- a/packages/uploads/src/format-usage.ts
+++ b/packages/uploads/src/format-usage.ts
@@ -21,6 +21,11 @@ export type UsageSnapshotLike = {
   storageRemainingBytes?: number;
   maxUploadsPerPeriod?: number;
   uploadsRemaining?: number;
+  /** Bytes still on hosted storage (shared-lane residue). */
+  sharedBytes?: number;
+  /** "shared" = BYO bucket active: the storage cap meters only hosted
+   * residue; bytes in the customer's own bucket are unmetered. */
+  storageBudgetBasis?: "total" | "shared";
   /** Catalog plan id when the API reports it (`free` | `pro`). */
   plan?: string;
 };
@@ -37,9 +42,15 @@ export type FormatUsageOptions = {
 /** True when the API reported any cumulative workspace quota. */
 export function isUsageMetered(result: UsageSnapshotLike): boolean {
   return (
-    usagePct(result.bytes, result.maxStorageBytes) !== null ||
+    usagePct(storageMeteredBytes(result), result.maxStorageBytes) !== null ||
     usagePct(result.uploadsInPeriod, result.maxUploadsPerPeriod) !== null
   );
+}
+
+/** The usage number the storage cap actually meters — hosted residue only
+ * when a BYO bucket is active (`storageBudgetBasis: "shared"`). */
+function storageMeteredBytes(result: UsageSnapshotLike): number {
+  return result.storageBudgetBasis === "shared" ? (result.sharedBytes ?? 0) : result.bytes;
 }
 
 /** 0–100, one decimal. Missing/invalid caps → no bar. Matches web `usagePct`. */
@@ -146,20 +157,27 @@ export function formatUsageHuman(
   const label = planLabel(result.plan);
   if (label) lines.push(`plan:      ${label}`);
 
-  const storagePct = usagePct(result.bytes, result.maxStorageBytes);
+  const byoActive = result.storageBudgetBasis === "shared";
+  const meteredBytes = storageMeteredBytes(result);
+  const storagePct = usagePct(meteredBytes, result.maxStorageBytes);
   if (storagePct !== null && result.maxStorageBytes != null) {
     // Caps (and remaining-against-cap) use SI marketed formatting so Free's
     // 250_000_000 reads as "250 MB", not binary "238.4 MB". Used bytes share
     // the same base on this line so the three numbers stay coherent.
     const detail =
-      `${formatMarketedBytes(result.bytes)} / ${formatMarketedBytes(result.maxStorageBytes)}` +
+      `${formatMarketedBytes(meteredBytes)} / ${formatMarketedBytes(result.maxStorageBytes)}` +
       (result.storageRemainingBytes != null
         ? ` (${formatMarketedBytes(result.storageRemainingBytes)} free)`
         : "");
     const bar = formatProgressBar(storagePct, { width, color });
-    lines.push(`storage:   ${bar}  ${detail}`);
+    lines.push(`storage:   ${bar}  ${detail}${byoActive ? " on hosted storage" : ""}`);
   } else {
     lines.push(`storage:   ${formatByteSize(result.bytes)}`);
+  }
+  if (byoActive) {
+    lines.push(
+      "note:      your own bucket is unmetered — the storage quota only counts files on hosted storage",
+    );
   }
 
   lines.push(`objects:   ${formatCount(result.objects)}`);

--- a/packages/uploads/test/format-usage.test.ts
+++ b/packages/uploads/test/format-usage.test.ts
@@ -109,6 +109,27 @@ describe("formatUsageHuman", () => {
     expect(lines.some((l) => l.startsWith("note:"))).toBe(false);
   });
 
+  it("meters hosted residue and notes the unmetered bucket when BYO is active", () => {
+    const lines = formatUsageHuman(
+      {
+        workspace: "acme",
+        bytes: 900,
+        objects: 3,
+        uploadsInPeriod: 2,
+        periodStart: "2026-08",
+        updatedAt: "2026-08-24T12:00:00.000Z",
+        maxStorageBytes: 1_000,
+        sharedBytes: 250,
+        storageBudgetBasis: "shared",
+      },
+      { timeZone: "UTC" },
+    );
+    const storageLine = lines.find((l) => l.startsWith("storage:"));
+    expect(storageLine).toContain("250 B / 1 KB");
+    expect(storageLine).toContain("on hosted storage");
+    expect(lines.some((l) => l.startsWith("note:") && l.includes("unmetered"))).toBe(true);
+  });
+
   it("meters only the capped dimensions (partial quotas)", () => {
     const lines = formatUsageHuman(
       {


### PR DESCRIPTION
## Summary

Takes bring-your-own-bucket out of preview.

- **Gate default-on**: `byoBucketAllowed` now treats an absent `byoBucketEnabled` as allowed; only an operator-set explicit `false` (admin Storage toggle) blocks the surface, kept as a per-workspace kill switch. Plan-level gating remains available via the dark `planAllowsByoBucket` predicate.
- **Honest usage metering**: the usage API adds `storageBudgetBasis` (`"total" | "shared"`). On BYO-active workspaces the storage cap is enforced only against hosted-storage residue, so the web rail meter and `uploads usage` now meter that number (labeled "Hosted storage" / "on hosted storage") and add a note that storage in the customer's own bucket is unmetered.
- **Copy**: `/docs/byo-bucket` loses the "In preview" callout (replaced with availability + unmetered note), `/docs/limits` notes the cap only counts hosted storage, the storage settings page mentions unmetered BYO storage in both the empty state and the active-lane note, and the create-workspace BYO checkbox is always visible (the `?byo=1` early-access reveal is gone).

Changeset included for `@buildinternet/uploads` (BYO-aware `uploads usage` output).

## Testing

- Full suite: 5160 tests passing
- Typecheck clean across the workspace (web on Node 24)
- New tests: gate default-on semantics, `storageBudgetBasis` in `usageWithLimits`, BYO-aware web meter and CLI formatter
