### PR TITLE
fix(api,web): local BYOB public-URL probe + inconclusive hint wording

### DIFF
--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -385,6 +385,39 @@ describe("verifyStorageConfig — recommended public-URL probe", () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
+  it("probes with redirect: 'manual', not 'error' — local workerd throws synchronously on 'error'", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      expect(init?.redirect).toBe("manual");
+      return new Response(new Uint8Array([9]), { status: 200 });
+    });
+    await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("reports an un-followed redirect (redirect: 'manual' response) as a conclusive, non-inconclusive failure", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(null, { status: 301, headers: { location: "https://other.example.com/" } }),
+    );
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    const publicUrl = result.checks.find((c) => c.id === "public-url")!;
+    expect(publicUrl.ok).toBe(false);
+    expect(publicUrl.required).toBe(false);
+    expect(publicUrl.inconclusive).toBeUndefined();
+    expect(publicUrl.hint).toMatch(/redirected/);
+    expect(result.ok).toBe(true);
+  });
+
   it("warns (embed-cache) when the domain serves cacheable headers, without gating ok", async () => {
     const client = new FakeStorageClient();
     const fetchImpl = vi.fn(async () => {

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -52,10 +52,11 @@ export interface StorageVerifyCheck {
   hint?: string;
   /**
    * True when the check could not actually run rather than failing — today
-   * only the public-URL probe, when the fetch itself threw (a same-account
-   * custom domain is often unreachable as a Workers subrequest even while it
-   * serves the public internet fine, issues #783/#853). Callers that gate on
-   * a check should treat an inconclusive result as "unknown", not "broken".
+   * only the public-URL probe, when the fetch itself threw (any
+   * Cloudflare-fronted custom domain is often unreachable as a Workers
+   * subrequest even while it serves the public internet fine, issues
+   * #783/#853). Callers that gate on a check should treat an inconclusive
+   * result as "unknown", not "broken".
    */
   inconclusive?: boolean;
 }
@@ -240,7 +241,18 @@ async function checkPublicUrl(
   const url = `${publicBaseUrl.replace(/\/$/, "")}/${probeKey}`;
   try {
     const res = await fetchImpl(url, {
-      redirect: "error",
+      // NOT `redirect: "error"`: local workerd (wrangler dev) throws a
+      // synchronous TypeError for that value — it's simply unimplemented
+      // there ("won't be implemented since it does not make sense at the
+      // edge"), unrelated to the timeout below. Prod's real edge fetch does
+      // support it, so this was silently turning every local probe into the
+      // thrown-fetch/inconclusive branch. `"manual"` is supported
+      // everywhere (local and prod): it hands back the 3xx response
+      // un-followed instead of throwing, so the existing `!res.ok` branch
+      // below already fails a redirecting domain — same "never verified"
+      // outcome as `"error"`, just via a normal failed check instead of an
+      // inconclusive one.
+      redirect: "manual",
       signal: AbortSignal.timeout(PUBLIC_URL_PROBE_TIMEOUT_MS),
     });
     // Read the header before consuming the body: the embed-cache check
@@ -248,12 +260,15 @@ async function checkPublicUrl(
     // reading rides along with whichever public-url outcome this is.
     const cacheControl = res.headers.get("cache-control");
     if (!res.ok) {
+      const isRedirect = res.status >= 300 && res.status < 400;
       return {
         check: {
           id: "public-url",
           ok: false,
           required: false,
-          hint: `fetching the probe object via publicBaseUrl returned HTTP ${res.status} — the domain may be connected to a different bucket, or public access isn't enabled yet`,
+          hint: isRedirect
+            ? `fetching the probe object via publicBaseUrl redirected (HTTP ${res.status}) instead of serving it directly — connect a domain that serves the bucket without redirecting, or fix the redirect rule`
+            : `fetching the probe object via publicBaseUrl returned HTTP ${res.status} — the domain may be connected to a different bucket, or public access isn't enabled yet`,
         },
         cacheControl: undefined,
       };
@@ -273,18 +288,19 @@ async function checkPublicUrl(
     return { check: { id: "public-url", ok: true, required: false }, cacheControl };
   } catch {
     // A thrown fetch means this probe — run from inside the API worker —
-    // couldn't reach the domain; it does NOT mean the domain is broken. A
-    // same-account/zone-set customer domain in particular can be unreachable
-    // as a Workers subrequest while serving the public internet fine (issue
-    // #783). Say "we couldn't verify it from here", not "your domain is
-    // broken", and point at the one check that actually settles it.
+    // couldn't reach the domain; it does NOT mean the domain is broken. Any
+    // Cloudflare-fronted custom domain can be unreachable as a Workers
+    // subrequest while serving the public internet fine — not just a
+    // same-account one, per issue #853. Say "we couldn't verify it from
+    // here", not "your domain is broken", and point at the one check that
+    // actually settles it.
     return {
       check: {
         id: "public-url",
         ok: false,
         required: false,
         inconclusive: true,
-        hint: "we couldn't verify publicBaseUrl from here — this can happen even when the domain is working fine (a same-account custom domain isn't always reachable as a server-side request). Open a known object's URL in a browser to check for yourself; if that loads, the domain is fine.",
+        hint: "we couldn't verify publicBaseUrl from here — this can happen even when the domain is working fine (Cloudflare-fronted custom domains often aren't reachable as a server-side request). Open a known object's URL in a browser to check for yourself; if that loads, the domain is fine.",
       },
       cacheControl: undefined,
     };

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1923,7 +1923,7 @@ export interface StorageVerifyCheck {
   hint?: string;
   /**
    * True when the check couldn't actually run rather than failing — e.g. the
-   * public-URL probe threw because a same-account custom domain isn't
+   * public-URL probe threw because a Cloudflare-fronted custom domain isn't
    * reachable as a server-side request even when it works publicly
    * (issues #783/#853). Treat as "unknown", not "broken": it must not block
    * saving.

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -937,8 +937,9 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           // recommended but this form requires. Two exceptions never block
           // the save: `embed-cache` (#592, optional-but-recommended tip) and
           // any check marked `inconclusive` (#853 — the probe couldn't run
-          // at all, e.g. a same-account custom domain that's unreachable as
-          // a server-side request while serving the public internet fine).
+          // at all, e.g. a Cloudflare-fronted custom domain that's
+          // unreachable as a server-side request while serving the public
+          // internet fine).
           // Both are surfaced after the lane card appears instead.
           const embedCacheWarn = verify.result.checks.find(
             (check) => check.id === "embed-cache" && !check.ok,
@@ -983,7 +984,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             // themselves — plain text, the save succeeded.
             if (inconclusiveWarn) {
               const note =
-                "Saved — but we couldn't reach the public base URL from our servers to double-check it (common with same-account custom domains). Open a file's public URL in your browser to confirm it loads.";
+                "Saved — but we couldn't reach the public base URL from our servers to double-check it (Cloudflare-fronted custom domains often aren't reachable as a server-side request). Open a file's public URL in your browser to confirm it loads.";
               storageSavedActionStatus.textContent = note;
               storageActionStatus.textContent = note;
             }


### PR DESCRIPTION
## Task 1 — the public-URL probe was throwing for every host, in prod too

`checkPublicUrl` (`apps/api/src/storage-verify.ts`) fetches with
`redirect: "error"`. workerd throws a synchronous `TypeError` for that
value — `tryParseRedirect` accepts only `follow`/`manual`, unconditionally,
with no compatibility flag ([workerd `src/workerd/api/http.c++`](https://github.com/cloudflare/workerd/blob/main/src/workerd/api/http.c%2B%2B),
"won't be implemented since it does not make sense at the edge") — and
workerd is also the production runtime. So this was never a local-only
quirk: **every public-url probe, local and prod, has thrown since this
code shipped**, always landing in the thrown-fetch/`inconclusive` branch
regardless of the target host. (The Workers Request docs still list
`"error"` as valid; that page is stale.) This — not same-account
subrequest routing — is the actual explanation of issue #853's probe
result, and likely of #783's original observation as well. It is unrelated
to the `AbortSignal.timeout` budget alongside it.

Reproduced against `https://example.com`, `https://www.cloudflare.com`,
and confirmed the error text is the sole cause by removing `redirect`
in isolation.

Fixed by switching to `redirect: "manual"`, which is supported everywhere:
it returns the un-followed 3xx response instead of throwing, so the
existing `!res.ok` branch already fails a redirecting domain — same
"never counts as verified" outcome as `"error"`, just surfaced as a normal
failed check instead of a misleading inconclusive one. This makes the
conclusive pass/HTTP-status/byte-mismatch outcomes reachable in prod for
the first time. Added a redirect-specific hint and covered the
redirect-init and redirect-response paths with unit tests.

Kept `AbortSignal.timeout` as-is — it was never the culprit.

## Task 2 — soften the "same-account" wording in the inconclusive hint

Issue #853 showed the thrown-fetch case also happens for customer domains
on other Cloudflare accounts, not just same-account ones, so "same-account
custom domain" read as a wrong diagnosis. Reworded the inconclusive hint
(and its matching JSDoc/UI copy in `api-client.ts` and
`storage.astro`) to say Cloudflare-fronted custom domains generally,
keeping the rest of the sentence structure and the browser-check advice
intact. With the Task 1 fix the inconclusive branch should now be rare in
prod (genuine network failures only).

## Testing

- `npx vitest run src/storage-verify.test.ts` (apps/api) — 35 passed
- `pnpm -C apps/api typecheck` — clean
- `pnpm -C apps/web exec vitest run src/lib/api-client.test.ts` — 119 passed
- `pnpm lint` — clean (pre-existing warnings only)
- `pnpm test` (repo root) — 347 files / 5273 tests passed

Reproduced locally against a local wrangler dev stack (api + auth workers,
dev-session bypass, real R2 credentials) before and after the fix; see
commit messages for the exact root-cause chain. Context: issue #853.
