### PR TITLE
fix(web): don't show the pagination cap as a project file count

### DIFF
--- a/apps/api/src/file-metadata-facets.test.ts
+++ b/apps/api/src/file-metadata-facets.test.ts
@@ -11,6 +11,8 @@ import {
   projectLabelFromMeta,
   BY_PATH_CATALOG_LIMIT,
   BY_PATH_CATALOG_RECENT_LIMIT,
+  BY_PATH_COUNT_DISPLAY_CAP,
+  BY_PATH_COUNT_WINDOW_MS,
   BY_PATH_GROUP_LIMIT,
   BY_PATH_LATEST_LIMIT,
   BY_PATH_RECENT_LIMIT,
@@ -468,6 +470,8 @@ describe("groupObjectsByPath", () => {
         { workspace: "acme", key: "d.png", meta: { path: "/other", repo: "acme/web" } },
       ]),
       "acme",
+      // `db()` stamps 2026-07-25; pin the 30-day project-count window over it.
+      { now: new Date("2026-07-25T12:00:00.000Z") },
     );
     expect(result.groups.map((g) => [g.project, g.path, g.count])).toEqual(
       expect.arrayContaining([
@@ -481,6 +485,75 @@ describe("groupObjectsByPath", () => {
     const labels = result.projects.map((p) => p.label).sort();
     expect(labels).toEqual(["acme/api", "acme/web", "x.dev"]);
     expect(result.projects.find((p) => p.label === "acme/web")?.count).toBe(2);
+  });
+
+  it("counts project headings from the last 30 days and stops at cap+1", async () => {
+    const now = new Date("2026-08-20T00:00:00.000Z");
+    const inWindow = new Date(now.getTime() - BY_PATH_COUNT_WINDOW_MS + 86_400_000).toISOString();
+    const outside = new Date(now.getTime() - BY_PATH_COUNT_WINDOW_MS - 86_400_000).toISOString();
+    const rows = [
+      ...Array.from({ length: BY_PATH_COUNT_DISPLAY_CAP + 3 }, (_, i) => ({
+        workspace: "acme",
+        key: `new-${i}.png`,
+        meta: { path: "/home", repo: "acme/web" },
+        at: inWindow,
+      })),
+      {
+        workspace: "acme",
+        key: "old.png",
+        meta: { path: "/legacy", repo: "acme/web" },
+        at: outside,
+      },
+    ];
+    const result = await groupObjectsByPath(timedDb(rows), "acme", { now });
+    expect(result.projects).toHaveLength(1);
+    // 101st in-window file is enough to signal "100+"; older files are ignored.
+    expect(result.projects[0]).toMatchObject({
+      label: "acme/web",
+      count: BY_PATH_COUNT_DISPLAY_CAP + 1,
+    });
+    // Path groups share the window (and the cap). A path with nothing in
+    // the window falls back to its all-time total so it doesn't read "0".
+    const home = result.groups.find((g) => g.path === "/home")!;
+    const legacy = result.catalog.find((e) => e.path === "/legacy")!;
+    expect(home.count).toBe(BY_PATH_COUNT_DISPLAY_CAP + 1);
+    expect(legacy.count).toBe(1);
+  });
+
+  it("falls back to the capped all-time total when nothing in the window", async () => {
+    const now = new Date("2026-08-20T00:00:00.000Z");
+    const outside = new Date(now.getTime() - BY_PATH_COUNT_WINDOW_MS - 86_400_000).toISOString();
+    const result = await groupObjectsByPath(
+      timedDb([
+        {
+          workspace: "acme",
+          key: "old-a.png",
+          meta: { path: "/home", repo: "acme/web" },
+          at: outside,
+        },
+        {
+          workspace: "acme",
+          key: "old-b.png",
+          meta: { path: "/settings", repo: "acme/web" },
+          at: outside,
+        },
+      ]),
+      "acme",
+      { now },
+    );
+    expect(result.projects[0]).toMatchObject({ label: "acme/web", count: 2 });
+  });
+
+  it("keeps an exact 100 on a project heading when the 101st file is absent", async () => {
+    const now = new Date("2026-08-20T00:00:00.000Z");
+    const rows = Array.from({ length: BY_PATH_COUNT_DISPLAY_CAP }, (_, i) => ({
+      workspace: "acme",
+      key: `shot-${i}.png`,
+      meta: { path: "/home", repo: "acme/web" },
+      at: now.toISOString(),
+    }));
+    const result = await groupObjectsByPath(timedDb(rows), "acme", { now });
+    expect(result.projects[0]!.count).toBe(BY_PATH_COUNT_DISPLAY_CAP);
   });
 
   it("prefers repo over gh.repo over url when a file has several", async () => {

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -734,6 +734,26 @@ export const BY_PATH_CATALOG_RECENT_LIMIT = 3;
 export const BY_PATH_CATALOG_LIMIT = 500;
 /** Newest keys returned in the flat `latest` feed alongside the groups. */
 export const BY_PATH_LATEST_LIMIT = 30;
+/**
+ * How far back section headings count files. The scan still returns older
+ * paths and thumbs; only the number on each heading uses this window.
+ */
+export const BY_PATH_COUNT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+/**
+ * Display cap for section file counts. Count one past this so the UI can
+ * render "100+" instead of a number that matches the list page size.
+ */
+export const BY_PATH_COUNT_DISPLAY_CAP = 100;
+
+/** Increment `count` up to cap+1; the extra 1 is the "at least 101" signal. */
+function bumpDisplayCount(entry: { count: number }): void {
+  if (entry.count <= BY_PATH_COUNT_DISPLAY_CAP) entry.count += 1;
+}
+
+function inCountWindow(iso: string, nowMs: number): boolean {
+  const ts = Date.parse(iso);
+  return !Number.isNaN(ts) && ts >= nowMs - BY_PATH_COUNT_WINDOW_MS;
+}
 
 export type PathGroup = {
   project: string;
@@ -790,11 +810,17 @@ export type ProjectSummary = { label: string; count: number; lastUpdated: string
  * clause above, keeping only objects stamped `gh.merged=true`
  * (`MERGED_STATUS_SQL`). Applies to the single underlying query, so `groups`,
  * `catalog`, `projects`, and `latest` all reflect the same filtered rows.
+ *
+ * Section `count` is files in the last BY_PATH_COUNT_WINDOW_MS, capped at
+ * BY_PATH_COUNT_DISPLAY_CAP + 1 so the overview can say "100+" instead of
+ * echoing the list page size. A group with nothing in the window falls
+ * back to its capped all-time total rather than "0 files". `opts.now` is
+ * the window's right edge; tests freeze it.
  */
 export async function groupObjectsByPath(
   db: D1Queryable,
   workspace: string,
-  opts: { mergedOnly?: boolean } = {},
+  opts: { mergedOnly?: boolean; now?: Date } = {},
 ): Promise<{
   groups: PathGroup[];
   catalog: PathCatalogEntry[];
@@ -838,13 +864,27 @@ export async function groupObjectsByPath(
       app: string | null;
     }>();
 
+  const nowMs = (opts.now ?? new Date()).getTime();
   const groups: PathGroup[] = [];
   const byKey = new Map<string, PathGroup>();
   const catalog: PathCatalogEntry[] = [];
   const catalogByKey = new Map<string, PathCatalogEntry>();
+  const projectByLabel = new Map<string, ProjectSummary>();
+  const allTime = new Map<object, number>();
   const latest: LatestPathObject[] = [];
   let truncated = false;
   let catalogTruncated = false;
+
+  const bump = (entry: { count: number }, updatedAt: string) => {
+    allTime.set(entry, (allTime.get(entry) ?? 0) + 1);
+    if (inCountWindow(updatedAt, nowMs)) bumpDisplayCount(entry);
+  };
+  const applyCountFallback = (entry: { count: number }) => {
+    if (entry.count > 0) return;
+    const total = allTime.get(entry) ?? 0;
+    entry.count = Math.min(total, BY_PATH_COUNT_DISPLAY_CAP + 1);
+  };
+
   for (const row of result.results) {
     const project = projectLabelFromMeta({
       repo: row.repo,
@@ -870,9 +910,18 @@ export async function groupObjectsByPath(
       }
     }
     if (entry) {
-      entry.count += 1;
+      bump(entry, row.updated_at);
       if (entry.recent.length < BY_PATH_CATALOG_RECENT_LIMIT) entry.recent.push(row.object_key);
+      if (!projectByLabel.has(project)) {
+        projectByLabel.set(project, {
+          label: project,
+          count: 0,
+          lastUpdated: row.updated_at,
+        });
+      }
     }
+    const summary = projectByLabel.get(project);
+    if (summary) bump(summary, row.updated_at);
 
     let group = byKey.get(groupKey);
     if (!group) {
@@ -884,24 +933,13 @@ export async function groupObjectsByPath(
       byKey.set(groupKey, group);
       groups.push(group);
     }
-    group.count += 1;
+    bump(group, row.updated_at);
     if (group.recent.length < BY_PATH_RECENT_LIMIT) group.recent.push(row.object_key);
   }
 
-  const projectByLabel = new Map<string, ProjectSummary>();
-  for (const entry of catalog) {
-    const existing = projectByLabel.get(entry.project);
-    if (existing) {
-      existing.count += entry.count;
-      if (entry.lastUpdated > existing.lastUpdated) existing.lastUpdated = entry.lastUpdated;
-    } else {
-      projectByLabel.set(entry.project, {
-        label: entry.project,
-        count: entry.count,
-        lastUpdated: entry.lastUpdated,
-      });
-    }
-  }
+  for (const entry of catalog) applyCountFallback(entry);
+  for (const group of groups) applyCountFallback(group);
+  for (const summary of projectByLabel.values()) applyCountFallback(summary);
   const projects = [...projectByLabel.values()].sort((a, b) =>
     b.lastUpdated.localeCompare(a.lastUpdated),
   );

--- a/apps/web/src/components/ScreenshotsByPath.tsx
+++ b/apps/web/src/components/ScreenshotsByPath.tsx
@@ -59,6 +59,7 @@ import { makeFileOpener, newTabLinkProps, type FileOpener } from "../lib/file-op
 import {
   filterCatalog,
   focusIsKeyboardDriven,
+  formatShotCount,
   groupsFromCatalog,
   isRepoLabel,
   lastUpdatedLabel,
@@ -69,6 +70,7 @@ import {
   projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
+  SHOT_COUNT_DISPLAY_CAP,
   shotKindFromKey,
   shotPreviewCaption,
   shotPreviewPosition,
@@ -576,7 +578,7 @@ function FilterBar({
                     {entry.path}
                   </span>
                   <span className="wsp-suggest__count ml-auto text-[12px] whitespace-nowrap text-muted-foreground">
-                    {entry.count} {entry.count === 1 ? "file" : "files"}
+                    {formatShotCount(entry.count)}
                   </span>
                 </button>
               </li>
@@ -1300,6 +1302,7 @@ function ScreenshotsByPathInner({
             const groups = matchingGroups.filter((group) => group.project === label);
             const previewGroups = filtering ? groups : groups.slice(0, PREVIEW_PATHS_PER_PROJECT);
             const ghItems = showGh ? ghByProject.get(label) : undefined;
+            const ghTruncated = showGh && ghState.status === "ready" && ghState.truncated;
             return (
               <ProjectSection
                 key={label}
@@ -1307,6 +1310,7 @@ function ScreenshotsByPathInner({
                 summary={projectSummary}
                 groups={previewGroups}
                 ghItems={ghItems}
+                ghTruncated={ghTruncated}
                 showViewProject={!view.project}
                 // Each subsequent project opens with a full-width hairline —
                 // the section boundary is structural, not just whitespace —
@@ -1355,6 +1359,7 @@ function ProjectSection({
   summary,
   groups,
   ghItems,
+  ghTruncated,
   showViewProject,
   bordered,
   onViewProject,
@@ -1366,6 +1371,8 @@ function ProjectSection({
   summary: ProjectSummary | undefined;
   groups: FilesPathGroup[];
   ghItems: SearchFileItem[] | undefined;
+  /** GitHub search page hit its cap — only affects a GH-only heading. */
+  ghTruncated: boolean;
   showViewProject: boolean;
   /** True for every project section after the first — see call site. */
   bordered: boolean;
@@ -1377,6 +1384,7 @@ function ProjectSection({
   // A GH-only label (no by-path groups) has no ProjectSummary — fall back to
   // the GitHub items' count so the header still reads sensibly.
   const count = summary?.count ?? ghItems?.length ?? 0;
+  const countTruncated = !summary && ghTruncated && count >= SHOT_COUNT_DISPLAY_CAP;
   const lastUpdated = summary?.lastUpdated;
 
   const labelBody = (
@@ -1415,7 +1423,7 @@ function ProjectSection({
           </span>
         )}
         <span className="wsp-group__meta text-muted-foreground text-[12px] whitespace-nowrap">
-          {count} {count === 1 ? "file" : "files"}
+          {formatShotCount(count, { truncated: countTruncated })}
           {lastUpdated ? ` · ${lastUpdatedLabel(lastUpdated, new Date())}` : ""}
         </span>
       </div>
@@ -1428,17 +1436,21 @@ function ProjectSection({
           preview={preview}
         />
       ))}
-      {ghItems && <GitHubSection items={ghItems} opener={opener} preview={preview} />}
+      {ghItems && (
+        <GitHubSection items={ghItems} truncated={ghTruncated} opener={opener} preview={preview} />
+      )}
     </div>
   );
 }
 
 function GitHubSection({
   items,
+  truncated,
   opener,
   preview,
 }: {
   items: SearchFileItem[];
+  truncated: boolean;
   opener: FileOpener;
   preview: PreviewHandlers;
 }) {
@@ -1449,7 +1461,9 @@ function GitHubSection({
           From GitHub
         </span>
         <span className="wsp-group__meta text-muted-foreground text-[12px] whitespace-nowrap">
-          {items.length} {items.length === 1 ? "file" : "files"}
+          {formatShotCount(items.length, {
+            truncated: truncated && items.length >= SHOT_COUNT_DISPLAY_CAP,
+          })}
         </span>
       </div>
       <div className="wsp-strip">
@@ -1495,8 +1509,7 @@ function PathGroupSection({
           {group.path}
         </span>
         <span className="wsp-group__meta text-muted-foreground text-[12px] whitespace-nowrap">
-          {group.count} {group.count === 1 ? "file" : "files"} ·{" "}
-          {lastUpdatedLabel(group.lastUpdated, new Date())}
+          {formatShotCount(group.count)} · {lastUpdatedLabel(group.lastUpdated, new Date())}
         </span>
         {/* Hint, not a control (the whole head is the drill-in button) — disclosed
             on hover/focus; opacity (not display) keeps it in the accessible name

--- a/apps/web/src/lib/workspace-screenshots.test.ts
+++ b/apps/web/src/lib/workspace-screenshots.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   filterCatalog,
   focusIsKeyboardDriven,
+  formatShotCount,
   groupsFromCatalog,
   isRepoLabel,
   lastUpdatedLabel,
@@ -12,6 +13,7 @@ import {
   projectLabelFromItemMeta,
   readScreenshotsView,
   screenshotsSearch,
+  SHOT_COUNT_DISPLAY_CAP,
   shotKindFromKey,
   shotPreviewCaption,
   shotPreviewPosition,
@@ -94,6 +96,22 @@ describe("lastUpdatedLabel", () => {
   });
   it("falls back to the raw string on an unparseable date", () => {
     expect(lastUpdatedLabel("garbage", now)).toBe("garbage");
+  });
+});
+
+describe("formatShotCount", () => {
+  it("pluralizes below the display cap", () => {
+    expect(formatShotCount(0)).toBe("0 files");
+    expect(formatShotCount(1)).toBe("1 file");
+    expect(formatShotCount(12)).toBe("12 files");
+    expect(formatShotCount(SHOT_COUNT_DISPLAY_CAP)).toBe("100 files");
+  });
+
+  it("renders 100+ once the count is past the cap or the page is truncated", () => {
+    expect(formatShotCount(SHOT_COUNT_DISPLAY_CAP + 1)).toBe("100+ files");
+    expect(formatShotCount(400)).toBe("100+ files");
+    expect(formatShotCount(SHOT_COUNT_DISPLAY_CAP, { truncated: true })).toBe("100+ files");
+    expect(formatShotCount(3, { truncated: true })).toBe("100+ files");
   });
 });
 

--- a/apps/web/src/lib/workspace-screenshots.ts
+++ b/apps/web/src/lib/workspace-screenshots.ts
@@ -167,6 +167,21 @@ export function pairedShotKeys(items: Array<{ key: string; state?: string }>): S
   return paired;
 }
 
+/**
+ * Display cap for screenshots section counts. Matches the API's
+ * BY_PATH_COUNT_DISPLAY_CAP: a list page size must not read as an exact
+ * inventory, so anything past this (or a truncated search page) is "100+".
+ */
+export const SHOT_COUNT_DISPLAY_CAP = 100;
+
+/** "1 file" / "12 files" / "100+ files". */
+export function formatShotCount(count: number, opts?: { truncated?: boolean }): string {
+  if (opts?.truncated || count > SHOT_COUNT_DISPLAY_CAP) {
+    return `${SHOT_COUNT_DISPLAY_CAP}+ files`;
+  }
+  return count === 1 ? "1 file" : `${count} files`;
+}
+
 /** Overview layout: grouped by project/path, or one flat newest-first feed. */
 export type ScreenshotsFeed = "grouped" | "recent";
 


### PR DESCRIPTION
## In plain terms

Project headings on the screenshots overview were showing **100 files** whenever a project had at least that many uploads. 100 is the list page size, so it read as an exact inventory instead of a cap. Headings now count the last 30 days and say **100+** once there are at least 101 files.

<img width="700" alt="Screenshots overview with 100 files on each project heading" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/864/screenshots-overview-before.webp">

## What it does / what it is not

- Counts files in the last 30 days for each project and path heading.
- Probes one past 100 so the UI can render `100+ files` when there are at least 101.
- An exact 100 in the window still reads `100 files`.
- Older groups still appear; if nothing in the window qualifies, the heading falls back to a capped all-time total instead of `0 files`.
- Does not paginate the overview, hide older paths, or change drill-in search.

## How to try it

Open the screenshots tab on a workspace with a busy project:

```text
/account/workspaces/<name>/screenshots
```

A project with more than 100 uploads in the last 30 days should read `100+ files`, not `100 files`.

## Technical notes

- `groupObjectsByPath` now windows section counts to 30 days and stops incrementing at 101 (`BY_PATH_COUNT_DISPLAY_CAP + 1`).
- `formatShotCount` in the web app turns `count > 100` (or a truncated GitHub search page that filled the cap) into `100+ files`.
- Path groups, path suggestions, and the GitHub strip use the same formatter.

## Test plan

- [x] `apps/api` `file-metadata-facets.test.ts` (window, 101-probe, fallback, existing grouping)
- [x] `apps/api` by-path route tests (`me.test.ts`, `workspace-files`)
- [x] `apps/web` `workspace-screenshots.test.ts` (`formatShotCount`)
- [ ] CI on this PR
- [ ] Visual check on a workspace where a project heading previously showed 100
