### PR TITLE
fix(mcp): stop advertising attach on the hosted server card

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -266,7 +266,7 @@ function mcpServerCard() {
       name: "uploads-mcp",
       version: uploadsVersion,
       description:
-        "Host files on uploads.sh from an agent — put, attach, list, delete, usage, and GitHub attachment comments.",
+        "Host files on uploads.sh from an agent — put (including branch staging and PR attach), promote, list, delete, usage, galleries, whoami, and GitHub attachment comments.",
       homepage: "https://uploads.sh/",
       icons: MCP_SERVER_ICONS,
     },

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -7,6 +7,7 @@ import { FakeR2Bucket } from "@uploads/storage/test/fake-r2";
 import { resetOAuthJwksCacheForTests } from "../src/oauth";
 import { GalleryFakeD1 } from "./gallery-fake-d1";
 import { version as uploadsVersion } from "../../../packages/uploads/package.json";
+import webServerCard from "../../../apps/web/public/.well-known/mcp/server-card.json";
 
 const TOKEN = "up_test-ws_legacy-token-value";
 const ALPHA_TOKEN = "up_alpha_gallery-test";
@@ -534,6 +535,7 @@ describe("mcp worker", () => {
       serverInfo: {
         name: string;
         version: string;
+        description?: string;
         icons?: { src: string; mimeType?: string; sizes?: string[] }[];
       };
       transport: { type: string; endpoint: string };
@@ -548,6 +550,7 @@ describe("mcp worker", () => {
         sizes: ["180x180"],
       },
     ]);
+    expect(body.serverInfo.description).toBe(webServerCard.serverInfo.description);
     expect(body.transport.type).toBe("streamable-http");
     expect(body.transport.endpoint).toBe("https://agents.uploads.sh/mcp");
     expect(body.authentication.required).toBe(true);

--- a/apps/web/public/.well-known/mcp/server-card.json
+++ b/apps/web/public/.well-known/mcp/server-card.json
@@ -4,7 +4,7 @@
   "serverInfo": {
     "name": "uploads-mcp",
     "version": "0.48.1",
-    "description": "Host files on uploads.sh from an agent — put (including branch staging and PR attach), promote, list, delete, usage, galleries, and GitHub attachment comments.",
+    "description": "Host files on uploads.sh from an agent — put (including branch staging and PR attach), promote, list, delete, usage, galleries, whoami, and GitHub attachment comments.",
     "homepage": "https://uploads.sh/",
     "icons": [
       {

--- a/scripts/build-mcp-server-card.mjs
+++ b/scripts/build-mcp-server-card.mjs
@@ -27,7 +27,7 @@ function buildCard(server) {
       name: "uploads-mcp",
       version: server.version,
       description:
-        "Host files on uploads.sh from an agent — put (including branch staging and PR attach), promote, list, delete, usage, galleries, and GitHub attachment comments.",
+        "Host files on uploads.sh from an agent — put (including branch staging and PR attach), promote, list, delete, usage, galleries, whoami, and GitHub attachment comments.",
       homepage: `${String(server.websiteUrl).replace(/\/+$/, "")}/`,
       icons: server.icons ?? [],
     },


### PR DESCRIPTION
## In plain terms

The hosted MCP server card at `agents.uploads.sh` still advertised `attach`, which that worker has never had. It now matches the web discovery card: `put` (staging and PR attach), `promote`, galleries, and `whoami`. HTTP `GET /health` is unchanged.

## What it does / what it is not

- Updates `apps/mcp` server-card copy and regenerates `uploads.sh/.well-known/mcp/server-card.json` from the same string.
- Adds a test that the worker card description matches the web card, so they cannot drift again.
- Does **not** remove or change HTTP `GET /health` on the MCP worker. That liveness probe stays.
- Does **not** wait on the CLI npm release. `whoami` as a tool still ships with the worker deploy of #856.

## How to try it

After this worker deploys:

```text
curl -sS https://agents.uploads.sh/.well-known/mcp/server-card.json
curl -sS https://agents.uploads.sh/health
```

The card should mention `promote` / `whoami` and not `attach`. `/health` should still return `{"ok":true}`.

## Technical notes

Two cards existed: the worker handler in `apps/mcp/src/index.ts` and the generated web file from `scripts/build-mcp-server-card.mjs`. The web copy was rewritten in #855; the worker was not.

## Test plan

- [x] `pnpm --filter @uploads/mcp exec vitest run test/mcp.test.ts` (76 passed)
- [x] `curl https://agents.uploads.sh/health` still `{"ok":true}`
- [ ] Hosted `whoami` smoke: not live yet (this session's uploads MCP still lists `health` as a tool; `whoami` is tool-not-found). Recheck after Workers Builds deploys #856.
- [ ] CI on this PR
