### PR TITLE
Doctor reports storage lanes via a bearer-safe usage summary

### DIFF
--- a/.changeset/doctor-storage-lanes.md
+++ b/.changeset/doctor-storage-lanes.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads doctor` now reports the workspace's storage lanes: hosted storage vs your own bucket, how many previous lanes still serve old files, and whether the active lane is healthy — read from a new bearer-safe summary on the usage endpoint. Against older servers it keeps the honest "not checked from the CLI" line.

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -357,6 +357,7 @@ describe("GET /me/workspaces/:name/usage", () => {
       maxStorageBytes: 1000,
       storageRemainingBytes: 500,
       storageBudgetBasis: "total",
+      storage: { mode: "shared", fallbackLanes: 0, health: { ok: true } },
       scopes: ["files:read", "files:write", "files:delete"],
       plan: "free",
     });

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -142,6 +142,31 @@ export function storageStatusResponse(
 }
 
 /**
+ * Compact, bearer-safe lane summary for `GET /:workspace/usage` (issue
+ * #775). Deliberately smaller than `storageStatusResponse`: usage is
+ * readable by any member session or workspace bearer token (`files:read`),
+ * so this projects no bucket names, domains, or masked credential
+ * fragments — just which mode is active, how many former lanes still serve
+ * old files, and whether the active lane is healthy. The full projection
+ * stays admin/owner-session-gated on the settings routes.
+ */
+export function storageUsageSummary(record: WorkspaceRecord): {
+  mode: "shared" | "byo";
+  fallbackLanes: number;
+  health: StorageHealth;
+} {
+  const byo = isByoRecord(record);
+  return {
+    mode: byo ? "byo" : "shared",
+    // Fallback = a demoted former active (`lastActiveAt` set) that still
+    // participates in read resolution. Standby saves don't serve anything,
+    // so they don't count.
+    fallbackLanes: (record.storageLanes ?? []).filter((lane) => lane.lastActiveAt).length,
+    health: byo ? storageHealth(record) : { ok: true },
+  };
+}
+
+/**
  * Verify pipeline entry point the storage routes call, indirected through
  * this mutable binding so tests can substitute a fake without hitting the
  * network. Candidate storage is always HTTP-credential mode (no R2 binding

--- a/apps/api/src/routes/workspace-usage.ts
+++ b/apps/api/src/routes/workspace-usage.ts
@@ -16,6 +16,7 @@ import { reconcileWorkspaceUsage } from "../reconcile";
 import { purgeExpiredObjects } from "../retention";
 import { getWorkspaceUsage } from "../usage";
 import { requireScope } from "../workspace";
+import { storageUsageSummary } from "./workspace-storage";
 import { dbFor } from "../db-session";
 import { boundedDataRead } from "../data-read-bounds";
 
@@ -57,6 +58,9 @@ export const workspaceUsage = new Hono<DualAuthVars>()
       ...usageWithLimits(snapshot, workspace),
       scopes: c.get("authScopes"),
       plan: getPlan(workspace.plan).id,
+      // Bearer-safe lane summary (issue #775) — lets `uploads doctor` report
+      // the storage mode without the session-gated settings projection.
+      storage: storageUsageSummary(workspace),
     });
   })
   .post(

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -487,6 +487,13 @@ export interface UsageResult {
   /** "shared" = BYO bucket active: the storage cap meters only hosted
    * residue; the customer's own bucket is unmetered. */
   storageBudgetBasis?: "total" | "shared";
+  /** Bearer-safe lane summary (issue #775; servers ≥ this field's release). */
+  storage?: {
+    mode: "shared" | "byo";
+    /** Demoted former-active lanes that still serve previously uploaded files. */
+    fallbackLanes: number;
+    health: { ok: boolean; code?: string; message?: string; since?: string };
+  };
   /** File scopes of the presented token (servers ≥ this field's release). */
   scopes?: Array<TokenScope>;
   /**

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -4242,16 +4242,18 @@ export interface DoctorReport {
   /** Workspace/token mismatch warning (also present in hints). */
   warning?: string;
   /**
-   * Bring-your-own-bucket storage status (issue #583 Phase 3). `GET
-   * /me/workspaces/:name/storage` is session-gated (Better Auth cookie or
-   * bearer via the AUTH service — see `session-auth.ts`); the CLI only ever
-   * holds a minted `up_<workspace>_…` workspace token, never a session
-   * bearer, so doctor cannot reach that route today. Until a token-authed
-   * read path exists, this is an honest "can't check from here" rather than
-   * a fabricated mode.
+   * Storage-lane summary (issue #775): the usage endpoint carries a
+   * bearer-safe `storage` object (mode + fallback-lane count + health), so
+   * doctor reports it from the same call it already makes. `checked` is
+   * false when usage failed or the server predates the field — then `note`
+   * falls back to the honest "can't check from here" line (the full
+   * projection on `GET /me/workspaces/:name/storage` stays session-gated).
    */
   storage: {
-    checked: false;
+    checked: boolean;
+    mode?: "shared" | "byo";
+    fallbackLanes?: number;
+    healthy?: boolean;
     note: string;
   };
   hints: string[];
@@ -4355,6 +4357,10 @@ export async function buildDoctorReport(
         error?: string;
       }
     | undefined;
+  let storage: DoctorReport["storage"] = {
+    checked: false,
+    note: "not checked from the CLI — this server doesn't report a storage summary on the usage endpoint; sign in on the web (Account → workspace → Settings) to view mode and verification status",
+  };
   let scopes: string[] | undefined;
   if (authOk) {
     try {
@@ -4365,6 +4371,25 @@ export async function buildDoctorReport(
         objects: snap.objects,
         uploadsInPeriod: snap.uploadsInPeriod,
       };
+      if (snap.storage) {
+        const laneNote =
+          snap.storage.fallbackLanes > 0
+            ? ` (${snap.storage.fallbackLanes} previous lane${snap.storage.fallbackLanes === 1 ? "" : "s"} still serving old files)`
+            : "";
+        const healthNote = snap.storage.health.ok
+          ? ""
+          : " — not working; rotate credentials on the web settings page";
+        storage = {
+          checked: true,
+          mode: snap.storage.mode,
+          fallbackLanes: snap.storage.fallbackLanes,
+          healthy: snap.storage.health.ok,
+          note:
+            (snap.storage.mode === "byo" ? "your bucket" : "hosted storage") +
+            laneNote +
+            healthNote,
+        };
+      }
       scopes = snap.scopes;
       if (scopes && !scopes.includes("files:delete")) {
         hints.push(
@@ -4397,10 +4422,7 @@ export async function buildDoctorReport(
     usage,
     scopes,
     warning: mismatch,
-    storage: {
-      checked: false,
-      note: "not checked from the CLI — storage settings (shared vs. bring-your-own-bucket) live behind a signed-in session; sign in on the web (Account → workspace → Settings) to view mode and verification status",
-    },
+    storage,
     hints,
     browser,
   };

--- a/packages/uploads/test/commands-doctor.test.ts
+++ b/packages/uploads/test/commands-doctor.test.ts
@@ -62,13 +62,52 @@ describe("buildDoctorReport token scopes", () => {
 });
 
 describe("buildDoctorReport storage section", () => {
-  it("honestly reports it can't check storage settings from a workspace token", async () => {
-    // GET /me/workspaces/:name/storage is session-gated (Better Auth cookie
-    // or bearer); the CLI only ever holds a minted up_<workspace>_… token,
-    // so doctor must not fabricate a shared/byo mode it can't verify.
+  function clientWithStorage(storage: unknown): UploadsClient {
+    return {
+      list: async () => ({ items: [], cursor: null }),
+      health: async () => ({ ok: true }),
+      usage: async () => ({ bytes: 0, objects: 0, uploadsInPeriod: 0, storage }),
+    } as unknown as UploadsClient;
+  }
+
+  it("falls back to the honest can't-check note against a server without the usage summary", async () => {
+    // Pre-#775 servers report no `storage` object on the usage endpoint, and
+    // the full projection on GET /me/workspaces/:name/storage stays
+    // session-gated — doctor must not fabricate a shared/byo mode.
     const report = await buildDoctorReport(fakeConfig(), fakeClient());
     expect(report.storage.checked).toBe(false);
     expect(report.storage.note).toMatch(/sign in on the web/);
+  });
+
+  it("reports hosted storage from the usage summary", async () => {
+    const report = await buildDoctorReport(
+      fakeConfig(),
+      clientWithStorage({ mode: "shared", fallbackLanes: 0, health: { ok: true } }),
+    );
+    expect(report.storage).toMatchObject({
+      checked: true,
+      mode: "shared",
+      fallbackLanes: 0,
+      healthy: true,
+      note: "hosted storage",
+    });
+  });
+
+  it("reports an active BYO lane with fallback-lane count", async () => {
+    const report = await buildDoctorReport(
+      fakeConfig(),
+      clientWithStorage({ mode: "byo", fallbackLanes: 1, health: { ok: true } }),
+    );
+    expect(report.storage.note).toBe("your bucket (1 previous lane still serving old files)");
+  });
+
+  it("flags an unhealthy BYO lane", async () => {
+    const report = await buildDoctorReport(
+      fakeConfig(),
+      clientWithStorage({ mode: "byo", fallbackLanes: 0, health: { ok: false, code: "auth" } }),
+    );
+    expect(report.storage.healthy).toBe(false);
+    expect(report.storage.note).toMatch(/not working/);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements #775 by the issue's second option: instead of a new bearer-authed storage-status endpoint, `GET /v1/workspaces/:workspace/usage` (dual-auth, `files:read`) now carries a compact `storage` object:

```json
{ "mode": "byo", "fallbackLanes": 1, "health": { "ok": true } }
```

Deliberately smaller than `storageStatusResponse` — no bucket names, domains, or masked credential fragments, since usage is readable by any member or workspace bearer token. The full projection stays admin/owner-session-gated.

`uploads doctor` composes its storage line from the usage call it already makes:

- `storage:   hosted storage`
- `storage:   your bucket (1 previous lane still serving old files)`
- `storage:   your bucket — not working; rotate credentials on the web settings page`

Against a server that predates the field, doctor keeps the honest "not checked from the CLI" fallback. Fallback lanes count only demoted former actives (`lastActiveAt` set) — standby saves don't serve anything.

## Testing

- New doctor tests: hosted, BYO with fallback count, unhealthy lane, older-server fallback
- Usage-route shape assertion updated; full suite 5168 passing, typecheck clean
- Changeset included for the CLI

Closes #775.
