### PR TITLE
feat(api,cli): size comment images by real dimensions, flow small assets inline

### DIFF
--- a/.changeset/smart-small-image-layout.md
+++ b/.changeset/smart-small-image-layout.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Managed comment sizes images by their real dimensions: uploads now record server-derived `image.width`/`image.height`, small assets render at natural size instead of being upscaled into blurry tiles, and consecutive captionless icons flow on one line instead of stacking one per row.

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -32,10 +32,12 @@ const RESERVED_META_KEYS = new Set<string>([...PROVENANCE_SERVER_KEYS, "visibili
  * Namespaces the server owns outright (issue #299). A client must never write
  * these: `video.poster` decides whether a poster `<img>` renders in a public
  * PR comment, so a user-settable row would be a spoofable input to public
- * output. Reserved as a *prefix* rather than four exact keys so future derived
+ * output. `image.*` (issue #365 follow-up) carries the server-detected pixel
+ * dimensions the managed comment sizes embeds with — same spoofable-input
+ * rationale. Reserved as *prefixes* rather than exact keys so future derived
  * facts can't collide.
  */
-export const SERVER_META_PREFIXES = ["video."] as const;
+export const SERVER_META_PREFIXES = ["video.", "image."] as const;
 
 export function isServerMetaKey(key: string): boolean {
   return SERVER_META_PREFIXES.some((prefix) => key.startsWith(prefix));

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -32,7 +32,12 @@ import {
 } from "./content-hash";
 import { recordPrActivityFromMetadata } from "./github-pr-activity";
 import { noteStorageFailure, noteStorageSuccess } from "./storage-health";
-import { DEFAULT_MAX_UPLOAD_BYTES, inspectUpload, resolveUploadPolicy } from "./guards";
+import {
+  DEFAULT_MAX_UPLOAD_BYTES,
+  detectImageDimensions,
+  inspectUpload,
+  resolveUploadPolicy,
+} from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
 import {
   decodeLaneCursor,
@@ -192,6 +197,43 @@ async function existingSize(store: Files, key: string): Promise<number | null> {
 
 /** Reserved keys `makePoster` may write, cleared together when it fails. */
 const POSTER_META_KEYS = ["video.poster", "video.duration", "video.width", "video.height"];
+
+/** Server-owned pixel-dimension rows for an image, written at upload time so
+ * the managed comment can size embeds without re-fetching bytes (issue #365
+ * follow-up). Cleared together, mirroring `POSTER_META_KEYS`. */
+const IMAGE_META_KEYS = ["image.width", "image.height"];
+
+/**
+ * Best-effort `image.width`/`image.height` derived metadata. Never throws:
+ * the object is durably stored by the time this runs, and missing dims simply
+ * mean the comment renderer falls back to its filename heuristic.
+ *
+ * Delete-first always, for every content type: an image replaced by a
+ * non-image (or by an image whose header can't be parsed) must not keep the
+ * prior upload's stale dimensions. Runs after `replaceFileMetadata` for the
+ * same reason `generateAndStorePoster` does — replace is delete-then-insert
+ * and would wipe these server-owned rows.
+ */
+async function storeImageDimensions(
+  env: Env,
+  workspaceName: string,
+  key: string,
+  bytes: Uint8Array,
+  contentType: string,
+): Promise<void> {
+  try {
+    await deleteServerFileMetadataKeys(dbFor(env), workspaceName, key, IMAGE_META_KEYS);
+    if (!contentType.startsWith("image/")) return;
+    const dims = detectImageDimensions(bytes, contentType);
+    if (!dims) return;
+    await setServerFileMetadata(dbFor(env), workspaceName, key, {
+      "image.width": String(dims.width),
+      "image.height": String(dims.height),
+    });
+  } catch (err) {
+    console.error({ event: "image_dimension_meta_failed", workspace: workspaceName, key, err });
+  }
+}
 
 /**
  * Upper bound on frame extraction (issue #299 review): the MEDIA binding
@@ -667,7 +709,8 @@ export async function putObject(
   await recordContentHash(dbFor(env), workspaceName, finalKey, contentSha256);
 
   // After the metadata replace, never before: replaceFileMetadata is
-  // delete-then-insert and would wipe the server-owned video.* rows.
+  // delete-then-insert and would wipe the server-owned video.*/image.* rows.
+  await storeImageDimensions(env, workspaceName, finalKey, bytes, inspection.contentType);
   await generateAndStorePoster(
     env,
     ws,

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -526,3 +526,102 @@ describe("attachmentsCommentBody (api copy)", () => {
     });
   });
 });
+
+describe("image dimensions (issue #365 follow-up)", () => {
+  const img = (key: string, extra: Record<string, unknown> = {}): AttachmentItem => ({
+    key,
+    url: `https://uploads.sh/f/${key}`,
+    embedUrl: `https://embed.uploads.sh/f/${key}`,
+    pageUrl: `https://uploads.sh/f/acme/${key}`,
+    ...extra,
+  });
+
+  it("renders a small icon at natural width, never upscaled to the solo tier", () => {
+    const body = attachmentsCommentBody([
+      img("gh/acme/web/pull/12/icon.png", {
+        imageMeta: { width: 96, height: 96 },
+        meta: { path: "/settings" },
+      }),
+    ]);
+    // Solo density would otherwise pick 720.
+    expect(body).toContain('<img width="96"');
+    expect(body).not.toContain('width="720"');
+  });
+
+  it("groups consecutive captionless small icons onto one flowing line", () => {
+    const body = attachmentsCommentBody([
+      img("gh/acme/web/pull/12/icon-a.png", { imageMeta: { width: 96, height: 96 } }),
+      img("gh/acme/web/pull/12/icon-b.png", { imageMeta: { width: 128, height: 64 } }),
+    ]);
+    const groupLine = body
+      .split("\n")
+      .find((line) => line.includes("icon-a.png") && line.includes("icon-b.png"));
+    expect(groupLine).toBeDefined();
+    // Adjacent anchors joined by a single space, each at natural width.
+    expect(groupLine).toMatch(/<\/a> <a /);
+    expect(groupLine).toContain('<img width="96"');
+    expect(groupLine).toContain('<img width="128"');
+  });
+
+  it("keeps a captioned small icon as a standalone entry at natural size", () => {
+    const body = attachmentsCommentBody([
+      img("gh/acme/web/pull/12/icon-a.png", {
+        imageMeta: { width: 96, height: 96 },
+        meta: { state: "after" },
+      }),
+      img("gh/acme/web/pull/12/icon-b.png", { imageMeta: { width: 96, height: 96 } }),
+    ]);
+    const lines = body.split("\n");
+    const aLine = lines.find((l) => l.includes("icon-a.png"));
+    const bLine = lines.find((l) => l.includes("icon-b.png"));
+    expect(aLine).not.toContain("icon-b.png");
+    expect(bLine).not.toContain("icon-a.png");
+    expect(aLine).toContain('<img width="96"');
+    expect(body).toContain("<code>after</code>");
+  });
+
+  it("keeps the density tier width for a large landscape image", () => {
+    const body = attachmentsCommentBody([
+      img("gh/acme/web/pull/12/shot.png", { imageMeta: { width: 2000, height: 1200 } }),
+    ]);
+    // Solo default tier (720) — real dims select the tier, never exceed it.
+    expect(body).toContain('<img width="720"');
+  });
+
+  it("selects the portrait tier for tall dims and the wide tier for >=16:9", () => {
+    const portrait = attachmentsCommentBody([
+      img("gh/acme/web/pull/12/tall.png", { imageMeta: { width: 800, height: 1400 } }),
+    ]);
+    expect(portrait).toContain('<img width="360"'); // solo portrait tier
+    const wide = attachmentsCommentBody([
+      img("gh/acme/web/pull/12/cinema.png", { imageMeta: { width: 3840, height: 2160 } }),
+    ]);
+    expect(wide).toContain('<img width="800"'); // solo wide tier
+  });
+
+  it("a numeric imageWidth override beats dims and disables grouping", () => {
+    const body = attachmentsCommentBody(
+      [
+        img("gh/acme/web/pull/12/icon-a.png", { imageMeta: { width: 96, height: 96 } }),
+        img("gh/acme/web/pull/12/icon-b.png", { imageMeta: { width: 96, height: 96 } }),
+      ],
+      [],
+      ATTACHMENTS_MARKER,
+      { ...AUTO_RENDER_OPTIONS, imageWidth: 500 },
+    );
+    const widths = [...body.matchAll(/<img width="(\d+)"/g)].map((m) => Number(m[1]));
+    expect(widths).toEqual([500, 500]);
+    const lines = body.split("\n");
+    expect(lines.find((l) => l.includes("icon-a.png"))).not.toContain("icon-b.png");
+  });
+
+  it("caps a paired image's cell width at its natural width", () => {
+    const body = attachmentsCommentBody([
+      img("gh/acme/web/pull/12/hero-before.png", { imageMeta: { width: 150, height: 100 } }),
+      img("gh/acme/web/pull/12/hero-after.png", { imageMeta: { width: 150, height: 100 } }),
+    ]);
+    expect(body).toContain("<table><tr>");
+    const widths = [...body.matchAll(/<img width="(\d+)"/g)].map((m) => Number(m[1]));
+    expect(widths).toEqual([150, 150]);
+  });
+});

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -410,6 +410,42 @@ describe("gatherCommentBody poster hydration (issue #299)", () => {
     expect(result.body).toContain("0:14");
   });
 
+  it("hydrates imageMeta from server-owned image.width/height rows", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    const key = "gh/acme/web/pull/12/icon.png";
+    await bucket.put(`acme/${key}`, PNG, { httpMetadata: { contentType: "image/png" } });
+    await setServerFileMetadata(env.DB, workspaceName, key, {
+      "image.width": "96",
+      "image.height": "64",
+    });
+
+    const result = await gatherCommentBody(env, ws, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+    // Solo density's tier would be 720; real dims cap at natural width.
+    expect(result.body).toContain('<img width="96"');
+  });
+
+  it("drops non-finite or non-positive image dimension rows", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    const key = "gh/acme/web/pull/12/icon.png";
+    await bucket.put(`acme/${key}`, PNG, { httpMetadata: { contentType: "image/png" } });
+    await setServerFileMetadata(env.DB, workspaceName, key, {
+      "image.width": "abc",
+      "image.height": "-5",
+    });
+
+    const result = await gatherCommentBody(env, ws, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+    // Neither parses → no imageMeta → filename heuristic (solo default 720).
+    expect(result.body).toContain('<img width="720"');
+  });
+
   // Two-lane storage (simplify follow-up on PR #771): the poster resolves
   // its OWN lane, independent of where the primary video lives.
   it("resolves a poster living in a different (fallback) lane than the video", async () => {

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -76,7 +76,7 @@ export async function gatherCommentBody(
 
 /**
  * The only metadata keys the managed comment reads or renders (issue #365,
- * extended for #299). The `video.*` keys are server-owned derived facts about
+ * extended for #299). The `video.*`/`image.*` keys are server-owned derived facts about
  * the file itself — not EXIF-derived keys like `device`/`software` — so the
  * narrowness rationale still holds for a surface that posts publicly.
  */
@@ -87,6 +87,8 @@ const COMMENT_META_KEYS = [
   "video.duration",
   "video.width",
   "video.height",
+  "image.width",
+  "image.height",
 ];
 
 /**
@@ -209,6 +211,19 @@ async function gatherAttachments(
         ...(Number.isFinite(duration) && duration > 0 ? { durationSeconds: duration } : {}),
         ...(Number.isFinite(width) && width > 0 ? { width } : {}),
         ...(Number.isFinite(height) && height > 0 ? { height } : {}),
+      };
+    }
+    // Server-derived image dimensions (never client-settable — `image.*` is a
+    // reserved prefix). Omitted entirely when neither parses so renders
+    // without dims stay byte-identical to the pre-dimension goldens.
+    const imgWidth = Number(meta["image.width"]);
+    const imgHeight = Number(meta["image.height"]);
+    const hasImgWidth = Number.isFinite(imgWidth) && imgWidth > 0;
+    const hasImgHeight = Number.isFinite(imgHeight) && imgHeight > 0;
+    if (hasImgWidth || hasImgHeight) {
+      item.imageMeta = {
+        ...(hasImgWidth ? { width: imgWidth } : {}),
+        ...(hasImgHeight ? { height: imgHeight } : {}),
       };
     }
   }

--- a/apps/api/test/image-dimension-metadata.test.ts
+++ b/apps/api/test/image-dimension-metadata.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { makePosterEnv, MP4, PNG, WORKSPACE } from "./poster-fixtures";
+import { putObject } from "../src/files-core";
+import { getMetadataForKeys } from "../src/file-metadata";
+
+/**
+ * `image.width`/`image.height` server-owned metadata (issue #365 follow-up):
+ * written best-effort at upload from the image header so the managed comment
+ * can size embeds; cleared on any overwrite whose bytes carry no parsable
+ * dimensions (unparsable image or non-image replacement).
+ */
+
+/** Minimal valid PNG header: signature + IHDR with the given dimensions. */
+function pngWithDims(width: number, height: number): Uint8Array {
+  const b = new Uint8Array(33);
+  b.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  const view = new DataView(b.buffer);
+  view.setUint32(8, 13, false); // IHDR chunk length
+  b.set([0x49, 0x48, 0x44, 0x52], 12); // "IHDR"
+  view.setUint32(16, width, false);
+  view.setUint32(20, height, false);
+  return b;
+}
+
+describe("image dimension metadata on upload", () => {
+  it("writes image.width/height rows for a parsable image", async () => {
+    const { env, ws } = makePosterEnv();
+    const put = await putObject(env, ws, "images/icon.png", pngWithDims(96, 64), WORKSPACE);
+
+    const meta = (await getMetadataForKeys(env.DB, WORKSPACE, [put.key])).get(put.key);
+    expect(meta?.["image.width"]).toBe("96");
+    expect(meta?.["image.height"]).toBe("64");
+  });
+
+  it("clears stale dims when an overwrite's image header can't be parsed", async () => {
+    const { env, ws } = makePosterEnv();
+    const put1 = await putObject(env, ws, "images/icon.png", pngWithDims(96, 64), WORKSPACE);
+    let meta = (await getMetadataForKeys(env.DB, WORKSPACE, [put1.key])).get(put1.key);
+    expect(meta?.["image.width"]).toBe("96");
+
+    // The shared PNG fixture sniffs as image/png (signature only) but carries
+    // no IHDR — detectImageDimensions returns undefined.
+    const put2 = await putObject(env, ws, "images/icon.png", PNG, WORKSPACE, { replace: true });
+    meta = (await getMetadataForKeys(env.DB, WORKSPACE, [put2.key])).get(put2.key);
+    expect(meta?.["image.width"]).toBeUndefined();
+    expect(meta?.["image.height"]).toBeUndefined();
+  });
+
+  it("clears stale dims when an image is replaced by a non-image", async () => {
+    const { env, ws } = makePosterEnv();
+    const put1 = await putObject(env, ws, "images/icon.png", pngWithDims(96, 64), WORKSPACE);
+    let meta = (await getMetadataForKeys(env.DB, WORKSPACE, [put1.key])).get(put1.key);
+    expect(meta?.["image.width"]).toBe("96");
+
+    // A video is the non-image replacement the upload policy allows.
+    const put2 = await putObject(env, ws, "images/icon.png", MP4, WORKSPACE, { replace: true });
+    meta = (await getMetadataForKeys(env.DB, WORKSPACE, [put2.key])).get(put2.key);
+    expect(meta?.["image.width"]).toBeUndefined();
+    expect(meta?.["image.height"]).toBeUndefined();
+  });
+
+  it("does not write image.* rows for a video upload", async () => {
+    const { env, ws } = makePosterEnv();
+    const put = await putObject(env, ws, "videos/clip.mp4", MP4, WORKSPACE);
+    const meta = (await getMetadataForKeys(env.DB, WORKSPACE, [put.key])).get(put.key);
+    expect(meta?.["image.width"]).toBeUndefined();
+  });
+});

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -185,6 +185,11 @@ async function makeEnv(
             } else if (normalized.includes("meta_key = ?") && normalized.startsWith("DELETE")) {
               const [ws, objectKey, key] = values as [string, string, string];
               metadata.get(scopeKey(ws, objectKey))?.delete(key);
+            } else if (normalized.includes("meta_key IN (") && normalized.startsWith("DELETE")) {
+              // deleteServerFileMetadataKeys: drop only the named keys.
+              const [ws, objectKey, ...keys] = values as string[];
+              const map = metadata.get(scopeKey(ws, objectKey));
+              for (const key of keys) map?.delete(key);
             } else if (normalized.startsWith("DELETE FROM file_metadata")) {
               const [ws, objectKey] = values as [string, string];
               metadata.delete(scopeKey(ws, objectKey));

--- a/packages/comment-render/src/index.ts
+++ b/packages/comment-render/src/index.ts
@@ -190,6 +190,8 @@ export interface AttachmentItem {
   posterUrl?: string | null;
   /** Derived video facts used for the caption and display width. */
   videoMeta?: { durationSeconds?: number; width?: number; height?: number };
+  /** Server-derived pixel dimensions for an image (never client-settable). */
+  imageMeta?: { width?: number; height?: number };
 }
 
 /** A public gallery linked to the PR or issue whose managed comment is syncing. */
@@ -276,21 +278,36 @@ function formatDuration(seconds: number): string {
 }
 
 /**
- * Display width for a video poster. Real dimensions only *select* among the
- * density table's tiers — a raw 1920 would blow out the comment column — and
- * the result is capped at the real width so a small clip is never upscaled.
+ * Display width for an image or video-poster embed. Real dimensions only
+ * *select* among the density table's tiers — a raw 1920 would blow out the
+ * comment column — and the result is capped at the real width so a small
+ * asset is never upscaled into a blurry tile. Without dims (either missing),
+ * falls back to the filename heuristic exactly, keeping dimension-less
+ * renders byte-identical to before dims existed.
  */
-function posterImageWidth(
-  videoMeta: AttachmentItem["videoMeta"],
+function naturalMediaWidth(
+  dims: { width?: number; height?: number } | undefined,
   filename: string,
   density: AttachmentDensity = "dense",
 ): number {
-  const w = videoMeta?.width ?? 0;
-  const h = videoMeta?.height ?? 0;
+  const w = dims?.width ?? 0;
+  const h = dims?.height ?? 0;
   if (w <= 0 || h <= 0) return attachmentImageWidth(filename, density);
   const table = WIDTH_BY_DENSITY[density];
   const chosen = h > w ? table.portrait : w / h >= 16 / 9 ? table.wide : table.default;
   return Math.min(chosen, w);
+}
+
+/**
+ * Icons and other small assets: both dimensions known and no edge above this
+ * flow inline at natural size rather than each becoming a full row.
+ */
+export const SMALL_ASSET_MAX_EDGE = 200;
+
+function isSmallAsset(dims: AttachmentItem["imageMeta"]): boolean {
+  const w = dims?.width ?? 0;
+  const h = dims?.height ?? 0;
+  return w > 0 && h > 0 && Math.max(w, h) <= SMALL_ASSET_MAX_EDGE;
 }
 
 function escapeHtmlAttr(s: string): string {
@@ -469,7 +486,10 @@ function renderPairCell(
   const name = item.key.slice(item.key.lastIndexOf("/") + 1);
   const src = item.embedUrl ?? item.url;
   const link = item.pageUrl ?? item.url;
-  const autoPx = Math.min(attachmentImageWidth(name, density), attachmentPairWidth(density));
+  const autoPx = Math.min(
+    naturalMediaWidth(item.imageMeta, name, density),
+    attachmentPairWidth(density),
+  );
   const w = resolvedWidth(autoPx, options);
   const alt = escapeHtmlAttr(name);
   const href = escapeHtmlAttr((link ?? src) as string);
@@ -607,7 +627,7 @@ export function attachmentsCommentBody(
     }
     if (isPosterVideo) {
       inlinedImages++;
-      const autoPx = posterImageWidth(item.videoMeta, name, density);
+      const autoPx = naturalMediaWidth(item.videoMeta, name, density);
       const w = resolvedWidth(autoPx, options);
       const href = escapeHtmlAttr(link ?? (item.posterUrl as string));
       lines.push(
@@ -623,10 +643,54 @@ export function attachmentsCommentBody(
       if (metaCap) parts.push(metaCap);
       lines.push(parts.join(" · "), "");
     } else if (isImage) {
+      // Small-asset flow layout: consecutive captionless small images (icons)
+      // join onto one line so GitHub flows them horizontally at natural size
+      // instead of stacking a giant column per icon. Auto mode only — a
+      // numeric imageWidth override or "full" keeps today's one-per-row form.
+      const smallGroupable = (candidate: AttachmentItem, i: number): boolean => {
+        if (options.imageWidth !== "auto") return false;
+        if (consumedByPair.has(i) || partnerOf.has(i)) return false;
+        if (!isSmallAsset(candidate.imageMeta)) return false;
+        if (metaCaptionValues(candidate.meta, options).length > 0) return false;
+        const n = candidate.key.slice(candidate.key.lastIndexOf("/") + 1);
+        const s = candidate.embedUrl ?? candidate.url;
+        return Boolean(s) && inferContentType(n).startsWith("image/");
+      };
+      if (smallGroupable(item, idx)) {
+        const group = [item];
+        let j = idx + 1;
+        // Each grouped image still counts toward maxInlineImages.
+        while (
+          j < sorted.length &&
+          inlinedImages + group.length < options.maxInlineImages &&
+          smallGroupable(sorted[j], j)
+        ) {
+          group.push(sorted[j]);
+          j++;
+        }
+        if (group.length > 1) {
+          inlinedImages += group.length;
+          lines.push(
+            group
+              .map((g) => {
+                const gName = g.key.slice(g.key.lastIndexOf("/") + 1);
+                const gSrc = (g.embedUrl ?? g.url) as string;
+                const gHref = escapeHtmlAttr((g.pageUrl ?? g.url ?? gSrc) as string);
+                // Natural width — a small asset is never upscaled.
+                const gW = g.imageMeta?.width as number;
+                return `<a href="${gHref}">${imgTag(gW, escapeHtmlAttr(gName), escapeHtmlAttr(gSrc))}</a>`;
+              })
+              .join(" "),
+            "",
+          );
+          idx = j - 1;
+          continue;
+        }
+      }
       inlinedImages++;
       // Markdown ![]() has no width control — phone frames become full-column giants.
       // img src uses embed host when available (Camo revalidates); click-through prefers the file page.
-      const autoPx = attachmentImageWidth(name, density);
+      const autoPx = naturalMediaWidth(item.imageMeta, name, density);
       const w = resolvedWidth(autoPx, options);
       const alt = escapeHtmlAttr(name);
       const href = escapeHtmlAttr(link ?? (src as string));

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -924,6 +924,13 @@ export async function syncAttachmentsComment(
         // byte-identical.
         const path = metadata?.path;
         const state = metadata?.state;
+        // Server-derived image dimensions (parity with the bot path's
+        // COMMENT_META_KEYS hydration): finite positive numbers only, field
+        // omitted entirely when neither parses.
+        const imgWidth = Number(metadata?.["image.width"]);
+        const imgHeight = Number(metadata?.["image.height"]);
+        const hasImgWidth = Number.isFinite(imgWidth) && imgWidth > 0;
+        const hasImgHeight = Number.isFinite(imgHeight) && imgHeight > 0;
         return {
           key,
           url,
@@ -931,6 +938,14 @@ export async function syncAttachmentsComment(
           pageUrl,
           ...(path || state
             ? { meta: { ...(path ? { path } : {}), ...(state ? { state } : {}) } }
+            : {}),
+          ...(hasImgWidth || hasImgHeight
+            ? {
+                imageMeta: {
+                  ...(hasImgWidth ? { width: imgWidth } : {}),
+                  ...(hasImgHeight ? { height: imgHeight } : {}),
+                },
+              }
             : {}),
         };
       },

--- a/packages/uploads/src/comment-render.generated.ts
+++ b/packages/uploads/src/comment-render.generated.ts
@@ -192,6 +192,8 @@ export interface AttachmentItem {
   posterUrl?: string | null;
   /** Derived video facts used for the caption and display width. */
   videoMeta?: { durationSeconds?: number; width?: number; height?: number };
+  /** Server-derived pixel dimensions for an image (never client-settable). */
+  imageMeta?: { width?: number; height?: number };
 }
 
 /** A public gallery linked to the PR or issue whose managed comment is syncing. */
@@ -278,21 +280,36 @@ function formatDuration(seconds: number): string {
 }
 
 /**
- * Display width for a video poster. Real dimensions only *select* among the
- * density table's tiers — a raw 1920 would blow out the comment column — and
- * the result is capped at the real width so a small clip is never upscaled.
+ * Display width for an image or video-poster embed. Real dimensions only
+ * *select* among the density table's tiers — a raw 1920 would blow out the
+ * comment column — and the result is capped at the real width so a small
+ * asset is never upscaled into a blurry tile. Without dims (either missing),
+ * falls back to the filename heuristic exactly, keeping dimension-less
+ * renders byte-identical to before dims existed.
  */
-function posterImageWidth(
-  videoMeta: AttachmentItem["videoMeta"],
+function naturalMediaWidth(
+  dims: { width?: number; height?: number } | undefined,
   filename: string,
   density: AttachmentDensity = "dense",
 ): number {
-  const w = videoMeta?.width ?? 0;
-  const h = videoMeta?.height ?? 0;
+  const w = dims?.width ?? 0;
+  const h = dims?.height ?? 0;
   if (w <= 0 || h <= 0) return attachmentImageWidth(filename, density);
   const table = WIDTH_BY_DENSITY[density];
   const chosen = h > w ? table.portrait : w / h >= 16 / 9 ? table.wide : table.default;
   return Math.min(chosen, w);
+}
+
+/**
+ * Icons and other small assets: both dimensions known and no edge above this
+ * flow inline at natural size rather than each becoming a full row.
+ */
+export const SMALL_ASSET_MAX_EDGE = 200;
+
+function isSmallAsset(dims: AttachmentItem["imageMeta"]): boolean {
+  const w = dims?.width ?? 0;
+  const h = dims?.height ?? 0;
+  return w > 0 && h > 0 && Math.max(w, h) <= SMALL_ASSET_MAX_EDGE;
 }
 
 function escapeHtmlAttr(s: string): string {
@@ -471,7 +488,10 @@ function renderPairCell(
   const name = item.key.slice(item.key.lastIndexOf("/") + 1);
   const src = item.embedUrl ?? item.url;
   const link = item.pageUrl ?? item.url;
-  const autoPx = Math.min(attachmentImageWidth(name, density), attachmentPairWidth(density));
+  const autoPx = Math.min(
+    naturalMediaWidth(item.imageMeta, name, density),
+    attachmentPairWidth(density),
+  );
   const w = resolvedWidth(autoPx, options);
   const alt = escapeHtmlAttr(name);
   const href = escapeHtmlAttr((link ?? src) as string);
@@ -609,7 +629,7 @@ export function attachmentsCommentBody(
     }
     if (isPosterVideo) {
       inlinedImages++;
-      const autoPx = posterImageWidth(item.videoMeta, name, density);
+      const autoPx = naturalMediaWidth(item.videoMeta, name, density);
       const w = resolvedWidth(autoPx, options);
       const href = escapeHtmlAttr(link ?? (item.posterUrl as string));
       lines.push(
@@ -625,10 +645,54 @@ export function attachmentsCommentBody(
       if (metaCap) parts.push(metaCap);
       lines.push(parts.join(" · "), "");
     } else if (isImage) {
+      // Small-asset flow layout: consecutive captionless small images (icons)
+      // join onto one line so GitHub flows them horizontally at natural size
+      // instead of stacking a giant column per icon. Auto mode only — a
+      // numeric imageWidth override or "full" keeps today's one-per-row form.
+      const smallGroupable = (candidate: AttachmentItem, i: number): boolean => {
+        if (options.imageWidth !== "auto") return false;
+        if (consumedByPair.has(i) || partnerOf.has(i)) return false;
+        if (!isSmallAsset(candidate.imageMeta)) return false;
+        if (metaCaptionValues(candidate.meta, options).length > 0) return false;
+        const n = candidate.key.slice(candidate.key.lastIndexOf("/") + 1);
+        const s = candidate.embedUrl ?? candidate.url;
+        return Boolean(s) && inferContentType(n).startsWith("image/");
+      };
+      if (smallGroupable(item, idx)) {
+        const group = [item];
+        let j = idx + 1;
+        // Each grouped image still counts toward maxInlineImages.
+        while (
+          j < sorted.length &&
+          inlinedImages + group.length < options.maxInlineImages &&
+          smallGroupable(sorted[j], j)
+        ) {
+          group.push(sorted[j]);
+          j++;
+        }
+        if (group.length > 1) {
+          inlinedImages += group.length;
+          lines.push(
+            group
+              .map((g) => {
+                const gName = g.key.slice(g.key.lastIndexOf("/") + 1);
+                const gSrc = (g.embedUrl ?? g.url) as string;
+                const gHref = escapeHtmlAttr((g.pageUrl ?? g.url ?? gSrc) as string);
+                // Natural width — a small asset is never upscaled.
+                const gW = g.imageMeta?.width as number;
+                return `<a href="${gHref}">${imgTag(gW, escapeHtmlAttr(gName), escapeHtmlAttr(gSrc))}</a>`;
+              })
+              .join(" "),
+            "",
+          );
+          idx = j - 1;
+          continue;
+        }
+      }
       inlinedImages++;
       // Markdown ![]() has no width control — phone frames become full-column giants.
       // img src uses embed host when available (Camo revalidates); click-through prefers the file page.
-      const autoPx = attachmentImageWidth(name, density);
+      const autoPx = naturalMediaWidth(item.imageMeta, name, density);
       const w = resolvedWidth(autoPx, options);
       const alt = escapeHtmlAttr(name);
       const href = escapeHtmlAttr(link ?? (src as string));


### PR DESCRIPTION
## Problem

The managed attachments comment sizes images from filename heuristics alone, so a small asset (an app icon, a favicon) gets the density-tier width — up to `width="720"` for a solo image — and GitHub upscales it into a giant blurry tile, one stacked column per icon. Example: buildinternet/sunny#1527 (comment with two ~100px icons rendered as huge tiles).

## Change

**Server-derived image dimensions.** `putObject` now sniffs `image.width`/`image.height` from the bytes (`detectImageDimensions`, already used by ingest) and stores them as server-owned metadata, same tier as `video.*`:

- `SERVER_META_PREFIXES` gains `image.` — client-unwritable, exempt from the key budget, excluded from facets.
- Delete-first on every upload, so a replacement with unparsable or non-image bytes drops stale dims.
- Not content-hash-inheritable; dims are regenerated from bytes each upload.

**Renderer never upscales.** `posterImageWidth` is generalized to `naturalMediaWidth`: real dims select the density tier (portrait / wide / default) and the result is capped at the natural width. Applies to standalone images, pair cells, and video posters. No dims → byte-identical filename-heuristic output, so existing comments and goldens are unchanged.

**Small assets flow on one row.** Consecutive captionless images with both edges ≤ 200px join on a single line at natural size instead of stacking one full row per icon. Auto width mode only; numeric `imageWidth` overrides and `"full"` behave exactly as before. Grouped images still count toward the inline cap.

**Parity.** Bot path and local-`gh` fallback both wire `imageMeta`; the CLI's inlined renderer copy is regenerated via `inline-shared.mjs`.

## Notes

- Existing objects have no `image.*` rows and keep today's sizing until re-uploaded; backfill is possible later if wanted.
- Gallery web pages are out of scope (different consumer than the comment renderer).

## Tests

`pnpm test`: 347 files / 5286 tests passing. New coverage: natural-width icons, one-line grouping, captioned small images staying standalone, tier selection from real dims, numeric-override behavior, pair-cell caps, `imageMeta` hydration filtering, and upload-path write/clear of `image.*` rows.
