### PR TITLE
fix(api): don't hide PR attachments when the body URL spelling changes

### DIFF
--- a/apps/api/src/github-link-adopt.test.ts
+++ b/apps/api/src/github-link-adopt.test.ts
@@ -355,6 +355,73 @@ describe("adoptLinkedFiles", () => {
     const aMetaAfter = await getFileMetadata(seeded.env.DB, WS, `gh/acme/web/pull/${NUM}/a.png`);
     expect(aMetaAfter["gh.detached"]).toBe("false");
   });
+
+  it("PIN (#865): rewriting a staged URL to the pull dest URL does not detach", async () => {
+    const seeded = await seededEnv();
+    const branchKey = "gh/acme/web/branch/feat-x/shot.png";
+    const destKey = `gh/acme/web/pull/${NUM}/shot.png`;
+    await seedSource(seeded, branchKey);
+    seeded.kv.store.set("ghinst:acme/web", { value: "1" });
+
+    const first = await adoptLinkedFiles(
+      seeded.env,
+      WS,
+      null,
+      { repo: REPO, kind: "pull", num: NUM },
+      `https://storage.uploads.sh/acme/${branchKey}`,
+    );
+    expect(first.adopted).toEqual([destKey]);
+    expect(first.detached).toEqual([]);
+
+    // Body now embeds the promoted / `--pr` dest — same file, new spelling.
+    const rewritten = await adoptLinkedFiles(
+      seeded.env,
+      WS,
+      null,
+      { repo: REPO, kind: "pull", num: NUM },
+      `https://embed.uploads.sh/acme/${destKey}`,
+    );
+    expect(rewritten.adopted).toEqual([]);
+    expect(rewritten.detached).toEqual([]);
+    const destMeta = await getFileMetadata(seeded.env.DB, WS, destKey);
+    expect(destMeta["gh.detached"]).not.toBe("true");
+  });
+
+  it("PIN (#865): a dest URL reattaches after a real removal, without a re-copy", async () => {
+    const seeded = await seededEnv();
+    const branchKey = "gh/acme/web/branch/feat-x/shot.png";
+    const destKey = `gh/acme/web/pull/${NUM}/shot.png`;
+    await seedSource(seeded, branchKey);
+    seeded.kv.store.set("ghinst:acme/web", { value: "1" });
+
+    await adoptLinkedFiles(
+      seeded.env,
+      WS,
+      null,
+      { repo: REPO, kind: "pull", num: NUM },
+      `https://storage.uploads.sh/acme/${branchKey}`,
+    );
+    const removed = await adoptLinkedFiles(
+      seeded.env,
+      WS,
+      null,
+      { repo: REPO, kind: "pull", num: NUM },
+      "no links left",
+    );
+    expect(removed.detached).toEqual([destKey]);
+    expect((await getFileMetadata(seeded.env.DB, WS, destKey))["gh.detached"]).toBe("true");
+
+    const restored = await adoptLinkedFiles(
+      seeded.env,
+      WS,
+      null,
+      { repo: REPO, kind: "pull", num: NUM },
+      `https://storage.uploads.sh/acme/${destKey}`,
+    );
+    expect(restored.reattached).toEqual([destKey]);
+    expect(restored.adopted).toEqual([]);
+    expect((await getFileMetadata(seeded.env.DB, WS, destKey))["gh.detached"]).toBe("false");
+  });
 });
 
 describe("adoptLinkedFilesForWebhook", () => {

--- a/apps/api/src/github-link-adopt.ts
+++ b/apps/api/src/github-link-adopt.ts
@@ -48,10 +48,15 @@
  * rescanned is marked detached — the copy is never deleted, only hidden
  * from the managed comment render (`gh.detached` metadata, same convention
  * ingest uses) — and reappearing un-detaches it without a re-copy.
+ *
+ * "Still referenced" is the source key **or** the destination key (issue
+ * #865). A body edit that only rewrites a staged branch URL to the promoted
+ * `pull/<n>/` URL is the same file, not a removal — detaching would hide
+ * the real `--pr` / promoted attachment, which shares that destination.
  */
 import { attachExistingObject, resolveAttachSourceKey } from "./github-attach";
 import { commentCacheKey, gatherCommentBody } from "./github-comment";
-import type { GhTarget } from "./github-comment-render";
+import { GH_PRIVATE_ROOT, ghKeyPrefix, type GhTarget } from "./github-comment-render";
 import { postManagedComment } from "./github-comment-service";
 import { setFileMetadata } from "./file-metadata";
 import {
@@ -107,6 +112,17 @@ export interface AdoptSummary {
  * before any workspace/storage lookup exists. */
 export function hasLinkCandidate(text: string): boolean {
   return /https?:\/\//i.test(text);
+}
+
+/**
+ * True when `key` already lives under this target's attachment prefix — a
+ * promoted / `--pr` object, or a dest URL pasted after adoption. Not a
+ * source to copy onto itself (issue #865).
+ */
+function isTargetAttachmentKey(key: string, target: GhTarget): boolean {
+  if (key.startsWith(ghKeyPrefix(target))) return true;
+  if (!key.startsWith(GH_PRIVATE_ROOT)) return false;
+  return key.includes(`/${target.kind}/${target.num}/`);
 }
 
 const URL_RE = /https?:\/\/[^\s)"'<>\]]+/gi;
@@ -240,6 +256,11 @@ export async function adoptLinkedFiles(
   const before = await gatherCommentBody(env, ws, workspaceName, target);
 
   for (const key of keys) {
+    // A URL that already points at this PR/issue's attachment prefix is the
+    // attachment itself (promoted copy, or a dest-URL rewrite). Don't copy
+    // it onto itself or take adopt-ownership; the dest-key check below
+    // still counts it as "referenced."
+    if (isTargetAttachmentKey(key, target)) continue;
     const row = await adoptLedgerRow(db, repo, kind, num, key);
     if (row) {
       if (row.detachedAt === null) {
@@ -293,14 +314,26 @@ export async function adoptLinkedFiles(
     }
   }
 
-  // Un-adoption: a ledgered, non-detached key for THIS source that's no
-  // longer found when this source is rescanned. Scoped by source (not the
-  // whole target) so a link still referenced from a different comment isn't
-  // detached just because this particular comment stopped mentioning it.
+  // Un-adoption: a ledgered key for THIS source that's no longer referenced
+  // when this source is rescanned. Scoped by source (not the whole target)
+  // so a link still referenced from a different comment isn't detached just
+  // because this particular comment stopped mentioning it.
+  //
+  // Referenced = the original source key OR the destination key still
+  // appears in the text (issue #865: a staged URL rewritten to the
+  // `pull/<n>/` dest is the same file, not a removal).
   const existingForSource = await adoptLedgerRowsForSource(db, repo, kind, num, source);
   for (const row of existingForSource) {
+    const referenced = foundKeys.has(row.sourceKey) || foundKeys.has(row.objectKey);
+    if (referenced) {
+      if (row.detachedAt !== null) {
+        await setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "false" });
+        await setAdoptLedgerDetached(db, repo, kind, num, row.sourceKey, null);
+        summary.reattached.push(row.objectKey);
+      }
+      continue;
+    }
     if (row.detachedAt !== null) continue;
-    if (foundKeys.has(row.sourceKey)) continue;
     await setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "true" });
     await setAdoptLedgerDetached(db, repo, kind, num, row.sourceKey, new Date().toISOString());
     summary.detached.push(row.objectKey);

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -197,9 +197,8 @@ opens (whether via `gh pr create` or the GitHub UI), every branch-staged file
 gets promoted into that PR's attachments and the managed comment is created
 automatically. Files you never mention in the description still show up there.
 The comment is identified by a hidden HTML comment at the top:
-`<!-- uploads.sh:attachments ws=<workspace> -->` (legacy, no workspace:
-`<!-- uploads.sh:attachments -->`). Bot posts are from `uploads-sh[bot]`;
-the local-`gh` fallback uses the same marker.
+`<!-- uploads.sh:attachments ws=<workspace> -->`. Bot posts are from
+`uploads-sh[bot]`; the local-`gh` fallback uses the same marker.
 
 - **With the uploads-sh GitHub App installed** on the repo, a webhook does
   this the moment the PR opens, reopens, or gets a new commit — no CLI call

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -195,7 +195,11 @@ field) — don't ignore it. Viewport is derived for you on `screenshot`. See the
 **The PR comment assembles itself — you don't drive that step.** Once the PR
 opens (whether via `gh pr create` or the GitHub UI), every branch-staged file
 gets promoted into that PR's attachments and the managed comment is created
-automatically:
+automatically. Files you never mention in the description still show up there.
+The comment is identified by a hidden HTML comment at the top:
+`<!-- uploads.sh:attachments ws=<workspace> -->` (legacy, no workspace:
+`<!-- uploads.sh:attachments -->`). Bot posts are from `uploads-sh[bot]`;
+the local-`gh` fallback uses the same marker.
 
 - **With the uploads-sh GitHub App installed** on the repo, a webhook does
   this the moment the PR opens, reopens, or gets a new commit — no CLI call
@@ -218,8 +222,13 @@ uploads attach ./flow.gif --issue 45 --repo myorg/myapp
 uploads attach ./shot.png --no-comment      # stable URLs only, no comment
 ```
 
-For a URL you'll hard-code in a PR/issue body (re-uploads overwrite in place,
-URL never changes):
+For a URL you'll hard-code in a PR/issue **body** (re-uploads overwrite in
+place, URL never changes). Putting an image in the description works — that's
+the right place for a visual that belongs in the write-up (a before/after in
+"what it looks like"). You don't have to. Wait until the PR exists and use
+`--pr`, so the body gets the stable `pull/<n>/` key from the start. Don't
+paste a branch-staged URL into the description and later rewrite it to
+`pull/<n>/` just to "correct" it.
 
 ```bash
 uploads put ./after.png --pr 123 --alt "Dashboard after" --width 700
@@ -231,7 +240,7 @@ For a durable public link to share anywhere (Slack, docs, a teammate):
 uploads put ./demo.gif --format url
 ```
 
-Always embed the returned **markdown** (or `embedUrl`) in GitHub — it uses the
+When you do embed, use the returned **markdown** (or `embedUrl`) — the
 no-cache host so overwrites propagate. Don't hand-build storage URLs.
 
 **Comment briefly disappeared? Don't panic-repost.** If the App is installed

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -735,7 +735,9 @@ access-controlled — anyone who obtains it can read it until you rotate the id 
 assets). See `docs/private-attachments.md` for the full threat model.
 
 Then reference the **embed** URL in the PR/issue markdown you write with `gh`
-(CLI `--format markdown` / MCP `markdown` already do this):
+(CLI `--format markdown` / MCP `markdown` already do this). The description
+is optional — a visual that belongs in the write-up goes here; everything
+else is already in the managed comment:
 
 ```markdown
 <img width="700" alt="Dashboard after" src="https://embed.uploads.sh/default/gh/myorg/myapp/pull/123/after.webp">
@@ -754,7 +756,7 @@ than failing the upload if `gh` can't resolve one).
 
 ### Option B — managed attachments comment (default with `--pr`/`--issue`, or `comment`)
 
-`put --pr`/`--issue` (like `attach`) uploads **and** creates/updates a single marker-owned comment on the PR/issue by default — no separate flag needed. It keeps loose `gh/...` attachments and every public gallery linked to that PR/issue in clearly separate sections, with up to three available gallery images inline. It finds its own prior comment via a hidden marker and edits it in place — it never touches the description or other comments:
+`put --pr`/`--issue` (like `attach`) uploads **and** creates/updates a single marker-owned comment on the PR/issue by default — no separate flag needed. It keeps loose `gh/...` attachments and every public gallery linked to that PR/issue in clearly separate sections, with up to three available gallery images inline. Staged files you never paste into the description still show up here. It finds its own prior comment via a hidden HTML comment at the top (`<!-- uploads.sh:attachments ws=<workspace> -->`, or the legacy `<!-- uploads.sh:attachments -->` with no workspace) and edits it in place — it never touches the description or other comments. Bot posts are from `uploads-sh[bot]`. The local-`gh` fallback uses the same marker and adds a footer asking to install the App:
 
 ```bash
 uploads put ./after.png --pr 123

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -756,7 +756,7 @@ than failing the upload if `gh` can't resolve one).
 
 ### Option B — managed attachments comment (default with `--pr`/`--issue`, or `comment`)
 
-`put --pr`/`--issue` (like `attach`) uploads **and** creates/updates a single marker-owned comment on the PR/issue by default — no separate flag needed. It keeps loose `gh/...` attachments and every public gallery linked to that PR/issue in clearly separate sections, with up to three available gallery images inline. Staged files you never paste into the description still show up here. It finds its own prior comment via a hidden HTML comment at the top (`<!-- uploads.sh:attachments ws=<workspace> -->`, or the legacy `<!-- uploads.sh:attachments -->` with no workspace) and edits it in place — it never touches the description or other comments. Bot posts are from `uploads-sh[bot]`. The local-`gh` fallback uses the same marker and adds a footer asking to install the App:
+`put --pr`/`--issue` (like `attach`) uploads **and** creates/updates a single marker-owned comment on the PR/issue by default — no separate flag needed. It keeps loose `gh/...` attachments and every public gallery linked to that PR/issue in clearly separate sections, with up to three available gallery images inline. Staged files you never paste into the description still show up here. It finds its own prior comment via a hidden HTML comment at the top (`<!-- uploads.sh:attachments ws=<workspace> -->`) and edits it in place — it never touches the description or other comments. Bot posts are from `uploads-sh[bot]`. The local-`gh` fallback uses the same marker and adds a footer asking to install the App:
 
 ```bash
 uploads put ./after.png --pr 123


### PR DESCRIPTION
## In plain terms

Rewriting an uploads.sh URL in a PR body from the **branch-staged** spelling to the **stable `pull/<n>/` spelling** made the managed attachments comment drop the file. The bytes were still there; adoption stamped `gh.detached=true` on the promoted object. Hit this on #864.

Fixes #865.

## What it does / what it is not

- Counts a destination key as still referenced, so a URL spelling change is not a removal.
- Skips adopting URLs that already sit under the PR's attachment prefix (the attachment itself, not a new source to copy onto itself).
- A dest URL after a real removal still reattaches without a re-copy.
- Removing the image from the body entirely still detaches a paste-only adoption.
- Does not change promote, `put --pr`, or ingest of GitHub-native `user-attachments` URLs.

## How to try it

```bash
uploads put ./shot.png
# open a PR whose body embeds the returned branch URL
# edit the body to the pull/<n>/ URL for the same filename
# the managed comment should keep the image
```

## Technical notes

`adoptLinkedFiles` ledgered the **branch** key as the source and copied it to the same basename promote / `put --pr` already wrote. A later body edit that only changed the URL spelling made the rescan miss that source key, so un-adoption hid the shared destination.

## Test plan

- [x] `apps/api` `github-link-adopt.test.ts` (existing adopt/un-adopt/noise-guard cases plus two #865 PINs)
- [ ] CI on this PR
