### PR TITLE
fix(auth): let generic MCP clients complete OAuth

### DIFF
--- a/.changeset/mcp-server-icons.md
+++ b/.changeset/mcp-server-icons.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Advertise the uploads chevron as the MCP server icon so inspector UIs can show it.

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -21,8 +21,16 @@ import {
   magicLink,
   organization,
 } from "better-auth/plugins";
-import { fetchClientMetadataResource } from "./cimd-transport";
+import { fetchClientMetadataResource, rewriteClientMetadataGrantTypes } from "./cimd-transport";
 import { deviceWorkspacePlugin } from "./device-workspace";
+import {
+  oauthClientIdFromAuthorizationCode,
+  oauthClientIdFromConsentBody,
+  oauthClientIdFromQuery,
+  restrictAuthorizationCodeValue,
+  restrictOAuthConsentBody,
+  restrictOAuthQueryScopes,
+} from "./oauth-grant-scopes";
 import { sendAuthEmail } from "./email";
 import { localDemoEnabled, localDemoPlugin } from "./local-demo";
 import { memberCapDenial } from "./member-cap";
@@ -86,15 +94,60 @@ export const OAUTH_SCOPES = ["files:read", "files:write", "files:delete"] as con
 const OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES = ["files:read", "files:write"] as const;
 
 /**
+ * Extra scopes a CIMD/DCR client may request (consent still required). Better
+ * Auth 1.7 persists self-registered clients as default ∪ allowed.
+ */
+const OAUTH_CLIENT_REGISTRATION_ALLOWED_SCOPES = ["files:delete"] as const;
+
+/**
+ * Fallback when the oauth_client row is missing (CIMD first-use: persist
+ * can run after hooks.before). Matches what Better Auth writes on the row.
+ * Do not expand this to a future elevated scope that should stay off CIMD.
+ */
+const OAUTH_SELF_REGISTERED_SCOPES = [
+  ...OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES,
+  ...OAUTH_CLIENT_REGISTRATION_ALLOWED_SCOPES,
+] as const;
+
+/**
+ * Canonical MCP resource identifiers (`origin/mcp`). RFC 9728 metadata on
+ * the MCP worker advertises this form; generic clients often copy the
+ * origin instead. {@link oauthResources} adds both. Mirrored into
+ * apps/mcp's JWT verification config (`OAUTH_AUDIENCES`) — keep both in
+ * lockstep.
+ */
+const MCP_RESOURCE_IDENTIFIERS = [
+  "https://agents.uploads.sh/mcp",
+  "https://mcp.uploads.sh/mcp",
+] as const;
+
+/**
+ * `/mcp` identifier plus its RFC 9728 origin form. Non-`/mcp` URLs stay
+ * unchanged. Generic clients (MCPJam) copy the origin into authorize
+ * `resource=`; the MCP worker already needs to accept both as JWT `aud`.
+ */
+export function mcpResourceAndOrigin(resource: string): string[] {
+  try {
+    const url = new URL(resource);
+    if (url.pathname === "/mcp" || url.pathname === "/mcp/") {
+      return [resource, url.origin];
+    }
+  } catch {
+    // Non-URL env values stay as configured.
+  }
+  return [resource];
+}
+
+/**
  * Protected resources this AS issues access tokens for (Better Auth 1.7's
  * first-class `resources` model, which replaced the 1.6 `validAudiences`
  * list). Each identifier becomes an `oauth_resource` row (seeded at boot,
  * `resourceSeedMode: "insertOnly"`) and is the RFC 8707 `resource` value a
- * client requests; the minted token's `aud` is bound to it. Mirrored into
- * apps/mcp's JWT verification config (`OAUTH_AUDIENCES`) — keep both in
- * lockstep.
+ * client requests; the minted token's `aud` is bound to it.
  */
-const OAUTH_RESOURCES = ["https://agents.uploads.sh/mcp", "https://mcp.uploads.sh/mcp"];
+export function oauthResources(): string[] {
+  return [...new Set(MCP_RESOURCE_IDENTIFIERS.flatMap(mcpResourceAndOrigin))];
+}
 
 /**
  * Workspace claims embedded in every OAuth access-token JWT
@@ -195,12 +248,55 @@ async function getUserRoleState(
   return row;
 }
 
+type AuthBeforeCtx = {
+  path: string;
+  query?: Record<string, unknown>;
+  body?: unknown;
+};
+
+async function applyOAuthClientInterop(
+  ctx: AuthBeforeCtx,
+  registeredScopesForClientId: (clientId: string | undefined) => Promise<readonly string[]>,
+): Promise<{
+  context: { body?: Record<string, unknown>; query?: Record<string, unknown> };
+} | void> {
+  if (ctx.path === "/oauth2/register") {
+    const body = ctx.body as Record<string, unknown> | null;
+    const next = body ? rewriteClientMetadataGrantTypes(body) : undefined;
+    if (next) return { context: { body: next } };
+    return;
+  }
+  if (ctx.path === "/oauth2/authorize") {
+    const query = ctx.query;
+    const allowedScopes = await registeredScopesForClientId(oauthClientIdFromQuery(query));
+    const nextQuery = restrictOAuthQueryScopes(query, allowedScopes);
+    if (nextQuery) return { context: { query: nextQuery } };
+    return;
+  }
+  if (ctx.path === "/oauth2/consent") {
+    const body = ctx.body as Record<string, unknown> | undefined;
+    const allowedScopes = await registeredScopesForClientId(oauthClientIdFromConsentBody(body));
+    const nextBody = restrictOAuthConsentBody(body, allowedScopes);
+    if (nextBody) return { context: { body: nextBody } };
+  }
+}
+
+function authBeforeHook(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  registeredScopesForClientId: (clientId: string | undefined) => Promise<readonly string[]>,
+) {
+  return createAuthMiddleware(async (ctx) => {
+    const oauthOverride = await applyOAuthClientInterop(ctx, registeredScopesForClientId);
+    if (oauthOverride) return oauthOverride;
+    await enforceLastAdminGuard(ctx, db);
+  });
+}
+
 /**
- * `hooks.before` handler for the `admin()` plugin's remove-user/ban-user/
- * set-role/update-user endpoints (fail-closed guard, see `countActiveAdmins`
- * above). Runs on every request — it's the only per-request hook Better Auth
- * exposes at this level — so it no-ops for any path other than the ones it
- * guards.
+ * Last-admin check for the `admin()` plugin's remove-user/ban-user/
+ * set-role/update-user endpoints (fail-closed, see `countActiveAdmins`
+ * above). Called from `authBeforeHook` after the OAuth interop rewrite.
+ * No-ops for any path other than the ones it guards.
  *
  * - `/admin/remove-user`, `/admin/ban-user`: self-removal and self-ban are
  *   already rejected by the plugin itself; this only adds the last-admin
@@ -213,76 +309,77 @@ async function getUserRoleState(
  *   or banning them via `data.banned`. Verified against better-auth 1.6.23's
  *   `plugins/admin/routes.mjs` (`setRole`, `adminUpdateUser`).
  */
-function lastAdminGuardHook(db: ReturnType<typeof drizzle<typeof schema>>) {
-  return createAuthMiddleware(async (ctx) => {
-    if (ctx.path === "/admin/remove-user" || ctx.path === "/admin/ban-user") {
-      const userId = (ctx.body as { userId?: unknown } | undefined)?.userId;
-      if (typeof userId !== "string" || !userId) return;
+async function enforceLastAdminGuard(
+  ctx: AuthBeforeCtx,
+  db: ReturnType<typeof drizzle<typeof schema>>,
+): Promise<void> {
+  if (ctx.path === "/admin/remove-user" || ctx.path === "/admin/ban-user") {
+    const userId = (ctx.body as { userId?: unknown } | undefined)?.userId;
+    if (typeof userId !== "string" || !userId) return;
 
-      const target = await getUserRoleState(db, userId);
-      if (!target || !hasAdminRole(target.role)) return;
-      // A banned admin is not an active admin: removing or re-banning them
-      // cannot reduce the active-admin count, so the guard stays out of it.
-      if (target.banned) return;
+    const target = await getUserRoleState(db, userId);
+    if (!target || !hasAdminRole(target.role)) return;
+    // A banned admin is not an active admin: removing or re-banning them
+    // cannot reduce the active-admin count, so the guard stays out of it.
+    if (target.banned) return;
 
-      const activeAdmins = await countActiveAdmins(db);
-      if (activeAdmins <= 1) {
-        throw new APIError("BAD_REQUEST", {
-          message:
-            ctx.path === "/admin/remove-user"
-              ? "cannot remove the last admin"
-              : "cannot ban the last admin",
-        });
-      }
-      return;
+    const activeAdmins = await countActiveAdmins(db);
+    if (activeAdmins <= 1) {
+      throw new APIError("BAD_REQUEST", {
+        message:
+          ctx.path === "/admin/remove-user"
+            ? "cannot remove the last admin"
+            : "cannot ban the last admin",
+      });
     }
+    return;
+  }
 
-    if (ctx.path === "/admin/set-role") {
-      const body = ctx.body as { userId?: unknown; role?: unknown } | undefined;
-      const userId = body?.userId;
-      if (typeof userId !== "string" || !userId) return;
+  if (ctx.path === "/admin/set-role") {
+    const body = ctx.body as { userId?: unknown; role?: unknown } | undefined;
+    const userId = body?.userId;
+    if (typeof userId !== "string" || !userId) return;
 
-      const target = await getUserRoleState(db, userId);
-      // A banned target doesn't count toward `countActiveAdmins`, so it
-      // can't be "the last admin" being demoted — and if the incoming role
-      // still includes admin, nothing about admin-ness is changing.
-      if (!target || target.banned || !hasAdminRole(target.role)) return;
-      if (hasAdminRoleInput(body?.role)) return;
+    const target = await getUserRoleState(db, userId);
+    // A banned target doesn't count toward `countActiveAdmins`, so it
+    // can't be "the last admin" being demoted — and if the incoming role
+    // still includes admin, nothing about admin-ness is changing.
+    if (!target || target.banned || !hasAdminRole(target.role)) return;
+    if (hasAdminRoleInput(body?.role)) return;
 
-      const activeAdmins = await countActiveAdmins(db);
-      if (activeAdmins <= 1) {
-        throw new APIError("BAD_REQUEST", {
-          message: "cannot remove the last admin's admin role",
-        });
-      }
-      return;
+    const activeAdmins = await countActiveAdmins(db);
+    if (activeAdmins <= 1) {
+      throw new APIError("BAD_REQUEST", {
+        message: "cannot remove the last admin's admin role",
+      });
     }
+    return;
+  }
 
-    if (ctx.path === "/admin/update-user") {
-      const body = ctx.body as { userId?: unknown; data?: unknown } | undefined;
-      const userId = body?.userId;
-      if (typeof userId !== "string" || !userId) return;
-      const data = (body?.data ?? {}) as { role?: unknown; banned?: unknown };
+  if (ctx.path === "/admin/update-user") {
+    const body = ctx.body as { userId?: unknown; data?: unknown } | undefined;
+    const userId = body?.userId;
+    if (typeof userId !== "string" || !userId) return;
+    const data = (body?.data ?? {}) as { role?: unknown; banned?: unknown };
 
-      const target = await getUserRoleState(db, userId);
-      if (!target || target.banned || !hasAdminRole(target.role)) return;
+    const target = await getUserRoleState(db, userId);
+    if (!target || target.banned || !hasAdminRole(target.role)) return;
 
-      const willBan = data.banned === true;
-      const rolesInBody = Object.prototype.hasOwnProperty.call(data, "role");
-      const willStripAdmin = rolesInBody && !hasAdminRoleInput(data.role);
-      if (!willBan && !willStripAdmin) return;
+    const willBan = data.banned === true;
+    const rolesInBody = Object.prototype.hasOwnProperty.call(data, "role");
+    const willStripAdmin = rolesInBody && !hasAdminRoleInput(data.role);
+    if (!willBan && !willStripAdmin) return;
 
-      const activeAdmins = await countActiveAdmins(db);
-      if (activeAdmins <= 1) {
-        throw new APIError("BAD_REQUEST", {
-          message: willBan
-            ? "cannot ban the last admin"
-            : "cannot remove the last admin's admin role",
-        });
-      }
-      return;
+    const activeAdmins = await countActiveAdmins(db);
+    if (activeAdmins <= 1) {
+      throw new APIError("BAD_REQUEST", {
+        message: willBan
+          ? "cannot ban the last admin"
+          : "cannot remove the last admin's admin role",
+      });
     }
-  });
+    return;
+  }
 }
 
 export type AuthEnv = GitHubCredentialsEnv &
@@ -385,6 +482,27 @@ function buildAuth(
   const betterAuthUrl = env.BETTER_AUTH_URL || "https://auth.uploads.sh";
   const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
   const isProduction = env.ENVIRONMENT === "production";
+  /**
+   * Registered `oauth_client.scopes`, or {@link OAUTH_SELF_REGISTERED_SCOPES}
+   * when the row is missing (CIMD first-use: persist can run after this
+   * hook). Never the empty list: authorize still has to downscope extras
+   * such as `openid` on the first request.
+   */
+  const registeredScopesForClientId = async (
+    clientId: string | undefined,
+  ): Promise<readonly string[]> => {
+    if (!clientId) return OAUTH_SELF_REGISTERED_SCOPES;
+    try {
+      const rows = await db
+        .select({ scopes: schema.oauthClient.scopes })
+        .from(schema.oauthClient)
+        .where(eq(schema.oauthClient.clientId, clientId))
+        .limit(1);
+      return Array.isArray(rows[0]?.scopes) ? rows[0].scopes : OAUTH_SELF_REGISTERED_SCOPES;
+    } catch {
+      return OAUTH_SELF_REGISTERED_SCOPES;
+    }
+  };
 
   return betterAuth({
     appName: "uploads.sh",
@@ -577,14 +695,17 @@ function buildAuth(
         // files:delete here lets self-registered clients REQUEST it; every
         // grant still goes through the user's consent screen, and device-flow
         // workspace tokens already get files:delete by default.
-        clientRegistrationAllowedScopes: ["files:delete"],
+        // Generic clients also copy extras (openid, admin) that are not in
+        // this product's scope list; hooks.before downscopes those rather
+        // than expanding this allowlist further.
+        clientRegistrationAllowedScopes: [...OAUTH_CLIENT_REGISTRATION_ALLOWED_SCOPES],
         // Better Auth 1.7: `validAudiences` → the persisted `resources` model.
         // String form (plugin-level defaults) preserves the 1.6 accepted-audience
         // behavior; `resourceSeedMode` defaults to the safe "insertOnly".
         // (`silenceWarnings` was removed in 1.7 — the well-known warnings it
         // suppressed are gone; root /.well-known aliases are still served by
         // src/index.ts.)
-        resources: OAUTH_RESOURCES,
+        resources: oauthResources(),
         // `enforcePerClientResources` defaults to `true` in 1.7 (RFC 8707 §3):
         // /oauth2/authorize + /oauth2/token then require the client to be linked
         // to every requested resource via `oauth_client_resource`, else they
@@ -732,11 +853,26 @@ function buildAuth(
           },
         },
       },
+      verification: {
+        create: {
+          before: async (data) => {
+            const value = typeof data.value === "string" ? data.value : undefined;
+            if (!value || !value.includes("authorization_code")) return;
+            const allowedScopes = await registeredScopesForClientId(
+              oauthClientIdFromAuthorizationCode(value),
+            );
+            const next = restrictAuthorizationCodeValue(value, allowedScopes);
+            if (!next) return;
+            return { data: { ...data, value: next } };
+          },
+        },
+      },
     },
-    // Fail-closed last-admin guard for the admin() plugin's remove-user/
-    // ban-user endpoints — see lastAdminGuardHook above.
+    // CIMD/DCR grant_types + authorize/consent scope rewrite, then the
+    // fail-closed last-admin guard. One `hooks.before`: Better Auth takes a
+    // single middleware here.
     hooks: {
-      before: lastAdminGuardHook(db),
+      before: authBeforeHook(db, registeredScopesForClientId),
     },
     // Fail-closed in production, decoupled from secret resolution (D3/D7):
     // rate limiting is on whenever ENVIRONMENT === "production", regardless

--- a/apps/auth/src/cimd-transport.ts
+++ b/apps/auth/src/cimd-transport.ts
@@ -35,6 +35,128 @@
 import { validateClientIdUrl } from "@better-auth/cimd";
 import type { ClientMetadataResourceFetch } from "@better-auth/oauth-provider";
 
+/**
+ * Grants this AS's oauth-provider token endpoint actually issues. Matches
+ * `@better-auth/oauth-provider`'s default set. CIMD `grant_types` is a
+ * capability advertisement, not a demand that we implement every listed
+ * grant: MCPJam includes `device_code` and claude.ai includes `jwt-bearer`
+ * on a normal authorization_code + PKCE authorize URL.
+ *
+ * `@better-auth/cimd` 1.7 has no option to ignore extras, so the transport
+ * intersects fetched metadata (and DCR POST /oauth2/register, via the
+ * rewrite helper) with this list before the plugin parses it.
+ *
+ * `urn:ietf:params:oauth:grant-type:device_code` is intentionally absent.
+ * This worker does implement RFC 8628 for the seeded `uploads-cli` client
+ * (`deviceAuthorization()`), but oauth-provider's CIMD/DCR ingest validator
+ * does not treat that plugin's grant as supported. Adding it here would
+ * persist it on CIMD rows and still fail ingest. Do not add `jwt-bearer`
+ * without shipping that grant.
+ */
+export const AS_SUPPORTED_GRANT_TYPES = [
+  "authorization_code",
+  "refresh_token",
+  "client_credentials",
+] as const;
+
+const AS_SUPPORTED_GRANT_TYPE_SET: ReadonlySet<string> = new Set(AS_SUPPORTED_GRANT_TYPES);
+
+/** Plugin body cap is 5 KiB; skip the JSON rewrite above that. */
+const CIMD_METADATA_REWRITE_MAX_BYTES = 5 * 1024;
+
+/**
+ * Intersect advertised CIMD/DCR `grant_types` with {@link AS_SUPPORTED_GRANT_TYPES}.
+ *
+ * Returns the supported subset (order preserved, duplicates dropped) when
+ * `authorization_code` remains. Returns `undefined` when the value is
+ * missing, malformed, or has no usable grant, so the caller leaves the
+ * document alone and the plugin still rejects an unsupported-only list.
+ */
+export function intersectAdvertisedGrantTypes(grantTypes: unknown): string[] | undefined {
+  if (!Array.isArray(grantTypes)) return undefined;
+  const supported: string[] = [];
+  const seen = new Set<string>();
+  for (const grant of grantTypes) {
+    if (typeof grant !== "string" || !AS_SUPPORTED_GRANT_TYPE_SET.has(grant) || seen.has(grant)) {
+      continue;
+    }
+    seen.add(grant);
+    supported.push(grant);
+  }
+  if (!supported.includes("authorization_code")) return undefined;
+  return supported;
+}
+
+function grantTypesUnchanged(advertised: unknown, next: string[]): boolean {
+  return (
+    Array.isArray(advertised) &&
+    advertised.length === next.length &&
+    advertised.every((grant, i) => grant === next[i])
+  );
+}
+
+/**
+ * Drop unsupported `grant_types` from a parsed metadata document or DCR body.
+ * `undefined` means leave the document as fetched.
+ */
+export function rewriteClientMetadataGrantTypes(
+  metadata: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const next = intersectAdvertisedGrantTypes(metadata.grant_types);
+  if (next === undefined || grantTypesUnchanged(metadata.grant_types, next)) {
+    return undefined;
+  }
+  return { ...metadata, grant_types: next };
+}
+
+function shouldRewriteMetadataBody(res: Response): boolean {
+  if (res.status !== 200) return false;
+  const declared = Number(res.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > CIMD_METADATA_REWRITE_MAX_BYTES) {
+    return false;
+  }
+  const contentType = res.headers.get("content-type") ?? "";
+  return contentType === "" || /json/i.test(contentType);
+}
+
+async function rewriteFetchedMetadataGrantTypes(res: Response): Promise<Response> {
+  if (!shouldRewriteMetadataBody(res)) return res;
+
+  const text = await res.text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return new Response(text, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+    });
+  }
+  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return new Response(text, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+    });
+  }
+
+  const rewritten = rewriteClientMetadataGrantTypes(parsed as Record<string, unknown>);
+  if (!rewritten) {
+    return new Response(text, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+    });
+  }
+
+  const body = JSON.stringify(rewritten);
+  const headers = new Headers(res.headers);
+  headers.set("content-length", String(new TextEncoder().encode(body).byteLength));
+  if (!headers.has("content-type")) headers.set("content-type", "application/json");
+  return new Response(body, { status: res.status, statusText: res.statusText, headers });
+}
+
 export const fetchClientMetadataResource: ClientMetadataResourceFetch = async (input, init) => {
   // The plugin calls this with `redirect: "error"`, which workerd's Request
   // constructor REJECTS outright ("won't be implemented... use manual and
@@ -58,5 +180,6 @@ export const fetchClientMetadataResource: ClientMetadataResourceFetch = async (i
   if (urlError) {
     throw new TypeError(`metadata URL rejected: ${urlError}`);
   }
-  return fetch(request);
+  const res = await fetch(request);
+  return rewriteFetchedMetadataGrantTypes(res);
 };

--- a/apps/auth/src/cimd.test.ts
+++ b/apps/auth/src/cimd.test.ts
@@ -10,7 +10,11 @@ import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuthEnv } from "./auth";
-import { fetchClientMetadataResource } from "./cimd-transport";
+import {
+  fetchClientMetadataResource,
+  intersectAdvertisedGrantTypes,
+  rewriteClientMetadataGrantTypes,
+} from "./cimd-transport";
 import { app } from "./index";
 import * as schema from "./schema";
 import { createFakeD1 } from "./test/fake-d1";
@@ -122,6 +126,66 @@ describe("CIMD client resolution", () => {
     expect(res.headers.get("location")).toContain("/login");
   });
 
+  it("downscopes unknown extras (openid/admin) instead of invalid_scope", async () => {
+    const env = dbEnv();
+    stubMetadataFetch();
+
+    const res = await authorize(env, {
+      scope: "files:read files:write files:delete openid profile admin",
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/login");
+    expect(res.headers.get("location")).not.toContain("invalid_scope");
+  });
+
+  it("accepts resource= origin as well as origin/mcp", async () => {
+    const env = dbEnv();
+    stubMetadataFetch();
+
+    const origin = await authorize(env, { resource: "https://agents.uploads.sh" });
+    expect(origin.status).toBe(302);
+    expect(origin.headers.get("location")).toContain("/login");
+    expect(origin.headers.get("location")).not.toContain("invalid_target");
+
+    const path = await authorize(env, { resource: "https://agents.uploads.sh/mcp" });
+    expect(path.status).toBe(302);
+    expect(path.headers.get("location")).toContain("/login");
+  });
+
+  it("ingests MCPJam-shaped grant_types that include device_code", async () => {
+    const env = dbEnv();
+    stubMetadataFetch({
+      ...metadataDocument(),
+      grant_types: [
+        "authorization_code",
+        "refresh_token",
+        "urn:ietf:params:oauth:grant-type:device_code",
+      ],
+    });
+
+    const res = await authorize(env);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/login");
+    expect(res.headers.get("location")).not.toContain("invalid_client_metadata");
+  });
+
+  it("ingests claude.ai-shaped grant_types that include jwt-bearer", async () => {
+    const env = dbEnv();
+    stubMetadataFetch({
+      ...metadataDocument(),
+      grant_types: [
+        "authorization_code",
+        "refresh_token",
+        "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      ],
+    });
+
+    const res = await authorize(env);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/login");
+    expect(res.headers.get("location")).not.toContain("invalid_client_metadata");
+  });
+
   it("rejects a metadata document missing the MCP profile's required fields", async () => {
     const env = dbEnv();
     const { client_name: _omitted, ...withoutName } = metadataDocument();
@@ -186,7 +250,74 @@ describe("Workers CIMD transport", () => {
   });
 });
 
+describe("CIMD grant_types interop", () => {
+  const DEVICE_CODE = "urn:ietf:params:oauth:grant-type:device_code";
+  const JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+  it("intersects MCPJam-shaped extras down to authorization_code + refresh_token", () => {
+    expect(
+      intersectAdvertisedGrantTypes(["authorization_code", "refresh_token", DEVICE_CODE]),
+    ).toEqual(["authorization_code", "refresh_token"]);
+  });
+
+  it("also drops jwt-bearer extras", () => {
+    expect(
+      intersectAdvertisedGrantTypes(["authorization_code", "refresh_token", JWT_BEARER]),
+    ).toEqual(["authorization_code", "refresh_token"]);
+  });
+
+  it("does not invent a supported grant when only device_code is advertised", () => {
+    expect(intersectAdvertisedGrantTypes([DEVICE_CODE])).toBeUndefined();
+    expect(
+      rewriteClientMetadataGrantTypes({
+        ...metadataDocument(),
+        grant_types: [DEVICE_CODE],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("rewrites fetched MCPJam metadata so the CIMD profile accepts it", async () => {
+    const advertised = {
+      ...metadataDocument(),
+      grant_types: ["authorization_code", "refresh_token", DEVICE_CODE],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(advertised, { headers: { "content-type": "application/json" } }),
+      ),
+    );
+
+    const res = await fetchClientMetadataResource(CLIENT_ID_URL);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.grant_types).toEqual(["authorization_code", "refresh_token"]);
+    expect(body.grant_types).not.toContain(DEVICE_CODE);
+    expect(body.redirect_uris).toEqual([REDIRECT_URI]);
+  });
+});
+
 describe("dynamic client registration (SEP-837)", () => {
+  it("tolerates extra grant_types (device_code) at /oauth2/register", async () => {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "Test MCP Client",
+          redirect_uris: ["https://client.example.com/callback"],
+          grant_types: [
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code",
+          ],
+        }),
+      },
+      dbEnv(),
+    );
+    expect(res.status).toBe(201);
+  });
+
   it("tolerates the application_type field at /oauth2/register", async () => {
     const res = await app.request(
       "/api/auth/oauth2/register",

--- a/apps/auth/src/oauth-grant-scopes.test.ts
+++ b/apps/auth/src/oauth-grant-scopes.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  oauthClientIdFromAuthorizationCode,
+  oauthClientIdFromConsentBody,
+  oauthClientIdFromQuery,
+  restrictAuthorizationCodeValue,
+  restrictOAuthConsentBody,
+  restrictOAuthQueryScopes,
+} from "./oauth-grant-scopes";
+
+const DEFAULT_SCOPES = ["files:read", "files:write"] as const;
+const SELF_REGISTERED = ["files:read", "files:write", "files:delete"] as const;
+const KITCHEN_SINK = "files:read files:write files:delete openid profile admin";
+
+describe("restrictOAuthQueryScopes", () => {
+  it("drops unknown scope ids rather than failing the request", () => {
+    expect(
+      restrictOAuthQueryScopes({ client_id: "c1", scope: KITCHEN_SINK }, SELF_REGISTERED),
+    ).toEqual({
+      client_id: "c1",
+      scope: "files:read files:write files:delete",
+    });
+  });
+
+  it("downscopes to the client's registered list when files:delete is not allowed", () => {
+    expect(restrictOAuthQueryScopes({ scope: KITCHEN_SINK }, DEFAULT_SCOPES)).toEqual({
+      scope: "files:read files:write",
+    });
+  });
+
+  it("leaves the query alone when every requested id is already allowed", () => {
+    expect(
+      restrictOAuthQueryScopes({ scope: "files:read files:write" }, SELF_REGISTERED),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when there is no scope to rewrite", () => {
+    expect(restrictOAuthQueryScopes({ client_id: "c1" }, SELF_REGISTERED)).toBeUndefined();
+    expect(restrictOAuthQueryScopes(undefined, SELF_REGISTERED)).toBeUndefined();
+  });
+
+  it("rewrites to empty when nothing grantable remains", () => {
+    expect(restrictOAuthQueryScopes({ scope: "openid admin" }, SELF_REGISTERED)).toEqual({
+      scope: "",
+    });
+  });
+});
+
+describe("restrictOAuthConsentBody", () => {
+  it("strips unknown ids from an explicit body.scope", () => {
+    expect(
+      restrictOAuthConsentBody({ accept: true, scope: KITCHEN_SINK }, SELF_REGISTERED),
+    ).toEqual({
+      accept: true,
+      scope: "files:read files:write files:delete",
+    });
+  });
+
+  it("injects a filtered scope from oauth_query when the body omitted one", () => {
+    const oauth_query = "client_id=c1&scope=files%3Aread+openid+files%3Awrite&sig=abc";
+    expect(restrictOAuthConsentBody({ accept: true, oauth_query }, DEFAULT_SCOPES)).toEqual({
+      accept: true,
+      oauth_query,
+      scope: "files:read files:write",
+    });
+  });
+
+  it("does not invent a scope when oauth_query has none", () => {
+    expect(
+      restrictOAuthConsentBody(
+        { accept: true, oauth_query: "client_id=c1&sig=abc" },
+        SELF_REGISTERED,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("restrictAuthorizationCodeValue", () => {
+  it("rewrites query.scope inside an authorization_code blob", () => {
+    const value = JSON.stringify({
+      type: "authorization_code",
+      userId: "u1",
+      query: { client_id: "c1", scope: KITCHEN_SINK },
+    });
+    const next = restrictAuthorizationCodeValue(value, SELF_REGISTERED);
+    expect(JSON.parse(next ?? "")).toEqual({
+      type: "authorization_code",
+      userId: "u1",
+      query: { client_id: "c1", scope: "files:read files:write files:delete" },
+    });
+  });
+
+  it("leaves non-authorization_code values alone", () => {
+    expect(
+      restrictAuthorizationCodeValue(
+        JSON.stringify({ type: "email", value: "x" }),
+        SELF_REGISTERED,
+      ),
+    ).toBeUndefined();
+    expect(restrictAuthorizationCodeValue("not-json", SELF_REGISTERED)).toBeUndefined();
+    expect(restrictAuthorizationCodeValue(undefined, SELF_REGISTERED)).toBeUndefined();
+  });
+});
+
+describe("client_id extractors", () => {
+  it("reads client_id from an authorize query", () => {
+    expect(oauthClientIdFromQuery({ client_id: "https://client.example/meta.json" })).toBe(
+      "https://client.example/meta.json",
+    );
+    expect(oauthClientIdFromQuery({})).toBeUndefined();
+  });
+
+  it("reads client_id from a consent body or signed oauth_query", () => {
+    expect(oauthClientIdFromConsentBody({ client_id: "direct" })).toBe("direct");
+    expect(
+      oauthClientIdFromConsentBody({ oauth_query: "client_id=from-query&scope=files%3Aread" }),
+    ).toBe("from-query");
+  });
+
+  it("reads client_id from an authorization_code blob", () => {
+    const value = JSON.stringify({
+      type: "authorization_code",
+      query: { client_id: "c1", scope: "files:read" },
+    });
+    expect(oauthClientIdFromAuthorizationCode(value)).toBe("c1");
+    expect(oauthClientIdFromAuthorizationCode("nope")).toBeUndefined();
+  });
+});

--- a/apps/auth/src/oauth-grant-scopes.ts
+++ b/apps/auth/src/oauth-grant-scopes.ts
@@ -1,0 +1,122 @@
+/**
+ * AS-side seam for authorize/consent/token-code scope rewrite.
+ *
+ * `@better-auth/oauth-provider` has no per-authorize scope hook and rejects
+ * the whole authorize when the request asks for a scope the client is not
+ * registered for. Generic MCP clients copy `scopes_supported` (and extras
+ * such as `openid`) into `scope=`. RFC 6749 §3.3 lets the AS ignore
+ * requested scopes it will not grant: downscope to the intersection with
+ * the client's registered list, and only `invalid_scope` when nothing
+ * grantable remains.
+ *
+ * Known ids stay in lockstep with `OAUTH_SCOPES` in auth.ts (duplicated
+ * rather than imported: auth.ts wires this module from `hooks.before`).
+ */
+const KNOWN_SCOPES: ReadonlySet<string> = new Set(["files:read", "files:write", "files:delete"]);
+
+function filterScopeString(scope: string, allowedScopes: readonly string[]): string | undefined {
+  const requested = scope.split(/\s+/).filter(Boolean);
+  const allow = new Set(allowedScopes);
+  const permitted = requested.filter((id) => KNOWN_SCOPES.has(id) && allow.has(id));
+  const next = permitted.join(" ");
+  return next === requested.join(" ") ? undefined : next;
+}
+
+/** Rewrite `query.scope` for `/oauth2/authorize`. Undefined when unchanged. */
+export function restrictOAuthQueryScopes(
+  query: Record<string, unknown> | undefined,
+  allowedScopes: readonly string[],
+): Record<string, unknown> | undefined {
+  if (!query || typeof query.scope !== "string") return undefined;
+  const next = filterScopeString(query.scope, allowedScopes);
+  if (next === undefined) return undefined;
+  return { ...query, scope: next };
+}
+
+function paramsFromOAuthQuery(oauthQuery: unknown): URLSearchParams | undefined {
+  if (typeof oauthQuery !== "string" || !oauthQuery) return undefined;
+  try {
+    return new URLSearchParams(oauthQuery.startsWith("?") ? oauthQuery.slice(1) : oauthQuery);
+  } catch {
+    return undefined;
+  }
+}
+
+function scopeFromOAuthQuery(oauthQuery: unknown): string | undefined {
+  const scope = paramsFromOAuthQuery(oauthQuery)?.get("scope");
+  return scope && scope.length > 0 ? scope : undefined;
+}
+
+/** `client_id` on an authorize query object. */
+export function oauthClientIdFromQuery(
+  query: Record<string, unknown> | undefined,
+): string | undefined {
+  const id = query?.client_id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+/** `client_id` on a consent body (`client_id` or the signed `oauth_query`). */
+export function oauthClientIdFromConsentBody(
+  body: Record<string, unknown> | undefined,
+): string | undefined {
+  const direct = oauthClientIdFromQuery(body);
+  if (direct) return direct;
+  const id = paramsFromOAuthQuery(body?.oauth_query)?.get("client_id");
+  return id && id.length > 0 ? id : undefined;
+}
+
+/** `client_id` inside an authorization-code verification blob. */
+export function oauthClientIdFromAuthorizationCode(value: string | undefined): string | undefined {
+  const parsed = parseAuthorizationCode(value);
+  return parsed ? oauthClientIdFromQuery(parsed.query) : undefined;
+}
+
+/**
+ * Rewrite `/oauth2/consent`. The plugin persists `body.scope` if present,
+ * otherwise the signed query's full list — so when the body omitted
+ * `scope`, inject a filtered list from `oauth_query`.
+ */
+export function restrictOAuthConsentBody(
+  body: Record<string, unknown> | undefined,
+  allowedScopes: readonly string[],
+): Record<string, unknown> | undefined {
+  if (!body) return undefined;
+  const source =
+    typeof body.scope === "string" ? body.scope : scopeFromOAuthQuery(body.oauth_query);
+  if (source === undefined) return undefined;
+  const next = filterScopeString(source, allowedScopes);
+  if (next === undefined) return undefined;
+  return { ...body, scope: next };
+}
+
+function parseAuthorizationCode(
+  value: string | undefined,
+): { record: Record<string, unknown>; query: Record<string, unknown> } | undefined {
+  if (typeof value !== "string" || !value) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const record = parsed as Record<string, unknown>;
+  if (record.type !== "authorization_code") return undefined;
+  const query = record.query;
+  if (query == null || typeof query !== "object" || Array.isArray(query)) return undefined;
+  return { record, query: query as Record<string, unknown> };
+}
+
+/** Rewrite an authorization-code blob so token exchange cannot issue disallowed scopes. */
+export function restrictAuthorizationCodeValue(
+  value: string | undefined,
+  allowedScopes: readonly string[],
+): string | undefined {
+  const parsed = parseAuthorizationCode(value);
+  if (!parsed) return undefined;
+  const { record, query } = parsed;
+  if (typeof query.scope !== "string") return undefined;
+  const next = filterScopeString(query.scope, allowedScopes);
+  if (next === undefined) return undefined;
+  return JSON.stringify({ ...record, query: { ...query, scope: next } });
+}

--- a/apps/auth/src/oauth-resources.test.ts
+++ b/apps/auth/src/oauth-resources.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { mcpResourceAndOrigin, oauthResources } from "./auth";
+
+describe("mcpResourceAndOrigin", () => {
+  it("adds the origin form next to a /mcp identifier", () => {
+    expect(mcpResourceAndOrigin("https://agents.uploads.sh/mcp")).toEqual([
+      "https://agents.uploads.sh/mcp",
+      "https://agents.uploads.sh",
+    ]);
+  });
+
+  it("treats a trailing slash on /mcp the same as /mcp", () => {
+    expect(mcpResourceAndOrigin("https://mcp.uploads.sh/mcp/")).toEqual([
+      "https://mcp.uploads.sh/mcp/",
+      "https://mcp.uploads.sh",
+    ]);
+  });
+
+  it("leaves an already origin-shaped identifier unchanged", () => {
+    expect(mcpResourceAndOrigin("https://agents.uploads.sh")).toEqual([
+      "https://agents.uploads.sh",
+    ]);
+  });
+
+  it("passes through a non-URL value", () => {
+    expect(mcpResourceAndOrigin("not-a-url")).toEqual(["not-a-url"]);
+  });
+});
+
+describe("oauthResources", () => {
+  it("lists /mcp and origin for every hosted MCP identifier", () => {
+    expect(oauthResources()).toEqual([
+      "https://agents.uploads.sh/mcp",
+      "https://agents.uploads.sh",
+      "https://mcp.uploads.sh/mcp",
+      "https://mcp.uploads.sh",
+    ]);
+  });
+});

--- a/apps/auth/src/oauth.test.ts
+++ b/apps/auth/src/oauth.test.ts
@@ -43,6 +43,27 @@ describe("oauth-provider migration/schema parity", () => {
   });
 });
 
+describe("oauth resources", () => {
+  it("seeds origin-shaped MCP identifiers alongside /mcp", async () => {
+    const env = dbEnv();
+    const res = await app.request("/.well-known/oauth-authorization-server", {}, env);
+    expect(res.status).toBe(200);
+    const orm = drizzle(env.DB, { schema });
+    const rows = await orm
+      .select({ identifier: schema.oauthResource.identifier })
+      .from(schema.oauthResource);
+    const ids = rows.map((r) => r.identifier);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "https://agents.uploads.sh/mcp",
+        "https://agents.uploads.sh",
+        "https://mcp.uploads.sh/mcp",
+        "https://mcp.uploads.sh",
+      ]),
+    );
+  });
+});
+
 describe("dynamic client registration", () => {
   it("registers a client via POST /api/auth/oauth2/register (unauthenticated)", async () => {
     const res = await app.request(

--- a/apps/auth/src/stripe-plugin.ts
+++ b/apps/auth/src/stripe-plugin.ts
@@ -71,7 +71,7 @@ export function checkoutSessionParamsFor(env: CheckoutConsentEnv): {
  * True when `userId` is an `owner` or `admin` member of the org identified
  * by `referenceId` — the only roles allowed to start/manage a subscription.
  * Same select-then-check style as auth.ts's other org-role guards
- * (lastAdminGuardHook). Exported for direct unit testing.
+ * (`enforceLastAdminGuard`). Exported for direct unit testing.
  */
 export async function isOrgBillingAdmin(
   db: Db,

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -39,10 +39,17 @@ import { ROBOTS_TXT } from "./robots";
 
 /**
  * Both prod hostnames this worker answers on (see wrangler.jsonc routes) are
- * accepted as `aud` — mirrored into the AS's own audience allow-list (parallel
- * lane). A JWT minted against either resource works on either route.
+ * accepted as `aud`, in `/mcp` and origin form. Generic clients copy the
+ * origin into authorize `resource=` (RFC 8707); the AS mints `aud` from
+ * that. Mirrored into the AS's `oauthResources()` list — keep both in
+ * lockstep. A JWT minted against any of these works on either route.
  */
-const OAUTH_AUDIENCES = ["https://agents.uploads.sh/mcp", "https://mcp.uploads.sh/mcp"];
+const OAUTH_AUDIENCES = [
+  "https://agents.uploads.sh/mcp",
+  "https://agents.uploads.sh",
+  "https://mcp.uploads.sh/mcp",
+  "https://mcp.uploads.sh",
+];
 
 /**
  * The JSON Schema validator for `createMcpServer`'s tool registration. Built
@@ -283,8 +290,10 @@ function respondProtectedResource(c: Context<WorkspaceVars>): Response {
   return c.json(
     protectedResourceMetadata({
       // The protected resource is the `/mcp` endpoint itself (matches the
-      // server-card transport endpoint and the RFC 8707 resource an MCP
-      // client indicates when requesting a token).
+      // server-card transport endpoint). Generic clients still copy the
+      // origin into authorize `resource=`; the AS and this worker's JWT
+      // `aud` list accept both forms. Do not switch this advertisement to
+      // origin-only.
       resource: `${requestOrigin(c.req.url)}/mcp`,
       resourceName: "uploads.sh MCP server",
       webOrigin: c.env.WEB_ORIGIN || "https://uploads.sh",

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -8,7 +8,7 @@
  * bearer-token middleware; the protocol core is the CLI package's
  * `createMcpServer`, shared verbatim.
  */
-import { createMcpServer, type McpServer } from "@buildinternet/uploads/mcp";
+import { createMcpServer, MCP_SERVER_ICONS, type McpServer } from "@buildinternet/uploads/mcp";
 import {
   createMcpHandler,
   isLegacyRequest,
@@ -165,7 +165,7 @@ async function workspacePathAuth(c: Context<WorkspaceVars>, next: Next): Promise
 /** Builds a fresh server for this request — same tool catalog for both eras, so they can't drift. */
 function buildServer(c: Context<WorkspaceVars>): McpServer {
   return createMcpServer({
-    serverInfo: { name: "uploads-mcp", version: pkg.version },
+    serverInfo: { name: "uploads-mcp", version: pkg.version, icons: MCP_SERVER_ICONS },
     tools: createRemoteTools({
       env: c.env,
       workspace: c.get("workspace"),
@@ -266,6 +266,7 @@ function mcpServerCard() {
       description:
         "Host files on uploads.sh from an agent — put, attach, list, delete, usage, and GitHub attachment comments.",
       homepage: "https://uploads.sh/",
+      icons: MCP_SERVER_ICONS,
     },
     transport: {
       type: "streamable-http",

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1902,6 +1902,16 @@ describe("OAuth JWT bearer (issue #224)", () => {
     expect(result.isError).toBe(false);
   });
 
+  it("accepts the origin-shaped audience generic clients copy from RFC 9728", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken(
+      { sub: "user-1", workspace: "test-ws", workspaces: ["test-ws"], scope: "files:read" },
+      { audience: "https://agents.uploads.sh" },
+    );
+    const result = await callTool(env, "list", {}, jwt, "/mcp");
+    expect(result.isError).toBe(false);
+  });
+
   it("still authenticates the legacy up_ token path unaffected by the JWT lane", async () => {
     const { env, bucket } = await makeEnv();
     const result = await callTool(

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -530,12 +530,23 @@ describe("mcp worker", () => {
     const response = await app.request("/.well-known/mcp/server-card.json", { method: "GET" }, env);
     expect(response.status).toBe(200);
     const body = (await response.json()) as {
-      serverInfo: { name: string; version: string };
+      serverInfo: {
+        name: string;
+        version: string;
+        icons?: { src: string; mimeType?: string; sizes?: string[] }[];
+      };
       transport: { type: string; endpoint: string };
       authentication: { required: boolean };
     };
     expect(body.serverInfo.name).toBe("uploads-mcp");
     expect(body.serverInfo.version).toBeTruthy();
+    expect(body.serverInfo.icons).toEqual([
+      {
+        src: "https://uploads.sh/apple-touch-icon.png",
+        mimeType: "image/png",
+        sizes: ["180x180"],
+      },
+    ]);
     expect(body.transport.type).toBe("streamable-http");
     expect(body.transport.endpoint).toBe("https://agents.uploads.sh/mcp");
     expect(body.authentication.required).toBe(true);
@@ -626,10 +637,14 @@ describe("mcp worker", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("application/json");
     const body = (await response.json()) as {
-      result: { protocolVersion: string; serverInfo: { name: string } };
+      result: {
+        protocolVersion: string;
+        serverInfo: { name: string; icons?: { src: string }[] };
+      };
     };
     expect(body.result.protocolVersion).toBe("2025-06-18");
     expect(body.result.serverInfo.name).toBe("uploads-mcp");
+    expect(body.result.serverInfo.icons?.[0]?.src).toBe("https://uploads.sh/apple-touch-icon.png");
   });
 
   it("lists exactly the remote tools", async () => {

--- a/apps/web/public/.well-known/mcp/server-card.json
+++ b/apps/web/public/.well-known/mcp/server-card.json
@@ -5,7 +5,14 @@
     "name": "uploads-mcp",
     "version": "0.6.0",
     "description": "Host files on uploads.sh from an agent — put (including branch staging and PR attach), promote, list, delete, usage, galleries, and GitHub attachment comments.",
-    "homepage": "https://uploads.sh/"
+    "homepage": "https://uploads.sh/",
+    "icons": [
+      {
+        "src": "https://uploads.sh/apple-touch-icon.png",
+        "mimeType": "image/png",
+        "sizes": ["180x180"]
+      }
+    ]
   },
   "transport": {
     "type": "streamable-http",

--- a/apps/web/public/auth.md
+++ b/apps/web/public/auth.md
@@ -89,7 +89,13 @@ registration, no manual setup — preferably via Client ID Metadata Documents
 metadata JSON as the `client_id`; the metadata must include `client_name` and
 `redirect_uris`, and `redirect_uri` must exactly match a listed entry).
 Dynamic client registration (RFC 7591) remains supported for older clients.
-Discovery (advertises `client_id_metadata_document_supported`):
+A metadata document may list extra `grant_types` (`device_code`, `jwt-bearer`):
+the AS keeps `authorization_code` and `refresh_token` and ignores the rest.
+Authorize `scope=` may include extras (`openid`, `admin`): the AS downscopes to
+the client's registered `files:*` list instead of failing the whole request.
+Authorize `resource=` may be `https://agents.uploads.sh` or
+`https://agents.uploads.sh/mcp` (same pair for `mcp.uploads.sh`). Discovery
+(advertises `client_id_metadata_document_supported`):
 
 ```bash
 curl -s https://uploads.sh/.well-known/oauth-authorization-server

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ This folder is the repo companion: CLI and API reference, then contributor and o
 | [api](api.md)                                 | REST routes                               |
 | [private-attachments](private-attachments.md) | Private-repo URL prefixes                 |
 | [enrollment](enrollment.md)                   | uploads login, scopes, and token lifetime |
+| [mcp-cimd-interop](mcp-cimd-interop.md)       | Generic MCP client OAuth/CIMD failures    |
 
 ## Contributors
 

--- a/docs/mcp-cimd-interop.md
+++ b/docs/mcp-cimd-interop.md
@@ -1,0 +1,72 @@
+# Generic MCP client interop (CIMD + OAuth)
+
+Playbook for this stack: one Better Auth OAuth 2.1 authorization server, [CIMD](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/02/) (and leftover DCR) client registration, RFC 8707 resource indicators, and a hosted MCP resource server at `agents.uploads.sh`.
+
+The four failures below are the order a generic client (we used [MCPJam](https://www.mcpjam.com/)) hits them: ingest, authorize `scope=`, authorize `resource=`, then a tool that HTTP-fetches a sibling REST API. The first three apply here. The fourth does not: hosted MCP tools call `@uploads/api` in process, and `api.uploads.sh` does not accept OAuth JWTs.
+
+Source for the pattern: [sunny/docs/mcp-cimd-interop.md](https://github.com/buildinternet/sunny/blob/main/docs/mcp-cimd-interop.md). Read this before changing discovery, implementing a grant this AS does not issue, or expanding CIMD default scopes.
+
+## 1. `invalid_client_metadata` / unsupported `grant_type` `device_code`
+
+**Error (AS, CIMD ingest):**
+
+```json
+{
+  "error": "invalid_client_metadata",
+  "error_description": "unsupported grant_type urn:ietf:params:oauth:grant-type:device_code"
+}
+```
+
+**Why a generic client does it.** CIMD `grant_types` is a capability advertisement. MCPJam's document lists `authorization_code`, `refresh_token`, and `urn:ietf:params:oauth:grant-type:device_code` because its CLI can run the device flow. The authorize URL it actually sends is a normal `response_type=code` + PKCE request. Same class: claude.ai adds `urn:ietf:params:oauth:grant-type:jwt-bearer`.
+
+**Rule.** Intersect advertised grants with the grants oauth-provider issues. Ignore extras at ingest. Enforce at the token endpoint (`unsupported_grant_type`) if someone actually requests a grant you do not implement. Do not treat CIMD `grant_types` as a demand that you implement every listed grant.
+
+**What we do.** `rewriteClientMetadataGrantTypes` in `apps/auth/src/cimd-transport.ts` rewrites fetched metadata, and `hooks.before` on `/oauth2/register` rewrites DCR bodies, so `grant_types` is the intersection with `authorization_code`, `refresh_token`, and `client_credentials` before the plugin parses it. Leave the document untouched if `authorization_code` would not remain: ingest still rejects a device-code-only client.
+
+This worker does implement RFC 8628 for the seeded `uploads-cli` client (`deviceAuthorization()` in `apps/auth/src/auth.ts`). oauth-provider's CIMD/DCR ingest validator does not treat that plugin's grant as supported, so `device_code` stays out of the intersection list. Adding it there would persist it on CIMD rows and still fail ingest.
+
+**Do not.** Add `device_code` or `jwt-bearer` to the CIMD supported-grant list without shipping that grant through oauth-provider. Do not implement RFC 8628 for CIMD clients just so the metadata document parses.
+
+## 2. `invalid_scope` on authorize
+
+**Error (AS, `/oauth2/authorize`):**
+
+```
+invalid_scope: The following scopes are invalid: openid, profile, admin
+```
+
+**Why a generic client does it.** RFC 9728 / AS metadata `scopes_supported` is the product's full list (`files:read`, `files:write`, `files:delete`). Generic clients copy that list into authorize `scope=` and often add extras (`openid`, `profile`). A CIMD document often has no `scope` field. Better Auth then rejects the entire authorize when the request is a superset of the registered list.
+
+**Rule.** [RFC 6749 §3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3): the AS MAY ignore requested scopes it cannot or will not grant. Downscope to the client's registered list and drop unknown ids. Fail authorize only when nothing usable remains. Keep any future elevated scope per-client. Do not expand CIMD/DCR defaults to "every string a client might copy."
+
+**What we do.** `apps/auth/src/oauth-grant-scopes.ts` intersects `scope=` with `oauth_client.scopes` (fallback: `OAUTH_SELF_REGISTERED_SCOPES` = default ∪ allowed, which today is all three `files:*` scopes) on authorize, consent, and the authorization-code blob. `files:delete` stays on `clientRegistrationAllowedScopes` so a self-registered client can still request it through consent. Discovery still lists all three in `scopes_supported`.
+
+This product has no OAuth `admin` scope. The Sunny admin-strip does not apply.
+
+**Do not.** Expand CIMD default scopes to whatever a client puts in `scope=`. Do not fail the whole authorize when a usable subset remains. Do not add a new elevated scope to `clientRegistrationAllowedScopes` without deciding it is CIMD-requestable.
+
+## 3. `invalid_target` / requested resource not configured
+
+**Error (AS, authorize):**
+
+```
+invalid_target: requested resource https://agents.uploads.sh is not configured
+```
+
+**Why a generic client does it.** RFC 9728 protected-resource metadata commonly advertises `resource` as the origin. Clients copy that string into authorize `resource=` (RFC 8707). This AS listed only the transport URL (`origin/mcp`) as a configured resource, because that is what the MCP server card and this worker's RFC 9728 document use (`resource: origin/mcp` in `apps/mcp/src/index.ts`).
+
+**Rule.** Accept both the origin and the `/mcp` form for every MCP identifier the AS is willing to mint. The MCP resource server must accept both as JWT `aud`. Discovery can keep advertising `/mcp`. Clients that pass `resource=origin` must keep working, and so must clients that pass `origin/mcp`.
+
+**What we do.** `mcpResourceAndOrigin` in `apps/auth/src/auth.ts` (`oauthResources()`): for every MCP identifier that is `origin + /mcp` (canonical + the `mcp.uploads.sh` alias), also list the origin. `/mcp` stays. MCP JWT verification in `apps/mcp/src/index.ts` (`OAUTH_AUDIENCES`) lists the same four values. RFC 9728 on the MCP worker still advertises `origin/mcp`.
+
+**Do not.** Change discovery to origin-only. Do not drop the `/mcp` form. Do not accept arbitrary `resource=` values.
+
+## 4. REST 401 when an MCP tool forwards the Bearer
+
+Does not apply. Hosted tools in `apps/mcp/src/tools.ts` import `@uploads/api` and use the worker's storage, D1, and GitHub bindings directly. They do not HTTP-fetch `api.uploads.sh` with the caller's access token. `api.uploads.sh` does not verify OAuth JWTs (see `apps/api/src/well-known.ts` and `apps/web/public/auth.md`).
+
+If a later tool starts forwarding the Bearer to the REST API, the Sunny fix is: accept same-environment MCP origin and `/mcp` as JWT `aud` on every API gate that already verifies Bearer JWTs. Do not invent a second auth path for that route. Do not let a preview MCP token verify on prod.
+
+## Hosted `/mcp` credentials
+
+Hosted `/mcp` accepts an OAuth JWT or a workspace token (`up_<workspace>_…`). An API session cookie will 401 there. `uploads login`'s device flow is the CLI path for minting a workspace token; it is not the CIMD path.

--- a/packages/uploads/src/commands/mcp.ts
+++ b/packages/uploads/src/commands/mcp.ts
@@ -2,7 +2,7 @@ import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { AjvJsonSchemaValidator } from "@modelcontextprotocol/server/validators/ajv";
 import { parseCommandArgs, type GlobalFlags } from "../cli-args.js";
 import { resolveApiUrl } from "../config.js";
-import { createMcpServer } from "../mcp/server.js";
+import { createMcpServer, MCP_SERVER_ICONS } from "../mcp/server.js";
 import { createUploadsMcpTools } from "../mcp/tools.js";
 import { packageVersion } from "../package-version.js";
 import { writeCommandHelp } from "../cli-style.js";
@@ -42,7 +42,7 @@ export async function runMcp(
   const validator = new AjvJsonSchemaValidator();
   const handle = serveStdio(() =>
     createMcpServer({
-      serverInfo: { name: "uploads", version: packageVersion() },
+      serverInfo: { name: "uploads", version: packageVersion(), icons: MCP_SERVER_ICONS },
       tools: createUploadsMcpTools({ globals: opts.globals }),
       apiUrl: resolveApiUrl(opts.globals),
       validator,

--- a/packages/uploads/src/mcp/server.ts
+++ b/packages/uploads/src/mcp/server.ts
@@ -22,6 +22,7 @@ import {
   McpServer,
   type CacheHint,
   type CallToolResult,
+  type Implementation,
   type jsonSchemaValidator,
 } from "@modelcontextprotocol/server";
 import { UploadsError } from "../errors.js";
@@ -227,8 +228,21 @@ function wrapHandler(tool: McpTool, apiUrl: string | undefined) {
   };
 }
 
+/**
+ * Brand mark on `serverInfo.icons` (MCP `Icon`, spec 2026-07-28). PNG is the
+ * type clients that render icons MUST support. The file is the site's
+ * apple-touch-icon (180×180 pixel chevron), already public on uploads.sh.
+ */
+export const MCP_SERVER_ICONS: NonNullable<Implementation["icons"]> = [
+  {
+    src: "https://uploads.sh/apple-touch-icon.png",
+    mimeType: "image/png",
+    sizes: ["180x180"],
+  },
+];
+
 export function createMcpServer(opts: {
-  serverInfo: { name: string; version: string };
+  serverInfo: Implementation;
   tools: McpTool[];
   /** API base for telemetry (honors uploads --api-url). */
   apiUrl?: string;

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -424,6 +424,34 @@ describe("createMcpServer protocol", () => {
     });
   });
 
+  it("echoes serverInfo.icons on initialize and server/discover", async () => {
+    const { factory } = fakeFactory();
+    const icons = [
+      {
+        src: "https://uploads.sh/apple-touch-icon.png",
+        mimeType: "image/png",
+        sizes: ["180x180"],
+      },
+    ];
+    const server = createMcpServer({
+      serverInfo: { name: "uploads", version: "0.0.0-test", icons },
+      validator,
+      tools: createUploadsMcpTools({
+        globals: { apiUrl: "https://x.test", token: "up_test_x" },
+        runner: noRun,
+        clientFactory: factory,
+      }),
+    });
+    const init = await legacyRpc(server, "initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "test", version: "0" },
+    });
+    expect(init.result.serverInfo.icons).toEqual(icons);
+    const discover = await rpc(server, "server/discover");
+    expect(discover.result._meta["io.modelcontextprotocol/serverInfo"].icons).toEqual(icons);
+  });
+
   it("rejects unknown methods with -32601", async () => {
     const { server } = serverWith();
     const res = await rpc(server, "resources/list");


### PR DESCRIPTION
## In plain terms

Generic MCP clients (MCPJam, and the same class of inspector) could not finish OAuth against the hosted MCP. They advertise extra grant types, copy every advertised scope plus extras like `openid`, and send `resource=` as the origin rather than `origin/mcp`. The authorization server treated each of those as a hard error. This change intersects and downscopes instead of failing, and accepts both resource forms.

The hosted MCP also omitted `serverInfo.icons`, so inspector Overview tabs showed an empty icon. The spec field now points at the existing public chevron PNG.

## What it does / what it is not

- CIMD ingest and DCR registration drop unsupported `grant_types` (`device_code`, `jwt-bearer`) when `authorization_code` remains. Device-code-only documents still fail.
- Authorize, consent, and the authorization-code blob downscope `scope=` to the client's registered `files:*` list. Unknown ids are dropped; `files:delete` stays requestable through consent.
- The AS and the MCP worker accept both `https://agents.uploads.sh` and `https://agents.uploads.sh/mcp` (same pair for `mcp.uploads.sh`). Discovery still advertises `origin/mcp`.
- `serverInfo.icons` (and both server-card copies) advertise `https://uploads.sh/apple-touch-icon.png`.
- Not a change to `uploads login` or workspace tokens. RFC 9728 on `api.uploads.sh` is unchanged: the REST API still does not accept OAuth JWTs, and hosted MCP tools still call the API in-process.

## How to try it

In MCPJam, add an HTTP server at `https://agents.uploads.sh/mcp` with OAuth and CIMD registration (leave an `up_` token out of it). Connect, sign in on uploads.sh, pick a workspace, consent. You should land back in MCPJam with tools. A read call such as `list` confirms the JWT `aud` was accepted. After `pnpm deploy:mcp` for this branch, Overview should show the chevron instead of "No icon provided."

Auth and MCP for the OAuth path are already deployed to production and that path completed. The icon needs a MCP redeploy to show up.

## Technical notes

Playbook: [docs/mcp-cimd-interop.md](docs/mcp-cimd-interop.md), adapted from the sibling Sunny note. The CLI device-code grant stays on the seeded `uploads-cli` client; it is not added to the CIMD supported-grant list, because oauth-provider's ingest validator still rejects it.

## Test plan

- [x] `pnpm --filter @uploads/auth test`
- [x] `pnpm --filter @uploads/mcp test`
- [x] `pnpm --filter @buildinternet/uploads test`
- [x] type-aware oxlint on the changed files
- [x] MCPJam against `https://agents.uploads.sh/mcp` after `pnpm deploy:auth` and `pnpm deploy:mcp` (OAuth)
- [ ] MCPJam Overview icon after a MCP redeploy of this branch
