### PR TITLE
feat(web): show usage meters on the screenshots rail

### DIFF
--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -4,7 +4,8 @@
  * Overview = one `files/by-path` fetch; `?project=` / `?q=` filter that
  * payload in the toolbar (project select + path input). Drill-in (?path=)
  * = the existing `files/search?meta.path=…` route. Files without `path`
- * metadata never appear here — the empty state says how to get them.
+ * metadata never appear here — the empty state points at `uploads put`
+ * with `--meta path=`.
  *
  * Every rendered group's thumb strip comes from that one overview response:
  * its `catalog` carries a short strip per (project, path), so filtering past
@@ -21,7 +22,13 @@
  */
 import { Callout, Input, Select } from "@uploads/ui";
 import "@uploads/ui/styles.css";
-import { Empty, EmptyContent, EmptyHeader, EmptyTitle } from "@uploads/ui/components/ui/empty";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@uploads/ui/components/ui/empty";
 import { Kbd } from "@uploads/ui/components/ui/kbd";
 import {
   useEffect,
@@ -73,12 +80,13 @@ import {
 /** How many path groups a project section previews before "view project →". */
 const PREVIEW_PATHS_PER_PROJECT = 3;
 
-const EMPTY_CTA_CMD = "uploads screenshot https://app.example/settings";
+const EMPTY_CTA_CMD = "uploads put ./shot.png --meta path=/settings";
 
 /**
  * Gallery-style empty state (renderGalleriesEmptyHtml's markup, React-side):
- * a title and ONE copyable command, nothing else competing for attention —
- * the rail tip carries the how-grouping-works detail.
+ * a title, a one-line hint, and ONE copyable command. `put` is the general
+ * upload path; `--meta path=` is what actually groups the file here. The
+ * rail tip still carries the how-grouping-works detail.
  */
 function EmptyShotsCta({ title }: { title: string }) {
   const [copied, setCopied] = useState(false);
@@ -95,10 +103,11 @@ function EmptyShotsCta({ title }: { title: string }) {
     <Empty>
       <EmptyHeader>
         <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>Upload a file with a page path and it groups here.</EmptyDescription>
       </EmptyHeader>
-      <EmptyContent>
+      <EmptyContent className="max-w-xl">
         <div className="ws-empty__command flex w-full min-w-0 items-center gap-2 rounded-[6px] border border-line bg-panel px-3 py-2">
-          <code className="min-w-0 flex-1 overflow-x-auto font-[var(--mono)] text-[13px] text-fg [overflow-wrap:anywhere]">
+          <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-[var(--mono)] text-[13px] text-fg">
             {EMPTY_CTA_CMD}
           </code>
           <button

--- a/apps/web/src/components/dev/UiKit.tsx
+++ b/apps/web/src/components/dev/UiKit.tsx
@@ -271,9 +271,7 @@ export default function UiKit() {
           <EmptyHeader>
             <EmptyMedia variant="icon">⌁</EmptyMedia>
             <EmptyTitle>No screenshots yet</EmptyTitle>
-            <EmptyDescription>
-              Capture one with <code>uploads screenshot &lt;url&gt;</code> and it shows up here.
-            </EmptyDescription>
+            <EmptyDescription>Upload a file with a page path and it groups here.</EmptyDescription>
           </EmptyHeader>
           <EmptyContent>
             <Button variant="outline" size="sm">

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -3,10 +3,11 @@
  * Workspace shell: `AccountLayout` + content slot + right-rail summary.
  * Section links live in the sidebar switcher; tab routes only wrap content.
  * Rail data is filled by `initWorkspaceRail` (connected work / usage). The
- * usage section only renders with `showUsage` — billing is the only tab that
- * sets it, since meters repeated on every tab were pure noise (issue #365
- * follow-up). `initWorkspaceRail` tolerates `[data-rail-usage]` being absent
- * from the DOM on every other tab.
+ * usage section only renders with `showUsage` — billing and screenshots set
+ * it. Meters on every tab were noise (issue #365 follow-up), but screenshots
+ * is the workspace home, so the meters belong there too.
+ * `initWorkspaceRail` tolerates `[data-rail-usage]` being absent from the
+ * DOM on every other tab.
  *
  * The details section (slug + base URL) that used to sit here was dropped —
  * the switcher/URL already carries the slug and the settings tab has its own
@@ -31,7 +32,7 @@ import AccountLayout from "./AccountLayout.astro";
 
 interface Props {
   workspace: string;
-  /** Show the rail's usage section. Billing only — see module doc. */
+  /** Show the rail's usage section. Billing and screenshots — see module doc. */
   showUsage?: boolean;
   /** Static per-tab hint. `body` may include inline markup (e.g. `<code>`). */
   tip?: { body: string; href?: string; linkLabel?: string; label?: string };

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -205,7 +205,8 @@ export function initWorkspaceRail(
   // Tier 1 — last known value, no network. Runs at module-eval time, before
   // the session gate resolves. The server-rendered placeholder it overwrites
   // occupies the same height, so this repaint moves nothing on the page.
-  // `usageEl` (and so this whole tier) only exists on the billing tab.
+  // `usageEl` (and so this whole tier) only exists on tabs that pass
+  // `showUsage` (billing and screenshots).
   const cached = readWorkspaceSnapshot(workspace);
   if (cached?.usage) paint(cached.usage, true);
 

--- a/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/screenshots.astro
@@ -2,7 +2,8 @@
 /**
  * Screenshots grouped by `path` metadata — `WorkspaceLayout` + the
  * `ScreenshotsByPath` island. Workspace home; files live at `[name]/files`.
- * cloned structure, own mount id.
+ * cloned structure, own mount id. The rail shows usage meters (`showUsage`)
+ * because this is where people land most often; quick actions stay off.
  *
  * SSR-first (plan 006, following plan 005's `WorkspaceFileTable`/`[name].astro`
  * shape): when the request carries a session, server-fetch the workspace
@@ -97,7 +98,7 @@ const screenshotsSeedJson = JSON.stringify({
 }).replace(/</g, "\\u003c");
 ---
 
-<WorkspaceLayout workspace={workspace} tip={tip} showQuickActions={false}>
+<WorkspaceLayout workspace={workspace} tip={tip} showUsage showQuickActions={false}>
   <div id="ws-screenshots">
     <ScreenshotsByPath
       apiOrigin={apiOrigin}


### PR DESCRIPTION
## In plain terms

People land on Screenshots more often than Billing, so that tab now shows the same storage and monthly-upload meters in the right rail. The empty state also pitches `uploads put` instead of `uploads screenshot`.

<img width="800" alt="Screenshots tab with usage meters in the right rail" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/861/screenshots-usage-rail.webp">

<img width="800" alt="Screenshots empty state with put command" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/861/screenshots-empty.webp">

## What it does / what it is not

- Turns on the existing rail usage section on the screenshots tab (the workspace home).
- Replaces the empty-state CTA with `uploads put ./shot.png --meta path=/settings`. Put is the general upload path; the path flag is what groups a file here.
- Billing still shows the meters. Files, galleries, people, and settings still do not.
- Does not change how usage is fetched or rendered.

## How to try it

Sign in, open a workspace. The Screenshots tab should show Storage / Uploads this month / object count in the right rail, above the grouping tip. An empty workspace should offer the put command, not `uploads screenshot`. Files should still omit the usage section.

## Technical notes

`WorkspaceLayout` already gated the meters behind `showUsage`. Billing was the only caller.

## Test plan

- [x] `pnpm check` (0 errors)
- [x] `pnpm test:web` (884 passed)
- [x] Browser: screenshots rail shows meters; files does not; billing still does; mobile stacks the rail under the body
- [x] Browser: empty screenshots state shows put + path metadata, copy button present
- [ ] CI
