### PR TITLE
fix(web): save BYOB config when the public-URL probe is inconclusive

### DIFF
--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -457,6 +457,35 @@ describe("verifyStorageConfig — recommended public-URL probe", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("marks only the thrown-fetch case inconclusive — conclusive failures (bad status, byte mismatch) stay definite (#853)", async () => {
+    const client = new FakeStorageClient();
+    const thrown = vi.fn(async () => {
+      throw new Error("network error: ENOTFOUND");
+    });
+    const unreachable = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      thrown as unknown as typeof fetch,
+    );
+    expect(unreachable.checks.find((c) => c.id === "public-url")!.inconclusive).toBe(true);
+
+    const notFound = vi.fn(async () => new Response(null, { status: 404 }));
+    const answered = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      new FakeStorageClient(),
+      notFound as unknown as typeof fetch,
+    );
+    expect(answered.checks.find((c) => c.id === "public-url")!.inconclusive).toBeUndefined();
+
+    const wrongBytes = vi.fn(async () => new Response(new Uint8Array([9, 9, 9]), { status: 200 }));
+    const mismatch = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      new FakeStorageClient(),
+      wrongBytes as unknown as typeof fetch,
+    );
+    expect(mismatch.checks.find((c) => c.id === "public-url")!.inconclusive).toBeUndefined();
+  });
+
   it("skips the public-url check (marked failed) when the round-trip itself failed", async () => {
     const client = new FakeStorageClient();
     client.uploadError = new FakeError("Unauthorized", "read-only token");

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -50,6 +50,14 @@ export interface StorageVerifyCheck {
   required: boolean;
   /** Human remediation text, present when `ok` is false. */
   hint?: string;
+  /**
+   * True when the check could not actually run rather than failing — today
+   * only the public-URL probe, when the fetch itself threw (a same-account
+   * custom domain is often unreachable as a Workers subrequest even while it
+   * serves the public internet fine, issues #783/#853). Callers that gate on
+   * a check should treat an inconclusive result as "unknown", not "broken".
+   */
+  inconclusive?: boolean;
 }
 
 export interface StorageVerifyResult {
@@ -275,6 +283,7 @@ async function checkPublicUrl(
         id: "public-url",
         ok: false,
         required: false,
+        inconclusive: true,
         hint: "we couldn't verify publicBaseUrl from here — this can happen even when the domain is working fine (a same-account custom domain isn't always reachable as a server-side request). Open a known object's URL in a browser to check for yourself; if that loads, the domain is fine.",
       },
       cacheControl: undefined,

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1639,6 +1639,32 @@ describe("verifyWorkspaceStorage", () => {
     });
   });
 
+  it("passes through `inconclusive` on a check so the form can save past an unverifiable public URL (#853)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          ok: true,
+          checks: [
+            { id: "round-trip", ok: true, required: true },
+            {
+              id: "public-url",
+              ok: false,
+              required: false,
+              inconclusive: true,
+              hint: "we couldn't verify publicBaseUrl from here",
+            },
+          ],
+        }),
+      ),
+    );
+    const result = await verifyWorkspaceStorage("http://127.0.0.1:8787", "acme", CANDIDATE);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.result.checks.find((c) => c.id === "public-url")?.inconclusive).toBe(true);
+    expect(result.result.checks.find((c) => c.id === "round-trip")?.inconclusive).toBeUndefined();
+  });
+
   it("reports 403 as forbidden — byo_bucket_disabled", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1921,6 +1921,14 @@ export interface StorageVerifyCheck {
   required: boolean;
   /** Human remediation text, present when `ok` is false. Surfaced verbatim. */
   hint?: string;
+  /**
+   * True when the check couldn't actually run rather than failing — e.g. the
+   * public-URL probe threw because a same-account custom domain isn't
+   * reachable as a server-side request even when it works publicly
+   * (issues #783/#853). Treat as "unknown", not "broken": it must not block
+   * saving.
+   */
+  inconclusive?: boolean;
 }
 
 export interface StorageVerifyResult {
@@ -1953,6 +1961,7 @@ function toStorageVerifyResult(body: unknown): StorageVerifyResult | null {
         // Normalized rather than passed through: a non-string hint would
         // reach the checklist renderer typed as string.
         hint: typeof check.hint === "string" ? check.hint : undefined,
+        inconclusive: check.inconclusive === true ? true : undefined,
       },
     ];
   });

--- a/apps/web/src/lib/thumb-url.ts
+++ b/apps/web/src/lib/thumb-url.ts
@@ -13,6 +13,11 @@
  * roughly 2× the CSS size so tiles stay crisp on retina displays.
  */
 
+// Only hosts on zones WE control, with Image Transformations enabled. Never
+// add customer-controlled hosts (BYO-bucket publicBaseUrl domains) here: the
+// `/cdn-cgi/image/` path and the `onerror=redirect` fallback both exist only
+// on Cloudflare zones with Transformations turned on — on anyone else's zone
+// the rewrite serves a 404 with no fallback to the original bytes.
 const TRANSFORMABLE_HOSTS = new Set(["embed.uploads.sh", "storage.uploads.sh", "store.uploads.sh"]);
 
 export function thumbUrl(src: string, width: number): string;

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -870,9 +870,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       /**
        * Renders only the FAILING checks, as plain what-went-wrong sentences
        * — the passing ones are process detail nobody needs to review. The
-       * public base URL is required by this form, so a failing `public-url`
-       * check blocks saving here even though the API still classifies it as
-       * recommended-only.
+       * public base URL is required by this form, so a conclusive `public-url`
+       * failure blocks saving here even though the API still classifies it as
+       * recommended-only — but an `inconclusive` one (the probe couldn't run)
+       * doesn't block and never reaches this renderer (#853).
        */
       function renderFailures(result: StorageVerifyResult): void {
         storageFormChecklist.innerHTML = result.checks
@@ -931,14 +932,25 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             return;
           }
           // Any failing check keeps you on the form with the fix in reach —
-          // including `public-url`, which the API treats as recommended but
-          // this form requires. The one exception is `embed-cache` (#592):
-          // optional but recommended, so it never blocks the save — the tip
-          // is surfaced after the lane card appears instead.
+          // including a conclusive `public-url` failure (the domain answered
+          // with the wrong status or bytes), which the API treats as
+          // recommended but this form requires. Two exceptions never block
+          // the save: `embed-cache` (#592, optional-but-recommended tip) and
+          // any check marked `inconclusive` (#853 — the probe couldn't run
+          // at all, e.g. a same-account custom domain that's unreachable as
+          // a server-side request while serving the public internet fine).
+          // Both are surfaced after the lane card appears instead.
           const embedCacheWarn = verify.result.checks.find(
             (check) => check.id === "embed-cache" && !check.ok,
           );
-          if (verify.result.checks.some((check) => !check.ok && check.id !== "embed-cache")) {
+          const inconclusiveWarn = verify.result.checks.find(
+            (check) => !check.ok && check.inconclusive,
+          );
+          if (
+            verify.result.checks.some(
+              (check) => !check.ok && check.id !== "embed-cache" && !check.inconclusive,
+            )
+          ) {
             storageSaveBtn.disabled = false;
             renderFailures(verify.result);
             revealAdoptRowIfNotEmpty(verify.result);
@@ -965,6 +977,15 @@ if (!workspace) return Astro.redirect("/account/workspaces");
                 "Optional but recommended: add a cache rule to this domain so GitHub embeds refresh after overwrites — see the setup guide.";
               storageSavedActionStatus.textContent = tip;
               storageActionStatus.textContent = tip;
+            }
+            // Saved fine, but the public-URL probe couldn't run from the
+            // server (#853): tell the user to eyeball a known object's URL
+            // themselves — plain text, the save succeeded.
+            if (inconclusiveWarn) {
+              const note =
+                "Saved — but we couldn't reach the public base URL from our servers to double-check it (common with same-account custom domains). Open a file's public URL in your browser to confirm it loads.";
+              storageSavedActionStatus.textContent = note;
+              storageActionStatus.textContent = note;
             }
             return;
           }


### PR DESCRIPTION
Fixes #853 — our first user-filed bug report 🎉

## What happened

@MarkLyck configured a working R2 bucket, but "Verify & Save" refused with *"The public base URL didn't serve our test file"* even though the verify response was `ok: true` with only the non-required `public-url` check failing.

Two deliberate decisions collided:

- The API treats `public-url` as **recommended-only** because the probe runs as a Workers subrequest, and a same-account custom domain often isn't reachable that way even while it serves the public internet fine (#783). The check's own hint says exactly this.
- The settings form **blocks saving** on any failing check except `embed-cache` — including `public-url`.

Result: a correctly wired config could never be saved from the UI.

## The fix

- `storage-verify.ts` now marks the thrown-fetch case `inconclusive: true` on the check — distinct from conclusive failures (the domain answered with a wrong status or mismatched bytes), which still block the form.
- The web form saves through inconclusive checks and shows a plain post-save note: open a file's public URL in your browser to confirm it loads.
- The server-side PUT already only gates on required checks, so no change was needed there.

## Tests

- API: inconclusive is set only for the thrown-fetch case; 404 and byte-mismatch stay definite.
- Web: decoder passes `inconclusive` through.
- Full suite: 5271 tests pass; typecheck and lint clean.
