### PR TITLE
feat: list the MCP server on the official registry as sh.uploads/mcp

### DIFF
--- a/.changeset/mcp-registry.md
+++ b/.changeset/mcp-registry.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Publish the stdio MCP server (`uploads mcp`) and the hosted remote to the official MCP Registry as `sh.uploads/mcp`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,7 @@ jobs:
       - name: Changeset lint
         run: pnpm changeset:lint
 
-      # server.json name/version must match packages/uploads mcpName and version.
-      # Schema validation is mcp-publisher's job at publish time.
+      # Lockstep server.json name/version with packages/uploads mcpName/version.
       - name: MCP Registry manifest
         run: pnpm server-json:check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
       - name: Changeset lint
         run: pnpm changeset:lint
 
+      # server.json name/version must match packages/uploads mcpName and version.
+      # Schema validation is mcp-publisher's job at publish time.
+      - name: MCP Registry manifest
+        run: pnpm server-json:check
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,10 +106,9 @@ jobs:
               --notes "${NOTES:-@buildinternet/uploads ${VERSION}}"
           fi
 
-      # MCP Registry only hosts metadata. Ownership is the npm package's
+      # MCP Registry hosts metadata only. Ownership is the npm package's
       # `mcpName`, so this step follows a successful npm publish of that version.
-      # HTTP domain proof grants sh.uploads/* (uploads.sh). Private key is
-      # MCP_PRIVATE_KEY; public proof is /.well-known/mcp-registry-auth.
+      # HTTP domain proof: MCP_PRIVATE_KEY + /.well-known/mcp-registry-auth.
       - name: Publish to MCP Registry
         if: steps.publish.outputs.published == 'true'
         env:
@@ -122,25 +121,31 @@ jobs:
           fi
           node scripts/sync-server-json-version.mjs
 
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m)"
+          case "$arch" in
+            x86_64) arch=amd64 ;;
+            aarch64) arch=arm64 ;;
+          esac
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${os}_${arch}.tar.gz" \
             | tar xz mcp-publisher
 
           ./mcp-publisher login http --domain uploads.sh --private-key "${MCP_PRIVATE_KEY}"
           ./mcp-publisher validate
 
-          # npm's metadata can lag the publish by a few seconds; the registry
-          # fetches mcpName from registry.npmjs.org.
-          VERSION="$(node -p "require('./packages/uploads/package.json').version")"
+          # npm metadata can lag the publish; the registry reads mcpName from registry.npmjs.org.
+          version="$(node -p "require('./packages/uploads/package.json').version")"
+          name=""
           for attempt in 1 2 3 4 5 6 7 8 9 10; do
-            NAME="$(npm view "@buildinternet/uploads@${VERSION}" mcpName 2>/dev/null || true)"
-            if [ "$NAME" = "sh.uploads/mcp" ]; then
+            name="$(npm view "@buildinternet/uploads@${version}" mcpName 2>/dev/null || true)"
+            if [ "$name" = "sh.uploads/mcp" ]; then
               break
             fi
             echo "npm mcpName not visible yet (attempt ${attempt}); waiting"
             sleep 6
           done
-          if [ "$NAME" != "sh.uploads/mcp" ]; then
-            echo "npm has not published mcpName for @buildinternet/uploads@${VERSION} yet"
+          if [ "$name" != "sh.uploads/mcp" ]; then
+            echo "npm has not published mcpName for @buildinternet/uploads@${version} yet"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,3 +105,43 @@ jobs:
               --title "uploads-v${VERSION}" \
               --notes "${NOTES:-@buildinternet/uploads ${VERSION}}"
           fi
+
+      # MCP Registry only hosts metadata. Ownership is the npm package's
+      # `mcpName`, so this step follows a successful npm publish of that version.
+      # HTTP domain proof grants sh.uploads/* (uploads.sh). Private key is
+      # MCP_PRIVATE_KEY; public proof is /.well-known/mcp-registry-auth.
+      - name: Publish to MCP Registry
+        if: steps.publish.outputs.published == 'true'
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MCP_PRIVATE_KEY}" ]; then
+            echo "MCP_PRIVATE_KEY secret is not set"
+            exit 1
+          fi
+          node scripts/sync-server-json-version.mjs
+
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+
+          ./mcp-publisher login http --domain uploads.sh --private-key "${MCP_PRIVATE_KEY}"
+          ./mcp-publisher validate
+
+          # npm's metadata can lag the publish by a few seconds; the registry
+          # fetches mcpName from registry.npmjs.org.
+          VERSION="$(node -p "require('./packages/uploads/package.json').version")"
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            NAME="$(npm view "@buildinternet/uploads@${VERSION}" mcpName 2>/dev/null || true)"
+            if [ "$NAME" = "sh.uploads/mcp" ]; then
+              break
+            fi
+            echo "npm mcpName not visible yet (attempt ${attempt}); waiting"
+            sleep 6
+          done
+          if [ "$NAME" != "sh.uploads/mcp" ]; then
+            echo "npm has not published mcpName for @buildinternet/uploads@${VERSION} yet"
+            exit 1
+          fi
+
+          ./mcp-publisher publish

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ coverage/
 # in hooks/hooks.json, and the script that file points at is not installed here,
 # so it is inert. Ignored so a context.mjs run does not dirty the tree.
 .github/hooks/impeccable.json
+# mcp-publisher binary extracted into the repo root (see docs/releasing.md)
+/mcp-publisher
+
 # Local agent notes, private plans, pricing scratch (not for the public repo)
 .context/
 .superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ coverage/
 # in hooks/hooks.json, and the script that file points at is not installed here,
 # so it is inert. Ignored so a context.mjs run does not dirty the tree.
 .github/hooks/impeccable.json
-# mcp-publisher binary extracted into the repo root (see docs/releasing.md)
+# mcp-publisher binary extracted into the repo root
 /mcp-publisher
 
 # Local agent notes, private plans, pricing scratch (not for the public repo)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,8 @@ version PR that blocks the next npm publish, which `pnpm changeset:lint` rejects
 as a CI gate. And never hand-edit the package `version`.
 
 Merging to `main` opens a "version packages" PR; merging that PR publishes to
-npm. Do not merge one unless shipping is intentional. The full process is in
+npm and then to the MCP Registry (`sh.uploads/mcp`). Do not
+merge one unless shipping is intentional. The full process is in
 [docs/releasing.md](docs/releasing.md).
 
 ## Deployment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,8 +181,8 @@ version PR that blocks the next npm publish, which `pnpm changeset:lint` rejects
 as a CI gate. And never hand-edit the package `version`.
 
 Merging to `main` opens a "version packages" PR; merging that PR publishes to
-npm and then to the MCP Registry (`sh.uploads/mcp`). Do not
-merge one unless shipping is intentional. The full process is in
+npm, then to the MCP Registry as `sh.uploads/mcp`. Do not merge one unless
+shipping is intentional. The full process is in
 [docs/releasing.md](docs/releasing.md).
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ REST routes are in [docs/api.md](docs/api.md).
 | `packages/`                       | Shared code — most notably `@buildinternet/uploads` (the CLI, published to npm) and `@uploads/storage` (the files-sdk adapter factory all storage goes through) |
 | `skills/`                         | The three agent skills that ship to users                                                                                                                       |
 | `hooks/`, `plugins/`, `.mcp.json` | Agent-runtime wiring: the shared pre-PR screenshot hook and the Claude / Codex plugin manifests                                                                 |
+| `server.json`                     | MCP Registry manifest: stdio (`uploads mcp` on `@buildinternet/uploads`) and the hosted remote at `https://agents.uploads.sh/mcp`                               |
 
 Each worker and the web app deploy separately. All storage access goes through
 `createStorage()` in `packages/storage` — adding a provider is one new case

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ REST routes are in [docs/api.md](docs/api.md).
 | `packages/`                       | Shared code — most notably `@buildinternet/uploads` (the CLI, published to npm) and `@uploads/storage` (the files-sdk adapter factory all storage goes through) |
 | `skills/`                         | The three agent skills that ship to users                                                                                                                       |
 | `hooks/`, `plugins/`, `.mcp.json` | Agent-runtime wiring: the shared pre-PR screenshot hook and the Claude / Codex plugin manifests                                                                 |
-| `server.json`                     | MCP Registry manifest: stdio (`uploads mcp` on `@buildinternet/uploads`) and the hosted remote at `https://agents.uploads.sh/mcp`                               |
+| `server.json`                     | MCP Registry listing (`sh.uploads/mcp`): stdio `uploads mcp` plus the hosted remote                                                                             |
 
 Each worker and the web app deploy separately. All storage access goes through
 `createStorage()` in `packages/storage` — adding a provider is one new case

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -68,18 +68,19 @@ rules there.
 
 ## Agent discovery (easy wins)
 
-| Check           | Location                                                             |
-| --------------- | -------------------------------------------------------------------- |
-| robots.txt      | `/robots.txt`                                                        |
-| sitemap         | `/sitemap.xml` (referenced from robots)                              |
-| Link headers    | homepage `/` via `_headers`                                          |
-| Integrations    | `/.well-known/integrations.json` (integrations.sh v3 declaration)    |
-| API catalog     | `/.well-known/api-catalog`                                           |
-| OpenAPI         | `/.well-known/openapi.json` (canonical) and `/openapi.json` (probe)  |
-| MCP server card | `/.well-known/mcp/server-card.json`                                  |
-| Agent skills    | `/.well-known/agent-skills/index.json`                               |
-| Auth for agents | `/auth.md` (bearer / invite; also documents the hosted-MCP OAuth AS) |
-| oEmbed          | `/oembed?url=…` for public `/f/…` and `/g/…` pages (JSON only)       |
+| Check             | Location                                                                |
+| ----------------- | ----------------------------------------------------------------------- |
+| robots.txt        | `/robots.txt`                                                           |
+| sitemap           | `/sitemap.xml` (referenced from robots)                                 |
+| Link headers      | homepage `/` via `_headers`                                             |
+| Integrations      | `/.well-known/integrations.json` (integrations.sh v3 declaration)       |
+| API catalog       | `/.well-known/api-catalog`                                              |
+| OpenAPI           | `/.well-known/openapi.json` (canonical) and `/openapi.json` (probe)     |
+| MCP server card   | `/.well-known/mcp/server-card.json`                                     |
+| MCP Registry auth | `/.well-known/mcp-registry-auth` (HTTP domain proof for `sh.uploads/*`) |
+| Agent skills      | `/.well-known/agent-skills/index.json`                                  |
+| Auth for agents   | `/auth.md` (bearer / invite; also documents the hosted-MCP OAuth AS)    |
+| oEmbed            | `/oembed?url=…` for public `/f/…` and `/g/…` pages (JSON only)          |
 
 ### Integration surfaces (`/.well-known/integrations.json`)
 

--- a/apps/web/public/.well-known/mcp-registry-auth
+++ b/apps/web/public/.well-known/mcp-registry-auth
@@ -1,0 +1,1 @@
+v=MCPv1; k=ed25519; p=uCGm901Pt9oVAo/UApV35QXzi154+8ez4zZGqrRqxC0=

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -91,6 +91,13 @@
   Cache-Control: public, max-age=300
   Access-Control-Allow-Origin: *
 
+# MCP Registry HTTP domain proof (Ed25519 public key). Private key is the
+# MCP_PRIVATE_KEY Actions secret; see docs/releasing.md.
+/.well-known/mcp-registry-auth
+  Content-Type: text/plain; charset=utf-8
+  Cache-Control: public, max-age=300
+  Access-Control-Allow-Origin: *
+
 # releases.sh listing — where uploads publishes release notes (GitHub Releases).
 /.well-known/releases.json
   Content-Type: application/json; charset=utf-8

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -91,8 +91,7 @@
   Cache-Control: public, max-age=300
   Access-Control-Allow-Origin: *
 
-# MCP Registry HTTP domain proof (Ed25519 public key). Private key is the
-# MCP_PRIVATE_KEY Actions secret; see docs/releasing.md.
+# MCP Registry HTTP domain proof (see docs/releasing.md)
 /.well-known/mcp-registry-auth
   Content-Type: text/plain; charset=utf-8
   Cache-Control: public, max-age=300

--- a/apps/web/public/auth.md
+++ b/apps/web/public/auth.md
@@ -74,6 +74,7 @@ inferred from the `up_<workspace>_…` token form).
 | API catalog (RFC 9727) | https://uploads.sh/.well-known/api-catalog                       |
 | OpenAPI (summary)      | https://uploads.sh/.well-known/openapi.json (also /openapi.json) |
 | MCP server card        | https://uploads.sh/.well-known/mcp/server-card.json              |
+| MCP Registry auth      | https://uploads.sh/.well-known/mcp-registry-auth                 |
 | Agent skills index     | https://uploads.sh/.well-known/agent-skills/index.json           |
 | Narrative API docs     | https://github.com/buildinternet/uploads/blob/main/docs/api.md   |
 | API health             | https://api.uploads.sh/health                                    |

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,6 @@ This folder is the repo companion: CLI and API reference, then contributor and o
 
 ## Operators and self-hosting
 
-ops, deploy, releasing (including the MCP Registry listing), contract-testing, admin-tokens, workspaces, and deletion assume you run or deploy the service. They are not getting-started docs.
+ops, deploy, releasing, contract-testing, admin-tokens, workspaces, and deletion assume you run or deploy the service. They are not getting-started docs.
 
 docs/superpowers/ is historical implementation plans, not product docs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,6 @@ This folder is the repo companion: CLI and API reference, then contributor and o
 
 ## Operators and self-hosting
 
-ops, deploy, releasing, contract-testing, admin-tokens, workspaces, and deletion assume you run or deploy the service. They are not getting-started docs.
+ops, deploy, releasing (including the MCP Registry listing), contract-testing, admin-tokens, workspaces, and deletion assume you run or deploy the service. They are not getting-started docs.
 
 docs/superpowers/ is historical implementation plans, not product docs.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -57,15 +57,64 @@ they deploy via Workers Builds.
    - tests / builds / pack-checks the package
    - runs `changeset publish` (OIDC provenance)
    - creates a GitHub release tagged `uploads-v<version>` (same prefix as before)
+   - publishes `server.json` to the [MCP Registry](https://registry.modelcontextprotocol.io)
+     as `sh.uploads/mcp`
 
-Verify the version and provenance on npm after the workflow succeeds.
+Verify the version and provenance on npm after the workflow succeeds. Confirm
+the MCP listing with:
+
+```bash
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=sh.uploads/mcp"
+```
+
+## MCP Registry
+
+The registry stores metadata only. It checks that the published npm package
+declares `mcpName` equal to `server.json`'s `name`, then records how clients
+should run the server: stdio via `uploads mcp`, and the hosted remote at
+`https://agents.uploads.sh/mcp`.
+
+The listing name is the reverse-DNS of uploads.sh: `sh.uploads/mcp`. `mcpName`
+on `@buildinternet/uploads` must match. A registry publish always follows an
+npm publish of that version. `changeset version` copies the new package version
+into `server.json` so the version PR shows the stamp. The publish job stamps
+again before `mcp-publisher publish`. CI runs `pnpm server-json:check` on
+every pull request so `name`, `mcpName`, and the two version fields cannot
+drift.
+
+Publish authenticates with HTTP domain proof, not GitHub OIDC. The public
+record is `https://uploads.sh/.well-known/mcp-registry-auth` (served from
+`apps/web/public/.well-known/mcp-registry-auth`). The matching Ed25519
+private key is the `MCP_PRIVATE_KEY` Actions secret (64-character hex). The
+publish job runs `mcp-publisher login http --domain uploads.sh`. That grant
+is `sh.uploads/*`.
+
+The proof file has to be live on uploads.sh before the first registry
+publish. Merge the change that adds the file, let the web worker deploy, then
+merge the version PR.
+
+Do not change `server.json` `name` or `packages/uploads` `mcpName` without a
+matching npm publish. The registry treats those strings as the server's
+identity.
 
 ## Manual / recovery
 
 ```bash
 pnpm changeset              # add a pending bump
-pnpm run changeset:version  # apply pending → version + CHANGELOG (local only)
+pnpm run changeset:version  # apply pending → version + CHANGELOG + server.json (local only)
 pnpm run changeset:publish  # npm publish packages that need it (needs auth)
 ```
 
 Do not re-use or move a published version or release tag.
+
+If the MCP Registry step fails after npm already published, re-running the
+Release workflow will not retry: `changeset publish` prints no new tag, so the
+MCP step is skipped. Publish `server.json` locally instead:
+
+```bash
+brew install mcp-publisher
+mcp-publisher login http --domain uploads.sh --private-key "$MCP_PRIVATE_KEY"
+pnpm server-json:check
+mcp-publisher validate
+mcp-publisher publish
+```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -70,24 +70,24 @@ curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=sh.uploads/mc
 ## MCP Registry
 
 The registry stores metadata only. It checks that the published npm package
-declares `mcpName` equal to `server.json`'s `name`, then records how clients
-should run the server: stdio via `uploads mcp`, and the hosted remote at
+declares `mcpName` equal to `server.json` `name`, then records how clients
+run the server: stdio via `uploads mcp`, and the hosted remote at
 `https://agents.uploads.sh/mcp`.
 
-The listing name is the reverse-DNS of uploads.sh: `sh.uploads/mcp`. `mcpName`
-on `@buildinternet/uploads` must match. A registry publish always follows an
-npm publish of that version. `changeset version` copies the new package version
-into `server.json` so the version PR shows the stamp. The publish job stamps
-again before `mcp-publisher publish`. CI runs `pnpm server-json:check` on
-every pull request so `name`, `mcpName`, and the two version fields cannot
-drift.
+The listing name is the reverse-DNS of uploads.sh: `sh.uploads/mcp`. That
+string must match `mcpName` on `@buildinternet/uploads`. A registry publish
+always follows an npm publish of that version.
+
+`changeset version` copies the new package version into `server.json` so the
+version PR shows the stamp. The publish job stamps again before
+`mcp-publisher publish`. CI runs `pnpm server-json:check` on every pull
+request so `name`, `mcpName`, and the two version fields cannot drift.
 
 Publish authenticates with HTTP domain proof, not GitHub OIDC. The public
 record is `https://uploads.sh/.well-known/mcp-registry-auth` (served from
 `apps/web/public/.well-known/mcp-registry-auth`). The matching Ed25519
-private key is the `MCP_PRIVATE_KEY` Actions secret (64-character hex). The
-publish job runs `mcp-publisher login http --domain uploads.sh`. That grant
-is `sh.uploads/*`.
+private key is the `MCP_PRIVATE_KEY` Actions secret. The publish job runs
+`mcp-publisher login http --domain uploads.sh`. That grant is `sh.uploads/*`.
 
 The proof file has to be live on uploads.sh before the first registry
 publish. Merge the change that adds the file, let the web worker deploy, then

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "uploads": "pnpm exec uploads",
     "changeset": "changeset",
     "changeset:lint": "node scripts/changeset-lint.mjs",
-    "changeset:version": "changeset version && pnpm install --lockfile-only",
+    "server-json:check": "node scripts/check-server-json.mjs",
+    "changeset:version": "changeset version && node scripts/sync-server-json-version.mjs && pnpm install --lockfile-only",
     "changeset:publish": "changeset publish",
     "prepare": "husky"
   },

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -202,7 +202,9 @@ Config layers (first match wins): CLI flags → env vars → `--env-file` → `~
 { "command": "uploads", "args": ["--env-file", "/path/to/.env", "mcp"] }
 ```
 
-Or with `UPLOADS_TOKEN`/`UPLOADS_WORKSPACE` in the environment or user config. Claude Code: `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`. The MCP Registry name is `sh.uploads/mcp` (`server.json` at the repo root).
+Or with `UPLOADS_TOKEN`/`UPLOADS_WORKSPACE` in the environment or user config. Claude Code: `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`.
+
+The MCP Registry lists this server as `sh.uploads/mcp`.
 
 For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/mcp` — the workspace is inferred from the bearer token, so only the URL and token are needed (`https://agents.uploads.sh/<workspace>/mcp` and the `mcp.uploads.sh` hostname also work). Tools: file operations (including `get_metadata` / `set_metadata` / `find_files`) plus `gallery_create`, `gallery_get`, `gallery_add`, `gallery_link`, and `gallery_find_by_reference`; all use the same bearer-token workspace scopes and gallery URLs come from the API — see `apps/mcp` in the repo. The hosted `put` also accepts a `metadata` param. `uploads install` registers the skills + hosted MCP with whichever of Claude Code, Codex, and Grok are on PATH (a missing CLI is skipped) + Grok/Cursor hooks (short progress; `--verbose` for underlying output). Claude and Codex use their plugins for the same pre-PR screenshot reminder (`uploads hook pre-pr-screenshot`). Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -202,7 +202,7 @@ Config layers (first match wins): CLI flags → env vars → `--env-file` → `~
 { "command": "uploads", "args": ["--env-file", "/path/to/.env", "mcp"] }
 ```
 
-Or with `UPLOADS_TOKEN`/`UPLOADS_WORKSPACE` in the environment or user config. Claude Code: `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`.
+Or with `UPLOADS_TOKEN`/`UPLOADS_WORKSPACE` in the environment or user config. Claude Code: `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`. The MCP Registry name is `sh.uploads/mcp` (`server.json` at the repo root).
 
 For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/mcp` — the workspace is inferred from the bearer token, so only the URL and token are needed (`https://agents.uploads.sh/<workspace>/mcp` and the `mcp.uploads.sh` hostname also work). Tools: file operations (including `get_metadata` / `set_metadata` / `find_files`) plus `gallery_create`, `gallery_get`, `gallery_add`, `gallery_link`, and `gallery_find_by_reference`; all use the same bearer-token workspace scopes and gallery URLs come from the API — see `apps/mcp` in the repo. The hosted `put` also accepts a `metadata` param. `uploads install` registers the skills + hosted MCP with whichever of Claude Code, Codex, and Grok are on PATH (a missing CLI is skipped) + Grok/Cursor hooks (short progress; `--verbose` for underlying output). Claude and Codex use their plugins for the same pre-PR screenshot reminder (`uploads hook pre-pr-screenshot`). Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
 

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@buildinternet/uploads",
   "version": "0.48.0",
+  "mcpName": "sh.uploads/mcp",
   "description": "CLI and client for uploads.sh — workspace-scoped image hosting for GitHub embeds",
   "type": "module",
   "sideEffects": false,

--- a/packages/uploads/scripts/check-pack.mjs
+++ b/packages/uploads/scripts/check-pack.mjs
@@ -46,11 +46,7 @@ try {
   );
   assert.equal(manifest.private, undefined, "package must not be marked private");
   assert.equal(manifest.publishConfig?.access, "public");
-  assert.equal(
-    manifest.mcpName,
-    "sh.uploads/mcp",
-    "packed manifest must retain mcpName for MCP Registry ownership verification",
-  );
+  assert.equal(manifest.mcpName, "sh.uploads/mcp", "packed manifest must retain mcpName");
   // Workers (apps/mcp) import helpers from the main entry; without this, esbuild
   // keeps the optimize/frame re-exports and bundles native `sharp`, which fails
   // Cloudflare startup validation (createRequire / path undefined).

--- a/packages/uploads/scripts/check-pack.mjs
+++ b/packages/uploads/scripts/check-pack.mjs
@@ -46,6 +46,11 @@ try {
   );
   assert.equal(manifest.private, undefined, "package must not be marked private");
   assert.equal(manifest.publishConfig?.access, "public");
+  assert.equal(
+    manifest.mcpName,
+    "sh.uploads/mcp",
+    "packed manifest must retain mcpName for MCP Registry ownership verification",
+  );
   // Workers (apps/mcp) import helpers from the main entry; without this, esbuild
   // keeps the optimize/frame re-exports and bundles native `sharp`, which fails
   // Cloudflare startup validation (createRequire / path undefined).

--- a/scripts/check-server-json.mjs
+++ b/scripts/check-server-json.mjs
@@ -1,8 +1,8 @@
 /**
- * Keep server.json in lockstep with the published CLI package. The MCP Registry
- * verifies `mcpName` on the npm tarball against `server.json` `name`, and
- * clients install from `packages[0].identifier` / `version`. Drift here fails
- * publish (ownership check) or installs the wrong binary.
+ * Lockstep: server.json vs packages/uploads. The MCP Registry verifies `mcpName`
+ * on the npm tarball against `server.json` `name`; clients install from
+ * `packages[0].identifier` / `version`. Drift fails publish or installs the
+ * wrong binary.
  *
  * Static by design: no network, no mcp-publisher. Schema validation runs in
  * the Release workflow via `mcp-publisher validate` before publish.
@@ -13,14 +13,17 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const pkg = JSON.parse(readFileSync(join(root, "packages/uploads/package.json"), "utf8"));
-const server = JSON.parse(readFileSync(join(root, "server.json"), "utf8"));
 
+function readJson(rel) {
+  return JSON.parse(readFileSync(join(root, rel), "utf8"));
+}
+
+const pkg = readJson("packages/uploads/package.json");
+const server = readJson("server.json");
 const NAME = "sh.uploads/mcp";
 
 assert.equal(pkg.mcpName, NAME, "packages/uploads/package.json mcpName");
 assert.equal(server.name, NAME, "server.json name");
-assert.equal(server.name, pkg.mcpName, "server.json name must equal package mcpName");
 assert.equal(server.version, pkg.version, "server.json version must equal the CLI version");
 
 assert.equal(typeof server.description, "string");

--- a/scripts/check-server-json.mjs
+++ b/scripts/check-server-json.mjs
@@ -1,0 +1,61 @@
+/**
+ * Keep server.json in lockstep with the published CLI package. The MCP Registry
+ * verifies `mcpName` on the npm tarball against `server.json` `name`, and
+ * clients install from `packages[0].identifier` / `version`. Drift here fails
+ * publish (ownership check) or installs the wrong binary.
+ *
+ * Static by design: no network, no mcp-publisher. Schema validation runs in
+ * the Release workflow via `mcp-publisher validate` before publish.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(root, "packages/uploads/package.json"), "utf8"));
+const server = JSON.parse(readFileSync(join(root, "server.json"), "utf8"));
+
+const NAME = "sh.uploads/mcp";
+
+assert.equal(pkg.mcpName, NAME, "packages/uploads/package.json mcpName");
+assert.equal(server.name, NAME, "server.json name");
+assert.equal(server.name, pkg.mcpName, "server.json name must equal package mcpName");
+assert.equal(server.version, pkg.version, "server.json version must equal the CLI version");
+
+assert.equal(typeof server.description, "string");
+assert.ok(server.description.length >= 1, "server.json description is required");
+assert.ok(
+  server.description.length <= 100,
+  `server.json description must be ≤100 characters (got ${server.description.length})`,
+);
+
+assert.equal(server.websiteUrl, "https://uploads.sh");
+assert.equal(server.repository?.url, "https://github.com/buildinternet/uploads");
+assert.equal(server.repository?.source, "github");
+assert.equal(server.repository?.id, "1291468384");
+
+const npm = server.packages?.[0];
+assert.ok(npm, "server.json must declare the npm package");
+assert.equal(npm.registryType, "npm");
+assert.equal(npm.identifier, pkg.name);
+assert.equal(npm.version, pkg.version);
+assert.equal(npm.transport?.type, "stdio");
+assert.deepEqual(npm.packageArguments, [{ type: "positional", value: "mcp" }]);
+
+const remote = server.remotes?.[0];
+assert.ok(remote, "server.json must declare the hosted remote");
+assert.equal(remote.type, "streamable-http");
+assert.equal(remote.url, "https://agents.uploads.sh/mcp");
+
+const proof = readFileSync(
+  join(root, "apps/web/public/.well-known/mcp-registry-auth"),
+  "utf8",
+).trim();
+assert.match(
+  proof,
+  /^v=MCPv1; k=ed25519; p=[A-Za-z0-9+/]+=*$/,
+  "uploads.sh HTTP proof at /.well-known/mcp-registry-auth",
+);
+
+console.log(`server.json ok (${server.name} ${server.version})`);

--- a/scripts/sync-server-json-version.mjs
+++ b/scripts/sync-server-json-version.mjs
@@ -1,0 +1,29 @@
+/**
+ * Copy packages/uploads/package.json version into server.json. Called from
+ * `changeset:version` so the version PR includes the registry bump, and from
+ * the Release publish job as a safety net before `mcp-publisher publish`.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkgPath = join(root, "packages/uploads/package.json");
+const serverPath = join(root, "server.json");
+
+const version = JSON.parse(readFileSync(pkgPath, "utf8")).version;
+if (typeof version !== "string" || version.length === 0) {
+  throw new Error(`packages/uploads/package.json is missing version`);
+}
+
+const server = JSON.parse(readFileSync(serverPath, "utf8"));
+const before = JSON.stringify(server);
+server.version = version;
+if (server.packages?.[0]) server.packages[0].version = version;
+if (JSON.stringify(server) === before) {
+  console.log(`server.json already at ${version}`);
+  process.exit(0);
+}
+
+writeFileSync(serverPath, `${JSON.stringify(server, null, 2)}\n`);
+console.log(`server.json version → ${version}`);

--- a/scripts/sync-server-json-version.mjs
+++ b/scripts/sync-server-json-version.mjs
@@ -13,17 +13,21 @@ const serverPath = join(root, "server.json");
 
 const version = JSON.parse(readFileSync(pkgPath, "utf8")).version;
 if (typeof version !== "string" || version.length === 0) {
-  throw new Error(`packages/uploads/package.json is missing version`);
+  throw new Error("packages/uploads/package.json is missing version");
 }
 
 const server = JSON.parse(readFileSync(serverPath, "utf8"));
-const before = JSON.stringify(server);
-server.version = version;
-if (server.packages?.[0]) server.packages[0].version = version;
-if (JSON.stringify(server) === before) {
+const npm = server.packages?.[0];
+if (!npm) {
+  throw new Error("server.json is missing packages[0]");
+}
+
+if (server.version === version && npm.version === version) {
   console.log(`server.json already at ${version}`);
   process.exit(0);
 }
 
+server.version = version;
+npm.version = version;
 writeFileSync(serverPath, `${JSON.stringify(server, null, 2)}\n`);
 console.log(`server.json version → ${version}`);

--- a/server.json
+++ b/server.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "sh.uploads/mcp",
+  "title": "uploads.sh",
+  "description": "Host files from coding agents; stage on a branch and attach to GitHub PRs.",
+  "websiteUrl": "https://uploads.sh",
+  "repository": {
+    "url": "https://github.com/buildinternet/uploads",
+    "source": "github",
+    "id": "1291468384"
+  },
+  "version": "0.48.0",
+  "icons": [
+    {
+      "src": "https://uploads.sh/apple-touch-icon.png",
+      "mimeType": "image/png",
+      "sizes": ["180x180"]
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@buildinternet/uploads",
+      "version": "0.48.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "UPLOADS_TOKEN",
+          "description": "Workspace bearer token (up_<workspace>_…). Mint with uploads login.",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "UPLOADS_WORKSPACE",
+          "description": "Workspace name. Inferred from the token when omitted.",
+          "isRequired": false,
+          "format": "string"
+        },
+        {
+          "name": "UPLOADS_API_URL",
+          "description": "API origin. Defaults to https://api.uploads.sh.",
+          "isRequired": false,
+          "format": "string",
+          "default": "https://api.uploads.sh"
+        }
+      ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://agents.uploads.sh/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer workspace token (up_<workspace>_…) or OAuth access token. Omit this header to use the OAuth browser flow.",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## In plain terms

The hosted MCP at agents.uploads.sh and the local `uploads mcp` command have no listing on the official MCP Registry, so clients that install from the registry cannot find them. This prepares a listing named `sh.uploads/mcp` (reverse-DNS of uploads.sh) and publishes it automatically on the next CLI release.

## What it does / what it is not

- Adds `server.json` for both transports: stdio (`uploads mcp` on `@buildinternet/uploads`) and the hosted remote at `https://agents.uploads.sh/mcp`.
- Stamps `mcpName` on the npm package so the registry can verify ownership.
- Serves HTTP domain proof at `https://uploads.sh/.well-known/mcp-registry-auth`. The matching private key is the `MCP_PRIVATE_KEY` Actions secret (already set).
- After a successful npm publish, the Release workflow logs in with that proof and publishes `server.json`.
- Not live until this merges, the web worker deploys the proof file, and the next **version packages** PR publishes an npm version that includes `mcpName`. Current `0.48.0` on npm does not have it.
- Not a GitHub-org listing (`io.github.buildinternet/…`). Domain proof grants `sh.uploads/*`.

Merge this before the open version-packages PR ([#852](https://github.com/buildinternet/uploads/pull/852)) so that PR can pick up the changeset and the proof file is on uploads.sh before the registry publish runs.

## How to try it

Nothing to run in the CLI until the version PR ships. After this merge, the proof URL should return the Ed25519 public record:

```bash
curl -sS https://uploads.sh/.well-known/mcp-registry-auth
```

After the version PR publishes, confirm the listing:

```bash
curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=sh.uploads/mcp"
```

## Technical notes

`changeset version` copies the CLI version into `server.json`. CI runs `pnpm server-json:check` so `name`, `mcpName`, and the two version fields stay in lockstep. `mcp-publisher validate` passed against the live schema. The private key is not in git (main-checkout `.context/`, gitignored).

## Test plan

- [x] `pnpm server-json:check`
- [x] `pnpm --filter @buildinternet/uploads run pack:check` (packed tarball retains `mcpName`)
- [x] `mcp-publisher validate` against registry.modelcontextprotocol.io
- [ ] CI green on this PR
- [ ] After merge: proof file live at `/.well-known/mcp-registry-auth`
- [ ] After the version PR: listing visible in the registry search above