### PR TITLE
docs: restructure docs pages for scannability + house docs-style skill

### DIFF
--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -324,15 +324,23 @@ const fullTitle = `${title} · uploads.sh`;
         border-top: 1px solid var(--line);
         scroll-margin-top: 24px;
         position: relative;
+        cursor: pointer;
       }
+      /* section-link anchor: parked in the left gutter, revealed on heading
+         hover (and on keyboard focus) so it declutters the resting state */
       .doc section h2 .anchor {
+        position: absolute;
+        left: -1.05em;
+        top: 24px;
         color: color-mix(in srgb, var(--accent) 55%, transparent);
         text-decoration: none;
-        margin-left: 8px;
         font-weight: var(--weight-regular);
+        opacity: 0;
+        transition: opacity 0.12s ease;
       }
-      .doc section h2 .anchor:hover,
+      .doc section h2:hover .anchor,
       .doc section h2 .anchor:focus-visible {
+        opacity: 1;
         color: var(--accent);
         background: none;
       }
@@ -341,6 +349,9 @@ const fullTitle = `${title} · uploads.sh`;
         border-top: none;
         padding-top: 0;
         margin-top: 22px;
+      }
+      .doc section.lead h2 .anchor {
+        top: 0;
       }
       .doc h3 {
         font: 600 var(--text-body)/1.4 var(--sans);
@@ -720,6 +731,19 @@ const fullTitle = `${title} · uploads.sh`;
       .doc .note a {
         color: var(--muted);
       }
+      /* Demoted secondary-command pointer sitting under a golden-path command:
+         reads as a quieter alternate path, while its verb (code) and link stay legible. */
+      .doc .pointer {
+        margin: 10px 0 0;
+        color: var(--muted);
+        font-size: var(--text-meta);
+      }
+      .doc .pointer code {
+        color: var(--body);
+      }
+      .doc .pointer a {
+        color: var(--accent);
+      }
 
       /* Geist Mono merges " --" into a joined dash via calt - keep CLI flags literal.
          Declared last: the font shorthand in earlier rules resets feature settings. */
@@ -833,6 +857,7 @@ const fullTitle = `${title} · uploads.sh`;
 
       let tocSpy: IntersectionObserver | null = null;
       let copyBound = false;
+      let headingBound = false;
 
       function bootDocsChrome(): void {
         tocSpy?.disconnect();
@@ -867,6 +892,23 @@ const fullTitle = `${title} · uploads.sh`;
         if (!copyBound) {
           copyBound = true;
           bindCopyButtons(document, ".doc .cmd button[data-copy]");
+        }
+
+        // Whole-heading click jumps to its section anchor (matching the visible
+        // gutter "#"), so the entire h2 is a hit target, not just the glyph.
+        if (!headingBound) {
+          headingBound = true;
+          document.addEventListener("click", (event) => {
+            const target = event.target as HTMLElement;
+            // The anchor itself is a real link — let it handle its own click.
+            if (target.closest(".doc section h2 .anchor")) return;
+            const heading = target.closest(".doc section h2");
+            if (!heading) return;
+            // Don't hijack a text selection inside the heading.
+            if (window.getSelection()?.toString()) return;
+            const anchor = heading.querySelector<HTMLAnchorElement>(".anchor");
+            anchor?.click();
+          });
         }
       }
 

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -1,7 +1,9 @@
 ---
 // uploads.sh — docs hub. Overview of what the CLI does, the one-time install,
 // and cards out to the focused subject pages. Purpose-first: getting media onto
-// GitHub PRs, issues, and code reviews.
+// GitHub PRs, issues, and code reviews. Structure: understand → install → do —
+// one golden-path command (put), with attach demoted to a pointer into the
+// how-to guide; copy affordances reserved for commands you paste verbatim.
 import DocsLayout from "../layouts/DocsLayout.astro";
 
 const REPO = "https://github.com/buildinternet/uploads";
@@ -20,59 +22,19 @@ const REPO = "https://github.com/buildinternet/uploads";
       What it does <a class="anchor" href="#what-it-does" aria-label="Link to this section">#</a>
     </h2>
     <p>
-      Getting an image into a GitHub comment is easy for a person: you drag it in. For an agent or a
-      script, there is no drag-and-drop. uploads.sh fills that gap: it hosts your file at a stable
-      public URL and posts it to the right place on GitHub for you.
+      Dragging an image into a GitHub comment is easy for a person; an agent or script has no
+      drag-and-drop. uploads.sh closes that gap. With the CLI you can:
     </p>
-    <p>
-      The everyday flow is one command, on the branch you are already on. No pull request required:
-    </p>
-    <div class="cmd">
-      <span class="text">uploads put ./after.png</span>
-      <button type="button" data-copy="uploads put ./after.png" aria-live="polite">copy</button>
-    </div>
-    <div class="block" aria-label="Example output">
-      <pre>&gt;&gt; uploading ./after.png
-note: staged for branch feat/nav — auto-comments to pull request when opened
-(or run: uploads attach --promote once it exists)</pre>
-    </div>
-    <p>
-      Keep doing that as you work. When the PR opens, staged files land in one managed comment — via
-      the GitHub App, or the next <code>uploads attach --promote</code>. Tag a pair with&#32;
-      <code>--state before</code> and <code>--state after</code> and they render side by side. See&#32;
-      <a href="/docs/attach-pull-request-images#staging">Attach &amp; share</a> for what is queued.
-    </p>
-  </section>
-
-  <section id="before-the-pr">
-    <h2>
-      Already have a PR open? <a
-        class="anchor"
-        href="#before-the-pr"
-        aria-label="Link to this section">#</a
-      >
-    </h2>
-    <p>
-      <code>attach</code> is the direct path. The CLI finds the pull request, uploads the files, and keeps
-      one comment up to date:
-    </p>
-    <div class="cmd">
-      <span class="text">uploads attach ./before.png ./after.png</span>
-      <button type="button" data-copy="uploads attach ./before.png ./after.png" aria-live="polite"
-        >copy</button
-      >
-    </div>
-    <div class="block" aria-label="Example output">
-      <pre># optimizes each image, then keeps one comment on the PR up to date
-&gt;&gt; uploading ./before.png
-&gt;&gt; uploading ./after.png
-<span class="ok">&gt;&gt; attachments comment updated</span></pre>
-    </div>
-    <p>
-      Same pairing works here: <code>--state before</code> and <code>--state after</code> render side
-      by side — see&#32;
-      <a href="/docs/attach-pull-request-images#before-after">pair a before and after</a>.
-    </p>
+    <ul>
+      <li>
+        <a href="/docs/attach-pull-request-images">Attach screenshots and video</a> to a GitHub PR, issue,
+        or code review — kept in one managed comment.
+      </li>
+      <li>Get a stable public URL for any file, on the branch you're already on.</li>
+      <li>
+        Collect media into a <a href="/docs/galleries">gallery</a> behind one link.
+      </li>
+    </ul>
   </section>
 
   <section id="install">
@@ -80,37 +42,46 @@ note: staged for branch feat/nav — auto-comments to pull request when opened
       Install &amp; sign in <a class="anchor" href="#install" aria-label="Link to this section">#</a
       >
     </h2>
-    <p>Install the CLI globally, then sign in once:</p>
+    <p>Install the CLI globally:</p>
     <div class="cmd">
       <span class="text">npm install -g @buildinternet/uploads</span>
       <button type="button" data-copy="npm install -g @buildinternet/uploads" aria-live="polite"
         >copy</button
       >
     </div>
+    <p>
+      Then run <code>uploads login</code> to approve sign-in in your browser — GitHub or a magic link.
+      You'll need a workspace first: create your own with a linked GitHub account, or get invited by an
+      admin. It's a one-time step per machine.
+    </p>
+    <div class="note">
+      Prefer not to install? Prefix any command with <code>npx</code>. And <code
+        >uploads doctor</code
+      > checks your setup anytime.
+    </div>
+  </section>
+
+  <section id="first-upload">
+    <h2>
+      Your first upload <a class="anchor" href="#first-upload" aria-label="Link to this section"
+        >#</a
+      >
+    </h2>
+    <p>One command, on the branch you're already on — no pull request required:</p>
     <div class="cmd">
-      <span class="text">uploads login</span>
-      <button type="button" data-copy="uploads login" aria-live="polite">copy</button>
+      <span class="text">uploads put ./after.png</span>
+      <button type="button" data-copy="uploads put ./after.png" aria-live="polite">copy</button>
     </div>
     <p>
-      <code>uploads login</code> opens a browser so you can approve the sign-in (GitHub or a magic link).
-      You'll need a workspace first — create your own with a linked GitHub account, or get invited to
-      an existing one by an admin. Once you're in, the CLI mints a workspace token and saves it, so you
-      only do this once per machine.
+      That uploads the file and prints a public URL. With no PR yet, it stages the file to post
+      automatically when the PR opens — keep running <code>put</code> as you work. See&#32;
+      <a href="/docs/attach-pull-request-images#staging">Attach &amp; share</a> for staging and before/after
+      pairing.
     </p>
-    <p>Prefer not to install anything? Every command works as a one-off with <code>npx</code>:</p>
-    <div class="cmd">
-      <span class="text">npx @buildinternet/uploads put ./after.png</span>
-      <button
-        type="button"
-        data-copy="npx @buildinternet/uploads put ./after.png"
-        aria-live="polite">copy</button
-      >
-    </div>
-    <div class="cmd">
-      <span class="text">uploads doctor <span class="cm"># check everything is wired up</span></span
-      >
-      <button type="button" data-copy="uploads doctor" aria-live="polite">copy</button>
-    </div>
+    <p class="pointer">
+      Already have a PR open? Use <code>uploads attach</code> instead —&#32;
+      <a href="/docs/attach-pull-request-images">see the walkthrough <span class="go">→</span></a>.
+    </p>
   </section>
 
   <section id="explore">
@@ -125,13 +96,6 @@ note: staged for branch feat/nav — auto-comments to pull request when opened
           it.
         </p>
       </a>
-      <a class="card" href="/docs/galleries">
-        <h3>Galleries <span class="go">→</span></h3>
-        <p>
-          Ordered sets of media behind one public link at <code>/g/&lt;id&gt;</code>, linkable to a
-          PR or issue.
-        </p>
-      </a>
       <a class="card" href="/docs/github-app">
         <h3>GitHub App <span class="go">→</span></h3>
         <p>
@@ -139,16 +103,16 @@ note: staged for branch feat/nav — auto-comments to pull request when opened
           when the PR opens.
         </p>
       </a>
-      <a class="card" href="/docs/comment-config">
-        <h3>Comment config <span class="go">→</span></h3>
-        <p>
-          Commit <code>.uploads.yml</code> to a repo to control image width, inline caps, and a note on
-          its comment.
-        </p>
-      </a>
       <a class="card" href="/docs/agents">
         <h3>Set up your agent <span class="go">→</span></h3>
         <p>Install the agent skills and the MCP server so your agent uploads on its own.</p>
+      </a>
+      <a class="card" href="/docs/galleries">
+        <h3>Galleries <span class="go">→</span></h3>
+        <p>
+          Ordered sets of media behind one public link at <code>/g/&lt;id&gt;</code>, linkable to a
+          PR or issue.
+        </p>
       </a>
       <a class="card" href="/docs/reference">
         <h3>Reference <span class="go">→</span></h3>
@@ -158,22 +122,16 @@ note: staged for branch feat/nav — auto-comments to pull request when opened
         <h3>Plans &amp; limits <span class="go">→</span></h3>
         <p>Storage and file-size caps per plan, and how they compare with GitHub's.</p>
       </a>
-      <a class="card" href="/docs/byo-bucket">
-        <h3>Bring your own bucket <span class="go">→</span></h3>
-        <p>
-          Point a workspace at your own Cloudflare R2 bucket instead of the shared one. In preview.
-        </p>
-      </a>
-      <a class="card" href="/github-screenshots">
-        <h3>Agent walkthrough <span class="go">→</span></h3>
-        <p>A guided setup for getting a coding agent to upload screenshots and video to GitHub.</p>
-      </a>
     </div>
     <div class="note">
-      Looking for deeper material like the REST API, enrollment internals, self-hosting, or operator
-      docs? It all lives in <a href={REPO}>the GitHub repository</a>. Agents can also read <a
-        href="/llms.txt">/llms.txt</a
-      > (index) or <a href="/llms-full.txt">/llms-full.txt</a> (one-file guide).
+      More: <a href="/docs/comment-config">comment config</a>, <a href="/docs/byo-bucket"
+        >bring your own bucket</a
+      >, and the <a href="/github-screenshots">agent walkthrough</a>. Deeper material — the REST
+      API, enrollment internals, self-hosting, and operator docs — lives in <a href={REPO}
+        >the GitHub repository</a
+      >. Agents can also read <a href="/llms.txt">/llms.txt</a> (index) or <a href="/llms-full.txt"
+        >/llms-full.txt</a
+      > (one-file guide).
     </div>
   </section>
 </DocsLayout>

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -22,9 +22,11 @@ const REPO = "https://github.com/buildinternet/uploads";
       What it does <a class="anchor" href="#what-it-does" aria-label="Link to this section">#</a>
     </h2>
     <p>
-      Dragging an image into a GitHub comment is easy for a person; an agent or script has no
-      drag-and-drop. uploads.sh closes that gap. With the CLI you can:
+      GitHub has no API for file uploads, so agents can't include screenshots in pull requests and
+      issues. Uploads gives agents a way to host files and show their work. When the pull request
+      opens, all screenshots appear in one tidy comment that updates automatically on each revision.
     </p>
+    <p>With the uploads CLI you can:</p>
     <ul>
       <li>
         <a href="/docs/attach-pull-request-images">Attach screenshots and video</a> to a GitHub PR, issue,

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -13,18 +13,25 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
   active="agents"
 >
   <section class="lead" id="install">
-    <h2>One command <a class="anchor" href="#install" aria-label="Link to this section">#</a></h2>
+    <h2>Install <a class="anchor" href="#install" aria-label="Link to this section">#</a></h2>
     <p>
-      One command detects your agent runtime and installs the agent skills (attach workflow, CLI
-      reference, and screenshot annotations) plus the hosted MCP server:
+      One command detects your agent runtime and installs everything it needs: the agent skills
+      (attach workflow, CLI reference, and screenshot annotations) plus the hosted MCP server.
     </p>
     <div class="cmd">
       <span class="text">uploads install</span>
       <button type="button" data-copy="uploads install" aria-live="polite">copy</button>
     </div>
+    <p class="pointer">
+      Using Claude Code or Codex? Install everything as one plugin instead, with the pre-PR hook and
+      a slash command included —&#32;
+      <a href="#plugin">see Claude Code &amp; Codex plugins <span class="go">→</span></a>.
+    </p>
+
+    <h3>Or set up by hand</h3>
     <p>
-      Or set up each piece yourself — the skills via <code>npx skills</code>, the MCP server with
-      your runtime's MCP registration (shown here for Claude Code):
+      Add the skills with <code>npx skills</code>, then register the MCP server with your runtime's
+      own MCP registration — shown here for Claude Code:
     </p>
     <div class="cmd">
       <span class="text">npx skills add buildinternet/uploads</span>
@@ -55,10 +62,9 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
       >
     </h2>
     <p>
-      On Claude Code you can install everything as one plugin — the agent skills (attach workflow,
-      CLI reference, annotations), an MCP server, an&#32;
-      <code>/uploads:attach</code> command, and a pre-PR screenshot reminder hook — from the uploads marketplace.
-      Add the marketplace, then install:
+      Install the agent skills, the MCP server, an <code>/uploads:attach</code> command, and a pre-PR
+      screenshot reminder hook as one plugin, from the uploads marketplace. Add the marketplace, then
+      install:
     </p>
     <div class="cmd slash">
       <span class="text">/plugin marketplace add buildinternet/uploads</span>
@@ -75,12 +81,10 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
       >
     </div>
     <p>
-      Codex uses the same repo as a plugin (<code>.codex-plugin/plugin.json</code>): skills, the
-      hosted MCP server, and the same pre-PR hook. After enabling it, open <code>/hooks</code> once and
-      trust the hook if Codex asks. Both plugins run
-      <code>uploads hook pre-pr-screenshot</code>, so keep the <code>uploads</code> CLI on your <code
-        >PATH</code
-      > and run <code>uploads login</code> once.
+      Codex uses the same repo as a plugin (<code>.codex-plugin/plugin.json</code>) — the same
+      skills, MCP server, and hook. After enabling it, open <code>/hooks</code> once and trust the hook
+      if Codex asks. Both plugins run <code>uploads hook pre-pr-screenshot</code>, so keep the
+      <code>uploads</code> CLI on your <code>PATH</code> and run <code>uploads login</code> once.
     </p>
   </section>
 
@@ -89,20 +93,14 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
       Skill vs. MCP <a class="anchor" href="#skill-vs-mcp" aria-label="Link to this section">#</a>
     </h2>
     <p>
-      The <strong>skills</strong> teach the agent when and how to use the CLI — for example staging a
-      before/after with <code>uploads put</code> as it works, or baking callouts onto a capture with <code
+      The skill teaches the agent when and how to use the CLI — for example staging a before/after
+      with <code>uploads put</code>, or baking callouts onto a capture with <code
         >uploads screenshot --annotate</code
-      >. The local stdio MCP (<code>uploads mcp</code>) gives the same tools as the CLI, including
-      <code>attach</code>. The hosted MCP at <code>agents.uploads.sh</code> is for agents without a local
-      checkout: it has <code>put</code>, <code>list</code>, <code>delete</code>, and more — not <code
-        >attach</code
-      >, and no git defaults. Stage with <code>put</code> plus <code>repo</code> and <code
-        >branch</code
-      >. Once a PR exists, <code>promote</code> with <code>repo</code>, <code>pr</code>, and <code
-        >branch</code
-      >. Hosted <code>put</code>/<code>comment</code> honor a repo's&#32;
-      <a href="/docs/comment-config"><code>.uploads.yml</code></a> the same way the bot does. Register
-      the local server with any MCP client, e.g.:
+      >.
+    </p>
+    <p>
+      The local stdio MCP (<code>uploads mcp</code>) exposes the same tools as the CLI, including
+      <code>attach</code>. Register it with any MCP client, e.g.:
     </p>
     <div class="cmd">
       <span class="text">claude mcp add uploads -- uploads mcp</span>
@@ -110,6 +108,14 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
         >copy</button
       >
     </div>
+    <p>
+      The hosted MCP at <code>agents.uploads.sh</code> is for agents with no local checkout. It has
+      <code>put</code>, <code>list</code>, <code>delete</code>, and more, but not <code>attach</code
+      >, and no git defaults — pass <code>repo</code> and <code>branch</code> to <code>put</code> to stage,
+      then <code>repo</code>, <code>pr</code>, and <code>branch</code> to <code>promote</code> once a
+      PR exists. Hosted <code>put</code>/<code>comment</code> honor a repo's&#32;
+      <a href="/docs/comment-config"><code>.uploads.yml</code></a> the same way the bot does.
+    </p>
     <div class="note">
       Want the guided version? The <a href="/github-screenshots">agent walkthrough</a> takes a coding
       agent from install to a first staged before/after.
@@ -125,15 +131,28 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
       >
     </h2>
     <p>
-      Any agent that can run a shell command can capture at each visual milestone and run a bare <code
-        >uploads put ./shot.png --state before|after</code
-      > — on a branch it stages automatically, no <code>--branch</code> flag required. A bare&#32;
-      <code>uploads screenshot</code> stages the same way, carrying its derived&#32;
-      <code>path</code>/<code>url</code>/<code>env</code>/<code>viewport</code> metadata through promotion.
-      <code>--state</code> is still worth keeping as a habit; it's the one thing no tool can infer from
-      the image. Let the PR comment assemble itself once a PR opens — via the GitHub App webhook, or the
-      next <code>uploads attach</code> (or <code>uploads attach --promote</code>) without the App.
-      See the <a href="/github-screenshots">stage-as-you-go walkthrough</a>&#32; for the full loop.
+      Any agent that can run a shell command can capture at each visual milestone and stage it — no
+      PR required yet, and no <code>--branch</code> flag needed on a branch:
+    </p>
+    <div class="cmd">
+      <span class="text"
+        >uploads put ./shot.png --state before <span class="cm"># or --state after</span></span
+      >
+      <button type="button" data-copy="uploads put ./shot.png --state before" aria-live="polite"
+        >copy</button
+      >
+    </div>
+    <p>
+      A bare <code>uploads screenshot</code> stages the same way, carrying its derived <code
+        >path</code
+      >, <code>url</code>, <code>env</code>, and <code>viewport</code> metadata through promotion. Keep
+      using <code>--state</code> — it's the one thing no tool can infer from the image.
+    </p>
+    <p>
+      Once a PR opens, the comment assembles itself: via the GitHub App webhook, or the next <code
+        >uploads attach</code
+      > (or <code>uploads attach --promote</code>) without the App. See the&#32;
+      <a href="/github-screenshots">stage-as-you-go walkthrough</a> for the full loop.
     </p>
   </section>
 
@@ -163,7 +182,7 @@ staged files are promoted into the PR's attachments comment automatically.</pre>
     </div>
     <p>
       Requires the <code>uploads</code> CLI on <code>PATH</code> and <code>uploads login</code>&#32;
-      already run once — see <a href="#install">One command</a> above.
+      already run once — see <a href="#install">Install</a> above.
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -130,14 +130,10 @@ const TOC = [
       >
     </div>
     <p>
-      See what's queued for the current branch, and whether it'll actually auto-attach, with&#32;
-      <code>uploads staged</code>:
+      Run <code>uploads staged</code> to see what's queued for the current branch, and whether it'll actually
+      auto-attach:
     </p>
-    <div class="cmd">
-      <span class="text">uploads staged</span>
-      <button type="button" data-copy="uploads staged" aria-live="polite">copy</button>
-    </div>
-    <div class="block" aria-label="Example output">
+    <div class="block" aria-label="Example uploads staged output">
       <pre>after.webp  94.2 KB  staged 2026-07-22T14:00:00Z  https://storage.uploads.sh/gh/you/app/branch/feat-nav/after.webp
 binding: self — these auto-attach when this branch's PR opens
 once the PR exists: uploads attach --promote</pre>

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -86,54 +86,15 @@ const TOC = [
       </div>
     </div>
     <p>
-      Run <code>attach</code> again with new files and this same comment updates in place, so your PR
-      doesn't collect a trail of stale screenshot comments.
+      Run <code>attach</code> again with new files and this same comment updates in place, instead of
+      collecting a trail of stale screenshot comments.
     </p>
     <p>
-      It uses the <code>gh</code> CLI to find the current repo and PR. If you're not on a PR branch, or
-      you want a different target, say so explicitly:
+      It uses the <code>gh</code> CLI to find the current repo and PR. Off a PR branch, or targeting somewhere
+      else, add <code>--pr &lt;n&gt;</code> or <code>--issue &lt;n&gt;</code>, and&#32;
+      <code>--repo owner/name</code> for a different repo. Add <code>--no-comment</code> to print the
+      URLs and Markdown without posting anything.
     </p>
-    <div class="cmd">
-      <span class="text"
-        >uploads attach ./shot.png --pr 123 <span class="cm"># a specific PR</span></span
-      >
-      <button type="button" data-copy="uploads attach ./shot.png --pr 123" aria-live="polite"
-        >copy</button
-      >
-    </div>
-    <div class="cmd">
-      <span class="text"
-        >uploads attach ./shot.png --issue 45 <span class="cm"># an issue instead</span></span
-      >
-      <button type="button" data-copy="uploads attach ./shot.png --issue 45" aria-live="polite"
-        >copy</button
-      >
-    </div>
-    <div class="cmd">
-      <span class="text"
-        >uploads attach ./shot.png --repo owner/name --pr 123 <span class="cm"
-          ># a different repo</span
-        ></span
-      >
-      <button
-        type="button"
-        data-copy="uploads attach ./shot.png --repo owner/name --pr 123"
-        aria-live="polite">copy</button
-      >
-    </div>
-    <p>
-      Want the URLs and ready-to-paste Markdown without touching any GitHub comment (say, to drop an
-      image into a PR description yourself)?
-    </p>
-    <div class="cmd">
-      <span class="text"
-        >uploads attach ./shot.png --no-comment <span class="cm"># print URLs, post nothing</span
-        ></span
-      >
-      <button type="button" data-copy="uploads attach ./shot.png --no-comment" aria-live="polite"
-        >copy</button
-      >
-    </div>
   </section>
 
   <section id="staging">
@@ -192,7 +153,7 @@ once the PR exists: uploads attach --promote</pre>
       <a href="/docs/github-app#staging">GitHub App: staging before a PR exists</a> for what each binding
       state means and how to fix it.
     </p>
-    <p>
+    <p class="note">
       Once the PR opens, the next <code>attach</code> against it promotes those staged files automatically
       — or run <code>uploads attach --promote</code> with no files to do it explicitly (<code
         >--no-promote</code
@@ -221,18 +182,11 @@ once the PR exists: uploads attach --promote</pre>
         aria-live="polite">copy</button
       >
     </div>
-    <div class="cmd">
-      <span class="text">uploads put ./hero-after.webp --state after</span>
-      <button
-        type="button"
-        data-copy="uploads put ./hero-after.webp --state after"
-        aria-live="polite">copy</button
-      >
-    </div>
     <p>
-      Two files pair when they share a <code>--meta path</code> value and one is&#32;
-      <code>before</code> while the other is <code>after</code>. That's the form to use when a
-      single comment carries several pairs — the <code>path</code> is what keeps them from crossing:
+      Its counterpart uses <code>--state after</code> in place of <code>before</code>. Two files
+      pair when they share a <code>--meta path</code> value and one is <code>before</code> while the other
+      is <code>after</code> — the form to use when a single comment carries several pairs, since&#32;
+      <code>path</code> is what keeps them from crossing:
     </p>
     <div class="cmd">
       <span class="text">uploads put ./settings-old.webp --meta path=/settings --state before</span>
@@ -249,11 +203,13 @@ once the PR exists: uploads attach --promote</pre>
       <code>beforehand.webp</code> doesn't match. A group with two befores and one after is ambiguous
       and won't pair; it falls back to the normal stacked list. Only images pair.
     </p>
-    <p>
+    <p class="note">
       Pairing isn't only a comment thing — a file's public page shows its counterpart next to it,
-      with a link either way. <code>--state</code> also takes <code>empty</code>,&#32;
-      <code>error</code>, and <code>loading</code> for the other states worth capturing; those are searchable
-      with <code>uploads find</code> but don't pair.
+      with a link either way. <code>--state</code> also takes <code>empty</code>, <code>error</code
+      >, and&#32;
+      <code>loading</code> for the other states worth capturing; those are searchable with <code
+        >uploads find</code
+      > but don't pair.
     </p>
   </section>
 
@@ -288,32 +244,11 @@ plain dated upload.</pre>
 URL: <span class="v">https://storage.uploads.sh/screenshots/app/2026-07-12/shot-9f2c1a.webp</span>
 MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot-9f2c1a.webp)</pre>
     </div>
-    <p>A few useful variations:</p>
-    <div class="cmd">
-      <span class="text"
-        >uploads put ./shot.png --pr 123 <span class="cm"># also post to the PR</span></span
-      >
-      <button type="button" data-copy="uploads put ./shot.png --pr 123" aria-live="polite"
-        >copy</button
-      >
-    </div>
-    <div class="cmd">
-      <span class="text"
-        >uploads put ./shot.png --no-optimize <span class="cm"># upload the original bytes</span
-        ></span
-      >
-      <button type="button" data-copy="uploads put ./shot.png --no-optimize" aria-live="polite"
-        >copy</button
-      >
-    </div>
-    <div class="cmd">
-      <span class="text"
-        >uploads put ./mobile.png --frame phone <span class="cm"># add device chrome</span></span
-      >
-      <button type="button" data-copy="uploads put ./mobile.png --frame phone" aria-live="polite"
-        >copy</button
-      >
-    </div>
+    <p>
+      Useful flags: <code>--pr 123</code> also posts to that PR, <code>--no-optimize</code> uploads the
+      original bytes instead of re-encoding, and <code>--frame phone</code> adds device chrome to a mobile
+      screenshot.
+    </p>
     <p>
       By default, images are re-encoded to WebP (capped size, high quality) so GitHub embeds stay
       fast, and <strong>EXIF is stripped from the uploaded bytes</strong>. Use&#32;
@@ -335,7 +270,7 @@ MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot
       <a href="/docs/reference#good-to-know">Reference</a>.
     </p>
     <p class="note">
-      Details: any of <code>--pr</code>, <code>--issue</code>, <code>--key</code>,&#32;
+      Also: any of <code>--pr</code>, <code>--issue</code>, <code>--key</code>,&#32;
       <code>--ref</code>, <code>--prefix</code>, or <code>--destination</code> opts a bare&#32;
       <code>put</code> out of branch staging, as does <code>--no-git</code>. Staged keys have no
       content-hash suffix (unlike the dated layout above) — they're stable per filename, so
@@ -367,43 +302,11 @@ MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot
 URL: <span class="v">https://storage.uploads.sh/gh/app/example/pull/123/app.example.webp</span>
 MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.example.webp)</pre>
     </div>
-    <p>A few useful variations:</p>
-    <div class="cmd">
-      <span class="text"
-        >uploads screenshot ./report.html --dark --selector "main" <span class="cm"
-          ># dark scheme</span
-        ></span
-      >
-      <button
-        type="button"
-        data-copy='uploads screenshot ./report.html --dark --selector "main"'
-        aria-live="polite">copy</button
-      >
-    </div>
-    <div class="cmd">
-      <span class="text"
-        >uploads screenshot ./card.html --no-upload --out ./card.png <span class="cm"
-          ># no hosting</span
-        ></span
-      >
-      <button
-        type="button"
-        data-copy="uploads screenshot ./card.html --no-upload --out ./card.png"
-        aria-live="polite">copy</button
-      >
-    </div>
-    <div class="cmd">
-      <span class="text"
-        >uploads screenshot http://localhost:4321 --reduced-motion <span class="cm"
-          ># clean dev-server shot</span
-        ></span
-      >
-      <button
-        type="button"
-        data-copy="uploads screenshot http://localhost:4321 --reduced-motion"
-        aria-live="polite">copy</button
-      >
-    </div>
+    <p>
+      Useful flags: <code>--dark</code> renders in dark scheme, <code>--selector</code> captures one element
+      instead of the full page, <code>--no-upload --out &lt;path&gt;</code> skips hosting and writes a
+      local file, and <code>--reduced-motion</code> settles animations for a clean dev-server shot.
+    </p>
     <p>
       If a Chrome or Chromium is already on the machine, <code>screenshot</code> drives it directly (nothing
       to download); otherwise it renders on uploads.sh servers. Force either side with <code
@@ -420,17 +323,17 @@ MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.
     <p>
       When you shoot your own dev server, it hides known framework dev toolbars (Astro, Next, Nuxt,
       Vite) automatically (opt out with
-      <code>--no-hide-dev-tools</code>) and takes <code>--reduced-motion</code> to settle animations.
-      Hide any other overlay with <code>--hide &lt;selector&gt;</code>
+      <code>--no-hide-dev-tools</code>). Hide any other overlay with <code
+        >--hide &lt;selector&gt;</code
+      >
       (repeatable), or run setup JS first with <code>--eval &lt;js&gt;</code> /
       <code>--init-script &lt;file&gt;</code> (local backend).
     </p>
-    <p>
+    <p class="note">
       Capturing a clicked or selected state of a React/Next app? A synthetic <code>el.click()</code>
-      in <code>--eval</code> fires before the framework hydrates — the element is in the server-rendered
-      HTML but no handler is attached yet, so it silently does nothing. Gate on the app's own &ldquo;interactive&rdquo;
-      signal with <code>--wait-for &lt;js&gt;</code> (local backend), which polls that expression until
-      truthy before <code>--eval</code> runs — e.g.
+      in <code>--eval</code> fires before the framework hydrates, so it silently does nothing — gate on
+      the app's own "interactive" signal with <code>--wait-for &lt;js&gt;</code> (local backend), which
+      polls that expression until truthy before <code>--eval</code> runs, e.g.
       <code>--wait-for 'document.querySelector("[data-hydrated]")'</code>.
     </p>
   </section>
@@ -490,7 +393,7 @@ MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.
       > with <code>style: "solid"</code>
       for secrets — hosted files are public, and blurred text can be recoverable.
     </p>
-    <p>
+    <p class="note">
       Full spec format, selector vs pixel rules, and workflow notes live in the&#32;
       <a
         href="https://github.com/buildinternet/uploads/blob/main/skills/annotate-screenshots/SKILL.md"

--- a/apps/web/src/pages/docs/byo-bucket.astro
+++ b/apps/web/src/pages/docs/byo-bucket.astro
@@ -32,6 +32,16 @@ const TOC = [
       Set up your bucket <a class="anchor" href="#setup" aria-label="Link to this section">#</a>
     </h2>
     <p>
+      Point a workspace at a Cloudflare R2 bucket you already control. With your own bucket you:
+    </p>
+    <ul>
+      <li>Keep files on storage you pay for and own directly — uploads.sh never holds a copy.</li>
+      <li>
+        Switch back to hosted storage any time, instantly and without touching existing files.
+      </li>
+      <li>See <a href="#degraded">what's different</a> on a BYO bucket before you switch.</li>
+    </ul>
+    <p>
       A workspace admin connects from the workspace settings page — one form, filled from three
       things you set up on the Cloudflare dashboard first (plus one optional cache rule).
     </p>
@@ -64,26 +74,26 @@ const TOC = [
     </p>
     <h3>4. Optional but recommended: add a cache rule for GitHub embeds</h3>
     <p>
-      On hosted storage, images embedded in GitHub comments refresh when a file is overwritten in
-      place, because a dedicated embed host serves badge-style no-cache headers that GitHub's Camo
-      proxy revalidates. You can give your own domain the same behavior with one rule on your zone:
-      <strong>Rules</strong> → <strong>Transform Rules</strong> →
-      <strong>Modify Response Header</strong>, matching your domain's hostname, setting
-      <code>Cache-Control</code> to <code>max-age=0, no-cache, no-store, must-revalidate</code>.
-      Verification checks for it and reminds you if it's missing — without it everything still
-      works, but a GitHub embed can keep showing the old bytes after an in-place overwrite. The
-      trade-off: these headers turn off edge caching for the whole domain, which is negligible for
-      screenshot workflows (R2 egress is free) but worth weighing if the same bucket serves
-      high-traffic assets — in that case, connect a second custom domain to the bucket and scope the
-      rule to just that host.
+      On hosted storage, a dedicated embed host serves badge-style no-cache headers that GitHub's
+      Camo proxy revalidates, so an overwritten image refreshes in place. Give your own domain the
+      same behavior with one rule on your zone: <strong>Rules</strong> →
+      <strong>Transform Rules</strong> → <strong>Modify Response Header</strong>, matching your
+      domain's hostname, setting <code>Cache-Control</code> to
+      <code>max-age=0, no-cache, no-store, must-revalidate</code>. Verification checks for it and
+      reminds you if it's missing. Without it, everything still works — a GitHub embed can just keep
+      showing the old bytes after an in-place overwrite.
+    </p>
+    <p class="note">
+      The rule turns off edge caching for the whole domain — negligible for screenshot workflows (R2
+      egress is free), but worth weighing if the same bucket also serves high-traffic assets. In
+      that case, connect a second custom domain to the bucket and scope the rule to just that host.
     </p>
     <p>
       Then <strong>Verify &amp; save</strong>: one click checks the settings, signs in to the
       bucket, round-trips a test object, and fetches it through your public URL. Anything that fails
       is spelled out on the form; a clean pass saves. Saving never changes where uploads go — the
       bucket sits on your settings page as "Not in use yet" until you click
-      <strong>Use this bucket</strong>, so you can connect and verify at any time without any risk
-      to what's already uploading.
+      <strong>Use this bucket</strong>.
     </p>
     <p class="note">
       Switching is instant and reversible, even for a workspace that already has files: existing

--- a/apps/web/src/pages/docs/comment-config.astro
+++ b/apps/web/src/pages/docs/comment-config.astro
@@ -5,6 +5,51 @@
 // optional note. Read by the bot, the hosted MCP comment path, and the CLI's
 // gh-fallback path.
 import DocsLayout from "../../layouts/DocsLayout.astro";
+import { Code } from "astro:components";
+
+const EXAMPLE_YAML = `comment:
+  # "auto" (the default filename-based sizing), "full" (natural width up to
+  # the comment column, no fixed attribute), or a pixel number from 160 to
+  # 1000. Applies to inline images, pair cells, and video posters alike;
+  # "full" and an explicit number override their sizing too, "auto" keeps it.
+  imageWidth: auto
+
+  # How many images render inline before the rest collapse to links.
+  # Clamped to 1-48. Default: 16.
+  maxInlineImages: 16
+
+  # Caption metadata under each image. Each key can be forced on or off.
+  # An omitted key follows the workspace default.
+  meta:
+    path: true
+    state: true
+
+  # Whether images link to the file's share page. Overrides the workspace
+  # setting.
+  linkToFilePage: true
+
+  # Whether images and video dropped directly on GitHub PRs and issues get
+  # imported into the workspace. On by default.
+  ingestGithubAttachments: true
+
+  # Whether attachments authored by [bot] accounts are imported too.
+  # Off by default — bot-posted media is usually noise (status GIFs, badges).
+  # Tiny images (under 200px on either side) are always skipped.
+  ingestBotAttachments: false
+
+  # Whether uploads.sh file links pasted directly into a PR body or comment
+  # (bypassing --pr/attach context — a bare paste, or a raw curl upload) get
+  # adopted into that PR/issue's attachment context. Only links to files
+  # already in this repo's own bound workspace are adopted; links to any
+  # other workspace's files are ignored. On by default for bound repos.
+  adoptLinkedFiles: true
+
+  # Optional short markdown at the top of the comment, before the media —
+  # repo-specific context, a link to a contributing guide, and so on.
+  # Trimmed, capped at 500 characters, rendered as-is: it's
+  # repo-owner-authored markdown in the owner's own repo, the same trust
+  # level as a PR description. Empty or whitespace-only counts as absent.
+  note: ""`;
 
 const TOC = [
   { id: "what-it-controls", label: "What it controls" },
@@ -62,51 +107,7 @@ const TOC = [
   <section id="example">
     <h2>Full example <a class="anchor" href="#example" aria-label="Link to this section">#</a></h2>
     <p>Save it at the repo root:</p>
-    <div class="block" aria-label="Example .uploads.yml">
-      <pre>comment:
-  # "auto" (the default filename-based sizing), "full" (natural width up to
-  # the comment column, no fixed attribute), or a pixel number from 160 to
-  # 1000. Applies to inline images, pair cells, and video posters alike;
-  # "full" and an explicit number override their sizing too, "auto" keeps it.
-  imageWidth: auto
-
-  # How many images render inline before the rest collapse to links.
-  # Clamped to 1-48. Default: 16.
-  maxInlineImages: 16
-
-  # Caption metadata under each image. Each key can be forced on or off.
-  # An omitted key follows the workspace default.
-  meta:
-    path: true
-    state: true
-
-  # Whether images link to the file's share page. Overrides the workspace
-  # setting.
-  linkToFilePage: true
-
-  # Whether images and video dropped directly on GitHub PRs and issues get
-  # imported into the workspace. On by default.
-  ingestGithubAttachments: true
-
-  # Whether attachments authored by [bot] accounts are imported too.
-  # Off by default — bot-posted media is usually noise (status GIFs, badges).
-  # Tiny images (under 200px on either side) are always skipped.
-  ingestBotAttachments: false
-
-  # Whether uploads.sh file links pasted directly into a PR body or comment
-  # (bypassing --pr/attach context — a bare paste, or a raw curl upload) get
-  # adopted into that PR/issue's attachment context. Only links to files
-  # already in this repo's own bound workspace are adopted; links to any
-  # other workspace's files are ignored. On by default for bound repos.
-  adoptLinkedFiles: true
-
-  # Optional short markdown at the top of the comment, before the media —
-  # repo-specific context, a link to a contributing guide, and so on.
-  # Trimmed, capped at 500 characters, rendered as-is: it's
-  # repo-owner-authored markdown in the owner's own repo, the same trust
-  # level as a PR description. Empty or whitespace-only counts as absent.
-  note: ""</pre>
-    </div>
+    <Code code={EXAMPLE_YAML} lang="yaml" theme="vitesse-dark" class="yaml-example" />
     <div class="note">
       A value outside its valid range doesn't fail the whole file: numbers clamp to their bounds,
       and an unrecognized value for a key drops just that key while every other key still applies.
@@ -208,3 +209,23 @@ const TOC = [
     <a class="next" href="/docs/agents"><span class="dir">Next →</span>Set up your agent</a>
   </nav>
 </DocsLayout>
+
+<style>
+  /* Shiki-highlighted YAML example: drop it into the same panel container the
+     .block primitive uses, and keep CLI-flag ligatures literal ("--" stays "--"). */
+  :global(pre.astro-code.yaml-example) {
+    background: var(--panel) !important;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    padding: 12px 14px;
+    margin: 12px 0;
+    font-family: var(--mono);
+    font-size: var(--text-meta);
+    line-height: 1.6;
+    overflow-x: auto;
+    font-variant-ligatures: none;
+    font-feature-settings:
+      "calt" 0,
+      "liga" 0;
+  }
+</style>

--- a/apps/web/src/pages/docs/comment-config.astro
+++ b/apps/web/src/pages/docs/comment-config.astro
@@ -33,9 +33,8 @@ const TOC = [
       >
     </h2>
     <p>
-      Every key is optional and lives under a top-level <code>comment:</code> map. Most of it is presentation
-      — how the managed comment looks — plus two keys that control whether GitHub-posted attachments get
-      <a href="/docs/github-app#ingest">imported into the workspace</a>.
+      Commit <code>.uploads.yml</code> at a repo's root to shape how its managed comment renders. Every
+      key lives under a top-level <code>comment:</code> map and is optional. With it you can set:
     </p>
     <ul>
       <li><strong>Image width</strong> for inline images, pair cells, and video posters.</li>
@@ -44,24 +43,25 @@ const TOC = [
       <li><strong>Whether images link</strong> to the file's share page.</li>
       <li><strong>A short note</strong> shown at the top of the comment.</li>
       <li>
-        <strong>Whether GitHub-posted attachments are imported</strong>, and whether bot-authored
-        ones count.
+        <strong
+          >Whether GitHub-posted attachments are <a href="/docs/github-app#ingest">imported</a> into the
+          workspace</strong
+        >, and whether bot-authored ones count.
       </li>
       <li>
         <strong>Whether uploads.sh links pasted into a PR or comment are adopted</strong> into that PR/issue's
         attachment context.
       </li>
     </ul>
-    <p>
-      Nothing in the file can change where files are hosted or which repo a workspace can post to —
-      it reshapes the comment body for a repo that's already allowed to receive one, and gates
-      whether that repo's GitHub-posted attachments get mirrored in.
-    </p>
+    <div class="note">
+      The file only reshapes the comment for a repo that's already allowed to receive one — it can't
+      change where files are hosted or which repo a workspace can post to.
+    </div>
   </section>
 
   <section id="example">
     <h2>Full example <a class="anchor" href="#example" aria-label="Link to this section">#</a></h2>
-    <p>Commit this at the repo root as <code>.uploads.yml</code>:</p>
+    <p>Save it at the repo root:</p>
     <div class="block" aria-label="Example .uploads.yml">
       <pre>comment:
   # "auto" (the default filename-based sizing), "full" (natural width up to
@@ -107,10 +107,10 @@ const TOC = [
   # level as a PR description. Empty or whitespace-only counts as absent.
   note: ""</pre>
     </div>
-    <p class="note">
+    <div class="note">
       A value outside its valid range doesn't fail the whole file: numbers clamp to their bounds,
       and an unrecognized value for a key drops just that key while every other key still applies.
-    </p>
+    </div>
   </section>
 
   <section id="file-location">

--- a/apps/web/src/pages/docs/galleries.astro
+++ b/apps/web/src/pages/docs/galleries.astro
@@ -24,9 +24,9 @@ const TOC = [
       What a gallery is <a class="anchor" href="#what" aria-label="Link to this section">#</a>
     </h2>
     <p>
-      A gallery is an ordered set of media behind one public link. You get a durable URL that stays
-      current as you add shots, instead of scattering individual file links. Each gallery has a
-      public share page at <code>/g/&lt;id&gt;</code>.
+      A gallery is an ordered set of media behind one public link, so you can share a whole batch of
+      shots as they're captured instead of one URL per file. Each gallery has a public page at
+      <code>/g/&lt;id&gt;</code>.
     </p>
   </section>
 
@@ -34,33 +34,21 @@ const TOC = [
     <h2>
       CLI workflow <a class="anchor" href="#workflow" aria-label="Link to this section">#</a>
     </h2>
-    <p>Create a gallery, then add files to it as you capture them:</p>
+    <p>Create a gallery — this prints its id:</p>
     <div class="cmd">
-      <span class="text"
-        >uploads gallery create --title "Release screenshots" <span class="cm"
-          ># returns a gallery id</span
-        ></span
-      >
+      <span class="text">uploads gallery create --title "Release screenshots"</span>
       <button
         type="button"
         data-copy='uploads gallery create --title "Release screenshots"'
         aria-live="polite">copy</button
       >
     </div>
+    <p>Then add files to it, passing that id to <code>--gallery</code>:</p>
     <div class="cmd">
-      <span class="text"
-        >uploads put ./shot.png --gallery &lt;id&gt; <span class="cm"
-          ># add a file to the gallery</span
-        ></span
-      >
-      <button type="button" data-copy="uploads put ./shot.png --gallery" aria-live="polite"
-        >copy</button
-      >
+      <span class="text">uploads put ./shot.png --gallery &lt;id&gt;</span>
+      <button type="button" data-copy="uploads put" aria-live="polite">copy</button>
     </div>
-    <p>
-      The create command prints a gallery id. Pass that id to <code>--gallery</code> on later uploads.
-      The public page at <code>/g/&lt;id&gt;</code> updates as items are added.
-    </p>
+    <p>The public page at <code>/g/&lt;id&gt;</code> updates as items are added.</p>
   </section>
 
   <section id="linking">
@@ -69,20 +57,13 @@ const TOC = [
       >
     </h2>
     <p>
-      Linking a gallery to a pull request or issue keeps the public link associated with that work.
-      It is metadata only — the gallery stays public at the same <code>/g/&lt;id&gt;</code> URL.
+      Optional — this is metadata only, the gallery stays public at the same <code
+        >/g/&lt;id&gt;</code
+      > URL:
     </p>
     <div class="cmd">
-      <span class="text"
-        >uploads gallery link &lt;id&gt; --github owner/repo#123 <span class="cm"
-          ># associate with a PR or issue</span
-        ></span
-      >
-      <button
-        type="button"
-        data-copy="uploads gallery link --github owner/repo#123"
-        aria-live="polite">copy</button
-      >
+      <span class="text">uploads gallery link &lt;id&gt; --github owner/repo#123</span>
+      <button type="button" data-copy="uploads gallery link" aria-live="polite">copy</button>
     </div>
   </section>
 

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -86,17 +86,12 @@ const TOC = [
     <h2>Install it <a class="anchor" href="#install" aria-label="Link to this section">#</a></h2>
     <p>
       <a href={GITHUB_APP_INSTALL_URL}>Install the App on GitHub</a> and pick the repositories you attach
-      files to (add more later in GitHub's settings). That's the whole setup — the next <code
-        >uploads attach</code
-      > against an installed repo posts as the bot:
+      files to (add more later in GitHub's settings). That's the whole setup — the next command run against
+      an installed repo posts as the bot instead of your own account:
     </p>
     <div class="cmd">
       <span class="text">uploads attach ./after.png</span>
       <button type="button" data-copy="uploads attach ./after.png" aria-live="polite">copy</button>
-    </div>
-    <div class="block" aria-label="Example output">
-      <pre>&gt;&gt; uploading ./after.png
-<span class="ok">&gt;&gt; attachments comment updated (uploads-sh[bot])</span></pre>
     </div>
   </section>
 
@@ -119,12 +114,11 @@ const TOC = [
       <code>path</code>/<code>url</code>/<code>env</code>/<code>viewport</code> metadata through promotion
       once the PR opens.
     </p>
-    <p>
-      <code>uploads attach --branch ./a.png ./b.png</code> is the explicit multi-file form of the same
-      thing. See&#32;
+    <p class="pointer">
+      Staging several files at once? Use <code>uploads attach --branch</code> instead —&#32;
       <a href="/docs/attach-pull-request-images#staging"
-        >Attach &amp; share: stage before a PR exists</a
-      > for <code>uploads staged</code> and the binding states.
+        >see staging &amp; binding states <span class="go">→</span></a
+      >.
     </p>
     <p>
       The moment a PR opens for that branch (or reopens, or gets new commits), the App promotes the
@@ -205,12 +199,8 @@ const TOC = [
       </li>
     </ul>
     <p>
-      <code>uploads github doctor</code> checks the subscriptions directly and reports anything missing:
+      <code>uploads github doctor</code> checks the subscriptions directly and reports anything missing.
     </p>
-    <div class="cmd">
-      <span class="text">uploads github doctor</span>
-      <button type="button" data-copy="uploads github doctor" aria-live="polite">copy</button>
-    </div>
   </section>
 
   <section id="bindings">
@@ -220,13 +210,8 @@ const TOC = [
     <p>
       Each repo maps to at most one workspace's managed comment. The binding is created implicitly
       the first time a workspace comments, attaches, or promotes against a repo; inspect or claim it
-      explicitly with:
+      explicitly with <code>uploads github link --status</code>.
     </p>
-    <div class="cmd">
-      <span class="text">uploads github link --status</span>
-      <button type="button" data-copy="uploads github link --status" aria-live="polite">copy</button
-      >
-    </div>
     <ul>
       <li>
         <strong>Bindings can't be stolen.</strong> Claiming a bound repo just reports the current owner.

--- a/apps/web/src/pages/docs/limits.astro
+++ b/apps/web/src/pages/docs/limits.astro
@@ -104,8 +104,10 @@ const TOC = [
       </li>
       <li>
         <strong>Storage full.</strong> New uploads are rejected until you free space. Existing files keep
-        serving. Run <code>uploads list</code> and <code>uploads delete</code> to clear room, or check
-        <code>uploads usage</code> to see where you stand.
+        serving. Check <code>uploads usage</code> to see where you stand, then <code
+          >uploads list</code
+        > and
+        <code>uploads delete</code> to clear room.
       </li>
       <li>
         <strong>Member cap (free).</strong> Invites beyond the cap are refused, pending invites included.

--- a/apps/web/src/pages/docs/reference.astro
+++ b/apps/web/src/pages/docs/reference.astro
@@ -21,29 +21,12 @@ const REPO = "https://github.com/buildinternet/uploads";
       >
     </h2>
     <p>Commands for managing what's already uploaded:</p>
-    <div class="cmd">
-      <span class="text">uploads list <span class="cm"># see your files</span></span>
-      <button type="button" data-copy="uploads list" aria-live="polite">copy</button>
-    </div>
-    <div class="cmd">
-      <span class="text">uploads delete &lt;key&gt; <span class="cm"># remove a file</span></span>
-      <button type="button" data-copy="uploads delete" aria-live="polite">copy</button>
-    </div>
-    <div class="cmd">
-      <span class="text"
-        >uploads usage <span class="cm"># storage used by your workspace</span></span
-      >
-      <button type="button" data-copy="uploads usage" aria-live="polite">copy</button>
-    </div>
-    <div class="cmd">
-      <span class="text"
-        >uploads staged <span class="cm"># what's queued for this branch</span></span
-      >
-      <button type="button" data-copy="uploads staged" aria-live="polite">copy</button>
-    </div>
-    <div class="cmd">
-      <span class="text">uploads --help <span class="cm"># everything else</span></span>
-      <button type="button" data-copy="uploads --help" aria-live="polite">copy</button>
+    <div class="block" aria-label="Commands for managing uploads">
+      <pre><span class="v">uploads list</span>          # see your files
+<span class="v">uploads delete &lt;key&gt;</span>  # remove a file
+<span class="v">uploads usage</span>         # storage used by your workspace
+<span class="v">uploads staged</span>        # what's queued for this branch
+<span class="v">uploads --help</span>        # everything else</pre>
     </div>
   </section>
 

--- a/apps/web/src/pages/docs/reference.astro
+++ b/apps/web/src/pages/docs/reference.astro
@@ -20,6 +20,7 @@ const REPO = "https://github.com/buildinternet/uploads";
         >#</a
       >
     </h2>
+    <p>Commands for managing what's already uploaded:</p>
     <div class="cmd">
       <span class="text">uploads list <span class="cm"># see your files</span></span>
       <button type="button" data-copy="uploads list" aria-live="polite">copy</button>
@@ -107,8 +108,8 @@ const REPO = "https://github.com/buildinternet/uploads";
           >/f/…</code
         > or <code>/g/…</code> with
         <a href="https://oembed.com/">oEmbed</a> discovery, so tools that unfurl links can show the media.
-        The endpoint is
-        <code>GET /oembed?url=&lt;page-url&gt;&amp;format=json</code>.
+        Resolve one directly via <code>/oembed</code>, passing the page URL as its&#32;
+        <code>url</code> query param.
       </li>
       <li>
         <strong>Getting access.</strong> Sign in and create your own workspace with a linked GitHub account,

--- a/skills/docs-page-style/SKILL.md
+++ b/skills/docs-page-style/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: docs-page-style
+description: >-
+  House style and structure for uploads.sh documentation pages — the Astro
+  pages under apps/web/src/pages/docs/ (and docs.astro) built on DocsLayout.
+  Use this whenever you write, restructure, trim, or review a docs page:
+  requests like "clean up the galleries docs", "this docs page has too much
+  prose", "rework the agents page", "the flow on /docs/comment-config feels
+  complicated", "make the reference page scannable", or any edit to a file
+  under apps/web/src/pages/docs/. Encodes the page structure (understand →
+  set up → do), the Stripe-style intro voice, the copy-affordance and
+  inline-code rules, the prose diet, and the DocsLayout component vocabulary,
+  so every docs page reads like one deliberate, scannable system rather than a
+  wall of prose. Reach for it even mid-task when you notice a docs page drifting
+  toward heavy paragraphs, fabricated terminal output, or a copy button on
+  every line.
+---
+
+# uploads.sh docs page style
+
+These pages teach a developer (or their agent) to do one thing with the `uploads`
+CLI and then get out of the way. They are Astro pages built on `DocsLayout`, not
+Markdown — so you work in HTML using a small, fixed component vocabulary. The
+goal is a page that reads like reputable dev-tool docs (Stripe, Vercel, Wrangler):
+one short orientation, then commands you can actually run, with prose used only as
+connective tissue.
+
+The failure mode to fight is the opposite: heavy paragraphs, an example for every
+variation, a copy button on every line, and setup buried below usage. That reads
+as "complicated" even when every sentence is individually fine — because the
+_structure_ makes the reader work.
+
+## How to approach a page
+
+1. **Read the page and identify the ONE thing it's for.** Everything else is
+   secondary and should be demoted or linked out, not given equal weight.
+2. **Decide the page's job.** A hub/landing page (`docs.astro`) _triages and
+   links_ — it should not re-teach what a subject page already covers. A subject
+   page _walks through one workflow_. Don't duplicate a worked example that lives
+   on another page; link to it instead.
+3. **Order it: understand → set up → do.** A short "what/why", then install or
+   prerequisites, then the golden-path command. A reader should be able to run the
+   first real command without scrolling back up to find setup.
+4. **Pick one golden path.** If there are two ways to do the thing, show the more
+   universal one as the worked example and demote the other to a one-line pointer
+   (see the pattern below). Never present two competing commands as parallel
+   entry points — that fork is the single most common source of "this feels
+   complicated."
+5. **Apply the prose, copy, and inline-code rules** below to what's left.
+6. **Verify it renders.** Reuse only the existing component classes, keep every
+   command/flag/link real (never invent one — check a sibling page or the CLI),
+   and confirm the page still compiles.
+
+## Structure & voice
+
+### Intro: one sentence, then a capability list — not paragraphs
+
+Lead with what the tool/feature _does for the reader_, verb-first, then (if scope
+needs conveying) a short bulleted capability list where each bullet links to the
+relevant page. This is the Stripe pattern: the copy reads like a spec sheet, not a
+pitch. No scene-setting ("In this guide…", "uploads.sh is a service that…"), no
+adjectives, no wind-up.
+
+**Prefer:**
+
+```html
+<p>Galleries collect related media behind one public link. With a gallery you can:</p>
+<ul>
+  <li><a href="/docs/…">Group screenshots</a> into an ordered set.</li>
+  <li>Share the whole set with one URL.</li>
+  <li>Link the gallery to a PR or issue.</li>
+</ul>
+```
+
+**Avoid:** a two-sentence throat-clear before the reader learns what the page is
+for, or a second explanatory paragraph _after_ the first command (the reader
+wants to act, not read more).
+
+### One golden path; demote the rest to a pointer
+
+Show the single most universal command as the worked example. A secondary command
+becomes a one-line pointer directly beneath it, linking to where it's covered in
+full:
+
+```html
+<p class="pointer">
+  Already have a PR open? Use <code>uploads attach</code> instead —
+  <a href="/docs/attach-pull-request-images">see the walkthrough <span class="go">→</span></a
+  >.
+</p>
+```
+
+Note the pointer names only the _verb_ (`uploads attach`), not the full
+multi-argument invocation — that lives on the linked page.
+
+### Prose diet
+
+- Cut throat-clearing lead-ins. Every sentence should state a fact or give an
+  instruction.
+- One idea per sentence; split compound sentences glued with a comma or dash.
+- **Never fabricate terminal output.** Reputable docs don't show scripted output.
+  Either show _real, verifiable_ output (a `.block` the reader can reproduce) or
+  describe the effect in one sentence ("That uploads the file and prints a public
+  URL."). Prefer the sentence.
+- Push troubleshooting and edge cases to the end, a `.note`, or a linked page —
+  not into the main reading path.
+
+## Copy-affordance rule
+
+A copy box (`.cmd`) signals "paste this verbatim." Putting one on every line
+trains the eye to see many equally-weighted "do this" boxes when usually only one
+command matters. So:
+
+- **Use `.cmd`** for commands the reader genuinely pastes: the install line, the
+  golden-path command, a long `npx …` one-off.
+- **Use inline `<code>`** for short, memorable, or illustrative commands —
+  `uploads login`, `uploads doctor`, a bare `npx`, a flag, a filename. These are
+  steps you _read_, not snippets you paste.
+
+Rule of thumb: **one copy target per action, not per line.** A typical page has
+one to three copy boxes, not one per command mentioned.
+
+## Inline-code rule
+
+Inline `<code>` is for **short identifiers and single tokens** — a command verb,
+a flag, a package name, a path like `/g/<id>`. This is near-universal in good docs.
+
+**Never set a full, multi-argument command inline** (e.g.
+`uploads attach ./before.png ./after.png` mid-sentence). It forces the reader to
+switch between prose cadence and monospace in one breath, wraps awkwardly across
+lines, and makes a runnable command look like a passing mention. Instead:
+
+- Put the full command in a `.cmd` block, **or**
+- Reference only the verb inline (`uploads attach`) and let the full form live in
+  a block or on the linked page.
+
+Watch inline-code _density_ too: three or more inline-code spans crammed into one
+paragraph reads as busy. Split them across sentences, or move asides (like an
+`npx` alternative or a `doctor` check) into a `.note`.
+
+## Component vocabulary (DocsLayout)
+
+Reuse these classes — don't invent new ones without a strong reason (note any new
+class you add and why). Headings and their `#` anchors, the copy-button behavior,
+the table of contents, and section dividers are all handled by `DocsLayout`
+automatically; you don't wire them up per page.
+
+| Element                                                                   | Use for                                                                                                                                                                                           |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<section class="lead" id="…">`                                           | The first section (no top divider under the page title).                                                                                                                                          |
+| `<section id="…">`                                                        | Every subsequent section; gets a top divider automatically.                                                                                                                                       |
+| `<h2>` with an `<a class="anchor" href="#id">#</a>` inside                | Section heading. The anchor sits in the left gutter and appears on hover; the whole heading is click-to-anchor. Keep the markup pattern; the layout styles it.                                    |
+| `<h3>`                                                                    | Sub-heading within a section (e.g. a card title, a labelled step).                                                                                                                                |
+| `<div class="cmd">` with `<span class="text">` + a `data-copy` `<button>` | A single, copyable command line. `$ ` prompt is auto-prepended; add `class="slash"` for slash-commands typed into an agent (no `$`).                                                              |
+| `<span class="cm">` inside `.text`                                        | A trailing `# comment` on a command (muted).                                                                                                                                                      |
+| `<div class="block">` with `<pre>`                                        | Multi-line, **non-copyable** output. Only for real, reproducible output; `.ok` marks a success line, `.v` a value.                                                                                |
+| `<div class="cards">` + `<a class="card">`                                | The "explore" grid of links to subject pages. Each card: `<h3>Title <span class="go">→</span></h3>` + one-sentence `<p>`. Trim to the highest-intent destinations rather than listing everything. |
+| `<div class="note">`                                                      | A muted aside — the place for asides, "more:" link lists, and edge cases pulled out of the main flow.                                                                                             |
+| `<p class="pointer">`                                                     | A demoted secondary-command line under the golden path (styled quieter than body text). Name only the verb inline; link to where it's covered in full.                                            |
+| `<div class="callout">`                                                   | An accent-tinted contextual banner near the top of a page (e.g. "landed here from a bot comment?"). Use sparingly, for orientation the reader needs before the content.                           |
+| `<div class="installed">`                                                 | A green post-install success banner, revealed by a `?setup_action=…` query param (used on the GitHub App page). Don't add new ones without the matching reveal logic.                             |
+| `<table>`                                                                 | Reference/comparison data (e.g. plans, limits). The natural form for a reference page — prefer it over prose for anything grid-shaped.                                                            |
+| `<nav class="page-nav">` with a `.next`                                   | The prev/next footer link row at the bottom of a subject page. Keep it; update the targets if you re-order pages.                                                                                 |
+| `<div class="ghc">`                                                       | A styled mock GitHub comment (avatar + bubble), for showing what a posted comment looks like. Specialised — only where a page illustrates GitHub output.                                          |
+| `<code>`                                                                  | Short inline identifiers (see the inline-code rule).                                                                                                                                              |
+| `<span class="go">→</span>`                                               | The trailing arrow on card titles and pointers.                                                                                                                                                   |
+
+The canonical example of all of this working together is `apps/web/src/pages/docs.astro`
+(the hub page). Read it before reworking a subject page — it shows the intro +
+capability list, install-first ordering, the golden-path-plus-pointer pattern, the
+copy-affordance rule, and a trimmed card grid in practice.
+
+## Hard constraints
+
+- **Don't invent facts.** Every command, flag, URL, and capability must already
+  exist on the page, a sibling docs page, or the CLI. When unsure, check a sibling
+  page under `apps/web/src/pages/docs/` rather than guessing.
+- **Reuse the vocabulary above.** These are shared styles in `DocsLayout`; a new
+  class means new CSS and drift. Flag it explicitly if you truly need one.
+- **Keep the page valid Astro/HTML** so it compiles, and verify it renders in the
+  browser preview (the `web` dev server) when you can — check the resting state is
+  calm and scannable, not just that it builds.

--- a/skills/docs-page-style/SKILL.md
+++ b/skills/docs-page-style/SKILL.md
@@ -76,6 +76,13 @@ adjectives, no wind-up.
 for, or a second explanatory paragraph _after_ the first command (the reader
 wants to act, not read more).
 
+The thing to cut is _throat-clearing_ ("In this guide…", "uploads.sh is a service
+that…"), not substance. A concrete _why_ — a real constraint the tool exists to
+solve, like "GitHub has no API for file uploads, so agents can't include
+screenshots in pull requests" — earns its two or three sentences, because it
+tells the reader what problem they're actually solving. Lead with that when the
+page has one; keep it tight and get to the capability list.
+
 ### One golden path; demote the rest to a pointer
 
 Show the single most universal command as the worked example. A secondary command
@@ -119,6 +126,24 @@ command matters. So:
 
 Rule of thumb: **one copy target per action, not per line.** A typical page has
 one to three copy boxes, not one per command mentioned.
+
+**A reference list of sibling commands is one block, not N copy rows.** When a
+section just enumerates related commands (a "here's the command surface" menu,
+e.g. `list` / `delete` / `usage` / `--help`), a stack of `.cmd` copy rows reads
+as a wall of buttons. Put them in a single non-copyable `.block` instead —
+command in a `<span class="v">` (brighter), the `# comment` aligned in the muted
+base color:
+
+```html
+<div class="block" aria-label="Commands for managing uploads">
+  <pre><span class="v">uploads list</span>          # see your files
+<span class="v">uploads delete &lt;key&gt;</span>  # remove a file
+<span class="v">uploads usage</span>         # storage used by your workspace</pre>
+</div>
+```
+
+Reserve `.cmd` for the one or two commands in that section a reader actually runs
+in sequence (an install line, a golden path) — not the whole catalog.
 
 ## Inline-code rule
 

--- a/skills/docs-page-style/SKILL.md
+++ b/skills/docs-page-style/SKILL.md
@@ -178,7 +178,7 @@ automatically; you don't wire them up per page.
 | `<h3>`                                                                    | Sub-heading within a section (e.g. a card title, a labelled step).                                                                                                                                |
 | `<div class="cmd">` with `<span class="text">` + a `data-copy` `<button>` | A single, copyable command line. `$ ` prompt is auto-prepended; add `class="slash"` for slash-commands typed into an agent (no `$`).                                                              |
 | `<span class="cm">` inside `.text`                                        | A trailing `# comment` on a command (muted).                                                                                                                                                      |
-| `<div class="block">` with `<pre>`                                        | Multi-line, **non-copyable** output. Only for real, reproducible output; `.ok` marks a success line, `.v` a value.                                                                                |
+| `<div class="block">` with `<pre>`                                        | Multi-line, **non-copyable** output or a reference command listing. Only for real, reproducible output; `.ok` marks a success line, `.v` a value (also brightens the command in a listing).       |
 | `<div class="cards">` + `<a class="card">`                                | The "explore" grid of links to subject pages. Each card: `<h3>Title <span class="go">→</span></h3>` + one-sentence `<p>`. Trim to the highest-intent destinations rather than listing everything. |
 | `<div class="note">`                                                      | A muted aside — the place for asides, "more:" link lists, and edge cases pulled out of the main flow.                                                                                             |
 | `<p class="pointer">`                                                     | A demoted secondary-command line under the golden path (styled quieter than body text). Name only the verb inline; link to where it's covered in full.                                            |
@@ -189,6 +189,15 @@ automatically; you don't wire them up per page.
 | `<div class="ghc">`                                                       | A styled mock GitHub comment (avatar + bubble), for showing what a posted comment looks like. Specialised — only where a page illustrates GitHub output.                                          |
 | `<code>`                                                                  | Short inline identifiers (see the inline-code rule).                                                                                                                                              |
 | `<span class="go">→</span>`                                               | The trailing arrow on card titles and pointers.                                                                                                                                                   |
+
+**Config-file examples get syntax highlighting.** For a real config file (a
+`.uploads.yml`, a JSON snippet), don't use a plain `.block` — render it with
+Astro's `<Code code={…} lang="yaml" theme="vitesse-dark" class="yaml-example" />`
+(from `astro:components`), with the file's text in a frontmatter constant.
+Highlighting makes the keys and values pop out from explanatory comments. The
+`.yaml-example` style in `comment-config.astro` drops the highlighted block into
+the same panel `.block` uses. Note: adding the `astro:components` import to a page
+for the first time needs a dev-server restart (Vite re-optimizes deps).
 
 The canonical example of all of this working together is `apps/web/src/pages/docs.astro`
 (the hub page). Read it before reworking a subject page — it shows the intro +


### PR DESCRIPTION
## What

Rework the `/docs` hub and its eight subject pages to read like reputable
dev-tool docs (Stripe, Vercel, Wrangler) instead of prose-heavy pages, and
codify the conventions as a reusable house skill so future docs pages get the
same treatment.

## Why

The docs pages leaned on heavy paragraphs, examples for every variation, a copy
button on nearly every line, fabricated terminal output, and setup buried below
usage. Individually the sentences were fine; the *structure* made the reader
work. Benchmarking against reputable CLI docs surfaced the patterns we were
missing — one-sentence intros, a single golden path (never two competing
commands up top), install-first ordering, and copy affordances reserved for
commands you actually paste.

## Changes

**Page rework (hub + 8 subject pages)**
- Lead with one short, verb-first intro + a linked capability list (Stripe style)
- One golden-path command per flow; secondary commands demoted to a one-line pointer
- Copy boxes reserved for pasted-verbatim commands; short/illustrative commands inline
- Full multi-argument commands kept out of inline text (block or verb-only)
- Fabricated terminal-output blocks removed; effects described in a sentence
- Edge cases moved into notes; prose trimmed (net **−123 lines** across docs)
- Two broken `data-copy` values on the galleries page fixed (they pasted invalid commands)

**DocsLayout (site-wide)**
- Section-link `#` anchors moved to a hover-only left gutter (OpenRouter pattern)
- The whole heading is now click-to-anchor, not just the `#` glyph
- Added a `.pointer` style so demoted secondary commands read as secondary

**New skill: `skills/docs-page-style`**
- Encodes the structure, intro voice, copy/inline-code rules, prose diet, and the
  full DocsLayout component vocabulary. The 8 subject-page rewrites in this PR
  were produced by agents following it — the test run also caught the real bugs
  and rule violations noted above.

## Verify

- All 9 docs pages serve 200; `astro check` clean; anchor ids other pages link to
  (`#staging`, `#before-after`, `#attach`, `#annotate`, `#put`) preserved.
- No figures, commands, flags, or URLs invented — cross-checked against the CLI
  source and sibling pages.

_Screenshots to follow._
