### PR TITLE
chore: harden MCP Registry publishes and pin advertised versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      mcp_registry_only:
+        description: Only publish server.json to the MCP Registry (skip version PR and npm)
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -56,6 +62,7 @@ jobs:
       # is incompatible with OIDC. Publish runs as its own step below.
       - name: Create Release PR
         id: changesets
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mcp_registry_only != true }}
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm run changeset:version
@@ -107,18 +114,17 @@ jobs:
           fi
 
       # MCP Registry hosts metadata only. Ownership is the npm package's
-      # `mcpName`, so this step follows a successful npm publish of that version.
-      # HTTP domain proof: MCP_PRIVATE_KEY + /.well-known/mcp-registry-auth.
+      # `mcpName`, so the default path follows a successful npm publish.
+      # workflow_dispatch + mcp_registry_only retries a failed publish without
+      # cutting another npm tag. HTTP domain proof: PEM secret (preferred) or
+      # legacy hex MCP_PRIVATE_KEY; public proof is /.well-known/mcp-registry-auth.
       - name: Publish to MCP Registry
-        if: steps.publish.outputs.published == 'true'
+        if: ${{ steps.publish.outputs.published == 'true' || inputs.mcp_registry_only == true }}
         env:
+          MCP_REGISTRY_PRIVATE_KEY_PEM: ${{ secrets.MCP_REGISTRY_PRIVATE_KEY_PEM }}
           MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "${MCP_PRIVATE_KEY}" ]; then
-            echo "MCP_PRIVATE_KEY secret is not set"
-            exit 1
-          fi
           node scripts/sync-server-json-version.mjs
 
           os="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -130,10 +136,23 @@ jobs:
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${os}_${arch}.tar.gz" \
             | tar xz mcp-publisher
 
-          ./mcp-publisher login http --domain uploads.sh --private-key "${MCP_PRIVATE_KEY}"
+          if [ -n "${MCP_REGISTRY_PRIVATE_KEY_PEM:-}" ]; then
+            key_file="$(mktemp)"
+            trap 'rm -f "$key_file"' EXIT
+            printf '%s\n' "$MCP_REGISTRY_PRIVATE_KEY_PEM" > "$key_file"
+            PRIVATE_KEY="$(openssl pkey -in "$key_file" -noout -text | grep -A3 'priv:' | tail -n +2 | tr -d ' :\n')"
+          elif [ -n "${MCP_PRIVATE_KEY:-}" ]; then
+            PRIVATE_KEY="$MCP_PRIVATE_KEY"
+          else
+            echo "Set MCP_REGISTRY_PRIVATE_KEY_PEM (PEM) or MCP_PRIVATE_KEY (hex)"
+            exit 1
+          fi
+
+          ./mcp-publisher login http --domain uploads.sh --private-key "${PRIVATE_KEY}"
           ./mcp-publisher validate
 
           # npm metadata can lag the publish; the registry reads mcpName from registry.npmjs.org.
+          # Skip the wait on a registry-only retry: the version is already on npm.
           version="$(node -p "require('./packages/uploads/package.json').version")"
           name=""
           for attempt in 1 2 3 4 5 6 7 8 9 10; do
@@ -149,4 +168,15 @@ jobs:
             exit 1
           fi
 
-          ./mcp-publisher publish
+          # Registry rejects re-publishing an existing version; treat that as a
+          # no-op so workflow_dispatch retries and a double-run don't fail Release.
+          if ./mcp-publisher publish > /tmp/mcp-publisher-publish.log 2>&1; then
+            cat /tmp/mcp-publisher-publish.log
+          else
+            cat /tmp/mcp-publisher-publish.log
+            if grep -qE 'already exists|duplicate version' /tmp/mcp-publisher-publish.log; then
+              echo "Version already published — skipping"
+              exit 0
+            fi
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ in one tidy comment that updates automatically on each revision. Built on
   <a href="https://skills.sh/buildinternet/uploads"><img alt="skills.sh" src="https://skills.sh/b/buildinternet/uploads"></a>
   <a href="https://github.com/buildinternet/uploads/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/buildinternet/uploads/actions/workflows/ci.yml/badge.svg"></a>
   <a href="https://www.npmjs.com/package/@buildinternet/uploads"><img alt="npm (CLI)" src="https://img.shields.io/npm/v/@buildinternet/uploads?color=cb3837&label=%40buildinternet%2Fuploads&logo=npm"></a>
+  <a href="https://registry.modelcontextprotocol.io/v0.1/servers?search=sh.uploads/mcp"><img alt="MCP server" src="https://img.shields.io/badge/exposes-MCP_server-000"></a>
   <a href="https://github.com/apps/uploads-sh"><img alt="GitHub App: uploads-sh" src="https://img.shields.io/badge/GitHub%20App-uploads--sh-181717?logo=github&logoColor=white"></a>
   <a href="https://deepwiki.com/buildinternet/uploads"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"></a>
   <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache%202.0-blue"></a>
@@ -136,6 +137,14 @@ an invite into one — see [enrollment](docs/enrollment.md). Hosted files are
 public URLs — private-repo attachments get non-guessable links
 ([how that works](docs/private-attachments.md)), but anyone holding a URL can
 view the file. Do not upload secrets or sensitive UI.
+
+**MCP.** Hosted at `agents.uploads.sh`, listed in the
+[MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=sh.uploads/mcp)
+as `sh.uploads/mcp`. Local stdio is `uploads mcp` on the same npm package.
+
+```bash
+claude mcp add --transport http uploads https://agents.uploads.sh/mcp
+```
 
 **Teach your agent the loop.** `uploads install` wires in the agent skills and
 the MCP server, so future sessions capture at each visual milestone on their

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -4,6 +4,7 @@ Remote MCP server for uploads.sh — a standalone Hono worker on
 `agents.uploads.sh` (with `mcp.uploads.sh` as an alternate), sibling to `apps/api`. It shares the API's bindings
 (registry KV, D1, R2 buckets) and its per-workspace bearer auth, and reuses
 the CLI package's transport-agnostic MCP core (`@buildinternet/uploads/mcp`).
+`serverInfo.version` is the published CLI version, not this package's `version`.
 
 Stateless MCP Streamable HTTP: one JSON-RPC message per POST, no sessions or
 SSE (GET/DELETE on the endpoint are 405). Tools cover put/list/delete, metadata

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -32,7 +32,7 @@ import {
 import { protectedResourceMetadata, requestOrigin } from "@uploads/api/well-known";
 import { Hono, type Context, type Next } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import pkg from "../package.json";
+import { version as uploadsVersion } from "../../../packages/uploads/package.json";
 import { createRemoteTools } from "./tools";
 import { invalidTokenChallenge, isJwtShaped, missingTokenChallenge, verifyOAuthJwt } from "./oauth";
 import { ROBOTS_TXT } from "./robots";
@@ -165,7 +165,9 @@ async function workspacePathAuth(c: Context<WorkspaceVars>, next: Next): Promise
 /** Builds a fresh server for this request — same tool catalog for both eras, so they can't drift. */
 function buildServer(c: Context<WorkspaceVars>): McpServer {
   return createMcpServer({
-    serverInfo: { name: "uploads-mcp", version: pkg.version, icons: MCP_SERVER_ICONS },
+    // Advertise the published CLI version (the MCP Registry listing), not
+    // this worker's private package.json, which is inert.
+    serverInfo: { name: "uploads-mcp", version: uploadsVersion, icons: MCP_SERVER_ICONS },
     tools: createRemoteTools({
       env: c.env,
       workspace: c.get("workspace"),
@@ -256,13 +258,13 @@ function mcpServerCard() {
     // Plural, mirroring the ratified `server/discover` result. There is no
     // ratified server-card schema to key off — the `$schema` URL above 404s
     // and SEP-2127 is still an unmerged draft with a different shape — so the
-    // discover result is the closest thing to an authority. Keep this list in
-    // sync with apps/web/public/.well-known/mcp/server-card.json, which serves
-    // the same document from the uploads.sh origin.
+    // discover result is the closest thing to an authority. The same document
+    // is generated onto uploads.sh from server.json
+    // (scripts/build-mcp-server-card.mjs).
     supportedVersions: ["2026-07-28", "2025-06-18"],
     serverInfo: {
       name: "uploads-mcp",
-      version: pkg.version,
+      version: uploadsVersion,
       description:
         "Host files on uploads.sh from an agent — put, attach, list, delete, usage, and GitHub attachment comments.",
       homepage: "https://uploads.sh/",

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -6,6 +6,7 @@ import { sha256Hex, type WorkspaceRecord } from "@uploads/api/workspace";
 import { FakeR2Bucket } from "@uploads/storage/test/fake-r2";
 import { resetOAuthJwksCacheForTests } from "../src/oauth";
 import { GalleryFakeD1 } from "./gallery-fake-d1";
+import { version as uploadsVersion } from "../../../packages/uploads/package.json";
 
 const TOKEN = "up_test-ws_legacy-token-value";
 const ALPHA_TOKEN = "up_alpha_gallery-test";
@@ -539,7 +540,7 @@ describe("mcp worker", () => {
       authentication: { required: boolean };
     };
     expect(body.serverInfo.name).toBe("uploads-mcp");
-    expect(body.serverInfo.version).toBeTruthy();
+    expect(body.serverInfo.version).toBe(uploadsVersion);
     expect(body.serverInfo.icons).toEqual([
       {
         src: "https://uploads.sh/apple-touch-icon.png",

--- a/apps/web/public/.well-known/mcp/server-card.json
+++ b/apps/web/public/.well-known/mcp/server-card.json
@@ -3,7 +3,7 @@
   "supportedVersions": ["2026-07-28", "2025-06-18"],
   "serverInfo": {
     "name": "uploads-mcp",
-    "version": "0.6.0",
+    "version": "0.48.1",
     "description": "Host files on uploads.sh from an agent — put (including branch staging and PR attach), promote, list, delete, usage, galleries, and GitHub attachment comments.",
     "homepage": "https://uploads.sh/",
     "icons": [

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -85,13 +85,15 @@ request so `name`, `mcpName`, and the two version fields cannot drift.
 
 Publish authenticates with HTTP domain proof, not GitHub OIDC. The public
 record is `https://uploads.sh/.well-known/mcp-registry-auth` (served from
-`apps/web/public/.well-known/mcp-registry-auth`). The matching Ed25519
-private key is the `MCP_PRIVATE_KEY` Actions secret. The publish job runs
+`apps/web/public/.well-known/mcp-registry-auth`). Prefer the
+`MCP_REGISTRY_PRIVATE_KEY_PEM` Actions secret (PEM). The job still accepts the
+legacy hex secret `MCP_PRIVATE_KEY`. The publish job runs
 `mcp-publisher login http --domain uploads.sh`. That grant is `sh.uploads/*`.
 
-The proof file has to be live on uploads.sh before the first registry
-publish. Merge the change that adds the file, let the web worker deploy, then
-merge the version PR.
+`changeset version` also regenerates
+`apps/web/public/.well-known/mcp/server-card.json` from `server.json`. The
+hosted worker advertises the same CLI version in `serverInfo`, not
+`apps/mcp`'s private `package.json`.
 
 Do not change `server.json` `name` or `packages/uploads` `mcpName` without a
 matching npm publish. The registry treats those strings as the server's
@@ -107,9 +109,9 @@ pnpm run changeset:publish  # npm publish packages that need it (needs auth)
 
 Do not re-use or move a published version or release tag.
 
-If the MCP Registry step fails after npm already published, re-running the
-Release workflow will not retry: `changeset publish` prints no new tag, so the
-MCP step is skipped. Publish `server.json` locally instead:
+If the MCP Registry step fails after npm already published, re-run **Release**
+with `mcp_registry_only` (Actions → Release → Run workflow). Republishing the
+same version is a no-op. Or publish `server.json` locally:
 
 ```bash
 brew install mcp-publisher

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "uploads": "pnpm exec uploads",
     "changeset": "changeset",
     "changeset:lint": "node scripts/changeset-lint.mjs",
-    "server-json:check": "node scripts/check-server-json.mjs",
-    "changeset:version": "changeset version && node scripts/sync-server-json-version.mjs && pnpm install --lockfile-only",
+    "server-json:check": "node scripts/check-server-json.mjs && node scripts/build-mcp-server-card.mjs --check",
+    "changeset:version": "changeset version && node scripts/sync-server-json-version.mjs && node scripts/build-mcp-server-card.mjs && pnpm install --lockfile-only",
     "changeset:publish": "changeset publish",
     "prepare": "husky"
   },

--- a/scripts/build-mcp-server-card.mjs
+++ b/scripts/build-mcp-server-card.mjs
@@ -1,0 +1,73 @@
+/**
+ * Write apps/web/public/.well-known/mcp/server-card.json from server.json.
+ * Version, homepage, icons, and the streamable-http endpoint come from the
+ * registry manifest so the card cannot drift. Card-only fields (protocol
+ * versions, capabilities, auth copy) live here.
+ *
+ *   node scripts/build-mcp-server-card.mjs         # write
+ *   node scripts/build-mcp-server-card.mjs --check # fail if stale
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const cardPath = join(root, "apps/web/public/.well-known/mcp/server-card.json");
+
+function buildCard(server) {
+  const endpoint = server.remotes?.[0]?.url;
+  if (typeof endpoint !== "string" || endpoint.length === 0) {
+    throw new Error("server.json is missing remotes[0].url");
+  }
+  return {
+    $schema: "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",
+    supportedVersions: ["2026-07-28", "2025-06-18"],
+    serverInfo: {
+      name: "uploads-mcp",
+      version: server.version,
+      description:
+        "Host files on uploads.sh from an agent — put (including branch staging and PR attach), promote, list, delete, usage, galleries, and GitHub attachment comments.",
+      homepage: `${String(server.websiteUrl).replace(/\/+$/, "")}/`,
+      icons: server.icons ?? [],
+    },
+    transport: {
+      type: "streamable-http",
+      endpoint,
+    },
+    capabilities: {
+      tools: true,
+      resources: false,
+      prompts: false,
+    },
+    authentication: {
+      required: true,
+      schemes: ["bearer", "oauth2"],
+      description:
+        "Bearer token — either a per-workspace token (Authorization: Bearer up_<workspace>_…, via invitation + `uploads login`) or an OAuth 2.1 access token from the uploads-auth authorization server (browser consent flow; see /.well-known/oauth-protected-resource). See https://uploads.sh/auth.md",
+    },
+  };
+}
+
+const server = JSON.parse(readFileSync(join(root, "server.json"), "utf8"));
+const next = `${JSON.stringify(buildCard(server), null, 2)}\n`;
+
+if (process.argv.includes("--check")) {
+  const prev = readFileSync(cardPath, "utf8");
+  if (JSON.stringify(JSON.parse(prev)) !== JSON.stringify(JSON.parse(next))) {
+    console.error(
+      "apps/web/public/.well-known/mcp/server-card.json is stale. Run:\n" +
+        "  node scripts/build-mcp-server-card.mjs",
+    );
+    process.exit(1);
+  }
+  console.log(`server-card.json ok (${server.name} ${server.version})`);
+} else {
+  writeFileSync(cardPath, next);
+  try {
+    execFileSync("pnpm", ["exec", "oxfmt", cardPath], { cwd: root, stdio: "inherit" });
+  } catch {
+    // oxfmt is optional; CI's format:check still gates the committed file.
+  }
+  console.log(`server-card.json → ${server.version}`);
+}


### PR DESCRIPTION
## In plain terms

The first listing of `sh.uploads/mcp` is live. This follow-up copies the operational bits that already work on releases.sh, so a failed registry publish is retryable, advertised versions cannot drift from the CLI, and people can find the listing from the README.

## What it does / what it is not

- Treats “version already published” as success, matching releases’ Deploy Workers job.
- Adds **Release → Run workflow → `mcp_registry_only`** so a failed MCP step can be retried without cutting another npm tag.
- Prefers `MCP_REGISTRY_PRIVATE_KEY_PEM` (PEM, already set) and still accepts the legacy hex `MCP_PRIVATE_KEY`.
- Generates `/.well-known/mcp/server-card.json` from `server.json` (was stuck at `0.6.0`; now `0.48.1`).
- Hosted MCP `serverInfo.version` is the published CLI version, not `apps/mcp`’s private `0.1.0`.
- README badge and a short MCP Registry block.
- Not a new registry identity. Not a worker-only publish path. Listing version still tracks npm.

## How to try it

Retry path (after this merges): Actions → **Release** → Run workflow → check `mcp_registry_only`.

```bash
curl -sS https://uploads.sh/.well-known/mcp/server-card.json | python3 -c 'import json,sys; print(json.load(sys.stdin)["serverInfo"]["version"])'
# after web deploy: 0.48.1
```

## Technical notes

Sibling reference: `buildinternet/releases` `.github/workflows/deploy-workers.yml` job `publish-mcp-registry`, plus `web/scripts/build-well-known.ts`.

## Test plan

- [x] `pnpm server-json:check` (includes card `--check`)
- [x] `pnpm --filter @uploads/mcp test` (server card version assertion)
- [ ] CI green on this PR
- [ ] After merge: card on uploads.sh shows `0.48.1`