### PR TITLE
feat(api,auth,web): admin invite-link management and workspace-admin join links

### DIFF
--- a/apps/api/migrations/20260827160000_auth_enrollments_kind.sql
+++ b/apps/api/migrations/20260827160000_auth_enrollments_kind.sql
@@ -1,0 +1,8 @@
+-- Issue #869 phase B: workspace-admin "join" invite links.
+--
+-- `auth_enrollments` rows have so far only ever redeemed into a CLI token
+-- (`kind = 'token'`, the implicit behavior before this column existed).
+-- Adds a `kind = 'member'` variant whose redemption instead adds the
+-- redeemer as an org member (see apps/api/src/routes/auth.ts's
+-- `POST /auth/enrollments/join` and apps/auth's `POST /internal/join`).
+ALTER TABLE auth_enrollments ADD COLUMN kind TEXT NOT NULL DEFAULT 'token';

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -56,6 +56,18 @@ export interface AuthTokenRecord {
   last_used_at: string | null;
 }
 
+/**
+ * What redeeming an enrollment code does. `'token'` (the default, and the
+ * only kind that existed before issue #869 phase B) mints a workspace-scoped
+ * `auth_tokens` row via `exchangeEnrollment` — it never touches org
+ * membership or the member cap. `'member'` links are minted by workspace
+ * admins from the People page and redeemed through `POST
+ * /auth/enrollments/join` instead, which adds the signed-in redeemer as an
+ * org member (member-cap-enforced). `exchangeEnrollment` rejects any
+ * non-'token' row outright — see its docblock.
+ */
+export type EnrollmentKind = "token" | "member";
+
 interface EnrollmentRecord {
   id: string;
   workspace: string;
@@ -67,6 +79,7 @@ interface EnrollmentRecord {
   token_expires_at: string;
   used_at: string | null;
   page_id: string | null;
+  kind: EnrollmentKind;
 }
 
 /** One outstanding (unredeemed, unexpired) invite-link enrollment, as
@@ -77,6 +90,7 @@ export interface OpenEnrollment {
   pageId: string | null;
   label: string | null;
   scopes: FileScope[];
+  kind: EnrollmentKind;
   createdAt: string;
   expiresAt: string;
 }
@@ -232,6 +246,8 @@ export async function createEnrollment(
     workspace: string;
     label?: string;
     scopes: FileScope[];
+    /** Defaults to `'token'` — the only kind that existed before #869 phase B. */
+    kind?: EnrollmentKind;
     enrollmentSeconds?: number;
     tokenSeconds?: number;
     now?: Date;
@@ -257,8 +273,8 @@ export async function createEnrollment(
     .prepare(
       `INSERT INTO auth_enrollments
        (id, workspace, code_hash, label, scopes, created_at, expires_at, token_expires_at, used_at,
-        page_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
+        page_id, kind)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)`,
     )
     .bind(
       enrollmentId,
@@ -270,6 +286,7 @@ export async function createEnrollment(
       expiresAt.toISOString(),
       tokenExpiresAt.toISOString(),
       pageId,
+      input.kind ?? "token",
     )
     .run();
   return {
@@ -291,23 +308,31 @@ export async function listOpenEnrollments(
   db: D1Queryable,
   workspace: string,
   now = new Date(),
+  /** Restrict to one `kind` — e.g. the People page's `'member'`-only list.
+   * Omitted keeps the pre-#869 behavior (every outstanding link, any kind) —
+   * the `/admin` panel deliberately shows both. */
+  kind?: EnrollmentKind,
 ): Promise<OpenEnrollment[]> {
   const result = await db
     .prepare(
-      `SELECT id, page_id, label, scopes, created_at, expires_at
+      `SELECT id, page_id, label, scopes, kind, created_at, expires_at
        FROM auth_enrollments
-       WHERE workspace = ? AND used_at IS NULL AND expires_at > ?
+       WHERE workspace = ? AND used_at IS NULL AND expires_at > ?${kind ? " AND kind = ?" : ""}
        ORDER BY created_at DESC`,
     )
-    .bind(workspace, now.toISOString())
+    .bind(...(kind ? [workspace, now.toISOString(), kind] : [workspace, now.toISOString()]))
     .all<
-      Pick<EnrollmentRecord, "id" | "page_id" | "label" | "scopes" | "created_at" | "expires_at">
+      Pick<
+        EnrollmentRecord,
+        "id" | "page_id" | "label" | "scopes" | "kind" | "created_at" | "expires_at"
+      >
     >();
   return result.results.map((row) => ({
     id: row.id,
     pageId: row.page_id,
     label: row.label,
     scopes: parseScopes(row.scopes),
+    kind: row.kind,
     createdAt: row.created_at,
     expiresAt: row.expires_at,
   }));
@@ -323,10 +348,16 @@ export async function revokeEnrollment(
   db: D1Queryable,
   workspace: string,
   id: string,
+  /** Restrict the delete to one `kind` — the People page's revoke can only
+   * touch its own `'member'` links, never a token-kind link minted from
+   * `/admin`. Omitted matches every kind (pre-#869 behavior). */
+  kind?: EnrollmentKind,
 ): Promise<boolean> {
   const result = await db
-    .prepare(`DELETE FROM auth_enrollments WHERE workspace = ? AND id = ?`)
-    .bind(workspace, id)
+    .prepare(
+      `DELETE FROM auth_enrollments WHERE workspace = ? AND id = ?${kind ? " AND kind = ?" : ""}`,
+    )
+    .bind(...(kind ? [workspace, id, kind] : [workspace, id]))
     .run();
   return (result.meta?.changes ?? 0) > 0;
 }
@@ -335,17 +366,22 @@ export async function findEnrollmentPage(
   db: D1Queryable,
   pageId: string,
   now = new Date(),
-): Promise<{ workspace: string; expiresAt: string; used: boolean } | null> {
+): Promise<{ workspace: string; expiresAt: string; used: boolean; kind: EnrollmentKind } | null> {
   if (!/^upi_[A-Za-z0-9_-]{16}$/.test(pageId)) return null;
   const record = await db
     .prepare(
-      `SELECT workspace, expires_at, used_at FROM auth_enrollments
+      `SELECT workspace, expires_at, used_at, kind FROM auth_enrollments
        WHERE page_id = ? AND expires_at > ? LIMIT 1`,
     )
     .bind(pageId, now.toISOString())
-    .first<Pick<EnrollmentRecord, "workspace" | "expires_at" | "used_at">>();
+    .first<Pick<EnrollmentRecord, "workspace" | "expires_at" | "used_at" | "kind">>();
   return record
-    ? { workspace: record.workspace, expiresAt: record.expires_at, used: record.used_at !== null }
+    ? {
+        workspace: record.workspace,
+        expiresAt: record.expires_at,
+        used: record.used_at !== null,
+        kind: record.kind,
+      }
     : null;
 }
 
@@ -357,12 +393,16 @@ export async function exchangeEnrollment(
   if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) return null;
   const nowIso = now.toISOString();
   const codeHash = await sha256Hex(code);
+  // `kind = 'token'` (issue #869 phase B): a workspace-admin `'member'` join
+  // link must never be exchangeable for a CLI token — same uniform `null`
+  // failure as an expired/unknown/already-used code, so a caller can't tell
+  // "wrong kind" apart from "invalid" by probing this endpoint.
   const enrollment = await db
     .prepare(
       `SELECT id, workspace, code_hash, label, scopes, created_at, expires_at,
-              token_expires_at, used_at
+              token_expires_at, used_at, kind
        FROM auth_enrollments
-       WHERE code_hash = ? AND used_at IS NULL AND expires_at > ?
+       WHERE code_hash = ? AND used_at IS NULL AND expires_at > ? AND kind = 'token'
        LIMIT 1`,
     )
     .bind(codeHash, nowIso)

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -130,6 +130,21 @@ export function validateScopes(
   return [...new Set(value)] as (FileScope | OperatorScope | WorkspaceScope)[];
 }
 
+/**
+ * Validates a user-supplied invite-link label: `undefined` in means "no
+ * label was supplied" (caller applies its own default), `null` out means
+ * invalid, otherwise the trimmed 1-100 char label. Shared by both invite-link
+ * mint handlers — `routes/admin-ui.ts`'s `kind: 'token'` links and
+ * `routes/workspace-members.ts`'s `kind: 'member'` links — same
+ * `auth_enrollments.label` column, same rule.
+ */
+export function labelValue(value: unknown): string | undefined | null {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") return null;
+  const label = value.trim();
+  return label.length >= 1 && label.length <= 100 ? label : null;
+}
+
 function randomSecret(prefix: string, bytes = 24): string {
   return `${prefix}${btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(bytes))))
     .replace(/\+/g, "-")
@@ -383,6 +398,64 @@ export async function findEnrollmentPage(
         kind: record.kind,
       }
     : null;
+}
+
+/**
+ * Claims an outstanding `kind: 'member'` invite link for redemption (issue
+ * #869 phase B) — the single-use, race-safe first half of `POST
+ * /auth/enrollments/join` (`routes/auth.ts`): a conditional UPDATE that only
+ * the first concurrent redeemer wins, done BEFORE the caller adds the member,
+ * so a lost race is indistinguishable from any other invalid code. Returns
+ * `null` for an unknown/expired/already-used/wrong-kind code — same uniform
+ * failure shape callers collapse to `INVALID_ENROLLMENT`. The returned
+ * `codeHash` is what {@link releaseEnrollmentClaim} needs to restore the
+ * claim; recomputing it there would mean hashing the code twice.
+ */
+export async function claimMemberEnrollment(
+  db: D1Queryable,
+  code: string,
+  now = new Date(),
+): Promise<{ id: string; workspace: string; codeHash: string } | null> {
+  const nowIso = now.toISOString();
+  const codeHash = await sha256Hex(code);
+  const enrollment = await db
+    .prepare(
+      `SELECT id, workspace FROM auth_enrollments
+       WHERE code_hash = ? AND used_at IS NULL AND expires_at > ? AND kind = 'member'
+       LIMIT 1`,
+    )
+    .bind(codeHash, nowIso)
+    .first<{ id: string; workspace: string }>();
+  if (!enrollment) return null;
+
+  const claim = await db
+    .prepare(
+      `UPDATE auth_enrollments SET used_at = ?
+       WHERE id = ? AND code_hash = ? AND used_at IS NULL AND expires_at > ? AND kind = 'member'`,
+    )
+    .bind(nowIso, enrollment.id, codeHash, nowIso)
+    .run();
+  if ((claim.meta?.changes ?? 0) !== 1) return null;
+
+  return { id: enrollment.id, workspace: enrollment.workspace, codeHash };
+}
+
+/**
+ * Restores a claim {@link claimMemberEnrollment} made (`used_at = NULL`),
+ * scoped by both `id` and `code_hash` so it can only ever touch the row it
+ * claimed. Shared by every `/auth/enrollments/join` path where the
+ * redemption didn't actually happen (or didn't consume a seat) — the link
+ * isn't permanently burned for something that never occurred.
+ */
+export async function releaseEnrollmentClaim(
+  db: D1Queryable,
+  id: string,
+  codeHash: string,
+): Promise<void> {
+  await db
+    .prepare(`UPDATE auth_enrollments SET used_at = NULL WHERE id = ? AND code_hash = ?`)
+    .bind(id, codeHash)
+    .run();
 }
 
 export async function exchangeEnrollment(

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -69,6 +69,18 @@ interface EnrollmentRecord {
   page_id: string | null;
 }
 
+/** One outstanding (unredeemed, unexpired) invite-link enrollment, as
+ * surfaced to the admin panel — deliberately excludes `code_hash`: a listed
+ * link's URL can never be reconstructed, only revoked. */
+export interface OpenEnrollment {
+  id: string;
+  pageId: string | null;
+  label: string | null;
+  scopes: FileScope[];
+  createdAt: string;
+  expiresAt: string;
+}
+
 export function parseScopes(value: string): FileScope[] {
   try {
     const parsed: unknown = JSON.parse(value);
@@ -224,7 +236,13 @@ export async function createEnrollment(
     tokenSeconds?: number;
     now?: Date;
   },
-): Promise<{ pageId: string; code: string; expiresAt: string; tokenExpiresAt: string }> {
+): Promise<{
+  id: string;
+  pageId: string;
+  code: string;
+  expiresAt: string;
+  tokenExpiresAt: string;
+}> {
   const now = input.now ?? new Date();
   const expiresAt = new Date(
     now.getTime() + (input.enrollmentSeconds ?? DEFAULT_ENROLLMENT_SECONDS) * 1000,
@@ -234,6 +252,7 @@ export async function createEnrollment(
   );
   const code = randomSecret("upe_", 18);
   const pageId = randomSecret("upi_", 12);
+  const enrollmentId = id();
   await db
     .prepare(
       `INSERT INTO auth_enrollments
@@ -242,7 +261,7 @@ export async function createEnrollment(
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
     )
     .bind(
-      id(),
+      enrollmentId,
       input.workspace,
       await sha256Hex(code),
       input.label ?? null,
@@ -254,11 +273,62 @@ export async function createEnrollment(
     )
     .run();
   return {
+    id: enrollmentId,
     pageId,
     code,
     expiresAt: expiresAt.toISOString(),
     tokenExpiresAt: tokenExpiresAt.toISOString(),
   };
+}
+
+/**
+ * Outstanding (unredeemed, unexpired) invite-link enrollments for a
+ * workspace, newest first — backs the admin panel's invite-link list. Never
+ * selects `code_hash`; the plaintext code is never stored either, so a
+ * listed link's URL can't be reconstructed (show-once stays show-once).
+ */
+export async function listOpenEnrollments(
+  db: D1Queryable,
+  workspace: string,
+  now = new Date(),
+): Promise<OpenEnrollment[]> {
+  const result = await db
+    .prepare(
+      `SELECT id, page_id, label, scopes, created_at, expires_at
+       FROM auth_enrollments
+       WHERE workspace = ? AND used_at IS NULL AND expires_at > ?
+       ORDER BY created_at DESC`,
+    )
+    .bind(workspace, now.toISOString())
+    .all<
+      Pick<EnrollmentRecord, "id" | "page_id" | "label" | "scopes" | "created_at" | "expires_at">
+    >();
+  return result.results.map((row) => ({
+    id: row.id,
+    pageId: row.page_id,
+    label: row.label,
+    scopes: parseScopes(row.scopes),
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+  }));
+}
+
+/**
+ * Delete one outstanding enrollment, scoped by both workspace and id so an
+ * admin can't revoke another workspace's link. Returns whether a row was
+ * actually deleted (false for an unknown id or one owned by another
+ * workspace — same 404 either way at the route layer).
+ */
+export async function revokeEnrollment(
+  db: D1Queryable,
+  workspace: string,
+  id: string,
+): Promise<boolean> {
+  const result = await db
+    .prepare(`DELETE FROM auth_enrollments WHERE workspace = ? AND id = ?`)
+    .bind(workspace, id)
+    .run();
+  return (result.meta?.changes ?? 0) > 0;
 }
 
 export async function findEnrollmentPage(

--- a/apps/api/src/routes/admin-enrollments-email.test.ts
+++ b/apps/api/src/routes/admin-enrollments-email.test.ts
@@ -17,6 +17,7 @@ const MIGRATIONS = [
   "migrations/20260711120000_invite_pages.sql",
   "migrations/20260712230000_token_minting_user.sql",
   "migrations/20260817180000_token_last_used.sql",
+  "migrations/20260827160000_auth_enrollments_kind.sql",
 ];
 
 const RECORD = {

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -254,12 +254,13 @@ describe("invite-link routes", () => {
         token_expires_at: this.values[7],
         used_at: null,
         page_id: this.values[8],
+        kind: this.values[9],
       });
       return Promise.resolve({ success: true } as unknown as D1Result);
     }
     all(): Promise<D1Result> {
       const sql = this.sql.replace(/\s+/g, " ").trim();
-      if (sql.startsWith("SELECT id, page_id, label, scopes, created_at, expires_at")) {
+      if (sql.startsWith("SELECT id, page_id, label, scopes, kind, created_at, expires_at")) {
         const [workspace, now] = this.values as string[];
         const results = this.db.enrollments
           .filter(
@@ -274,6 +275,7 @@ describe("invite-link routes", () => {
             page_id: row.page_id,
             label: row.label,
             scopes: row.scopes,
+            kind: row.kind,
             created_at: row.created_at,
             expires_at: row.expires_at,
           }));

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -219,7 +219,7 @@ describe("POST /admin-ui/workspaces/:name/invites", () => {
   });
 });
 
-describe("POST /admin-ui/workspaces/:name/invite-links", () => {
+describe("invite-link routes", () => {
   type Row = Record<string, unknown>;
 
   class FakeStatement {
@@ -233,6 +233,16 @@ describe("POST /admin-ui/workspaces/:name/invite-links", () => {
       return this;
     }
     run(): Promise<D1Result> {
+      const sql = this.sql.replace(/\s+/g, " ").trim();
+      if (sql.startsWith("DELETE FROM auth_enrollments")) {
+        const [workspace, id] = this.values;
+        const before = this.db.enrollments.length;
+        this.db.enrollments = this.db.enrollments.filter(
+          (row) => !(row.workspace === workspace && row.id === id),
+        );
+        const changes = before - this.db.enrollments.length;
+        return Promise.resolve({ success: true, meta: { changes } } as unknown as D1Result);
+      }
       this.db.enrollments.push({
         id: this.values[0],
         workspace: this.values[1],
@@ -246,6 +256,30 @@ describe("POST /admin-ui/workspaces/:name/invite-links", () => {
         page_id: this.values[8],
       });
       return Promise.resolve({ success: true } as unknown as D1Result);
+    }
+    all(): Promise<D1Result> {
+      const sql = this.sql.replace(/\s+/g, " ").trim();
+      if (sql.startsWith("SELECT id, page_id, label, scopes, created_at, expires_at")) {
+        const [workspace, now] = this.values as string[];
+        const results = this.db.enrollments
+          .filter(
+            (row) =>
+              row.workspace === workspace &&
+              row.used_at === null &&
+              (row.expires_at as string) > now,
+          )
+          .sort((a, b) => (b.created_at as string).localeCompare(a.created_at as string))
+          .map((row) => ({
+            id: row.id,
+            page_id: row.page_id,
+            label: row.label,
+            scopes: row.scopes,
+            created_at: row.created_at,
+            expires_at: row.expires_at,
+          }));
+        return Promise.resolve({ success: true, results } as unknown as D1Result);
+      }
+      throw new Error(`unsupported all: ${sql}`);
     }
   }
 
@@ -262,132 +296,313 @@ describe("POST /admin-ui/workspaces/:name/invite-links", () => {
   ): Env & { DB: FakeD1 } {
     const base = stubEnv(user, () => new Response(null, { status: 404 }));
     const db = new FakeD1();
+    const registry = fakeRegistry(Object.fromEntries(registryNames.map((n) => [n, {}])));
     return {
       ...base,
-      REGISTRY: {
-        get: (async (key: string) =>
-          registryNames.some((n) => `ws:${n}` === key)
-            ? "{}"
-            : null) as unknown as KVNamespace["get"],
-      } as unknown as KVNamespace,
+      REGISTRY: registry,
       DB: db,
     } as unknown as Env & { DB: FakeD1 };
   }
 
-  it("mints a redeemable code for an admin session", async () => {
-    const env = envWithDb(ADMIN_USER, ["acme"]);
-    const res = await app().request(
-      "/admin-ui/workspaces/acme/invite-links",
-      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
-      env,
-    );
-    expect(res.status).toBe(201);
-    const payload = (await res.json()) as {
-      workspace: string;
-      code: string;
-      pageId: string;
-      url: string;
-      scopes: string[];
-      expiresAt: string;
-    };
-    expect(payload.workspace).toBe("acme");
-    expect(payload.code).toMatch(/^upe_/);
-    expect(payload.pageId).toMatch(/^upi_/);
-    expect(payload.url).toContain(payload.pageId);
-    expect(payload.url).toContain("#code=");
-    expect(payload.scopes).toEqual(["files:read", "files:write"]);
-    expect(env.DB.enrollments).toHaveLength(1);
+  /** Same shape as `envWithDb`, but the named workspace is soft-deleted. */
+  function envWithSoftDeletedWorkspace(
+    user: typeof ADMIN_USER | null,
+    name: string,
+  ): Env & { DB: FakeD1 } {
+    const base = stubEnv(user, () => new Response(null, { status: 404 }));
+    const db = new FakeD1();
+    const registry = fakeRegistry({ [name]: { deletedAt: "2026-08-01T00:00:00.000Z" } });
+    return {
+      ...base,
+      REGISTRY: registry,
+      DB: db,
+    } as unknown as Env & { DB: FakeD1 };
+  }
+
+  describe("POST /admin-ui/workspaces/:name/invite-links", () => {
+    it("mints a redeemable code for an admin session", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]);
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links",
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+        env,
+      );
+      expect(res.status).toBe(201);
+      const payload = (await res.json()) as {
+        workspace: string;
+        code: string;
+        pageId: string;
+        url: string;
+        scopes: string[];
+        expiresAt: string;
+      };
+      expect(payload.workspace).toBe("acme");
+      expect(payload.code).toMatch(/^upe_/);
+      expect(payload.pageId).toMatch(/^upi_/);
+      expect(payload.url).toContain(payload.pageId);
+      expect(payload.url).toContain("#code=");
+      expect(payload.scopes).toEqual(["files:read", "files:write"]);
+      expect(env.DB.enrollments).toHaveLength(1);
+    });
+
+    it("401s with no session", async () => {
+      const env = envWithDb(null, ["acme"]);
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links",
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+        env,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("403s for a non-admin session", async () => {
+      const env = envWithDb(NON_ADMIN_USER, ["acme"]);
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links",
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+        env,
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("404s for an unknown workspace", async () => {
+      const env = envWithDb(ADMIN_USER, []);
+      const res = await app().request(
+        "/admin-ui/workspaces/nope/invite-links",
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+        env,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("400s for an empty label", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]);
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ label: "" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(400);
+      const payload = (await res.json()) as { error?: { code?: string } };
+      expect(payload.error?.code).toBe("invalid_label");
+    });
+
+    it("400s for a label over 100 characters", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]);
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ label: "x".repeat(101) }),
+        },
+        env,
+      );
+      expect(res.status).toBe(400);
+      const payload = (await res.json()) as { error?: { code?: string } };
+      expect(payload.error?.code).toBe("invalid_label");
+    });
+
+    it("400s for invalid scopes", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]);
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ scopes: ["not:a:real:scope"] }),
+        },
+        env,
+      );
+      expect(res.status).toBe(400);
+      const payload = (await res.json()) as { error?: { code?: string } };
+      expect(payload.error?.code).toBe("invalid_scopes");
+    });
+
+    it("429s when the per-workspace write budget is exhausted", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]) as Env & {
+        WRITE_LIMITER: { limit: (opts: { key: string }) => Promise<{ success: boolean }> };
+      };
+      env.WRITE_LIMITER = { limit: async () => ({ success: false }) };
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links",
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+        env,
+      );
+      expect(res.status).toBe(429);
+    });
+
+    it("404s for a soft-deleted workspace instead of minting", async () => {
+      const env = envWithSoftDeletedWorkspace(ADMIN_USER, "gone");
+      const res = await app().request(
+        "/admin-ui/workspaces/gone/invite-links",
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+        env,
+      );
+      expect(res.status).toBe(404);
+      const payload = (await res.json()) as { error?: { code?: string } };
+      expect(payload.error?.code).toBe("workspace_not_found");
+      expect(env.DB.enrollments).toHaveLength(0);
+    });
+
+    it("passes an admin-supplied label and scopes through to the minted enrollment", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]);
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ label: "contractor", scopes: ["files:read"] }),
+        },
+        env,
+      );
+      expect(res.status).toBe(201);
+      const payload = (await res.json()) as { label: string | null; scopes: string[] };
+      expect(payload.label).toBe("contractor");
+      expect(payload.scopes).toEqual(["files:read"]);
+      expect(env.DB.enrollments[0]?.label).toBe("contractor");
+    });
   });
 
-  it("401s with no session", async () => {
-    const env = envWithDb(null, ["acme"]);
-    const res = await app().request(
-      "/admin-ui/workspaces/acme/invite-links",
-      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
-      env,
-    );
-    expect(res.status).toBe(401);
+  describe("GET /admin-ui/workspaces/:name/invite-links", () => {
+    it("lists outstanding links without leaking code_hash", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]);
+      await app().request(
+        "/admin-ui/workspaces/acme/invite-links",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ label: "sales" }),
+        },
+        env,
+      );
+      const res = await app().request("/admin-ui/workspaces/acme/invite-links", {}, env);
+      expect(res.status).toBe(200);
+      const payload = (await res.json()) as {
+        links: { id: string; pageId: string | null; label: string | null; scopes: string[] }[];
+      };
+      expect(payload.links).toHaveLength(1);
+      expect(payload.links[0]?.label).toBe("sales");
+      expect(payload.links[0]?.scopes).toEqual(["files:read", "files:write"]);
+      expect(JSON.stringify(payload)).not.toContain("code_hash");
+      expect(JSON.stringify(payload)).not.toMatch(/upe_/);
+    });
+
+    it("200s empty for a workspace with no outstanding links", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]);
+      const res = await app().request("/admin-ui/workspaces/acme/invite-links", {}, env);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ links: [] });
+    });
+
+    it("404s for an unknown workspace", async () => {
+      const env = envWithDb(ADMIN_USER, []);
+      const res = await app().request("/admin-ui/workspaces/nope/invite-links", {}, env);
+      expect(res.status).toBe(404);
+    });
+
+    it("401s with no session", async () => {
+      const env = envWithDb(null, ["acme"]);
+      const res = await app().request("/admin-ui/workspaces/acme/invite-links", {}, env);
+      expect(res.status).toBe(401);
+    });
+
+    it("403s for a non-admin session", async () => {
+      const env = envWithDb(NON_ADMIN_USER, ["acme"]);
+      const res = await app().request("/admin-ui/workspaces/acme/invite-links", {}, env);
+      expect(res.status).toBe(403);
+    });
   });
 
-  it("403s for a non-admin session", async () => {
-    const env = envWithDb(NON_ADMIN_USER, ["acme"]);
-    const res = await app().request(
-      "/admin-ui/workspaces/acme/invite-links",
-      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
-      env,
-    );
-    expect(res.status).toBe(403);
-  });
+  describe("DELETE /admin-ui/workspaces/:name/invite-links/:id", () => {
+    async function mintOne(env: Env & { DB: FakeD1 }, workspace: string, label?: string) {
+      const res = await app().request(
+        `/admin-ui/workspaces/${workspace}/invite-links`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(label ? { label } : {}),
+        },
+        env,
+      );
+      const payload = (await res.json()) as { id: string };
+      return payload.id;
+    }
 
-  it("404s for an unknown workspace", async () => {
-    const env = envWithDb(ADMIN_USER, []);
-    const res = await app().request(
-      "/admin-ui/workspaces/nope/invite-links",
-      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
-      env,
-    );
-    expect(res.status).toBe(404);
-  });
+    it("revokes an outstanding link", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]);
+      const id = await mintOne(env, "acme");
+      const res = await app().request(
+        `/admin-ui/workspaces/acme/invite-links/${id}`,
+        { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(env.DB.enrollments).toHaveLength(0);
+    });
 
-  it("400s for an empty label", async () => {
-    const env = envWithDb(ADMIN_USER, ["acme"]);
-    const res = await app().request(
-      "/admin-ui/workspaces/acme/invite-links",
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ label: "" }),
-      },
-      env,
-    );
-    expect(res.status).toBe(400);
-    const payload = (await res.json()) as { error?: { code?: string } };
-    expect(payload.error?.code).toBe("invalid_label");
-  });
+    it("404s for an unknown id", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]);
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links/nope",
+        { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(404);
+      const payload = (await res.json()) as { error?: { code?: string } };
+      expect(payload.error?.code).toBe("invite_link_not_found");
+    });
 
-  it("400s for a label over 100 characters", async () => {
-    const env = envWithDb(ADMIN_USER, ["acme"]);
-    const res = await app().request(
-      "/admin-ui/workspaces/acme/invite-links",
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ label: "x".repeat(101) }),
-      },
-      env,
-    );
-    expect(res.status).toBe(400);
-    const payload = (await res.json()) as { error?: { code?: string } };
-    expect(payload.error?.code).toBe("invalid_label");
-  });
+    it("404s when the id belongs to a different workspace", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme", "other"]);
+      const id = await mintOne(env, "other");
+      const res = await app().request(
+        `/admin-ui/workspaces/acme/invite-links/${id}`,
+        { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(404);
+      expect(env.DB.enrollments).toHaveLength(1);
+    });
 
-  it("400s for invalid scopes", async () => {
-    const env = envWithDb(ADMIN_USER, ["acme"]);
-    const res = await app().request(
-      "/admin-ui/workspaces/acme/invite-links",
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ scopes: ["not:a:real:scope"] }),
-      },
-      env,
-    );
-    expect(res.status).toBe(400);
-    const payload = (await res.json()) as { error?: { code?: string } };
-    expect(payload.error?.code).toBe("invalid_scopes");
-  });
+    it("401s with no session", async () => {
+      const env = envWithDb(null, ["acme"]);
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links/anything",
+        { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(401);
+    });
 
-  it("429s when the per-workspace write budget is exhausted", async () => {
-    const env = envWithDb(ADMIN_USER, ["acme"]) as Env & {
-      WRITE_LIMITER: { limit: (opts: { key: string }) => Promise<{ success: boolean }> };
-    };
-    env.WRITE_LIMITER = { limit: async () => ({ success: false }) };
-    const res = await app().request(
-      "/admin-ui/workspaces/acme/invite-links",
-      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
-      env,
-    );
-    expect(res.status).toBe(429);
+    it("403s for a non-admin session", async () => {
+      const env = envWithDb(NON_ADMIN_USER, ["acme"]);
+      const res = await app().request(
+        "/admin-ui/workspaces/acme/invite-links/anything",
+        { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("429s when the per-workspace write budget is exhausted", async () => {
+      const env = envWithDb(ADMIN_USER, ["acme"]) as Env & {
+        DB: FakeD1;
+        WRITE_LIMITER: { limit: (opts: { key: string }) => Promise<{ success: boolean }> };
+      };
+      const id = await mintOne(env, "acme");
+      env.WRITE_LIMITER = { limit: async () => ({ success: false }) };
+      const res = await app().request(
+        `/admin-ui/workspaces/acme/invite-links/${id}`,
+        { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(429);
+    });
   });
 });
 

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_ENROLLMENT_SECONDS,
   DEFAULT_TOKEN_SECONDS,
   createEnrollment,
+  labelValue,
   listOpenEnrollments,
   revokeEnrollment,
   revokeTokensForMintingUser,
@@ -172,13 +173,8 @@ function parseBanReason(body: unknown): string {
 // POST /admin/enrollments path (apps/api/src/routes/admin.ts) — same code
 // format, same TTL defaults, same redemption flow (apps/web's /invite page
 // and `uploads login --code`). This route only adds a session-authed way to
-// mint one without an email recipient.
-function labelValue(value: unknown): string | undefined | null {
-  if (value === undefined || value === null) return undefined;
-  if (typeof value !== "string") return null;
-  const label = value.trim();
-  return label.length >= 1 && label.length <= 100 ? label : null;
-}
+// mint one without an email recipient. `labelValue` (shared with
+// `routes/workspace-members.ts`'s member-kind links) lives in `auth-db.ts`.
 
 interface OrgSummary {
   organization: { id: string; slug: string; name: string };

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -31,6 +31,8 @@ import {
   DEFAULT_ENROLLMENT_SECONDS,
   DEFAULT_TOKEN_SECONDS,
   createEnrollment,
+  listOpenEnrollments,
+  revokeEnrollment,
   revokeTokensForMintingUser,
   validateScopes,
 } from "../auth-db";
@@ -628,10 +630,10 @@ export const adminUi = new Hono<SessionVars>()
     if (!(await allowWrite(c.env, name))) {
       throw new RateLimitedError("rate limit exceeded");
     }
-    const existing = await c.env.REGISTRY.get(`ws:${name}`);
-    if (!existing) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
+    // Same existence rule as the sibling limits/plan/storage/settings edits —
+    // a soft-deleted or purged-tombstone workspace 404s rather than minting a
+    // live invite for a workspace that no longer serves.
+    await loadEditableWorkspace(c.env, name);
 
     const body = await c.req
       .json<{ label?: unknown; scopes?: unknown }>()
@@ -666,6 +668,32 @@ export const adminUi = new Hono<SessionVars>()
       },
       201,
     );
+  })
+
+  // Outstanding (unredeemed, unexpired) invite links for this workspace —
+  // never includes the plaintext code (never stored) or its hash, so a
+  // listed link's URL can't be reconstructed here; revoke and re-mint
+  // instead.
+  .get("/workspaces/:name/invite-links", async (c) => {
+    const name = c.req.param("name");
+    await loadEditableWorkspace(c.env, name);
+    const links = await listOpenEnrollments(dbFor(c.env), name);
+    return c.json({ links });
+  })
+
+  // Revoke one outstanding invite link before it's redeemed.
+  .delete("/workspaces/:name/invite-links/:id", async (c) => {
+    const name = c.req.param("name");
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+    await loadEditableWorkspace(c.env, name);
+    const id = c.req.param("id");
+    const revoked = await revokeEnrollment(dbFor(c.env), name, id);
+    if (!revoked) {
+      throw new NotFoundError("invite link not found", { code: "invite_link_not_found" });
+    }
+    return c.json({ ok: true, id });
   })
 
   // Read the four budget limits (+ current usage) for one workspace.

--- a/apps/api/src/routes/admin-workspace-required.test.ts
+++ b/apps/api/src/routes/admin-workspace-required.test.ts
@@ -23,6 +23,7 @@ const MIGRATIONS = [
   "migrations/20260710120000_auth.sql",
   "migrations/20260712230000_token_minting_user.sql",
   "migrations/20260817180000_token_last_used.sql",
+  "migrations/20260827160000_auth_enrollments_kind.sql",
 ];
 
 const RECORD = {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,18 +1,60 @@
 import { RateLimitedError, ValidationError } from "@uploads/errors";
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { exchangeEnrollment, findEnrollmentPage } from "../auth-db";
 import { dbFor } from "../db-session";
+import { resolveSessionUserId } from "../dual-workspace-auth";
+import { throwForInviteError } from "../invite-error";
+import { sha256Hex } from "../workspace";
+import type { SessionVars } from "../session-auth";
 
 const INVALID_ENROLLMENT = () =>
   new ValidationError("invalid or expired enrollment code", { code: "invalid_enrollment" });
 const MAX_EXCHANGE_BODY_BYTES = 1024;
 
-export const auth = new Hono<{ Bindings: Env }>()
+/**
+ * Parses and validates the `{ code }` body shared by `/exchange` and
+ * `/join`: ≤1KB, single-key object, `code` a string matching the enrollment
+ * code shape. Throws the uniform `INVALID_ENROLLMENT` on any deviation —
+ * same hygiene, same non-distinguishing failure, for both endpoints.
+ */
+async function readEnrollmentCode(c: {
+  req: { header: (name: string) => string | undefined; arrayBuffer: () => Promise<ArrayBuffer> };
+}): Promise<string> {
+  const contentLength = Number(c.req.header("Content-Length") ?? 0);
+  if (contentLength > MAX_EXCHANGE_BODY_BYTES) throw INVALID_ENROLLMENT();
+  const bytes = await c.req.arrayBuffer();
+  if (bytes.byteLength > MAX_EXCHANGE_BODY_BYTES) throw INVALID_ENROLLMENT();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw INVALID_ENROLLMENT();
+  }
+  if (
+    parsed === null ||
+    Array.isArray(parsed) ||
+    typeof parsed !== "object" ||
+    !("code" in parsed) ||
+    Object.keys(parsed).length !== 1 ||
+    typeof parsed.code !== "string"
+  ) {
+    throw INVALID_ENROLLMENT();
+  }
+  const code = parsed.code.trim();
+  if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) throw INVALID_ENROLLMENT();
+  return code;
+}
+
+export const auth = new Hono<{ Bindings: Env } & SessionVars>()
   .use("/enrollments/*", async (c, next) => {
     const limiter = c.env.INVITE_LIMITER;
     if (limiter) {
       const address = c.req.header("CF-Connecting-IP") ?? "unknown";
-      const operation = c.req.path.endsWith("/exchange") ? "exchange" : "lookup";
+      const operation = c.req.path.endsWith("/exchange")
+        ? "exchange"
+        : c.req.path.endsWith("/join")
+          ? "join"
+          : "lookup";
       const { success } = await limiter.limit({ key: `invite:${operation}:${address}` });
       if (!success) {
         throw new RateLimitedError("invitation rate limit exceeded", { retryAfterSeconds: 60 });
@@ -29,29 +71,75 @@ export const auth = new Hono<{ Bindings: Env }>()
   })
   .post("/enrollments/exchange", async (c) => {
     c.header("Cache-Control", "no-store");
-    const contentLength = Number(c.req.header("Content-Length") ?? 0);
-    if (contentLength > MAX_EXCHANGE_BODY_BYTES) throw INVALID_ENROLLMENT();
-    const bytes = await c.req.arrayBuffer();
-    if (bytes.byteLength > MAX_EXCHANGE_BODY_BYTES) throw INVALID_ENROLLMENT();
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(new TextDecoder().decode(bytes));
-    } catch {
-      throw INVALID_ENROLLMENT();
-    }
-    if (
-      parsed === null ||
-      Array.isArray(parsed) ||
-      typeof parsed !== "object" ||
-      !("code" in parsed) ||
-      Object.keys(parsed).length !== 1 ||
-      typeof parsed.code !== "string"
-    ) {
-      throw INVALID_ENROLLMENT();
-    }
-    const code = parsed.code.trim();
-    if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) throw INVALID_ENROLLMENT();
+    const code = await readEnrollmentCode(c);
     const result = await exchangeEnrollment(dbFor(c.env), code);
     if (!result) throw INVALID_ENROLLMENT();
     return c.json(result, 201);
+  })
+  // Issue #869 phase B: redeems a workspace-admin `kind: 'member'` join link
+  // as membership (not a CLI token — that's `/exchange` above, `kind:
+  // 'token'` only). Session-authed: the redeemer must be signed in (any
+  // signed-in user with a valid code may join — this is not admin-gated),
+  // 401 via `resolveSessionUserId` when they aren't.
+  .post("/enrollments/join", async (c) => {
+    c.header("Cache-Control", "no-store");
+    const code = await readEnrollmentCode(c);
+    // Resolve the session BEFORE touching D1: an unauthenticated caller gets
+    // a plain 401, not a code-shape-dependent response, so this endpoint
+    // can't be used to probe code validity while signed out.
+    const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+
+    const db = dbFor(c.env);
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const codeHash = await sha256Hex(code);
+
+    const enrollment = await db
+      .prepare(
+        `SELECT id, workspace FROM auth_enrollments
+         WHERE code_hash = ? AND used_at IS NULL AND expires_at > ? AND kind = 'member'
+         LIMIT 1`,
+      )
+      .bind(codeHash, nowIso)
+      .first<{ id: string; workspace: string }>();
+    if (!enrollment) throw INVALID_ENROLLMENT();
+
+    // Claim the link first (single-use, race-safe: a conditional UPDATE that
+    // only the first concurrent redeemer wins), THEN add the member. A lost
+    // race here is indistinguishable from any other invalid code.
+    const claim = await db
+      .prepare(
+        `UPDATE auth_enrollments SET used_at = ?
+         WHERE id = ? AND code_hash = ? AND used_at IS NULL AND expires_at > ? AND kind = 'member'`,
+      )
+      .bind(nowIso, enrollment.id, codeHash, nowIso)
+      .run();
+    if ((claim.meta?.changes ?? 0) !== 1) throw INVALID_ENROLLMENT();
+
+    const response = await c.env.AUTH.fetch("https://auth.internal/internal/join", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-uploads-internal": "1" },
+      body: JSON.stringify({ organizationSlug: enrollment.workspace, userId }),
+    });
+    if (!response.ok) {
+      // The member add failed (cap denial, or a transient auth-worker
+      // error) — restore the link so a redemption that didn't actually
+      // happen doesn't permanently burn it.
+      await db
+        .prepare(`UPDATE auth_enrollments SET used_at = NULL WHERE id = ? AND code_hash = ?`)
+        .bind(enrollment.id, codeHash)
+        .run();
+      const payload = (await response.json().catch(() => null)) as {
+        error?: { code?: unknown; message?: unknown };
+      } | null;
+      if (response.status === 403 && payload?.error?.code === "member_cap_reached") {
+        throwForInviteError(response.status, payload);
+      }
+      throw INVALID_ENROLLMENT();
+    }
+    const payload = (await response.json().catch(() => null)) as { alreadyMember?: unknown } | null;
+    return c.json(
+      { workspace: enrollment.workspace, alreadyMember: payload?.alreadyMember === true },
+      200,
+    );
   });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -107,19 +107,38 @@ export const auth = new Hono<{ Bindings: Env } & SessionVars>()
     // the link isn't permanently burned for something that never occurred.
     const restoreClaim = () => releaseEnrollmentClaim(db, claim.id, claim.codeHash);
 
-    let response: Response;
-    try {
-      response = await c.env.AUTH.fetch("https://auth.internal/internal/join", {
+    const callInternalJoin = () =>
+      c.env.AUTH.fetch("https://auth.internal/internal/join", {
         method: "POST",
         headers: { "content-type": "application/json", "x-uploads-internal": "1" },
         body: JSON.stringify({ organizationSlug: claim.workspace, userId }),
       });
+
+    let response: Response;
+    let isRetry = false;
+    try {
+      response = await callInternalJoin();
     } catch {
-      // A rejected fetch (transport failure, not an HTTP error) never got to
-      // `!response.ok` below — restore here too, or the link is burned with
-      // no member ever added.
-      await restoreClaim();
-      throw INVALID_ENROLLMENT();
+      // A rejected fetch is a transport failure, not an HTTP error — we don't
+      // know whether the downstream worker committed the membership before
+      // the transport broke. `/internal/join` is idempotent (atomic
+      // NOT-EXISTS insert; an already-member retry returns 200
+      // `{alreadyMember:true}` without consuming a seat), so reconcile by
+      // retrying the identical call rather than blindly restoring the claim.
+      isRetry = true;
+      try {
+        response = await callInternalJoin();
+      } catch {
+        // Still unknown after a retry — fail closed. Do NOT restore the
+        // claim: if the first (or second) attempt actually committed the
+        // membership, restoring would let the code be redeemed a second
+        // time (CWE-863). The link stays burned; surface the same
+        // retryable error as the cap-lookup outage path below.
+        throw new ServiceUnavailableError(
+          "Couldn't verify this workspace's member limit — try again.",
+          { code: "cap_check_unavailable" },
+        );
+      }
     }
     if (!response.ok) {
       // The member add failed (cap denial, a cap-check outage, or a transient
@@ -148,7 +167,14 @@ export const auth = new Hono<{ Bindings: Env } & SessionVars>()
     if (payload?.alreadyMember === true) {
       // No seat was consumed — restore the claim so an existing member
       // clicking a shared link doesn't permanently burn it for anyone else.
-      await restoreClaim();
+      //
+      // Exception: on the retry path, `alreadyMember` may mean our own
+      // first (transport-failed) attempt actually committed the membership
+      // before the failure — in that case restoring would hand the code a
+      // second seat. Only restore when this was a clean, non-retried call.
+      if (!isRetry) {
+        await restoreClaim();
+      }
       return c.json({ workspace: claim.workspace, alreadyMember: true }, 200);
     }
     return c.json({ workspace: claim.workspace, alreadyMember: false }, 200);

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,4 +1,4 @@
-import { RateLimitedError, ValidationError } from "@uploads/errors";
+import { RateLimitedError, ServiceUnavailableError, ValidationError } from "@uploads/errors";
 import { Hono, type Context } from "hono";
 import { exchangeEnrollment, findEnrollmentPage } from "../auth-db";
 import { dbFor } from "../db-session";
@@ -116,30 +116,58 @@ export const auth = new Hono<{ Bindings: Env } & SessionVars>()
       .run();
     if ((claim.meta?.changes ?? 0) !== 1) throw INVALID_ENROLLMENT();
 
-    const response = await c.env.AUTH.fetch("https://auth.internal/internal/join", {
-      method: "POST",
-      headers: { "content-type": "application/json", "x-uploads-internal": "1" },
-      body: JSON.stringify({ organizationSlug: enrollment.workspace, userId }),
-    });
-    if (!response.ok) {
-      // The member add failed (cap denial, or a transient auth-worker
-      // error) — restore the link so a redemption that didn't actually
-      // happen doesn't permanently burn it.
-      await db
+    // Restores the claim above (`used_at = NULL`) — shared by every path where
+    // the redemption didn't actually happen (or didn't consume a seat), so
+    // the link isn't permanently burned for something that never occurred.
+    const restoreClaim = () =>
+      db
         .prepare(`UPDATE auth_enrollments SET used_at = NULL WHERE id = ? AND code_hash = ?`)
         .bind(enrollment.id, codeHash)
         .run();
+
+    let response: Response;
+    try {
+      response = await c.env.AUTH.fetch("https://auth.internal/internal/join", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-uploads-internal": "1" },
+        body: JSON.stringify({ organizationSlug: enrollment.workspace, userId }),
+      });
+    } catch {
+      // A rejected fetch (transport failure, not an HTTP error) never got to
+      // `!response.ok` below — restore here too, or the link is burned with
+      // no member ever added.
+      await restoreClaim();
+      throw INVALID_ENROLLMENT();
+    }
+    if (!response.ok) {
+      // The member add failed (cap denial, a cap-check outage, or a transient
+      // auth-worker error) — restore the link so a redemption that didn't
+      // actually happen doesn't permanently burn it.
+      await restoreClaim();
       const payload = (await response.json().catch(() => null)) as {
         error?: { code?: unknown; message?: unknown };
       } | null;
       if (response.status === 403 && payload?.error?.code === "member_cap_reached") {
         throwForInviteError(response.status, payload);
       }
+      if (response.status === 503 && payload?.error?.code === "cap_check_unavailable") {
+        // Redemption-time cap enforcement fails closed (unlike mint-time,
+        // which fails open) — the client sees a distinct, retryable error
+        // rather than "invalid or expired".
+        const message =
+          typeof payload?.error?.message === "string" && payload.error.message
+            ? payload.error.message
+            : "Couldn't verify this workspace's member limit — try again.";
+        throw new ServiceUnavailableError(message, { code: "cap_check_unavailable" });
+      }
       throw INVALID_ENROLLMENT();
     }
     const payload = (await response.json().catch(() => null)) as { alreadyMember?: unknown } | null;
-    return c.json(
-      { workspace: enrollment.workspace, alreadyMember: payload?.alreadyMember === true },
-      200,
-    );
+    if (payload?.alreadyMember === true) {
+      // No seat was consumed — restore the claim so an existing member
+      // clicking a shared link doesn't permanently burn it for anyone else.
+      await restoreClaim();
+      return c.json({ workspace: enrollment.workspace, alreadyMember: true }, 200);
+    }
+    return c.json({ workspace: enrollment.workspace, alreadyMember: false }, 200);
   });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,10 +1,14 @@
 import { RateLimitedError, ServiceUnavailableError, ValidationError } from "@uploads/errors";
 import { Hono, type Context } from "hono";
-import { exchangeEnrollment, findEnrollmentPage } from "../auth-db";
+import {
+  claimMemberEnrollment,
+  exchangeEnrollment,
+  findEnrollmentPage,
+  releaseEnrollmentClaim,
+} from "../auth-db";
 import { dbFor } from "../db-session";
 import { resolveSessionUserId } from "../dual-workspace-auth";
 import { throwForInviteError } from "../invite-error";
-import { sha256Hex } from "../workspace";
 import type { SessionVars } from "../session-auth";
 
 const INVALID_ENROLLMENT = () =>
@@ -91,46 +95,24 @@ export const auth = new Hono<{ Bindings: Env } & SessionVars>()
 
     const db = dbFor(c.env);
     const now = new Date();
-    const nowIso = now.toISOString();
-    const codeHash = await sha256Hex(code);
-
-    const enrollment = await db
-      .prepare(
-        `SELECT id, workspace FROM auth_enrollments
-         WHERE code_hash = ? AND used_at IS NULL AND expires_at > ? AND kind = 'member'
-         LIMIT 1`,
-      )
-      .bind(codeHash, nowIso)
-      .first<{ id: string; workspace: string }>();
-    if (!enrollment) throw INVALID_ENROLLMENT();
 
     // Claim the link first (single-use, race-safe: a conditional UPDATE that
     // only the first concurrent redeemer wins), THEN add the member. A lost
     // race here is indistinguishable from any other invalid code.
-    const claim = await db
-      .prepare(
-        `UPDATE auth_enrollments SET used_at = ?
-         WHERE id = ? AND code_hash = ? AND used_at IS NULL AND expires_at > ? AND kind = 'member'`,
-      )
-      .bind(nowIso, enrollment.id, codeHash, nowIso)
-      .run();
-    if ((claim.meta?.changes ?? 0) !== 1) throw INVALID_ENROLLMENT();
+    const claim = await claimMemberEnrollment(db, code, now);
+    if (!claim) throw INVALID_ENROLLMENT();
 
     // Restores the claim above (`used_at = NULL`) — shared by every path where
     // the redemption didn't actually happen (or didn't consume a seat), so
     // the link isn't permanently burned for something that never occurred.
-    const restoreClaim = () =>
-      db
-        .prepare(`UPDATE auth_enrollments SET used_at = NULL WHERE id = ? AND code_hash = ?`)
-        .bind(enrollment.id, codeHash)
-        .run();
+    const restoreClaim = () => releaseEnrollmentClaim(db, claim.id, claim.codeHash);
 
     let response: Response;
     try {
       response = await c.env.AUTH.fetch("https://auth.internal/internal/join", {
         method: "POST",
         headers: { "content-type": "application/json", "x-uploads-internal": "1" },
-        body: JSON.stringify({ organizationSlug: enrollment.workspace, userId }),
+        body: JSON.stringify({ organizationSlug: claim.workspace, userId }),
       });
     } catch {
       // A rejected fetch (transport failure, not an HTTP error) never got to
@@ -167,7 +149,7 @@ export const auth = new Hono<{ Bindings: Env } & SessionVars>()
       // No seat was consumed — restore the claim so an existing member
       // clicking a shared link doesn't permanently burn it for anyone else.
       await restoreClaim();
-      return c.json({ workspace: enrollment.workspace, alreadyMember: true }, 200);
+      return c.json({ workspace: claim.workspace, alreadyMember: true }, 200);
     }
-    return c.json({ workspace: enrollment.workspace, alreadyMember: false }, 200);
+    return c.json({ workspace: claim.workspace, alreadyMember: false }, 200);
   });

--- a/apps/api/src/routes/workspace-members.ts
+++ b/apps/api/src/routes/workspace-members.ts
@@ -77,6 +77,7 @@ import {
   type OrgMember,
 } from "../org-workspaces";
 import type { SessionVars } from "../session-auth";
+import { isPurgedTombstone, loadWorkspaceRecordRaw } from "../workspace";
 
 /** Context vars a `sessionMemberGate`/`sessionAdminGate`-guarded route can rely on. */
 export type MembersVars = {
@@ -264,6 +265,22 @@ function labelValue(value: unknown): string | undefined | null {
 }
 
 /**
+ * 404s minting a member-kind invite link for a soft-deleted or
+ * purged-tombstone workspace — same existence rule `loadEditableWorkspace`
+ * (`routes/admin-ui.ts`) applies to the admin-minted token-kind links. Mint
+ * only: list/revoke stay unguarded here, since seeing or clearing out
+ * outstanding links during a deletion grace period is still legitimately
+ * useful (and `sessionAdminGate` already means the caller was a member of a
+ * workspace that still exists in the membership lookup at some point).
+ */
+async function requireLiveWorkspace(env: Env, name: string): Promise<void> {
+  const record = await loadWorkspaceRecordRaw(env, name);
+  if (!record || isPurgedTombstone(record) || record.deletedAt) {
+    throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  }
+}
+
+/**
  * `POST /:workspace/invite-links` — mint a `kind: 'member'` invite link
  * (issue #869 phase B). Its redemption (`POST /auth/enrollments/join`) adds
  * the redeemer as an org member with role `member`, never a CLI token — so
@@ -278,6 +295,7 @@ function labelValue(value: unknown): string | undefined | null {
 export async function inviteLinkMintHandler(c: Context<MembersVars>) {
   const org = c.get("memberOrg");
   if (!(await allowWrite(c.env, org.slug))) throw new RateLimitedError("rate limit exceeded");
+  await requireLiveWorkspace(c.env, org.slug);
 
   const body = await c.req.json<{ label?: unknown }>().catch(() => ({}) as { label?: unknown });
   const label = labelValue(body.label);

--- a/apps/api/src/routes/workspace-members.ts
+++ b/apps/api/src/routes/workspace-members.ts
@@ -31,6 +31,16 @@
  *    `POST /:workspace/invites` here would double-register/shadow that exact
  *    path — see that route's docblock for the "upgrade in place, don't
  *    parallel-register" reasoning.
+ *  - `POST /invite-links`, `GET /invite-links`, `DELETE /invite-links/:id`
+ *    (issue #869 phase B) — session-only, admin/owner-gated, same as the
+ *    email-invite routes above. Mint/list/revoke a `kind: 'member'`
+ *    `auth_enrollments` row: redeeming one (`POST /auth/enrollments/join` in
+ *    `routes/auth.ts`) adds the redeemer as an org member, member-cap
+ *    enforced at both mint and redemption. Distinct from the pre-existing
+ *    `kind: 'token'` invite links `/admin` mints for CLI onboarding (`POST
+ *    /admin-ui/workspaces/:name/invite-links`, `routes/admin-ui.ts`) — same
+ *    `auth_enrollments` table and `auth-db.ts` helpers, filtered by `kind` so
+ *    neither surface can list or revoke the other's links.
  *
  * Session auth here is session-only-with-admin-tier, NOT
  * `dualWorkspaceAuth`/`requireSessionAdmin` (those grant a session caller
@@ -43,9 +53,19 @@
  */
 import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { Hono, type Context, type MiddlewareHandler } from "hono";
+import {
+  createEnrollment,
+  DEFAULT_ENROLLMENT_SECONDS,
+  DEFAULT_TOKEN_SECONDS,
+  listOpenEnrollments,
+  revokeEnrollment,
+} from "../auth-db";
+import { dbFor } from "../db-session";
 import { hasPreresolvedSession, resolveSessionUserId } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
 import { allowWrite } from "../guards";
+import { throwForInviteError } from "../invite-error";
+import { deriveWebOrigin, inviteLinkUrl } from "../invite-links";
 import {
   invitesForOrg,
   membersForOrg,
@@ -231,6 +251,99 @@ export async function memberRoleUpdateHandler(c: Context<MembersVars>) {
   return c.json({ member });
 }
 
+/** `sessionAdminGate`'s `MembersVars["memberOrg"]["slug"]` IS the workspace
+ * name (the 1:1 org<->workspace mapping `org-workspaces.ts` documents), so
+ * every invite-link handler below reuses it instead of re-reading (and
+ * re-widening) the `:workspace` path param — same pattern as
+ * `inviteRevokeHandler`'s `allowWrite(c.env, org.slug)` call above. */
+function labelValue(value: unknown): string | undefined | null {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") return null;
+  const label = value.trim();
+  return label.length >= 1 && label.length <= 100 ? label : null;
+}
+
+/**
+ * `POST /:workspace/invite-links` — mint a `kind: 'member'` invite link
+ * (issue #869 phase B). Its redemption (`POST /auth/enrollments/join`) adds
+ * the redeemer as an org member with role `member`, never a CLI token — so
+ * this route mints with `scopes: []` (never used by a member-kind exchange;
+ * `exchangeEnrollment` rejects non-'token' rows outright regardless) and
+ * checks the member cap at mint time, mirroring email invites' `POST
+ * /:workspace/invites` (`routes/workspaces.ts`): same `member_cap_reached`
+ * error shape via `throwForInviteError`, same fail-open posture on a cap
+ * lookup that can't be made (`memberCapDenial` in apps/auth). Redemption
+ * re-checks the cap independently — see `routes/auth.ts`'s join handler.
+ */
+export async function inviteLinkMintHandler(c: Context<MembersVars>) {
+  const org = c.get("memberOrg");
+  if (!(await allowWrite(c.env, org.slug))) throw new RateLimitedError("rate limit exceeded");
+
+  const body = await c.req.json<{ label?: unknown }>().catch(() => ({}) as { label?: unknown });
+  const label = labelValue(body.label);
+  if (label === null) {
+    throw new ValidationError("label must be between 1 and 100 characters", {
+      code: "invalid_label",
+    });
+  }
+
+  const capCheck = await c.env.AUTH.fetch("https://auth.internal/internal/member-cap/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-uploads-internal": "1" },
+    body: JSON.stringify({ workspace: org.slug }),
+  });
+  if (!capCheck.ok) {
+    const payload = await capCheck.json().catch(() => null);
+    throwForInviteError(capCheck.status, payload);
+  }
+
+  const enrollment = await createEnrollment(dbFor(c.env), {
+    workspace: org.slug,
+    label,
+    scopes: [],
+    kind: "member",
+    enrollmentSeconds: DEFAULT_ENROLLMENT_SECONDS,
+    tokenSeconds: DEFAULT_TOKEN_SECONDS,
+  });
+
+  const webOrigin = c.env.WEB_ORIGIN || deriveWebOrigin(c.req.url);
+  const url = inviteLinkUrl(webOrigin, enrollment.pageId, enrollment.code);
+
+  return c.json(
+    {
+      workspace: org.slug,
+      id: enrollment.id,
+      pageId: enrollment.pageId,
+      label: label ?? null,
+      url,
+      expiresAt: enrollment.expiresAt,
+    },
+    201,
+  );
+}
+
+/** `GET /:workspace/invite-links` — outstanding `kind: 'member'` links only;
+ * never the plaintext code or its hash (show-once stays show-once). */
+export async function inviteLinkListHandler(c: Context<MembersVars>) {
+  const org = c.get("memberOrg");
+  const links = await listOpenEnrollments(dbFor(c.env), org.slug, new Date(), "member");
+  return c.json({ links });
+}
+
+/** `DELETE /:workspace/invite-links/:id` — revoke one outstanding
+ * `kind: 'member'` link before it's redeemed; the `kind` filter means this
+ * can never revoke a token-kind link minted from `/admin`. */
+export async function inviteLinkRevokeHandler(c: Context<MembersVars>) {
+  const org = c.get("memberOrg");
+  if (!(await allowWrite(c.env, org.slug))) throw new RateLimitedError("rate limit exceeded");
+  const id = c.req.param("id") ?? "";
+  const revoked = await revokeEnrollment(dbFor(c.env), org.slug, id, "member");
+  if (!revoked) {
+    throw new NotFoundError("invite link not found", { code: "invite_link_not_found" });
+  }
+  return c.json({ ok: true, id });
+}
+
 export const workspaceMembers = new Hono<MembersVars>()
   .get("/:workspace/members", sessionMemberGate(), membersHandler)
   .get("/:workspace/people", sessionMemberGate(), peopleHandler)
@@ -238,4 +351,7 @@ export const workspaceMembers = new Hono<MembersVars>()
   .delete("/:workspace/invites/:id", sessionAdminGate(), inviteRevokeHandler)
   .delete("/:workspace/members/:memberId", sessionAdminGate(), memberRemoveHandler)
   .patch("/:workspace/members/:memberId", sessionAdminGate(), memberRoleUpdateHandler)
+  .post("/:workspace/invite-links", sessionAdminGate(), inviteLinkMintHandler)
+  .get("/:workspace/invite-links", sessionAdminGate(), inviteLinkListHandler)
+  .delete("/:workspace/invite-links/:id", sessionAdminGate(), inviteLinkRevokeHandler)
   .onError((err, c) => respondError(c, err));

--- a/apps/api/src/routes/workspace-members.ts
+++ b/apps/api/src/routes/workspace-members.ts
@@ -57,6 +57,7 @@ import {
   createEnrollment,
   DEFAULT_ENROLLMENT_SECONDS,
   DEFAULT_TOKEN_SECONDS,
+  labelValue,
   listOpenEnrollments,
   revokeEnrollment,
 } from "../auth-db";
@@ -252,18 +253,6 @@ export async function memberRoleUpdateHandler(c: Context<MembersVars>) {
   return c.json({ member });
 }
 
-/** `sessionAdminGate`'s `MembersVars["memberOrg"]["slug"]` IS the workspace
- * name (the 1:1 org<->workspace mapping `org-workspaces.ts` documents), so
- * every invite-link handler below reuses it instead of re-reading (and
- * re-widening) the `:workspace` path param — same pattern as
- * `inviteRevokeHandler`'s `allowWrite(c.env, org.slug)` call above. */
-function labelValue(value: unknown): string | undefined | null {
-  if (value === undefined || value === null) return undefined;
-  if (typeof value !== "string") return null;
-  const label = value.trim();
-  return label.length >= 1 && label.length <= 100 ? label : null;
-}
-
 /**
  * 404s minting a member-kind invite link for a soft-deleted or
  * purged-tombstone workspace — same existence rule `loadEditableWorkspace`
@@ -281,6 +270,12 @@ async function requireLiveWorkspace(env: Env, name: string): Promise<void> {
 }
 
 /**
+ * `sessionAdminGate`'s `MembersVars["memberOrg"]["slug"]` IS the workspace
+ * name (the 1:1 org<->workspace mapping `org-workspaces.ts` documents), so
+ * every invite-link handler below reuses it instead of re-reading (and
+ * re-widening) the `:workspace` path param — same pattern as
+ * `inviteRevokeHandler`'s `allowWrite(c.env, org.slug)` call above.
+ *
  * `POST /:workspace/invite-links` — mint a `kind: 'member'` invite link
  * (issue #869 phase B). Its redemption (`POST /auth/enrollments/join`) adds
  * the redeemer as an org member with role `member`, never a CLI token — so
@@ -295,7 +290,20 @@ async function requireLiveWorkspace(env: Env, name: string): Promise<void> {
 export async function inviteLinkMintHandler(c: Context<MembersVars>) {
   const org = c.get("memberOrg");
   if (!(await allowWrite(c.env, org.slug))) throw new RateLimitedError("rate limit exceeded");
-  await requireLiveWorkspace(c.env, org.slug);
+
+  // requireLiveWorkspace (KV) and the AUTH member-cap-check fetch are
+  // independent lookups with no data dependency on each other — start both
+  // before awaiting either so their latencies overlap. requireLiveWorkspace
+  // is still awaited (and can still throw 404) before the label is
+  // validated and before the cap-check result is inspected, preserving
+  // today's precedence: not-found, then invalid label, then cap denial.
+  const liveWorkspace = requireLiveWorkspace(c.env, org.slug);
+  const capCheckFetch = c.env.AUTH.fetch("https://auth.internal/internal/member-cap/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-uploads-internal": "1" },
+    body: JSON.stringify({ workspace: org.slug }),
+  });
+  await liveWorkspace;
 
   const body = await c.req.json<{ label?: unknown }>().catch(() => ({}) as { label?: unknown });
   const label = labelValue(body.label);
@@ -305,11 +313,7 @@ export async function inviteLinkMintHandler(c: Context<MembersVars>) {
     });
   }
 
-  const capCheck = await c.env.AUTH.fetch("https://auth.internal/internal/member-cap/check", {
-    method: "POST",
-    headers: { "content-type": "application/json", "x-uploads-internal": "1" },
-    body: JSON.stringify({ workspace: org.slug }),
-  });
+  const capCheck = await capCheckFetch;
   if (!capCheck.ok) {
     const payload = await capCheck.json().catch(() => null);
     throwForInviteError(capCheck.status, payload);

--- a/apps/api/test/auth-db-enrollment-claim-sqlite.test.ts
+++ b/apps/api/test/auth-db-enrollment-claim-sqlite.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Issue #869 phase B follow-up (review cleanup): `claimMemberEnrollment` /
+ * `releaseEnrollmentClaim` were extracted out of `routes/auth.ts`'s join
+ * handler into `auth-db.ts` — see that file's docblocks. Route-level
+ * coverage for the full `/auth/enrollments/join` flow already lives in
+ * `routes-auth-join.test.ts`; this file covers the two helpers directly,
+ * sqlite-backed (real SQL, not the hand-rolled `FakeD1` in
+ * `auth-db.test.ts`) so the `kind = 'member'` / `code_hash` scoping is
+ * exercised for real.
+ */
+import { describe, expect, it } from "vitest";
+import { claimMemberEnrollment, createEnrollment, releaseEnrollmentClaim } from "../src/auth-db";
+import { database, SqliteD1 } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
+  "migrations/20260711120000_invite_pages.sql",
+  "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
+  "migrations/20260827160000_auth_enrollments_kind.sql",
+];
+
+function db() {
+  return database(new SqliteD1(MIGRATIONS)) as unknown as D1Database;
+}
+
+describe("claimMemberEnrollment", () => {
+  it("claims a member-kind link and marks it used", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, { workspace: "acme", scopes: [], kind: "member" });
+
+    const claim = await claimMemberEnrollment(d1, link.code);
+    expect(claim).toEqual({ id: link.id, workspace: "acme", codeHash: expect.any(String) });
+  });
+
+  it("is single-use: a second claim of the same code fails", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, { workspace: "acme", scopes: [], kind: "member" });
+
+    expect(await claimMemberEnrollment(d1, link.code)).not.toBeNull();
+    expect(await claimMemberEnrollment(d1, link.code)).toBeNull();
+  });
+
+  it("rejects a token-kind code — never exchangeable for membership", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, { workspace: "acme", scopes: ["files:read"] });
+    expect(await claimMemberEnrollment(d1, link.code)).toBeNull();
+  });
+
+  it("rejects an expired member-kind code", async () => {
+    const d1 = db();
+    const past = new Date("2020-01-01T00:00:00.000Z");
+    const link = await createEnrollment(d1, {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      enrollmentSeconds: 60,
+      now: past,
+    });
+    expect(await claimMemberEnrollment(d1, link.code)).toBeNull();
+  });
+
+  it("rejects an unknown code", async () => {
+    const d1 = db();
+    expect(await claimMemberEnrollment(d1, `upe_${"a".repeat(24)}`)).toBeNull();
+  });
+});
+
+describe("releaseEnrollmentClaim", () => {
+  it("restores used_at so the link is claimable again", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, { workspace: "acme", scopes: [], kind: "member" });
+
+    const claim = await claimMemberEnrollment(d1, link.code);
+    expect(claim).not.toBeNull();
+    await releaseEnrollmentClaim(d1, claim!.id, claim!.codeHash);
+
+    const reclaim = await claimMemberEnrollment(d1, link.code);
+    expect(reclaim).toEqual(claim);
+  });
+
+  it("is scoped to (id, code_hash) — a mismatched hash restores nothing", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, { workspace: "acme", scopes: [], kind: "member" });
+    const claim = await claimMemberEnrollment(d1, link.code);
+    expect(claim).not.toBeNull();
+
+    await releaseEnrollmentClaim(d1, claim!.id, "not-the-real-hash");
+    // Still claimed — the mismatched-hash release didn't touch the row.
+    expect(await claimMemberEnrollment(d1, link.code)).toBeNull();
+  });
+});

--- a/apps/api/test/auth-db.test.ts
+++ b/apps/api/test/auth-db.test.ts
@@ -6,7 +6,9 @@ import {
   exchangeEnrollment,
   findActiveToken,
   findEnrollmentPage,
+  listOpenEnrollments,
   parseScopes,
+  revokeEnrollment,
   touchTokenLastUsed,
 } from "../src/auth-db";
 
@@ -27,6 +29,10 @@ class FakeStatement {
 
   first<T>(): Promise<T | null> {
     return Promise.resolve(this.db.first(this) as T | null);
+  }
+
+  all<T>(): Promise<{ results: T[] }> {
+    return Promise.resolve({ results: this.db.all(this) as T[] });
   }
 
   run(): Promise<D1Result> {
@@ -136,7 +142,37 @@ class FakeD1 {
       enrollment.used_at = usedAt;
       return result(1);
     }
+    if (sql.startsWith("DELETE FROM auth_enrollments")) {
+      const [workspace, enrollmentId] = values;
+      const before = this.enrollments.length;
+      this.enrollments = this.enrollments.filter(
+        (row) => !(row.workspace === workspace && row.id === enrollmentId),
+      );
+      return result(before - this.enrollments.length);
+    }
     throw new Error(`unsupported run: ${sql}`);
+  }
+
+  all(statement: FakeStatement): Row[] {
+    const { sql, values } = statement;
+    if (sql.startsWith("SELECT id, page_id, label, scopes, created_at, expires_at")) {
+      const [workspace, now] = values as string[];
+      return this.enrollments
+        .filter(
+          (row) =>
+            row.workspace === workspace && row.used_at === null && (row.expires_at as string) > now,
+        )
+        .sort((a, b) => (b.created_at as string).localeCompare(a.created_at as string))
+        .map((row) => ({
+          id: row.id,
+          page_id: row.page_id,
+          label: row.label,
+          scopes: row.scopes,
+          created_at: row.created_at,
+          expires_at: row.expires_at,
+        }));
+    }
+    throw new Error(`unsupported all: ${sql}`);
   }
 
   async batch(statements: FakeStatement[]): Promise<D1Result[]> {
@@ -259,6 +295,96 @@ describe("D1 enrollment exchange", () => {
 
     expect(await exchangeEnrollment(database(fake), enrollment.code, later)).toBeNull();
     expect(await exchangeEnrollment(database(fake), "upe_unknown", later)).toBeNull();
+  });
+});
+
+describe("listOpenEnrollments", () => {
+  it("lists unredeemed, unexpired rows newest first, without code_hash", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    await createEnrollment(database(fake), {
+      workspace: "acme",
+      label: "first",
+      scopes: ["files:read"],
+      now,
+    });
+    await createEnrollment(database(fake), {
+      workspace: "acme",
+      label: "second",
+      scopes: ["files:read", "files:write"],
+      now: new Date(now.getTime() + 1000),
+    });
+
+    const links = await listOpenEnrollments(database(fake), "acme", now);
+    expect(links.map((l) => l.label)).toEqual(["second", "first"]);
+    expect(links[0]?.scopes).toEqual(["files:read", "files:write"]);
+    expect(links[0]?.pageId).toMatch(/^upi_/);
+    expect(JSON.stringify(links)).not.toContain("code_hash");
+  });
+
+  it("excludes other workspaces, used, and expired rows", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const other = await createEnrollment(database(fake), {
+      workspace: "other",
+      scopes: ["files:read"],
+      now,
+    });
+    const used = await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: ["files:read"],
+      now,
+    });
+    await exchangeEnrollment(database(fake), used.code, now);
+    await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: ["files:read"],
+      enrollmentSeconds: 60,
+      now,
+    });
+
+    const later = new Date(now.getTime() + 61_000);
+    const links = await listOpenEnrollments(database(fake), "acme", later);
+    expect(links).toEqual([]);
+    expect(other).toBeDefined();
+  });
+
+  it("returns an empty list for a workspace with no rows", async () => {
+    const fake = new FakeD1();
+    expect(await listOpenEnrollments(database(fake), "empty")).toEqual([]);
+  });
+});
+
+describe("revokeEnrollment", () => {
+  it("deletes a matching row and reports success", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const enrollment = await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: ["files:read"],
+      now,
+    });
+
+    expect(await revokeEnrollment(database(fake), "acme", enrollment.id)).toBe(true);
+    expect(fake.enrollments).toHaveLength(0);
+  });
+
+  it("is a no-op for an unknown id", async () => {
+    const fake = new FakeD1();
+    expect(await revokeEnrollment(database(fake), "acme", "nope")).toBe(false);
+  });
+
+  it("doesn't delete another workspace's row with the same id", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const enrollment = await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: ["files:read"],
+      now,
+    });
+
+    expect(await revokeEnrollment(database(fake), "other", enrollment.id)).toBe(false);
+    expect(fake.enrollments).toHaveLength(1);
   });
 });
 

--- a/apps/api/test/auth-db.test.ts
+++ b/apps/api/test/auth-db.test.ts
@@ -61,6 +61,7 @@ class FakeD1 {
             workspace: enrollment.workspace,
             expires_at: enrollment.expires_at,
             used_at: enrollment.used_at,
+            kind: enrollment.kind,
           }
         : null;
     }
@@ -69,7 +70,10 @@ class FakeD1 {
       return (
         this.enrollments.find(
           (row) =>
-            row.code_hash === hash && row.used_at === null && (row.expires_at as string) > now,
+            row.code_hash === hash &&
+            row.used_at === null &&
+            (row.expires_at as string) > now &&
+            row.kind === "token",
         ) ?? null
       );
     }
@@ -91,8 +95,18 @@ class FakeD1 {
   run(statement: FakeStatement): { meta: { changes: number }; success: true; results: never[] } {
     const { sql, values } = statement;
     if (sql.startsWith("INSERT INTO auth_enrollments")) {
-      const [id, workspace, codeHash, label, scopes, createdAt, expiresAt, tokenExpiresAt, pageId] =
-        values;
+      const [
+        id,
+        workspace,
+        codeHash,
+        label,
+        scopes,
+        createdAt,
+        expiresAt,
+        tokenExpiresAt,
+        pageId,
+        kind,
+      ] = values;
       this.enrollments.push({
         id,
         workspace,
@@ -104,6 +118,7 @@ class FakeD1 {
         token_expires_at: tokenExpiresAt,
         used_at: null,
         page_id: pageId,
+        kind,
       });
       return result(1);
     }
@@ -143,10 +158,15 @@ class FakeD1 {
       return result(1);
     }
     if (sql.startsWith("DELETE FROM auth_enrollments")) {
-      const [workspace, enrollmentId] = values;
+      const [workspace, enrollmentId, kind] = values;
       const before = this.enrollments.length;
       this.enrollments = this.enrollments.filter(
-        (row) => !(row.workspace === workspace && row.id === enrollmentId),
+        (row) =>
+          !(
+            row.workspace === workspace &&
+            row.id === enrollmentId &&
+            (kind === undefined || row.kind === kind)
+          ),
       );
       return result(before - this.enrollments.length);
     }
@@ -155,12 +175,15 @@ class FakeD1 {
 
   all(statement: FakeStatement): Row[] {
     const { sql, values } = statement;
-    if (sql.startsWith("SELECT id, page_id, label, scopes, created_at, expires_at")) {
-      const [workspace, now] = values as string[];
+    if (sql.startsWith("SELECT id, page_id, label, scopes, kind, created_at, expires_at")) {
+      const [workspace, now, kind] = values as string[];
       return this.enrollments
         .filter(
           (row) =>
-            row.workspace === workspace && row.used_at === null && (row.expires_at as string) > now,
+            row.workspace === workspace &&
+            row.used_at === null &&
+            (row.expires_at as string) > now &&
+            (kind === undefined || row.kind === kind),
         )
         .sort((a, b) => (b.created_at as string).localeCompare(a.created_at as string))
         .map((row) => ({
@@ -168,6 +191,7 @@ class FakeD1 {
           page_id: row.page_id,
           label: row.label,
           scopes: row.scopes,
+          kind: row.kind,
           created_at: row.created_at,
           expires_at: row.expires_at,
         }));
@@ -234,6 +258,7 @@ describe("D1 enrollment exchange", () => {
       workspace: "default",
       expiresAt: enrollment.expiresAt,
       used: false,
+      kind: "token",
     });
     await expect(findEnrollmentPage(database(fake), "upi_invalid", now)).resolves.toBeNull();
   });
@@ -296,6 +321,40 @@ describe("D1 enrollment exchange", () => {
     expect(await exchangeEnrollment(database(fake), enrollment.code, later)).toBeNull();
     expect(await exchangeEnrollment(database(fake), "upe_unknown", later)).toBeNull();
   });
+
+  // Issue #869 phase B: a workspace-admin join link (`kind: 'member'`) must
+  // never mint a CLI token — same uniform null failure as any other invalid
+  // code, so probing this endpoint can't distinguish "wrong kind" from
+  // "invalid/expired/used".
+  it("rejects a member-kind code with the same uniform failure", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const enrollment = await createEnrollment(database(fake), {
+      workspace: "default",
+      scopes: [],
+      kind: "member",
+      now,
+    });
+
+    expect(await exchangeEnrollment(database(fake), enrollment.code, now)).toBeNull();
+    expect(fake.tokens).toHaveLength(0);
+    // The link stays unredeemed — a rejected exchange doesn't burn it.
+    expect(fake.enrollments[0]?.used_at).toBeNull();
+  });
+});
+
+describe("enrollment kind", () => {
+  it("defaults to 'token' when not specified", async () => {
+    const fake = new FakeD1();
+    await createEnrollment(database(fake), { workspace: "acme", scopes: ["files:read"] });
+    expect(fake.enrollments[0]?.kind).toBe("token");
+  });
+
+  it("passes an explicit kind through to storage", async () => {
+    const fake = new FakeD1();
+    await createEnrollment(database(fake), { workspace: "acme", scopes: [], kind: "member" });
+    expect(fake.enrollments[0]?.kind).toBe("member");
+  });
 });
 
 describe("listOpenEnrollments", () => {
@@ -353,6 +412,31 @@ describe("listOpenEnrollments", () => {
     const fake = new FakeD1();
     expect(await listOpenEnrollments(database(fake), "empty")).toEqual([]);
   });
+
+  // Issue #869 phase B: the People page's list must show only its own
+  // 'member'-kind links, never a token-kind link minted from /admin.
+  it("filters by kind when passed, and includes kind in every row", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    await createEnrollment(database(fake), { workspace: "acme", scopes: ["files:read"], now });
+    await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      now: new Date(now.getTime() + 1000),
+    });
+
+    const all = await listOpenEnrollments(database(fake), "acme", now);
+    expect(all.map((l) => l.kind).sort()).toEqual(["member", "token"]);
+
+    const memberOnly = await listOpenEnrollments(database(fake), "acme", now, "member");
+    expect(memberOnly).toHaveLength(1);
+    expect(memberOnly[0]?.kind).toBe("member");
+
+    const tokenOnly = await listOpenEnrollments(database(fake), "acme", now, "token");
+    expect(tokenOnly).toHaveLength(1);
+    expect(tokenOnly[0]?.kind).toBe("token");
+  });
 });
 
 describe("revokeEnrollment", () => {
@@ -385,6 +469,21 @@ describe("revokeEnrollment", () => {
 
     expect(await revokeEnrollment(database(fake), "other", enrollment.id)).toBe(false);
     expect(fake.enrollments).toHaveLength(1);
+  });
+
+  it("doesn't delete a row of the wrong kind when a kind filter is passed", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const enrollment = await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: ["files:read"],
+      now,
+    });
+
+    expect(await revokeEnrollment(database(fake), "acme", enrollment.id, "member")).toBe(false);
+    expect(fake.enrollments).toHaveLength(1);
+    expect(await revokeEnrollment(database(fake), "acme", enrollment.id, "token")).toBe(true);
+    expect(fake.enrollments).toHaveLength(0);
   });
 });
 

--- a/apps/api/test/routes-auth-join.test.ts
+++ b/apps/api/test/routes-auth-join.test.ts
@@ -227,10 +227,81 @@ describe("POST /auth/enrollments/join", () => {
     expect(retry.status).toBe(200);
   });
 
-  // Review finding 6: a rejected AUTH.fetch (transport failure, not an HTTP
-  // error) must not skip the restore — otherwise the link is burned with no
-  // member ever added.
-  it("restores the link when the AUTH fetch itself rejects (transport failure)", async () => {
+  // CodeRabbit review (issue #869 follow-up): a thrown first attempt to
+  // `/internal/join` is reconciled by retrying the identical call, not by
+  // blindly restoring the claim — `/internal/join` is idempotent, so the
+  // retry tells us the real outcome.
+  it("retries once on a rejected AUTH fetch and succeeds if the retry is ok", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db);
+    let calls = 0;
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({
+        db,
+        joinResponse: () => {
+          calls++;
+          if (calls === 1) throw new Error("network exploded");
+          return Response.json({ alreadyMember: false }, { status: 201 });
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ workspace: "acme", alreadyMember: false });
+    expect(calls).toBe(2);
+
+    // The claim was consumed by the retry's success — the code is single-use.
+    const replay = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(replay.status).toBe(400);
+  });
+
+  // A thrown first attempt followed by a retry that reports `alreadyMember`
+  // may mean OUR OWN first attempt actually committed the membership before
+  // the transport failed — restoring the claim there would hand the code a
+  // second seat, so the claim-restore is skipped on the retry path.
+  it("does not restore the claim when a retry after a throw reports alreadyMember", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db);
+    let calls = 0;
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({
+        db,
+        joinResponse: () => {
+          calls++;
+          if (calls === 1) throw new Error("network exploded");
+          return Response.json({ alreadyMember: true }, { status: 200 });
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ workspace: "acme", alreadyMember: true });
+
+    // The claim was NOT restored — a second user cannot reuse the code.
+    const otherUser = { id: "u-other", email: "other@example.com", name: "Other" };
+    const replay = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db, sessionUser: otherUser }),
+    );
+    expect(replay.status).toBe(400);
+    expect(((await replay.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_enrollment",
+    );
+  });
+
+  // When both the first attempt AND the retry reject, the outcome is
+  // genuinely unknown (the downstream worker may have committed the
+  // membership before either transport failure) — fail closed: don't
+  // restore the claim, and surface the same retryable service-unavailable
+  // error as the cap-lookup outage path.
+  it("fails closed (no restore) when both the AUTH fetch and its retry reject", async () => {
     const db = new SqliteD1(MIGRATIONS);
     const link = await mintMemberLink(db);
     const res = await app.request(
@@ -243,17 +314,21 @@ describe("POST /auth/enrollments/join", () => {
         },
       }),
     );
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(503);
     expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
-      "invalid_enrollment",
+      "cap_check_unavailable",
     );
 
+    // The link stays burned — it was never restored.
     const retry = await app.request(
       "/auth/enrollments/join",
       { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
       makeEnv({ db }),
     );
-    expect(retry.status).toBe(200);
+    expect(retry.status).toBe(400);
+    expect(((await retry.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_enrollment",
+    );
   });
 
   it("rejects a token-kind code uniformly (not exchangeable for membership)", async () => {

--- a/apps/api/test/routes-auth-join.test.ts
+++ b/apps/api/test/routes-auth-join.test.ts
@@ -112,7 +112,7 @@ describe("POST /auth/enrollments/join", () => {
     );
   });
 
-  it("passes through alreadyMember: true without erroring", async () => {
+  it("passes through alreadyMember: true and restores the link — no seat was consumed", async () => {
     const db = new SqliteD1(MIGRATIONS);
     const link = await mintMemberLink(db);
     const res = await app.request(
@@ -122,6 +122,17 @@ describe("POST /auth/enrollments/join", () => {
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ workspace: "acme", alreadyMember: true });
+
+    // Review finding 2: an alreadyMember redemption must not burn the link —
+    // a different user can still redeem it afterward.
+    const otherUser = { id: "u-other", email: "other@example.com", name: "Other" };
+    const retry = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db, sessionUser: otherUser }),
+    );
+    expect(retry.status).toBe(200);
+    expect(await retry.json()).toEqual({ workspace: "acme", alreadyMember: false });
   });
 
   it("403s with member_cap_reached on cap denial, and restores the link (not burned)", async () => {
@@ -165,6 +176,72 @@ describe("POST /auth/enrollments/join", () => {
       "/auth/enrollments/join",
       { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
       makeEnv({ db, joinResponse: () => new Response(null, { status: 500 }) }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_enrollment",
+    );
+
+    const retry = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(retry.status).toBe(200);
+  });
+
+  // Review finding 3: redemption-time cap enforcement fails CLOSED — a
+  // lookup-failure 503 from apps/auth must surface as a distinct, retryable
+  // error, not the generic "invalid or expired" a plain cap denial gets.
+  it("maps a 503 cap_check_unavailable to a retryable error, and restores the link", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db);
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({
+        db,
+        joinResponse: () =>
+          Response.json(
+            {
+              error: {
+                code: "cap_check_unavailable",
+                message: "couldn't verify this workspace's member limit",
+              },
+            },
+            { status: 503 },
+          ),
+      }),
+    );
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "cap_check_unavailable",
+    );
+
+    // Not burned — retryable really means retryable.
+    const retry = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(retry.status).toBe(200);
+  });
+
+  // Review finding 6: a rejected AUTH.fetch (transport failure, not an HTTP
+  // error) must not skip the restore — otherwise the link is burned with no
+  // member ever added.
+  it("restores the link when the AUTH fetch itself rejects (transport failure)", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db);
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({
+        db,
+        joinResponse: () => {
+          throw new Error("network exploded");
+        },
+      }),
     );
     expect(res.status).toBe(400);
     expect(((await res.json()) as { error: { code: string } }).error.code).toBe(

--- a/apps/api/test/routes-auth-join.test.ts
+++ b/apps/api/test/routes-auth-join.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Issue #869 phase B: `POST /auth/enrollments/join` — redeems a
+ * workspace-admin `kind: 'member'` invite link as org membership (never a
+ * CLI token; that's `/auth/enrollments/exchange`, `kind: 'token'` only).
+ * Exercised through the real composed `app` (index.ts), same style as
+ * `routes-workspace-members.test.ts`.
+ */
+import { describe, expect, it } from "vitest";
+import { createEnrollment } from "../src/auth-db";
+import { app } from "../src/index";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
+  "migrations/20260711120000_invite_pages.sql",
+  "migrations/20260712230000_token_minting_user.sql",
+  "migrations/20260817180000_token_last_used.sql",
+  "migrations/20260827160000_auth_enrollments_kind.sql",
+];
+
+const USER = { id: "u-joiner", email: "joiner@example.com", name: "Joiner" };
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+interface EnvOpts {
+  sessionUser?: typeof USER | null;
+  db?: SqliteD1;
+  joinResponse?: (body: { organizationSlug?: string; userId?: string }) => Response;
+  inviteAllowed?: boolean;
+  joinCalls?: { count: number };
+}
+
+function makeEnv(opts: EnvOpts = {}) {
+  const {
+    sessionUser = USER,
+    db = new SqliteD1(MIGRATIONS),
+    joinResponse,
+    inviteAllowed,
+    joinCalls,
+  } = opts;
+
+  const auth = stubAuth(async (req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/auth/get-session") {
+      return sessionUser
+        ? Response.json({ session: {}, user: sessionUser })
+        : new Response(null, { status: 401 });
+    }
+    if (url.pathname === "/internal/join" && req.method === "POST") {
+      if (joinCalls) joinCalls.count++;
+      const body = (await req.json()) as { organizationSlug?: string; userId?: string };
+      if (joinResponse) return joinResponse(body);
+      return Response.json({ alreadyMember: false }, { status: 201 });
+    }
+    return new Response(null, { status: 404 });
+  });
+
+  const env = { AUTH: auth, DB: database(db) } as unknown as Env;
+  if (inviteAllowed !== undefined) {
+    (env as unknown as { INVITE_LIMITER: unknown }).INVITE_LIMITER = {
+      limit: async () => ({ success: inviteAllowed }),
+    };
+  }
+  return env;
+}
+
+const sessionHeaders = { cookie: "session=x", "content-type": "application/json" };
+
+async function mintMemberLink(db: SqliteD1, workspace = "acme") {
+  return createEnrollment(database(db) as unknown as D1Database, {
+    workspace,
+    scopes: [],
+    kind: "member",
+  });
+}
+
+async function mintTokenLink(db: SqliteD1, workspace = "acme") {
+  return createEnrollment(database(db) as unknown as D1Database, {
+    workspace,
+    scopes: ["files:read"],
+  });
+}
+
+describe("POST /auth/enrollments/join", () => {
+  it("adds the signed-in user as a member and marks the link used", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db);
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ workspace: "acme", alreadyMember: false });
+
+    // Single-use: a second redemption of the same code is rejected uniformly.
+    const replay = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(replay.status).toBe(400);
+    expect(((await replay.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_enrollment",
+    );
+  });
+
+  it("passes through alreadyMember: true without erroring", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db);
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db, joinResponse: () => Response.json({ alreadyMember: true }, { status: 200 }) }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ workspace: "acme", alreadyMember: true });
+  });
+
+  it("403s with member_cap_reached on cap denial, and restores the link (not burned)", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db);
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({
+        db,
+        joinResponse: () =>
+          Response.json(
+            {
+              error: {
+                code: "member_cap_reached",
+                message: "This workspace has reached its member limit.",
+              },
+            },
+            { status: 403 },
+          ),
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "member_cap_reached",
+    );
+
+    // The link was NOT burned — a later successful join call still works.
+    const retry = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(retry.status).toBe(200);
+  });
+
+  it("restores the link on a transient auth-worker failure too", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db);
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db, joinResponse: () => new Response(null, { status: 500 }) }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_enrollment",
+    );
+
+    const retry = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(retry.status).toBe(200);
+  });
+
+  it("rejects a token-kind code uniformly (not exchangeable for membership)", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintTokenLink(db);
+    const joinCalls = { count: 0 };
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db, joinCalls }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_enrollment",
+    );
+    // Never even reaches the auth worker's member-add path.
+    expect(joinCalls.count).toBe(0);
+  });
+
+  it("rejects an expired member-kind code uniformly", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const past = new Date("2020-01-01T00:00:00.000Z");
+    const link = await createEnrollment(database(db) as unknown as D1Database, {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      enrollmentSeconds: 60,
+      now: past,
+    });
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_enrollment",
+    );
+  });
+
+  it("rejects an unknown code uniformly", async () => {
+    const res = await app.request(
+      "/auth/enrollments/join",
+      {
+        method: "POST",
+        headers: sessionHeaders,
+        body: JSON.stringify({ code: `upe_${"a".repeat(24)}` }),
+      },
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_enrollment",
+    );
+  });
+
+  it("401s when not signed in, without ever claiming the link", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db);
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db, sessionUser: null }),
+    );
+    expect(res.status).toBe(401);
+
+    // The link is still redeemable — signing out and back in doesn't burn it.
+    const retry = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(retry.status).toBe(200);
+  });
+
+  it("enforces its own rate-limit quota, keyed separately from exchange/lookup", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db);
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db, inviteAllowed: false }),
+    );
+    expect(res.status).toBe(429);
+  });
+
+  it("uses the same 1KB/single-key/prefix hygiene as exchange", async () => {
+    const bodies = [
+      "{}",
+      "null",
+      JSON.stringify({ code: "upe_bad" }),
+      JSON.stringify({ code: `upe_${"a".repeat(24)}`, extra: true }),
+    ];
+    const env = makeEnv();
+    const responses = await Promise.all(
+      bodies.map((body) =>
+        app.request(
+          "/auth/enrollments/join",
+          { method: "POST", headers: sessionHeaders, body },
+          env,
+        ),
+      ),
+    );
+    expect(responses.map((r) => r.status)).toEqual([400, 400, 400, 400]);
+  });
+});

--- a/apps/api/test/routes-workspace-members.test.ts
+++ b/apps/api/test/routes-workspace-members.test.ts
@@ -18,8 +18,10 @@ import { SqliteD1, database } from "./helpers/sqlite-d1";
 
 const MIGRATIONS = [
   "migrations/20260710120000_auth.sql",
+  "migrations/20260711120000_invite_pages.sql",
   "migrations/20260712230000_token_minting_user.sql",
   "migrations/20260817180000_token_last_used.sql",
+  "migrations/20260827160000_auth_enrollments_kind.sql",
 ];
 
 const ADMIN = { id: "u-admin", email: "admin@example.com", name: "Admin" };
@@ -53,6 +55,9 @@ interface EnvOpts {
   db?: SqliteD1;
   onDelete?: (path: string) => Response;
   onPatch?: (path: string, body: unknown) => Response;
+  /** `undefined` = the cap check always 200s ok. */
+  memberCapDenied?: boolean;
+  onJoin?: (body: { organizationSlug?: string; userId?: string }) => Response;
 }
 
 function makeEnv(opts: EnvOpts = {}) {
@@ -67,6 +72,8 @@ function makeEnv(opts: EnvOpts = {}) {
     db = new SqliteD1(MIGRATIONS),
     onDelete,
     onPatch,
+    memberCapDenied = false,
+    onJoin,
   } = opts;
 
   const auth = stubAuth(async (req) => {
@@ -102,6 +109,25 @@ function makeEnv(opts: EnvOpts = {}) {
         { invitation: { id: "inv-1", email: body.email, role: "member", status: "pending" } },
         { status: 201 },
       );
+    }
+    if (url.pathname === "/internal/member-cap/check" && req.method === "POST") {
+      if (memberCapDenied) {
+        return Response.json(
+          {
+            error: {
+              code: "member_cap_reached",
+              message: "This workspace has reached its member limit.",
+            },
+          },
+          { status: 403 },
+        );
+      }
+      return Response.json({ ok: true });
+    }
+    if (url.pathname === "/internal/join" && req.method === "POST") {
+      const body = (await req.json()) as { organizationSlug?: string; userId?: string };
+      if (onJoin) return onJoin(body);
+      return Response.json({ alreadyMember: false }, { status: 201 });
     }
     if (req.method === "DELETE" && onDelete) return onDelete(url.pathname);
     if (req.method === "DELETE") return new Response(null, { status: 200 });
@@ -465,6 +491,234 @@ describe("POST /v1/workspaces/:workspace/invites (dual governance auth)", () => 
     expect(res.status).toBe(201);
     const body = (await res.json()) as { invitation: { email: string } };
     expect(body.invitation.email).toBe("bearer-session@example.com");
+  });
+});
+
+// Issue #869 phase B: workspace-admin "join" invite links.
+describe("POST /v1/workspaces/:workspace/invite-links", () => {
+  it("mints a kind:'member' link for an admin session", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ label: "for the design team" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      workspace: string;
+      id: string;
+      pageId: string;
+      label: string;
+      url: string;
+      expiresAt: string;
+    };
+    expect(body.workspace).toBe("acme");
+    expect(body.label).toBe("for the design team");
+    expect(body.pageId).toMatch(/^upi_/);
+    expect(body.url).toContain(body.pageId);
+    expect(body.url).toContain("#code=");
+    // The plaintext code is never persisted — only the show-once URL carries it.
+    expect(JSON.stringify(body)).not.toContain("code_hash");
+  });
+
+  it("defaults label to null when omitted", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as { label: unknown }).label).toBeNull();
+  });
+
+  it("400s for an invalid label", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ label: "" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe("invalid_label");
+  });
+
+  it("403s with member_cap_reached when the workspace is at cap, and mints no row", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const env = makeEnv({ db, memberCapDenied: true });
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "member_cap_reached",
+    );
+    const list = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      { headers: sessionHeaders },
+      makeEnv({ db }),
+    );
+    expect(((await list.json()) as { links: unknown[] }).links).toHaveLength(0);
+  });
+
+  it("non-admin member session 403s", async () => {
+    const env = makeEnv({
+      sessionUser: MEMBER,
+      memberships: [{ organizationId: "org-1", organizationSlug: "acme", role: "member" }],
+    });
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_admin_required",
+    );
+  });
+
+  it("non-member session 404s", async () => {
+    const env = makeEnv({ memberships: [] });
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("bearer token 403s (no bearer capability for this route)", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      { method: "POST", headers: { Authorization: "Bearer up_acme_whatever" }, body: "{}" },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "members_requires_session",
+    );
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/invite-links + DELETE .../:id", () => {
+  async function mint(db: SqliteD1, label?: string) {
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify(label ? { label } : {}),
+      },
+      makeEnv({ db }),
+    );
+    return (await res.json()) as { id: string; pageId: string };
+  }
+
+  it("lists only outstanding kind:'member' links, isolated per workspace", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    await mint(db, "one");
+    await mint(db, "two");
+
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      { headers: sessionHeaders },
+      makeEnv({ db }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { links: { label: string | null; kind?: string }[] };
+    expect(body.links.map((l) => l.label).sort()).toEqual(["one", "two"]);
+    // code_hash (or the plaintext code) is never exposed by the list.
+    expect(JSON.stringify(body)).not.toContain("code_hash");
+  });
+
+  it("revoke deletes the link so it no longer appears in the list", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mint(db, "revoke-me");
+
+    const del = await app.request(
+      `/v1/workspaces/acme/invite-links/${link.id}`,
+      { method: "DELETE", headers: sessionHeaders },
+      makeEnv({ db }),
+    );
+    expect(del.status).toBe(200);
+    expect(await del.json()).toEqual({ ok: true, id: link.id });
+
+    const list = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      { headers: sessionHeaders },
+      makeEnv({ db }),
+    );
+    expect(((await list.json()) as { links: unknown[] }).links).toHaveLength(0);
+  });
+
+  it("revoke 404s for an unknown id", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links/nope",
+      { method: "DELETE", headers: sessionHeaders },
+      makeEnv({ db }),
+    );
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "invite_link_not_found",
+    );
+  });
+
+  it("list: non-admin member 403s, non-member 404s, bearer 403s", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    await mint(db, "one");
+
+    const memberRes = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      { headers: sessionHeaders },
+      makeEnv({
+        db,
+        sessionUser: MEMBER,
+        memberships: [{ organizationId: "org-1", organizationSlug: "acme", role: "member" }],
+      }),
+    );
+    expect(memberRes.status).toBe(403);
+
+    const nonMemberRes = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      { headers: sessionHeaders },
+      makeEnv({ db, memberships: [] }),
+    );
+    expect(nonMemberRes.status).toBe(404);
+
+    const bearerRes = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      { headers: { Authorization: "Bearer up_acme_whatever" } },
+      makeEnv({ db }),
+    );
+    expect(bearerRes.status).toBe(403);
   });
 });
 

--- a/apps/api/test/routes-workspace-members.test.ts
+++ b/apps/api/test/routes-workspace-members.test.ts
@@ -58,6 +58,10 @@ interface EnvOpts {
   /** `undefined` = the cap check always 200s ok. */
   memberCapDenied?: boolean;
   onJoin?: (body: { organizationSlug?: string; userId?: string }) => Response;
+  /** `undefined` = a live workspace record; `null` = no record at all (KV
+   * miss); otherwise a raw record shape (e.g. `{ deletedAt: "..." }` or
+   * `{ status: "purged", ... }`) for review finding 5's soft-delete guard. */
+  workspaceRecord?: Record<string, unknown> | null;
 }
 
 function makeEnv(opts: EnvOpts = {}) {
@@ -74,6 +78,7 @@ function makeEnv(opts: EnvOpts = {}) {
     onPatch,
     memberCapDenied = false,
     onJoin,
+    workspaceRecord = { provider: "r2", bucket: "test" },
   } = opts;
 
   const auth = stubAuth(async (req) => {
@@ -138,7 +143,13 @@ function makeEnv(opts: EnvOpts = {}) {
     return new Response(null, { status: 404 });
   });
 
-  return { AUTH: auth, DB: database(db) } as unknown as Env;
+  const REGISTRY = {
+    get: async (_key: string, _opts?: unknown) =>
+      workspaceRecord === null ? null : { ...workspaceRecord, name: "acme" },
+    put: async () => undefined,
+  };
+
+  return { AUTH: auth, DB: database(db), REGISTRY } as unknown as Env;
 }
 
 const sessionHeaders = { cookie: "session=x" };
@@ -625,6 +636,69 @@ describe("POST /v1/workspaces/:workspace/invite-links", () => {
       "members_requires_session",
     );
   });
+
+  // Review finding 5: minting a member-kind link for a workspace mid-deletion
+  // must 404, same existence rule `loadEditableWorkspace` (routes/admin-ui.ts)
+  // already applies to the admin-minted token-kind links.
+  it("404s minting for a soft-deleted workspace, and mints no row", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const env = makeEnv({
+      db,
+      workspaceRecord: { provider: "r2", bucket: "test", deletedAt: "2026-08-01T00:00:00.000Z" },
+    });
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_not_found",
+    );
+    const list = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      { headers: sessionHeaders },
+      makeEnv({ db }),
+    );
+    expect(((await list.json()) as { links: unknown[] }).links).toHaveLength(0);
+  });
+
+  it("404s minting for a purged-tombstone workspace", async () => {
+    const env = makeEnv({
+      workspaceRecord: { status: "purged", name: "acme", purgedAt: "2026-08-15T00:00:00.000Z" },
+    });
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_not_found",
+    );
+  });
+
+  it("404s minting for a workspace with no registry record at all", async () => {
+    const env = makeEnv({ workspaceRecord: null });
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
 });
 
 describe("GET /v1/workspaces/:workspace/invite-links + DELETE .../:id", () => {
@@ -656,6 +730,42 @@ describe("GET /v1/workspaces/:workspace/invite-links + DELETE .../:id", () => {
     expect(body.links.map((l) => l.label).sort()).toEqual(["one", "two"]);
     // code_hash (or the plaintext code) is never exposed by the list.
     expect(JSON.stringify(body)).not.toContain("code_hash");
+  });
+
+  // Review finding 5 explicitly leaves list/revoke unguarded — useful during
+  // a soft-delete's grace period (unlike mint, which 404s: see the "POST"
+  // describe block above).
+  it("list still works for a soft-deleted workspace's outstanding links", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    await mint(db, "minted-while-live");
+
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      { headers: sessionHeaders },
+      makeEnv({
+        db,
+        workspaceRecord: { provider: "r2", bucket: "test", deletedAt: "2026-08-01T00:00:00.000Z" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(
+      ((await res.json()) as { links: { label: string | null }[] }).links.map((l) => l.label),
+    ).toEqual(["minted-while-live"]);
+  });
+
+  it("revoke still works for a soft-deleted workspace", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mint(db, "revoke-me-while-deleted");
+
+    const del = await app.request(
+      `/v1/workspaces/acme/invite-links/${link.id}`,
+      { method: "DELETE", headers: sessionHeaders },
+      makeEnv({
+        db,
+        workspaceRecord: { provider: "r2", bucket: "test", deletedAt: "2026-08-01T00:00:00.000Z" },
+      }),
+    );
+    expect(del.status).toBe(200);
   });
 
   it("revoke deletes the link so it no longer appears in the list", async () => {

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -1669,5 +1669,124 @@ describe("DB-backed behavior", () => {
         .where(and(eq(schema.member.organizationId, org.id), eq(schema.member.userId, joiner.id)));
       expect(rows).toHaveLength(0);
     });
+
+    // Review finding 3: redemption-time cap enforcement fails CLOSED, unlike
+    // mint-time (`/internal/member-cap/check`, tested above) and the
+    // email-invite path (`memberCapDenial`, `member-cap.test.ts`), which stay
+    // fail-open. A lookup failure here must deny the join with a distinct,
+    // retryable error rather than silently letting it through.
+    it("503s with cap_check_unavailable — not a silent unlimited pass — when the cap lookup fails", async () => {
+      const org = await seedOrg();
+      const joiner = await seedUser();
+      const api = {
+        fetch: async () => new Response(JSON.stringify({ error: "boom" }), { status: 500 }),
+      } as unknown as Fetcher;
+
+      const res = await join(
+        { organizationSlug: org.slug, userId: joiner.id },
+        dbEnv({ API: api, BILLING_INTERNAL_KEY: "shh-internal" } as unknown as Partial<AuthEnv>),
+      );
+      expect(res.status).toBe(503);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "cap_check_unavailable" },
+      });
+
+      const rows = await orm
+        .select()
+        .from(schema.member)
+        .where(and(eq(schema.member.organizationId, org.id), eq(schema.member.userId, joiner.id)));
+      expect(rows).toHaveLength(0);
+    });
+
+    // Review finding 4: the membership insert is the authoritative guard, not
+    // the pre-check SELECT — a plain check-then-insert has a race window
+    // between them. Simulated here by making the cap-lookup fetch (which runs
+    // between the pre-check and the insert) itself write a competing member
+    // row, standing in for a concurrent request that wins the race.
+    describe("concurrent redemption (atomic insert as the guard)", () => {
+      it("a competing join that lands mid-request resolves to alreadyMember, not a duplicate row", async () => {
+        const org = await seedOrg();
+        const joiner = await seedUser();
+        const api = {
+          fetch: async () => {
+            // Simulate a concurrent request completing its own join for the
+            // same user in the window between our pre-check and our insert.
+            await orm.insert(schema.member).values({
+              id: crypto.randomUUID(),
+              organizationId: org.id,
+              userId: joiner.id,
+              role: "member",
+              createdAt: new Date(),
+            });
+            return new Response(JSON.stringify({ workspace: org.slug, cap: null, message: null }), {
+              status: 200,
+            });
+          },
+        } as unknown as Fetcher;
+
+        const res = await join(
+          { organizationSlug: org.slug, userId: joiner.id },
+          dbEnv({ API: api, BILLING_INTERNAL_KEY: "shh-internal" } as unknown as Partial<AuthEnv>),
+        );
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ alreadyMember: true });
+
+        const rows = await orm
+          .select()
+          .from(schema.member)
+          .where(
+            and(eq(schema.member.organizationId, org.id), eq(schema.member.userId, joiner.id)),
+          );
+        expect(rows).toHaveLength(1); // exactly one — no duplicate from our own insert
+      });
+
+      it("a competing join that fills the cap mid-request denies ours rather than overshooting", async () => {
+        const org = await seedOrg();
+        const owner = await seedUser();
+        await orm.insert(schema.member).values({
+          id: crypto.randomUUID(),
+          organizationId: org.id,
+          userId: owner.id,
+          role: "owner",
+          createdAt: new Date(),
+        });
+        const joiner = await seedUser();
+        const other = await seedUser();
+        const api = {
+          fetch: async () => {
+            // Fills the 2-seat cap (owner + this concurrent joiner) before
+            // our insert's WHERE clause re-counts seats.
+            await orm.insert(schema.member).values({
+              id: crypto.randomUUID(),
+              organizationId: org.id,
+              userId: other.id,
+              role: "member",
+              createdAt: new Date(),
+            });
+            return new Response(
+              JSON.stringify({ workspace: org.slug, cap: 2, message: "At cap." }),
+              {
+                status: 200,
+              },
+            );
+          },
+        } as unknown as Fetcher;
+
+        const res = await join(
+          { organizationSlug: org.slug, userId: joiner.id },
+          dbEnv({ API: api, BILLING_INTERNAL_KEY: "shh-internal" } as unknown as Partial<AuthEnv>),
+        );
+        expect(res.status).toBe(403);
+        expect((await res.json()) as { error: { code: string } }).toMatchObject({
+          error: { code: "member_cap_reached" },
+        });
+
+        const rows = await orm
+          .select()
+          .from(schema.member)
+          .where(eq(schema.member.organizationId, org.id));
+        expect(rows).toHaveLength(2); // owner + the concurrent joiner only — cap held
+      });
+    });
   });
 });

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -1474,4 +1474,200 @@ describe("DB-backed behavior", () => {
       });
     });
   });
+
+  // Issue #869 phase B: mint-time member-cap check backing
+  // `POST /v1/workspaces/:workspace/invite-links` (apps/api). No `API`
+  // binding is configured in `dbEnv()`, so `memberCapDenial` fails open
+  // (unlimited) unless a test wires one up — matching `member-cap.test.ts`'s
+  // fail-open coverage, not re-litigated here.
+  describe("POST /internal/member-cap/check", () => {
+    it("400s when workspace is missing", async () => {
+      const res = await app().request(
+        "/internal/member-cap/check",
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+        dbEnv(),
+      );
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "invalid_request" },
+      });
+    });
+
+    it("404s for an unknown workspace", async () => {
+      const res = await app().request(
+        "/internal/member-cap/check",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ workspace: "nope" }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "organization_not_found" },
+      });
+    });
+
+    it("200s (ok:true) when under cap or the cap lookup fails open", async () => {
+      const org = await seedOrg();
+      const res = await app().request(
+        "/internal/member-cap/check",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ workspace: org.slug }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+    });
+
+    it("403s with member_cap_reached when the workspace is at cap", async () => {
+      const org = await seedOrg();
+      const owner = await seedUser();
+      await orm.insert(schema.member).values({
+        id: crypto.randomUUID(),
+        organizationId: org.id,
+        userId: owner.id,
+        role: "owner",
+        createdAt: new Date(),
+      });
+      const api = {
+        fetch: async () =>
+          new Response(JSON.stringify({ workspace: org.slug, cap: 1, message: "At cap." }), {
+            status: 200,
+          }),
+      } as unknown as Fetcher;
+      const res = await app().request(
+        "/internal/member-cap/check",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ workspace: org.slug }),
+        },
+        dbEnv({ API: api, BILLING_INTERNAL_KEY: "shh-internal" } as unknown as Partial<AuthEnv>),
+      );
+      expect(res.status).toBe(403);
+      expect((await res.json()) as { error: { code: string; message: string } }).toMatchObject({
+        error: { code: "member_cap_reached", message: "At cap." },
+      });
+    });
+  });
+
+  // Issue #869 phase B: redemption of a workspace-admin join link. Called by
+  // apps/api's `POST /auth/enrollments/join` after it has already atomically
+  // claimed the D1 enrollment row — this route only ever adds the member (or
+  // no-ops for an existing one) and re-checks the cap independently of mint.
+  describe("POST /internal/join", () => {
+    function join(body: Record<string, unknown>, e: AuthEnv = dbEnv()) {
+      return app().request(
+        "/internal/join",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        e,
+      );
+    }
+
+    it("400s when organizationSlug or userId is missing", async () => {
+      const res = await join({});
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "invalid_request" },
+      });
+    });
+
+    it("404s for an unknown organization", async () => {
+      const user = await seedUser();
+      const res = await join({ organizationSlug: "nope", userId: user.id });
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "organization_not_found" },
+      });
+    });
+
+    it("404s for an unknown user", async () => {
+      const org = await seedOrg();
+      const res = await join({ organizationSlug: org.slug, userId: "nope" });
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "user_not_found" },
+      });
+    });
+
+    it("adds the user as a member with role 'member'", async () => {
+      const org = await seedOrg();
+      const user = await seedUser();
+      const res = await join({ organizationSlug: org.slug, userId: user.id });
+      expect(res.status).toBe(201);
+      expect(await res.json()).toEqual({ alreadyMember: false });
+
+      const [member] = await orm
+        .select()
+        .from(schema.member)
+        .where(and(eq(schema.member.organizationId, org.id), eq(schema.member.userId, user.id)));
+      expect(member).toMatchObject({ role: "member" });
+    });
+
+    it("no-ops gracefully for an already-existing member", async () => {
+      const org = await seedOrg();
+      const user = await seedUser();
+      await orm.insert(schema.member).values({
+        id: crypto.randomUUID(),
+        organizationId: org.id,
+        userId: user.id,
+        role: "admin",
+        createdAt: new Date(),
+      });
+
+      const res = await join({ organizationSlug: org.slug, userId: user.id });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ alreadyMember: true });
+
+      // The pre-existing role is untouched — join never demotes.
+      const [member] = await orm
+        .select()
+        .from(schema.member)
+        .where(and(eq(schema.member.organizationId, org.id), eq(schema.member.userId, user.id)));
+      expect(member).toMatchObject({ role: "admin" });
+    });
+
+    it("403s with member_cap_reached at redemption, and adds no member row", async () => {
+      const org = await seedOrg();
+      const owner = await seedUser();
+      await orm.insert(schema.member).values({
+        id: crypto.randomUUID(),
+        organizationId: org.id,
+        userId: owner.id,
+        role: "owner",
+        createdAt: new Date(),
+      });
+      const joiner = await seedUser();
+      const api = {
+        fetch: async () =>
+          new Response(JSON.stringify({ workspace: org.slug, cap: 1, message: "At cap." }), {
+            status: 200,
+          }),
+      } as unknown as Fetcher;
+
+      const res = await join(
+        { organizationSlug: org.slug, userId: joiner.id },
+        dbEnv({ API: api, BILLING_INTERNAL_KEY: "shh-internal" } as unknown as Partial<AuthEnv>),
+      );
+      expect(res.status).toBe(403);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "member_cap_reached" },
+      });
+
+      const rows = await orm
+        .select()
+        .from(schema.member)
+        .where(and(eq(schema.member.organizationId, org.id), eq(schema.member.userId, joiner.id)));
+      expect(rows).toHaveLength(0);
+    });
+  });
 });

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -868,6 +868,103 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       201,
     );
   })
+  // Issue #869 phase B: the mint-time member-cap check for a workspace-admin
+  // "join" invite link (`POST /v1/workspaces/:workspace/invite-links` in
+  // apps/api's routes/workspace-members.ts). Mirrors `memberCapDenial`'s
+  // fail-open posture exactly like `/invite` above — a missing/erroring cap
+  // lookup must not block minting a link, only an actually-resolved cap does.
+  // Unlike `/invite`, there is no `inviterIsGlobalAdmin` bypass here: minting
+  // is workspace-admin-gated by `sessionAdminGate` in apps/api, not something
+  // a site operator does on someone else's behalf.
+  .post("/member-cap/check", async (c) => {
+    const body = await c.req
+      .json<{ workspace?: unknown }>()
+      .catch(() => ({}) as { workspace?: unknown });
+    const workspace = typeof body.workspace === "string" ? body.workspace.trim() : "";
+    if (!workspace) {
+      return c.json(errorJson("invalid_request", "workspace is required"), 400);
+    }
+
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, workspace))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+
+    const denial = await memberCapDenial(c.env, db, {
+      organizationId: org.id,
+      organizationSlug: org.slug,
+    });
+    if (denial) return c.json(errorJson(denial.code, denial.message), 403);
+    return c.json({ ok: true }, 200);
+  })
+  // Issue #869 phase B: redeems a workspace-admin "join" link. Called by
+  // apps/api's `POST /auth/enrollments/join` AFTER it has already atomically
+  // claimed the enrollment row (conditional UPDATE on `used_at IS NULL`) —
+  // this route only ever runs at most once per link, and its caller restores
+  // `used_at` to NULL if this call fails, so a transient error here doesn't
+  // permanently burn the link.
+  //
+  // Deliberately re-runs `memberCapDenial` (redemption-time check, separate
+  // from the mint-time one above) with no bypass of any kind: unlike
+  // `/invite`, an over-cap join must never silently succeed just because the
+  // cap lookup happens to fail open on THIS call — but `memberCapDenial`
+  // itself still fails open on a binding outage (same as every other caller),
+  // which is judged an acceptable, matched-to-existing-behavior tradeoff
+  // rather than blocking every join whenever the billing binding hiccups.
+  .post("/join", async (c) => {
+    const body = await c.req
+      .json<{ organizationSlug?: unknown; userId?: unknown }>()
+      .catch(() => ({}) as { organizationSlug?: unknown; userId?: unknown });
+    const organizationSlug =
+      typeof body.organizationSlug === "string" ? body.organizationSlug.trim() : "";
+    const userId = typeof body.userId === "string" ? body.userId.trim() : "";
+    if (!organizationSlug || !userId) {
+      return c.json(errorJson("invalid_request", "organizationSlug and userId are required"), 400);
+    }
+
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, organizationSlug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const [user] = await db.select().from(schema.user).where(eq(schema.user.id, userId)).limit(1);
+    if (!user) {
+      return c.json(errorJson("user_not_found", "no user with that id"), 404);
+    }
+
+    const [existingMembership] = await db
+      .select({ id: schema.member.id })
+      .from(schema.member)
+      .where(and(eq(schema.member.organizationId, org.id), eq(schema.member.userId, userId)))
+      .limit(1);
+    if (existingMembership) {
+      return c.json({ alreadyMember: true }, 200);
+    }
+
+    const denial = await memberCapDenial(c.env, db, {
+      organizationId: org.id,
+      organizationSlug: org.slug,
+    });
+    if (denial) return c.json(errorJson(denial.code, denial.message), 403);
+
+    await db.insert(schema.member).values({
+      id: crypto.randomUUID(),
+      organizationId: org.id,
+      userId,
+      role: "member",
+      createdAt: new Date(),
+    });
+    return c.json({ alreadyMember: false }, 201);
+  })
   // Self-serve provisioning (spec 2026-07-14): create an org WITH the caller
   // as owner member, non-idempotent — a taken slug is a 409 the API surfaces
   // to the user, unlike POST /orgs (admin backfill, idempotent by design).

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -935,15 +935,21 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     }
 
     const db = drizzle(c.env.DB, { schema });
-    const [org] = await db
-      .select()
-      .from(schema.organization)
-      .where(eq(schema.organization.slug, organizationSlug))
-      .limit(1);
+    // Independent lookups — run them concurrently, but keep the same
+    // not-found precedence (organization before user) that a sequential
+    // await gave: the organization result is checked first below regardless
+    // of which resolves first.
+    const [[org], [user]] = await Promise.all([
+      db
+        .select()
+        .from(schema.organization)
+        .where(eq(schema.organization.slug, organizationSlug))
+        .limit(1),
+      db.select().from(schema.user).where(eq(schema.user.id, userId)).limit(1),
+    ]);
     if (!org) {
       return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
     }
-    const [user] = await db.select().from(schema.user).where(eq(schema.user.id, userId)).limit(1);
     if (!user) {
       return c.json(errorJson("user_not_found", "no user with that id"), 404);
     }

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -9,7 +9,7 @@ import { and, count, countDistinct, eq, gt, gte, isNull, max, sql } from "drizzl
 import { Hono } from "hono";
 import { OAUTH_SCOPES, type AuthEnv } from "./auth";
 import { sendAuthEmail } from "./email";
-import { memberCapDenial } from "./member-cap";
+import { memberCapDenial, resolveMemberCapStrict } from "./member-cap";
 import * as schema from "./schema";
 
 function errorJson(code: string, message: string) {
@@ -909,13 +909,20 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
   // `used_at` to NULL if this call fails, so a transient error here doesn't
   // permanently burn the link.
   //
-  // Deliberately re-runs `memberCapDenial` (redemption-time check, separate
-  // from the mint-time one above) with no bypass of any kind: unlike
-  // `/invite`, an over-cap join must never silently succeed just because the
-  // cap lookup happens to fail open on THIS call — but `memberCapDenial`
-  // itself still fails open on a binding outage (same as every other caller),
-  // which is judged an acceptable, matched-to-existing-behavior tradeoff
-  // rather than blocking every join whenever the billing binding hiccups.
+  // Redemption-time cap check fails CLOSED (unlike mint-time and the
+  // email-invite path above, which keep `memberCapDenial`'s fail-open
+  // posture unchanged) — a lookup failure here must deny the join, not let
+  // it through uncounted. `resolveMemberCapStrict` is the one caller of the
+  // strict variant; see its docblock in member-cap.ts.
+  //
+  // The insert itself is the authoritative guard against a concurrent join
+  // exceeding the cap or double-adding the same user: a plain check-then-
+  // insert has a race window between the SELECT above and the INSERT, so the
+  // membership row is written by a single atomic `INSERT ... SELECT ...
+  // WHERE NOT EXISTS (...) AND (<cap>)` — 0 rows affected means either the
+  // membership already existed or the cap was hit, disambiguated by a
+  // read-after. Seat-counting semantics (members + pending invitations)
+  // mirror `countSeatsInUse` in member-cap.ts exactly.
   .post("/join", async (c) => {
     const body = await c.req
       .json<{ organizationSlug?: unknown; userId?: unknown }>()
@@ -941,6 +948,9 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       return c.json(errorJson("user_not_found", "no user with that id"), 404);
     }
 
+    // Fast path only — not the guard. A hit here skips the cap lookup for
+    // the common "already a member" case; a miss still has to go through
+    // the atomic insert below, which is what actually decides.
     const [existingMembership] = await db
       .select({ id: schema.member.id })
       .from(schema.member)
@@ -950,20 +960,63 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       return c.json({ alreadyMember: true }, 200);
     }
 
-    const denial = await memberCapDenial(c.env, db, {
-      organizationId: org.id,
-      organizationSlug: org.slug,
-    });
-    if (denial) return c.json(errorJson(denial.code, denial.message), 403);
+    const capResolution = await resolveMemberCapStrict(c.env, org.slug);
+    if (capResolution.status === "unavailable") {
+      return c.json(
+        errorJson("cap_check_unavailable", "couldn't verify this workspace's member limit"),
+        503,
+      );
+    }
+    const cap = capResolution.status === "capped" ? capResolution.cap : null;
 
-    await db.insert(schema.member).values({
-      id: crypto.randomUUID(),
-      organizationId: org.id,
-      userId,
-      role: "member",
-      createdAt: new Date(),
-    });
-    return c.json({ alreadyMember: false }, 201);
+    const insert = await c.env.DB.prepare(
+      `INSERT INTO member (id, organization_id, user_id, role, created_at)
+       SELECT ?, ?, ?, 'member', ?
+       WHERE NOT EXISTS (
+         SELECT 1 FROM member WHERE organization_id = ? AND user_id = ?
+       )
+       AND (
+         ? IS NULL OR (
+           (SELECT COUNT(*) FROM member WHERE organization_id = ?) +
+           (SELECT COUNT(*) FROM invitation WHERE organization_id = ? AND status = 'pending')
+         ) < ?
+       )`,
+    )
+      .bind(
+        crypto.randomUUID(),
+        org.id,
+        userId,
+        Math.floor(Date.now() / 1000),
+        org.id,
+        userId,
+        cap,
+        org.id,
+        org.id,
+        cap,
+      )
+      .run();
+
+    if ((insert.meta?.changes ?? 0) === 1) {
+      return c.json({ alreadyMember: false }, 201);
+    }
+
+    // 0 rows affected: either a concurrent request already added this user
+    // (alreadyMember) or the cap was hit (denial) — the pre-check above
+    // can't tell these apart since both happen strictly after it ran.
+    const [nowMember] = await db
+      .select({ id: schema.member.id })
+      .from(schema.member)
+      .where(and(eq(schema.member.organizationId, org.id), eq(schema.member.userId, userId)))
+      .limit(1);
+    if (nowMember) {
+      return c.json({ alreadyMember: true }, 200);
+    }
+    const message =
+      capResolution.status === "capped"
+        ? (capResolution.message ??
+          `This workspace includes ${capResolution.cap} members — cap reached.`)
+        : "This workspace has reached its member limit.";
+    return c.json(errorJson("member_cap_reached", message), 403);
   })
   // Self-serve provisioning (spec 2026-07-14): create an org WITH the caller
   // as owner member, non-idempotent — a taken slug is a 409 the API surfaces

--- a/apps/auth/src/member-cap.test.ts
+++ b/apps/auth/src/member-cap.test.ts
@@ -9,7 +9,7 @@ import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthEnv } from "./auth";
 import { internal } from "./internal-routes";
-import { memberCapDenial } from "./member-cap";
+import { memberCapDenial, resolveMemberCapStrict } from "./member-cap";
 import * as schema from "./schema";
 import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
 
@@ -193,6 +193,69 @@ describe("memberCapDenial", () => {
       code: "member_cap_reached",
       message: expect.stringContaining("3"),
     });
+  });
+});
+
+describe("resolveMemberCapStrict", () => {
+  // Same env shape as `memberCapDenial`'s describe block above, but this
+  // variant is exercised standalone (no org/db needed — the strict resolver
+  // doesn't count seats, only resolves the cap itself).
+  function env(api?: Fetcher, key: string | null = INTERNAL_KEY): AuthEnv {
+    return {
+      DB: {} as unknown as D1Database,
+      WEB_ORIGIN: "https://uploads.sh",
+      ENVIRONMENT: "development",
+      ...(api ? { API: api } : {}),
+      ...(key ? { BILLING_INTERNAL_KEY: key } : {}),
+    } as AuthEnv;
+  }
+
+  it("resolves 'capped' with the cap and message when apps/api answers", async () => {
+    const api = capBinding({ workspace: "acme", cap: 3, message: "at cap" });
+    expect(await resolveMemberCapStrict(env(api), "acme")).toEqual({
+      status: "capped",
+      cap: 3,
+      message: "at cap",
+    });
+  });
+
+  it("resolves 'unlimited' when apps/api reports no cap", async () => {
+    const api = capBinding({ workspace: "acme", cap: null, message: null });
+    expect(await resolveMemberCapStrict(env(api), "acme")).toEqual({ status: "unlimited" });
+  });
+
+  it("resolves 'unlimited' when the API binding is not configured (matches fail-open elsewhere)", async () => {
+    expect(await resolveMemberCapStrict(env(undefined), "acme")).toEqual({ status: "unlimited" });
+  });
+
+  it("resolves 'unavailable' — not 'unlimited' — when apps/api answers non-ok", async () => {
+    const api = capBinding({ error: "boom" }, { status: 500 });
+    expect(await resolveMemberCapStrict(env(api), "acme")).toEqual({ status: "unavailable" });
+  });
+
+  it("resolves 'unavailable' when the fetch throws", async () => {
+    const api = {
+      fetch: async () => {
+        throw new Error("binding exploded");
+      },
+    } as unknown as Fetcher;
+    expect(await resolveMemberCapStrict(env(api), "acme")).toEqual({ status: "unavailable" });
+  });
+
+  it("resolves 'unavailable' when the response body is malformed JSON", async () => {
+    const fetch = vi.fn(async () => new Response("not json", { status: 200 }));
+    const api = { fetch: fetch as unknown as Fetcher["fetch"] } as unknown as Fetcher;
+    expect(await resolveMemberCapStrict(env(api), "acme")).toEqual({ status: "unavailable" });
+  });
+
+  it("does not change memberCapDenial's own fail-open behavior for the same failures", async () => {
+    // Same non-ok response, run through the pre-existing fail-open path —
+    // must stay null, unaffected by the strict variant's addition.
+    const orm = drizzle(createFakeD1(), { schema });
+    const api = capBinding({ error: "boom" }, { status: 500 });
+    expect(
+      await memberCapDenial(env(api), orm, { organizationId: "org1", organizationSlug: "acme" }),
+    ).toBeNull();
   });
 });
 

--- a/apps/auth/src/member-cap.ts
+++ b/apps/auth/src/member-cap.ts
@@ -43,30 +43,63 @@ export interface MemberCapDenial {
   message: string;
 }
 
-/** The resolved cap for a workspace, or `null` when unlimited/unknown. */
-async function fetchMemberCap(
-  env: MemberCapEnv,
-  slug: string,
-): Promise<{ cap: number; message: string | null } | null> {
-  if (!env.API || !env.BILLING_INTERNAL_KEY) return null;
+/**
+ * Discriminated outcome of the member-cap lookup: `ok: true` with `cap: null`
+ * means no cap applies (unlimited plan, or the binding isn't configured at
+ * all — e.g. local/test); `ok: false` means the lookup itself failed (thrown
+ * fetch, non-OK response, malformed body) and no conclusion could be drawn.
+ * `fetchMemberCap` below collapses both "no cap" cases into `null` for the
+ * existing fail-open callers; `resolveMemberCapStrict` keeps the distinction
+ * for the one caller that must fail closed instead.
+ */
+type MemberCapLookup =
+  | { ok: true; cap: number; message: string | null }
+  | { ok: true; cap: null }
+  | { ok: false };
+
+async function lookupMemberCap(env: MemberCapEnv, slug: string): Promise<MemberCapLookup> {
+  if (!env.API || !env.BILLING_INTERNAL_KEY) return { ok: true, cap: null };
 
   const url = `https://internal/internal/billing/member-cap?workspace=${encodeURIComponent(slug)}`;
-  const response = await env.API.fetch(url, {
-    headers: { "x-internal-billing-key": env.BILLING_INTERNAL_KEY },
-  });
+  let response: Response;
+  try {
+    response = await env.API.fetch(url, {
+      headers: { "x-internal-billing-key": env.BILLING_INTERNAL_KEY },
+    });
+  } catch (error) {
+    console.error(`memberCap: GET /internal/billing/member-cap for ${slug} threw`, error);
+    return { ok: false };
+  }
   if (!response.ok) {
     console.error(
       `memberCap: GET /internal/billing/member-cap for ${slug} failed with status ${response.status}`,
     );
-    return null;
+    return { ok: false };
   }
   const body = (await response.json().catch(() => null)) as {
     cap?: unknown;
     message?: unknown;
   } | null;
-  const cap = body?.cap;
-  if (typeof cap !== "number" || !Number.isFinite(cap) || cap <= 0) return null;
-  return { cap, message: typeof body?.message === "string" ? body.message : null };
+  if (body === null) {
+    console.error(
+      `memberCap: GET /internal/billing/member-cap for ${slug} returned malformed JSON`,
+    );
+    return { ok: false };
+  }
+  const cap = body.cap;
+  if (typeof cap !== "number" || !Number.isFinite(cap) || cap <= 0) return { ok: true, cap: null };
+  return { ok: true, cap, message: typeof body.message === "string" ? body.message : null };
+}
+
+/** The resolved cap for a workspace, or `null` when unlimited/unknown —
+ * fail-open: a lookup failure is indistinguishable here from "no cap". */
+async function fetchMemberCap(
+  env: MemberCapEnv,
+  slug: string,
+): Promise<{ cap: number; message: string | null } | null> {
+  const result = await lookupMemberCap(env, slug);
+  if (!result.ok || result.cap === null) return null;
+  return { cap: result.cap, message: result.message };
 }
 
 /**
@@ -126,5 +159,37 @@ export async function memberCapDenial(
     // Fail open: an invite is worth more than a perfectly enforced cap.
     console.error(`memberCap: check failed for ${args.organizationSlug}`, error);
     return null;
+  }
+}
+
+/** The resolved cap for redemption-time enforcement (`POST /internal/join`
+ * only) — distinct from `null`-collapsing `fetchMemberCap`/`memberCapDenial`
+ * above so that caller can fail CLOSED on a lookup failure instead of
+ * treating it as "no cap". */
+export type MemberCapResolution =
+  | { status: "unlimited" }
+  | { status: "capped"; cap: number; message: string | null }
+  | { status: "unavailable" };
+
+/**
+ * Strict counterpart to `memberCapDenial`, for `/internal/join`'s
+ * redemption-time check only — every other caller (mint-time checks, the
+ * email-invite path) keeps `memberCapDenial`'s fail-open posture unchanged.
+ * A lookup failure here returns `"unavailable"` instead of being silently
+ * treated as unlimited, so the caller can deny the join rather than let it
+ * through uncounted.
+ */
+export async function resolveMemberCapStrict(
+  env: MemberCapEnv,
+  slug: string,
+): Promise<MemberCapResolution> {
+  try {
+    const result = await lookupMemberCap(env, slug);
+    if (!result.ok) return { status: "unavailable" };
+    if (result.cap === null) return { status: "unlimited" };
+    return { status: "capped", cap: result.cap, message: result.message };
+  } catch (error) {
+    console.error(`memberCap: strict check failed for ${slug}`, error);
+    return { status: "unavailable" };
   }
 }

--- a/apps/web/src/content/docs/reference.mdx
+++ b/apps/web/src/content/docs/reference.mdx
@@ -74,8 +74,10 @@ uploads --help        # everything else
   [oEmbed](https://oembed.com/) discovery, so tools that unfurl links can show the media. Resolve one
   directly via `/oembed`, passing the page URL as its `url` query param.
 - **Getting access.** Sign in and create your own workspace with a linked GitHub account, or get
-  invited to an existing one by a workspace admin. Questions? Reach out via <a href={REPO}>the GitHub
-  repo</a>.
+  invited to an existing one. A workspace admin can invite by email from the workspace's People page,
+  or generate a join link there — anyone signed in who opens it joins the workspace, once. Join links
+  expire after 2 hours and an admin can revoke one before it's used. Questions? Reach out via
+  <a href={REPO}>the GitHub repo</a>.
 - **Everything lands in your workspace.** Files are stored under a prefix for your workspace, and
   PR/issue attachments get stable, predictable paths, so re-attaching an updated screenshot replaces
   the old URL's spot instead of littering.

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -784,6 +784,123 @@ export async function updateWorkspaceMemberRole(
   );
 }
 
+/**
+ * Issue #869 phase B: workspace-admin "join" invite links — a shareable URL
+ * whose redemption (on `/invite`) adds the redeemer as an org member.
+ * Distinct from `inviteToWorkspace`'s email invites (no recipient needed)
+ * and from `/admin`'s CLI-token links (this workspace's own People page can
+ * only see/revoke its own `kind: 'member'` links, never a token-kind one).
+ */
+export type CreateInviteLinkResult =
+  | { kind: "ok"; id: string; pageId: string; label: string | null; url: string; expiresAt: string }
+  | {
+      kind: "unavailable";
+      reason: RequestFailure | "server" | "forbidden" | "invalid" | "member_cap";
+      /** Server-authored copy for "member_cap" — same contract as `InviteResult`. */
+      message?: string;
+    };
+
+/** POST /v1/workspaces/:name/invite-links */
+export async function createInviteLink(
+  apiOrigin: string,
+  name: string,
+  label?: string,
+): Promise<CreateInviteLinkResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/invite-links`,
+    {
+      method: "POST",
+      credentials: "include",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(label ? { label } : {}),
+    },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (response.status === 403) {
+    const error = (await response.json().catch(() => null)) as {
+      error?: { code?: string; message?: string };
+    } | null;
+    if (error?.error?.code === "member_cap_reached") {
+      return { kind: "unavailable", reason: "member_cap", message: error.error.message };
+    }
+    return { kind: "unavailable", reason: "forbidden" };
+  }
+  if (response.status === 400) return { kind: "unavailable", reason: "invalid" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const body = (await response.json().catch(() => null)) as {
+    id?: string;
+    pageId?: string;
+    label?: string | null;
+    url?: string;
+    expiresAt?: string;
+  } | null;
+  if (
+    !body ||
+    typeof body.id !== "string" ||
+    typeof body.pageId !== "string" ||
+    typeof body.url !== "string" ||
+    typeof body.expiresAt !== "string"
+  ) {
+    return { kind: "unavailable", reason: "server" };
+  }
+  return {
+    kind: "ok",
+    id: body.id,
+    pageId: body.pageId,
+    label: typeof body.label === "string" ? body.label : null,
+    url: body.url,
+    expiresAt: body.expiresAt,
+  };
+}
+
+export interface WorkspaceInviteLink {
+  id: string;
+  pageId: string | null;
+  label: string | null;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export type WorkspaceInviteLinksResult =
+  | { kind: "ok"; links: WorkspaceInviteLink[] }
+  | { kind: "unavailable" };
+
+/** GET /v1/workspaces/:name/invite-links — outstanding kind:'member' links, admin/owner only. */
+export async function listInviteLinks(
+  apiOrigin: string,
+  name: string,
+): Promise<WorkspaceInviteLinksResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/invite-links`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable" || !result.response.ok) return { kind: "unavailable" };
+  const body = (await result.response.json().catch(() => null)) as { links?: unknown } | null;
+  if (!body || !Array.isArray(body.links)) return { kind: "unavailable" };
+  return {
+    kind: "ok",
+    links: body.links.filter(
+      (v): v is WorkspaceInviteLink =>
+        !!v && typeof v === "object" && typeof (v as { id?: unknown }).id === "string",
+    ),
+  };
+}
+
+/** DELETE /v1/workspaces/:name/invite-links/:id */
+export async function revokeInviteLink(
+  apiOrigin: string,
+  name: string,
+  linkId: string,
+): Promise<ManageResult> {
+  return manageMutation(
+    apiOrigin,
+    `/v1/workspaces/${encodeURIComponent(name)}/invite-links/${encodeURIComponent(linkId)}`,
+    { method: "DELETE" },
+  );
+}
+
 export type CreateWorkspaceResult =
   | { kind: "created"; workspace: { name: string; publicBaseUrl?: string } }
   | { kind: "error"; code: string; message: string }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -631,6 +631,24 @@ export async function getWorkspaceBilling(
 }
 
 /**
+ * Classifies a 403 shared by `inviteToWorkspace` and `createInviteLink`: a
+ * plan member cap (issue #450), which the user can act on, vs. the
+ * pre-existing "you aren't an admin here". Both callers' result unions carry
+ * the same `"member_cap" | "forbidden"` shape for their 403 branch.
+ */
+async function classifyInviteForbidden(
+  response: Response,
+): Promise<{ reason: "member_cap"; message?: string } | { reason: "forbidden" }> {
+  const error = (await response.json().catch(() => null)) as {
+    error?: { code?: string; message?: string };
+  } | null;
+  if (error?.error?.code === "member_cap_reached") {
+    return { reason: "member_cap", message: error.error.message };
+  }
+  return { reason: "forbidden" };
+}
+
+/**
  * POST /v1/workspaces/:name/invites — workspace admin|owner invites an email.
  * Always prefer showing `acceptUrl` (works without outbound email).
  */
@@ -652,15 +670,7 @@ export async function inviteToWorkspace(
   if (result.kind === "unavailable") return result;
   const { response } = result;
   if (response.status === 403) {
-    // Two different 403s: a plan member cap (issue #450), which the user can
-    // act on, and the pre-existing "you aren't an admin here".
-    const error = (await response.json().catch(() => null)) as {
-      error?: { code?: string; message?: string };
-    } | null;
-    if (error?.error?.code === "member_cap_reached") {
-      return { kind: "unavailable", reason: "member_cap", message: error.error.message };
-    }
-    return { kind: "unavailable", reason: "forbidden" };
+    return { kind: "unavailable", ...(await classifyInviteForbidden(response)) };
   }
   if (response.status === 400) return { kind: "unavailable", reason: "invalid" };
   if (!response.ok) return { kind: "unavailable", reason: "server" };
@@ -819,13 +829,7 @@ export async function createInviteLink(
   if (result.kind === "unavailable") return result;
   const { response } = result;
   if (response.status === 403) {
-    const error = (await response.json().catch(() => null)) as {
-      error?: { code?: string; message?: string };
-    } | null;
-    if (error?.error?.code === "member_cap_reached") {
-      return { kind: "unavailable", reason: "member_cap", message: error.error.message };
-    }
-    return { kind: "unavailable", reason: "forbidden" };
+    return { kind: "unavailable", ...(await classifyInviteForbidden(response)) };
   }
   if (response.status === 400) return { kind: "unavailable", reason: "invalid" };
   if (!response.ok) return { kind: "unavailable", reason: "server" };

--- a/apps/web/src/lib/api-proxy.test.ts
+++ b/apps/web/src/lib/api-proxy.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { proxyApiRequest, serverApiFetch, serverApiFetchImpl } from "./api-proxy";
+import {
+  proxyApiRequest,
+  proxyEnrollmentJoinRequest,
+  serverApiFetch,
+  serverApiFetchImpl,
+} from "./api-proxy";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -282,5 +287,63 @@ describe("proxyApiRequest — Server-Timing wiring (issue #812)", () => {
     const response = await proxyApiRequest({}, request);
     expect(response.status).toBe(404);
     expect(response.headers.get("Server-Timing")).toBeNull();
+  });
+});
+
+// Issue #869 phase B: `POST /auth/enrollments/join` needs its own fixed-target
+// route because `proxyApiRequest`'s generic `/api/[...path]` 404s every
+// `/api/auth/*` path (that prefix is reserved for the Better Auth proxy).
+describe("proxyEnrollmentJoinRequest", () => {
+  it("forwards to /auth/enrollments/join over env.API, cookie and body intact", async () => {
+    const { API, fetchMock } = fakeApiBinding(
+      Response.json({ workspace: "acme", alreadyMember: false }),
+    );
+    const request = new Request("https://uploads.sh/api/enrollments/join", {
+      method: "POST",
+      headers: { cookie: "better-auth.session_token=abc", "content-type": "application/json" },
+      body: JSON.stringify({ code: "upe_test" }),
+    });
+
+    const response = await proxyEnrollmentJoinRequest({ API }, request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://uploads.sh/auth/enrollments/join");
+    expect(forwarded.method).toBe("POST");
+    expect(forwarded.redirect).toBe("manual");
+    expect(forwarded.headers.get("cookie")).toBe("better-auth.session_token=abc");
+    expect(await forwarded.text()).toBe(JSON.stringify({ code: "upe_test" }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ workspace: "acme", alreadyMember: false });
+  });
+
+  it("passes the upstream error response through untouched (e.g. 401/403)", async () => {
+    const { API } = fakeApiBinding(
+      Response.json({ error: { code: "member_cap_reached" } }, { status: 403 }),
+    );
+    const request = new Request("https://uploads.sh/api/enrollments/join", {
+      method: "POST",
+      body: JSON.stringify({ code: "upe_test" }),
+    });
+
+    const response = await proxyEnrollmentJoinRequest({ API }, request);
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: { code: "member_cap_reached" } });
+  });
+
+  it("falls back to HTTP when no API binding is configured", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ ok: true })),
+    );
+    const request = new Request("https://uploads.sh/api/enrollments/join", {
+      method: "POST",
+      body: "{}",
+    });
+
+    await proxyEnrollmentJoinRequest({ UPLOADS_API_ORIGIN: "https://api.example.com" }, request);
+
+    const forwarded = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Request;
+    expect(forwarded.url).toBe("https://api.example.com/auth/enrollments/join");
   });
 });

--- a/apps/web/src/lib/api-proxy.ts
+++ b/apps/web/src/lib/api-proxy.ts
@@ -58,6 +58,39 @@ function decodedStrippedPathForGuard(pathname: string): string | null {
   }
 }
 
+/**
+ * Shared transport for both `/api/*` proxy entry points below: rewrites
+ * `request`'s pathname to `targetPathname`, forwards it to the api worker
+ * (binding, else HTTP fallback), and applies Server-Timing. `routeLabel` is
+ * the Server-Timing route tag — the guarded, decoded path for
+ * `proxyApiRequest`, the fixed target for `proxyEnrollmentJoinRequest`.
+ *
+ * Structural choke point (issue #812): the one upstream hop every `/api/*`
+ * proxy request makes, api-worker-bound rather than auth-bound — see
+ * auth-proxy.ts's proxyAuthRequest for the "auth" counterpart.
+ */
+async function forwardToApi(
+  env: ApiProxyEnv,
+  request: Request,
+  targetPathname: string,
+  routeLabel: string,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const manual = new Request(request, { redirect: "manual" });
+  url.pathname = targetPathname;
+  const forwarded = new Request(url.toString(), manual);
+
+  const timing = new ServerTiming();
+  const upstream = await timeOp(
+    () =>
+      env.API
+        ? env.API.fetch(forwarded)
+        : fetch(rewriteOrigin(forwarded, env.UPLOADS_API_ORIGIN ?? LOCAL_API_ORIGIN_DEFAULT)),
+    { name: "api", timing, route: routeLabel, thresholdMs: slowOpThresholdMs(env) },
+  );
+  return timing.applyTo(upstream, { disabled: serverTimingDisabled(env) });
+}
+
 /** Forwards `request` to the api worker (binding, else HTTP fallback), `/api` prefix stripped. */
 export async function proxyApiRequest(env: ApiProxyEnv, request: Request): Promise<Response> {
   const url = new URL(request.url);
@@ -69,23 +102,7 @@ export async function proxyApiRequest(env: ApiProxyEnv, request: Request): Promi
   // The guard runs on the decoded form above; the request forwarded
   // upstream keeps the original (still-encoded where applicable) pathname
   // unchanged, `/api` prefix stripped literally rather than re-encoded.
-  const strippedPath = stripApiPrefix(url.pathname);
-  const manual = new Request(request, { redirect: "manual" });
-  url.pathname = strippedPath;
-  const forwarded = new Request(url.toString(), manual);
-
-  // Structural choke point (issue #812): the one upstream hop every
-  // `/api/*` proxy request makes, api-worker-bound rather than auth-bound —
-  // see auth-proxy.ts's proxyAuthRequest for the "auth" counterpart.
-  const timing = new ServerTiming();
-  const upstream = await timeOp(
-    () =>
-      env.API
-        ? env.API.fetch(forwarded)
-        : fetch(rewriteOrigin(forwarded, env.UPLOADS_API_ORIGIN ?? LOCAL_API_ORIGIN_DEFAULT)),
-    { name: "api", timing, route: decodedPath, thresholdMs: slowOpThresholdMs(env) },
-  );
-  return timing.applyTo(upstream, { disabled: serverTimingDisabled(env) });
+  return forwardToApi(env, request, stripApiPrefix(url.pathname), decodedPath);
 }
 
 /**
@@ -105,20 +122,7 @@ export async function proxyEnrollmentJoinRequest(
   env: ApiProxyEnv,
   request: Request,
 ): Promise<Response> {
-  const url = new URL(request.url);
-  url.pathname = "/auth/enrollments/join";
-  const manual = new Request(request, { redirect: "manual" });
-  const forwarded = new Request(url.toString(), manual);
-
-  const timing = new ServerTiming();
-  const upstream = await timeOp(
-    () =>
-      env.API
-        ? env.API.fetch(forwarded)
-        : fetch(rewriteOrigin(forwarded, env.UPLOADS_API_ORIGIN ?? LOCAL_API_ORIGIN_DEFAULT)),
-    { name: "api", timing, route: "/auth/enrollments/join", thresholdMs: slowOpThresholdMs(env) },
-  );
-  return timing.applyTo(upstream, { disabled: serverTimingDisabled(env) });
+  return forwardToApi(env, request, "/auth/enrollments/join", "/auth/enrollments/join");
 }
 
 /**

--- a/apps/web/src/lib/api-proxy.ts
+++ b/apps/web/src/lib/api-proxy.ts
@@ -89,6 +89,39 @@ export async function proxyApiRequest(env: ApiProxyEnv, request: Request): Promi
 }
 
 /**
+ * Dedicated same-origin proxy for `POST /auth/enrollments/join` (issue #869
+ * phase B) — the one apps/api route under `/auth/*` a signed-in browser
+ * legitimately needs to reach cookie-authenticated. `proxyApiRequest`'s
+ * `/api/[...path]` catch-all deliberately 404s every `/api/auth/*` path (see
+ * its docblock) because that prefix is reserved for the Better Auth proxy
+ * (`/api/auth/[...path].ts`, a distinct, more specific route Astro matches
+ * first) — so this join call needs its own fixed-target route instead of
+ * going through either of those. Mounted at `/api/enrollments/join`
+ * (`pages/api/enrollments/join.ts`), forwarding straight to the api worker's
+ * `/auth/enrollments/join`, cookie included exactly like `proxyApiRequest`
+ * (same-origin browser request, cookie already rides along).
+ */
+export async function proxyEnrollmentJoinRequest(
+  env: ApiProxyEnv,
+  request: Request,
+): Promise<Response> {
+  const url = new URL(request.url);
+  url.pathname = "/auth/enrollments/join";
+  const manual = new Request(request, { redirect: "manual" });
+  const forwarded = new Request(url.toString(), manual);
+
+  const timing = new ServerTiming();
+  const upstream = await timeOp(
+    () =>
+      env.API
+        ? env.API.fetch(forwarded)
+        : fetch(rewriteOrigin(forwarded, env.UPLOADS_API_ORIGIN ?? LOCAL_API_ORIGIN_DEFAULT)),
+    { name: "api", timing, route: "/auth/enrollments/join", thresholdMs: slowOpThresholdMs(env) },
+  );
+  return timing.applyTo(upstream, { disabled: serverTimingDisabled(env) });
+}
+
+/**
  * SSR helper (Task D2): resolves one api call from Astro frontmatter over the
  * same transport as `proxyApiRequest`, forwarding the incoming request's
  * `cookie` header when `init` doesn't already carry one (see

--- a/apps/web/src/lib/invite-code.test.ts
+++ b/apps/web/src/lib/invite-code.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   codeFromHash,
   codeStorageKey,
   loginHref,
   readStashedCode,
+  safeSessionStorage,
   stashCode,
   type CodeStorage,
 } from "./invite-code";
@@ -96,5 +97,41 @@ describe("stashCode / readStashedCode", () => {
   it('readStashedCode returns "" when nothing was stashed', () => {
     const storage = fakeStorage();
     expect(readStashedCode(storage, "upi_never-stashed")).toBe("");
+  });
+
+  it("readStashedCode/stashCode treat a null storage as unavailable, not a throw", () => {
+    expect(() => readStashedCode(null, "upi_1")).not.toThrow();
+    expect(readStashedCode(null, "upi_1")).toBe("");
+    expect(() => stashCode(null, "upi_1", "upe_secret")).not.toThrow();
+    expect(stashCode(null, "upi_1", "upe_secret")).toBe(false);
+  });
+});
+
+describe("safeSessionStorage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns window.sessionStorage when accessible", () => {
+    const stub = fakeStorage();
+    vi.stubGlobal("window", { sessionStorage: stub });
+    expect(safeSessionStorage()).toBe(stub);
+  });
+
+  // CodeRabbit review (issue #869 follow-up): some private-browsing /
+  // storage-disabled configurations throw on the `sessionStorage` property
+  // access itself (a SecurityError), not just on `getItem`/`setItem` — this
+  // must be caught too, before it ever reaches readStashedCode/stashCode's
+  // own try/catch.
+  it("returns null (never throws) when the sessionStorage getter itself throws", () => {
+    const fakeWindow: { sessionStorage?: Storage } = {};
+    Object.defineProperty(fakeWindow, "sessionStorage", {
+      get() {
+        throw new DOMException("access denied", "SecurityError");
+      },
+    });
+    vi.stubGlobal("window", fakeWindow);
+    expect(() => safeSessionStorage()).not.toThrow();
+    expect(safeSessionStorage()).toBeNull();
   });
 });

--- a/apps/web/src/lib/invite-code.test.ts
+++ b/apps/web/src/lib/invite-code.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  codeFromHash,
+  codeStorageKey,
+  loginHref,
+  readStashedCode,
+  stashCode,
+  type CodeStorage,
+} from "./invite-code";
+
+/** In-memory `CodeStorage`, optionally rigged to throw like a private
+ * window / disabled storage would. */
+function fakeStorage(opts: { throws?: boolean } = {}): CodeStorage {
+  const store = new Map<string, string>();
+  return {
+    getItem(key) {
+      if (opts.throws) throw new Error("storage disabled");
+      return store.has(key) ? store.get(key)! : null;
+    },
+    setItem(key, value) {
+      if (opts.throws) throw new Error("storage disabled");
+      store.set(key, value);
+    },
+    removeItem(key) {
+      if (opts.throws) throw new Error("storage disabled");
+      store.delete(key);
+    },
+  };
+}
+
+describe("codeStorageKey", () => {
+  it("scopes the key per pageId", () => {
+    expect(codeStorageKey("upi_abc")).toBe("invite:upi_abc");
+    expect(codeStorageKey("upi_abc")).not.toBe(codeStorageKey("upi_def"));
+  });
+});
+
+describe("loginHref", () => {
+  it("never embeds the code — only id survives into callbackURL", () => {
+    const href = loginHref("https://uploads.sh", "upi_abcdefghijklmnop");
+    expect(href).toBe(
+      "/login?callbackURL=" +
+        encodeURIComponent("https://uploads.sh/invite?id=upi_abcdefghijklmnop"),
+    );
+    expect(href).not.toContain("code");
+    expect(href).not.toContain("%23"); // no encoded '#' fragment either
+  });
+
+  it("percent-encodes the pageId", () => {
+    const href = loginHref("https://uploads.sh", "upi_weird value");
+    const returnTo = decodeURIComponent(href.slice("/login?callbackURL=".length));
+    expect(returnTo).toBe("https://uploads.sh/invite?id=upi_weird%20value");
+  });
+});
+
+describe("codeFromHash", () => {
+  it("extracts code from a #code=... fragment", () => {
+    expect(codeFromHash("#code=upe_deadbeef")).toBe("upe_deadbeef");
+  });
+
+  it("returns empty string when there is no code", () => {
+    expect(codeFromHash("")).toBe("");
+    expect(codeFromHash("#other=1")).toBe("");
+  });
+});
+
+describe("stashCode / readStashedCode", () => {
+  it("round-trips a stashed code and clears it on read", () => {
+    const storage = fakeStorage();
+    expect(stashCode(storage, "upi_1", "upe_secret")).toBe(true);
+    expect(readStashedCode(storage, "upi_1")).toBe("upe_secret");
+    // Single-use: a second read finds nothing.
+    expect(readStashedCode(storage, "upi_1")).toBe("");
+  });
+
+  it("scopes reads/writes per pageId — no cross-invite leakage", () => {
+    const storage = fakeStorage();
+    stashCode(storage, "upi_1", "upe_one");
+    stashCode(storage, "upi_2", "upe_two");
+    expect(readStashedCode(storage, "upi_2")).toBe("upe_two");
+    expect(readStashedCode(storage, "upi_1")).toBe("upe_one");
+  });
+
+  it("stashCode returns false (never throws) when storage is unavailable", () => {
+    const storage = fakeStorage({ throws: true });
+    expect(() => stashCode(storage, "upi_1", "upe_secret")).not.toThrow();
+    expect(stashCode(storage, "upi_1", "upe_secret")).toBe(false);
+  });
+
+  it('readStashedCode returns "" (never throws) when storage is unavailable', () => {
+    const storage = fakeStorage({ throws: true });
+    expect(() => readStashedCode(storage, "upi_1")).not.toThrow();
+    expect(readStashedCode(storage, "upi_1")).toBe("");
+  });
+
+  it('readStashedCode returns "" when nothing was stashed', () => {
+    const storage = fakeStorage();
+    expect(readStashedCode(storage, "upi_never-stashed")).toBe("");
+  });
+});

--- a/apps/web/src/lib/invite-code.ts
+++ b/apps/web/src/lib/invite-code.ts
@@ -37,11 +37,29 @@ export interface CodeStorage {
 }
 
 /**
- * Reads and clears a code previously stashed by `stashCode`, tolerating a
- * storage that throws (private window, storage disabled). Never throws;
- * returns `""` when nothing was stashed or storage is unavailable.
+ * Safely accesses `window.sessionStorage`, tolerating a browser that throws
+ * on the property access itself (not just on `getItem`/`setItem`) — e.g. a
+ * SecurityError in some private-browsing/storage-disabled configurations.
+ * Never throws; returns `null` when the getter itself throws or storage
+ * isn't available, so callers can fall back to the same storage-unavailable
+ * recovery path `readStashedCode`/`stashCode` already use.
  */
-export function readStashedCode(storage: CodeStorage, pageId: string): string {
+export function safeSessionStorage(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reads and clears a code previously stashed by `stashCode`, tolerating a
+ * storage that throws (private window, storage disabled) or is unavailable
+ * (`null`). Never throws; returns `""` when nothing was stashed or storage
+ * is unavailable.
+ */
+export function readStashedCode(storage: CodeStorage | null, pageId: string): string {
+  if (!storage) return "";
   try {
     const key = codeStorageKey(pageId);
     const stashed = storage.getItem(key);
@@ -56,10 +74,11 @@ export function readStashedCode(storage: CodeStorage, pageId: string): string {
 /**
  * Stashes `code` in `storage` so it survives the round trip through
  * `/login` without ever appearing in a URL. Never throws; returns `false`
- * when storage isn't available — callers MUST NOT fall back to putting the
- * code in a URL when this returns `false`.
+ * when storage isn't available (including a `null` storage) — callers MUST
+ * NOT fall back to putting the code in a URL when this returns `false`.
  */
-export function stashCode(storage: CodeStorage, pageId: string, code: string): boolean {
+export function stashCode(storage: CodeStorage | null, pageId: string, code: string): boolean {
+  if (!storage) return false;
   try {
     storage.setItem(codeStorageKey(pageId), code);
     return true;

--- a/apps/web/src/lib/invite-code.ts
+++ b/apps/web/src/lib/invite-code.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure helpers for `invite.astro`'s join-code handling (issue #869 review
+ * finding 1 — CRITICAL). Factored out of the page's inline `<script>` so the
+ * security-critical part is unit-testable without a DOM: the one-time code
+ * must never ride in a URL across the sign-in round trip (`callbackURL` is
+ * server-visible — magic-link emails, OAuth state — the fragment browsers
+ * "never send to the server" doesn't help once it's re-embedded there).
+ * Instead the code is stashed in sessionStorage, scoped per invite page.
+ */
+
+/** sessionStorage key for the code stash — scoped per pageId so two invite
+ * tabs (or two invites in the same tab, sequentially) don't collide. */
+export function codeStorageKey(pageId: string): string {
+  return `invite:${pageId}`;
+}
+
+/**
+ * `/login?callbackURL=` back to this invite page — deliberately WITHOUT the
+ * code, fragment or otherwise. `stashCode`/`readStashedCode` below are how
+ * the join flow resumes the code on return instead.
+ */
+export function loginHref(origin: string, pageId: string): string {
+  const returnTo = `${origin}/invite?id=${encodeURIComponent(pageId)}`;
+  return `/login?callbackURL=${encodeURIComponent(returnTo)}`;
+}
+
+/** Extracts the one-time code from a URL fragment shaped `#code=...`. */
+export function codeFromHash(hash: string): string {
+  return new URLSearchParams(hash.replace(/^#/, "")).get("code") ?? "";
+}
+
+/** The subset of the Web Storage API this module needs. */
+export interface CodeStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/**
+ * Reads and clears a code previously stashed by `stashCode`, tolerating a
+ * storage that throws (private window, storage disabled). Never throws;
+ * returns `""` when nothing was stashed or storage is unavailable.
+ */
+export function readStashedCode(storage: CodeStorage, pageId: string): string {
+  try {
+    const key = codeStorageKey(pageId);
+    const stashed = storage.getItem(key);
+    if (!stashed) return "";
+    storage.removeItem(key);
+    return stashed;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Stashes `code` in `storage` so it survives the round trip through
+ * `/login` without ever appearing in a URL. Never throws; returns `false`
+ * when storage isn't available — callers MUST NOT fall back to putting the
+ * code in a URL when this returns `false`.
+ */
+export function stashCode(storage: CodeStorage, pageId: string, code: string): boolean {
+  try {
+    storage.setItem(codeStorageKey(pageId), code);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -15,6 +15,7 @@ import {
   renderGalleriesPlaceholderHtml,
   renderGalleriesTableHtml,
   renderGalleriesViewToggleHtml,
+  renderInviteLinksHtml,
   renderInvitesHtml,
   renderMembersHtml,
   renderPeopleTableHtml,
@@ -115,6 +116,37 @@ describe("renderInvitesHtml", () => {
   });
   it("returns empty string for no invites", () => {
     expect(renderInvitesHtml([])).toBe("");
+  });
+});
+
+describe("renderInviteLinksHtml", () => {
+  it("renders a labeled row with expiry and revoke", () => {
+    const html = renderInviteLinksHtml([
+      { id: "l1", label: "for the design team", expiresAt: "2026-08-27T18:00:00.000Z" },
+    ]);
+    expect(html).toContain('data-link-id="l1"');
+    expect(html).toContain("for the design team");
+    expect(html).toContain("invite-link-row__revoke");
+    expect(html).toContain("expires");
+  });
+
+  it("falls back to a generic label when none was set", () => {
+    const html = renderInviteLinksHtml([
+      { id: "l1", label: null, expiresAt: "2026-08-27T18:00:00.000Z" },
+    ]);
+    expect(html).toContain("Unlabeled link");
+  });
+
+  it("escapes the label", () => {
+    const html = renderInviteLinksHtml([
+      { id: "l1", label: "<script>alert(1)</script>", expiresAt: "2026-08-27T18:00:00.000Z" },
+    ]);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("returns empty string for no links", () => {
+    expect(renderInviteLinksHtml([])).toBe("");
   });
 });
 

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -259,6 +259,33 @@ export function renderInvitesHtml(
     .join("");
 }
 
+/**
+ * Issue #869 phase B: the People page's outstanding `kind: 'member'`
+ * join-link list — a plain `<ul>`, not the people table (these aren't
+ * teammates or pending email invites, just live shareable links). Each row
+ * shows the label (or a generic fallback) and expiry, plus a revoke button
+ * matching the `text-btn` treatment `renderInvitesHtml`'s revoke uses.
+ * `[]` → `""` (caller renders its own empty state).
+ */
+export function renderInviteLinksHtml(
+  links: { id: string; label: string | null; expiresAt: string }[],
+): string {
+  return links
+    .map((link) => {
+      const label = link.label ? escapeHtml(link.label) : "Unlabeled link";
+      const when = new Date(link.expiresAt).toLocaleString([], {
+        dateStyle: "medium",
+        timeStyle: "short",
+      });
+      return `<li class="invite-link-row">
+  <span class="invite-link-row__label">${label}</span>
+  <span class="invite-link-row__expiry text-muted-foreground">expires ${escapeHtml(when)}</span>
+  <button type="button" class="text-btn invite-link-row__revoke" data-link-id="${escapeHtml(link.id)}" data-link-label="${label}">Revoke</button>
+</li>`;
+    })
+    .join("");
+}
+
 export function isWorkspaceAdminRole(role: string): boolean {
   return role === "admin" || role === "owner";
 }

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -93,6 +93,32 @@ if (cookie.trim()) {
         <p class="muted cli-note" id="ws-invite-link" hidden></p>
       </div>
     </div>
+
+    <div class="settings-section" id="ws-invite-links-section" hidden>
+      <h2>Invite links</h2>
+      <p class="settings-note muted">
+        Anyone with the link can join this workspace once — no email required.
+      </p>
+      <form class="ws-form" id="ws-invite-link-form">
+        <div class="input-group">
+          <label class="input-group__field">
+            <span class="sr-only">Label (optional)</span>
+            <input type="text" name="label" maxlength="100" placeholder="Label (optional)" />
+          </label>
+          <button type="submit" class="input-group__action">Generate link</button>
+        </div>
+      </form>
+      <div class="ws-messages">
+        <p class="muted cli-note" id="ws-invite-link-status" role="status" hidden></p>
+        <div class="command" id="ws-invite-link-url" hidden>
+          <code id="ws-invite-link-url-code"></code>
+          <button type="button" id="ws-invite-link-url-copy" data-copy="" aria-live="polite"
+            >copy</button
+          >
+        </div>
+      </div>
+      <ul class="invite-link-list" id="ws-invite-link-list"></ul>
+    </div>
   </section>
 
   <script>
@@ -104,18 +130,24 @@ if (cookie.trim()) {
       requireElement,
     } from "../../../../lib/account-shell";
     import {
+      createInviteLink,
       getWorkspacePeople,
       inviteToWorkspace,
+      listInviteLinks,
+      revokeInviteLink,
       revokeWorkspaceInvite,
       removeWorkspaceMember,
       updateWorkspaceMemberRole,
       type ManageResult,
+      type WorkspaceInviteLink,
     } from "../../../../lib/api-client";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
     import { loadWorkspaceSummary } from "../../../../lib/workspace-summary-source";
     import {
+      bindCopyButtons,
       escapeHtml,
       isWorkspaceAdminRole,
+      renderInviteLinksHtml,
       renderInvitesHtml,
       renderMembersHtml,
       renderPeopleTableHtml,
@@ -147,6 +179,16 @@ if (cookie.trim()) {
       const inviteForm = requireElement<HTMLFormElement>("#ws-invite-form", page);
       const inviteSection = requireElement<HTMLElement>("#ws-invite-section", page);
       const membersEl = requireElement<HTMLElement>("#ws-members", page);
+
+      // Issue #869 phase B: workspace-admin join links.
+      const inviteLinksSection = requireElement<HTMLElement>("#ws-invite-links-section", page);
+      const inviteLinkForm = requireElement<HTMLFormElement>("#ws-invite-link-form", page);
+      const inviteLinkStatus = requireElement<HTMLElement>("#ws-invite-link-status", page);
+      const inviteLinkUrl = requireElement<HTMLElement>("#ws-invite-link-url", page);
+      const inviteLinkUrlCode = requireElement<HTMLElement>("#ws-invite-link-url-code", page);
+      const inviteLinkUrlCopy = requireElement<HTMLButtonElement>("#ws-invite-link-url-copy", page);
+      const inviteLinkList = requireElement<HTMLElement>("#ws-invite-link-list", page);
+      bindCopyButtons(inviteLinkUrl);
 
       let sessionEmail: string | undefined;
       /** People-list controls: canManage + viewerRole feed renderMembersHtml. */
@@ -216,8 +258,22 @@ if (cookie.trim()) {
         const canInvite = isWorkspaceAdminRole(result.role);
         inviteSection.hidden = !canInvite;
         inviteForm.hidden = !canInvite;
+        inviteLinksSection.hidden = !canInvite;
         applyMemberOpts(result);
         paintPeopleList(result.members, result.invites);
+        if (canInvite) void loadInviteLinks();
+      }
+
+      function paintInviteLinks(links: WorkspaceInviteLink[]): void {
+        inviteLinkList.innerHTML = links.length
+          ? renderInviteLinksHtml(links)
+          : '<li class="muted">No outstanding invite links.</li>';
+      }
+
+      async function loadInviteLinks(): Promise<void> {
+        const result = await listInviteLinks(apiOrigin, workspaceName);
+        if (!stillHere() || result.kind !== "ok") return;
+        paintInviteLinks(result.links);
       }
 
       async function loadInvitePage(): Promise<void> {
@@ -263,19 +319,20 @@ if (cookie.trim()) {
         return `Couldn’t ${action}. Try again.`;
       }
 
-      /** Confirm → disable → API → refresh; shared by remove/revoke. */
+      /** Confirm → disable → API → refresh; shared by remove/revoke/invite-link revoke. */
       function runManageAction(
         btn: HTMLButtonElement,
         confirmMessage: string,
         actionLabel: string,
         request: () => Promise<ManageResult>,
+        onSuccess: () => void = () => void refreshPeopleLists(),
       ): void {
         if (!confirm(confirmMessage)) return;
         void (async () => {
           btn.disabled = true;
           const res = await request();
           if (!stillHere()) return;
-          if (res.kind === "ok") void refreshPeopleLists();
+          if (res.kind === "ok") onSuccess();
           else {
             btn.disabled = false;
             alert(manageErrorText(res.reason, actionLabel));
@@ -329,6 +386,62 @@ if (cookie.trim()) {
             inviteStatus.textContent = "Couldn’t create the invite. Try again.";
           }
         })();
+      });
+
+      inviteLinkForm.addEventListener("submit", (event) => {
+        void (async () => {
+          event.preventDefault();
+          if (!stillHere()) return;
+          const form = event.currentTarget as HTMLFormElement;
+          const labelInput = form.querySelector<HTMLInputElement>('input[name="label"]');
+          const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
+          const label = labelInput?.value.trim() || undefined;
+          if (!submit) return;
+
+          inviteLinkStatus.hidden = false;
+          inviteLinkStatus.textContent = "Generating link…";
+          inviteLinkUrl.hidden = true;
+          submit.disabled = true;
+          const result = await createInviteLink(apiOrigin, workspaceName, label);
+          if (!stillHere()) return;
+          submit.disabled = false;
+
+          if (result.kind === "ok") {
+            inviteLinkStatus.textContent = "Link created — copy it now, it won't be shown again.";
+            inviteLinkUrlCode.textContent = result.url;
+            inviteLinkUrlCopy.dataset.copy = result.url;
+            inviteLinkUrl.hidden = false;
+            if (labelInput) labelInput.value = "";
+            void loadInviteLinks();
+            return;
+          }
+          if (result.reason === "member_cap") {
+            inviteLinkStatus.textContent =
+              result.message ?? "This workspace has reached its member limit.";
+          } else if (result.reason === "forbidden") {
+            inviteLinkStatus.textContent = "You need workspace admin access to generate a link.";
+          } else if (result.reason === "invalid") {
+            inviteLinkStatus.textContent = "That label isn’t valid.";
+          } else {
+            inviteLinkStatus.textContent = "Couldn’t generate a link. Try again.";
+          }
+        })();
+      });
+
+      inviteLinkList.addEventListener("click", (event) => {
+        const target = event.target as HTMLElement;
+        const revokeBtn = target.closest<HTMLButtonElement>(".invite-link-row__revoke");
+        if (!revokeBtn) return;
+        const linkId = revokeBtn.dataset.linkId ?? "";
+        const label = revokeBtn.dataset.linkLabel || "this link";
+        if (!linkId) return;
+        runManageAction(
+          revokeBtn,
+          `Revoke the invite link "${label}"? Anyone still holding it will no longer be able to join.`,
+          "revoke this invite link",
+          () => revokeInviteLink(apiOrigin, workspaceName, linkId),
+          () => void loadInviteLinks(),
+        );
       });
 
       membersEl.addEventListener("click", (event) => {

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -272,7 +272,24 @@ if (cookie.trim()) {
 
       async function loadInviteLinks(): Promise<void> {
         const result = await listInviteLinks(apiOrigin, workspaceName);
-        if (!stillHere() || result.kind !== "ok") return;
+        if (!stillHere()) return;
+        if (result.kind !== "ok") {
+          // Matches the page's existing error copy (see `showError` above)
+          // and offers the same "Try again" affordance rather than leaving
+          // the list silently empty.
+          inviteLinkStatus.hidden = false;
+          inviteLinkStatus.dataset.state = "error";
+          inviteLinkStatus.innerHTML =
+            'Invite links are temporarily unavailable. <button type="button" id="ws-invite-link-status-retry">Try again</button>';
+          return;
+        }
+        // Success clears a previous load-failure message, but leaves alone
+        // any unrelated status text (e.g. "Link created…") the generate form
+        // just set — this function never owned that message on success.
+        if (inviteLinkStatus.dataset.state === "error") {
+          inviteLinkStatus.hidden = true;
+          inviteLinkStatus.removeAttribute("data-state");
+        }
         paintInviteLinks(result.links);
       }
 
@@ -407,7 +424,7 @@ if (cookie.trim()) {
           submit.disabled = false;
 
           if (result.kind === "ok") {
-            inviteLinkStatus.textContent = "Link created — copy it now, it won't be shown again.";
+            inviteLinkStatus.textContent = "Link created. Copy it now. It won't be shown again.";
             inviteLinkUrlCode.textContent = result.url;
             inviteLinkUrlCopy.dataset.copy = result.url;
             inviteLinkUrl.hidden = false;
@@ -426,6 +443,12 @@ if (cookie.trim()) {
             inviteLinkStatus.textContent = "Couldn’t generate a link. Try again.";
           }
         })();
+      });
+
+      inviteLinkStatus.addEventListener("click", (event) => {
+        const target = event.target as HTMLElement;
+        if (!target.closest("#ws-invite-link-status-retry")) return;
+        void loadInviteLinks();
       });
 
       inviteLinkList.addEventListener("click", (event) => {

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -58,6 +58,7 @@ export const prerender = false;
       clearExpandGroups,
       escapeHtml,
       loadOnce,
+      type LoadOnceFlag,
       wireExpandGroup,
     } from "../../lib/admin-ui";
 
@@ -561,8 +562,8 @@ export const prerender = false;
       /**
        * Outstanding invite links for a workspace, with a revoke button per
        * row. `onRevoke` fires after a successful DELETE so the caller can
-       * refresh the list; failures render an inline status message instead
-       * of throwing.
+       * refresh the list. A failed DELETE renders an inline status message
+       * instead of throwing.
        */
       function renderInviteLinks(
         host: HTMLElement,
@@ -696,9 +697,21 @@ export const prerender = false;
         const limitsLoaded = { done: false };
         const storageLoaded = { done: false };
         const githubLinksLoaded = { done: false };
-        const inviteLinksLoaded = { done: false };
+        const inviteLinksLoaded: LoadOnceFlag = { done: false };
+
+        // A reload requested while the initial GET is still in flight can't
+        // just clear `inviteLinksLoaded.done` and call `loadOnce` again —
+        // `loadOnce` no-ops while `flag.inflight` is set, so that reload
+        // would be silently dropped (a just-created link wouldn't show up
+        // until a full page reload). Track it as a pending flag instead and
+        // re-run once the in-flight load settles.
+        let inviteLinksReloadPending = false;
 
         function reloadInviteLinks(): void {
+          if (inviteLinksLoaded.inflight) {
+            inviteLinksReloadPending = true;
+            return;
+          }
           inviteLinksLoaded.done = false;
           loadInviteLinks();
         }
@@ -716,6 +729,12 @@ export const prerender = false;
               inviteLinksEl.innerHTML = `<p class="muted">Failed to load invite links.</p>`;
               throw new Error("invite-links");
             }
+          });
+          void inviteLinksLoaded.inflight?.then(() => {
+            if (!inviteLinksReloadPending) return;
+            inviteLinksReloadPending = false;
+            inviteLinksLoaded.done = false;
+            loadInviteLinks();
           });
         }
 

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -45,6 +45,7 @@ export const prerender = false;
     import { formatDate } from "../../lib/subscription-copy";
     import {
       ADMIN_BTN,
+      ADMIN_BTN_DANGER,
       ADMIN_CELL_MONO,
       ADMIN_CELL_MUTED,
       ADMIN_CELL_PRIMARY,
@@ -86,6 +87,14 @@ export const prerender = false;
         email: string;
         role: string | null;
         status: string;
+      }
+      interface InviteLink {
+        id: string;
+        pageId: string | null;
+        label: string | null;
+        scopes: string[];
+        createdAt: string;
+        expiresAt: string;
       }
 
       async function apiGet<T>(path: string): Promise<T> {
@@ -548,6 +557,66 @@ export const prerender = false;
         links: GithubLink[];
       }
 
+      /**
+       * Outstanding invite links for a workspace, with a revoke button per
+       * row. `onRevoke` fires after a successful DELETE so the caller can
+       * refresh the list; failures render an inline status message instead
+       * of throwing.
+       */
+      function renderInviteLinks(
+        host: HTMLElement,
+        workspace: string,
+        links: InviteLink[],
+        onRevoke: () => void,
+      ): void {
+        host.innerHTML = links.length
+          ? `<h4 class="${ADMIN_DETAIL_HEADING}">Invite links</h4>
+           <ul class="invite-links-items ${ADMIN_MINI_LIST}">
+             ${links
+               .map(
+                 (link) => `<li class="${ADMIN_MINI_LIST_ITEM}" data-id="${escapeHtml(link.id)}">
+                   <span>${link.label ? escapeHtml(link.label) : `<span class="muted">unlabeled</span>`} · ${escapeHtml(link.scopes.join(", "))} · expires ${escapeHtml(formatDate(link.expiresAt) ?? link.expiresAt)}</span>
+                   <button type="button" class="invite-link-revoke ${ADMIN_BTN} ${ADMIN_BTN_DANGER}" data-id="${escapeHtml(link.id)}">Revoke</button>
+                 </li>`,
+               )
+               .join("")}
+           </ul>
+           <div class="invite-links-status text-(length:--text-micro)" role="status" aria-live="polite" hidden></div>`
+          : `<p class="muted">No outstanding invite links.</p>`;
+
+        const statusEl = host.querySelector<HTMLElement>(".invite-links-status");
+        host.querySelectorAll<HTMLButtonElement>(".invite-link-revoke").forEach((btn) => {
+          btn.addEventListener("click", () => {
+            void (async () => {
+              const id = btn.dataset.id;
+              if (!id) return;
+              btn.disabled = true;
+              try {
+                const res = await fetch(
+                  `${apiOrigin}/admin-ui/workspaces/${encodeURIComponent(workspace)}/invite-links/${encodeURIComponent(id)}`,
+                  { method: "DELETE", credentials: "include" },
+                );
+                if (!res.ok) {
+                  const payload = (await res.json().catch(() => null)) as {
+                    error?: { message?: string };
+                  } | null;
+                  throw new Error(payload?.error?.message || `revoke failed: ${res.status}`);
+                }
+                onRevoke();
+              } catch (err) {
+                btn.disabled = false;
+                if (statusEl) {
+                  statusEl.dataset.state = "error";
+                  statusEl.textContent =
+                    err instanceof Error && err.message ? err.message : "Couldn't revoke the link.";
+                  statusEl.hidden = false;
+                }
+              }
+            })();
+          });
+        });
+      }
+
       function renderGithubLinks(host: HTMLElement, links: GithubLink[]): void {
         host.innerHTML = links.length
           ? `<h4 class="github-links-heading ${ADMIN_DETAIL_HEADING}">GitHub repos claimed</h4>
@@ -600,12 +669,23 @@ export const prerender = false;
                   <div class="invite-status text-(length:--text-micro)" hidden></div>`
                 : `<p class="muted admin-detail-block">No organization provisioned for this workspace yet - run the org backfill.</p>`
             }
-            <div class="invite-link-row admin-detail-block flex gap-2 items-center flex-wrap">
-              <button type="button" class="invite-link-generate ${ADMIN_BTN}">Generate invite link</button>
-              <input type="text" class="invite-link-url flex-1 min-w-[200px] bg-background border border-border rounded-sm text-foreground px-[9px] py-[7px] font-mono text-(length:--text-micro)" readonly hidden aria-label="Invite link" />
-              <button type="button" class="invite-link-copy ${ADMIN_BTN}" hidden>Copy</button>
+            <div class="invite-link-row admin-detail-block grid gap-2 max-w-[480px]">
+              <div class="flex flex-wrap gap-2 items-end">
+                <label class="grid gap-1 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]">Label (optional)<input type="text" class="invite-link-label bg-background border border-border rounded-sm text-foreground normal-case tracking-normal px-[9px] py-[7px] font-sans text-(length:--text-micro) flex-1 min-w-[160px]" placeholder="e.g. contractor" maxlength="100" /></label>
+                <fieldset class="invite-link-scopes flex gap-3 items-center border-0 p-0 m-0 text-(length:--text-micro) text-body">
+                  <legend class="sr-only">Scopes</legend>
+                  <label class="flex items-center gap-1"><input type="checkbox" class="invite-link-scope" value="files:read" checked /> files:read</label>
+                  <label class="flex items-center gap-1"><input type="checkbox" class="invite-link-scope" value="files:write" checked /> files:write</label>
+                </fieldset>
+              </div>
+              <div class="flex gap-2 items-center flex-wrap">
+                <button type="button" class="invite-link-generate ${ADMIN_BTN}">Generate invite link</button>
+                <input type="text" class="invite-link-url flex-1 min-w-[200px] bg-background border border-border rounded-sm text-foreground px-[9px] py-[7px] font-mono text-(length:--text-micro)" readonly hidden aria-label="Invite link" />
+                <button type="button" class="invite-link-copy ${ADMIN_BTN}" hidden>Copy</button>
+              </div>
             </div>
             <div class="invite-status invite-link-status text-(length:--text-micro)" role="status" aria-live="polite" hidden></div>
+            <div class="invite-links-list admin-detail-block" data-state="unloaded"></div>
           </div>
         </td>
       </tr>`;
@@ -615,6 +695,28 @@ export const prerender = false;
         const limitsLoaded = { done: false };
         const storageLoaded = { done: false };
         const githubLinksLoaded = { done: false };
+        const inviteLinksLoaded = { done: false };
+
+        function reloadInviteLinks(): void {
+          inviteLinksLoaded.done = false;
+          loadInviteLinks();
+        }
+
+        function loadInviteLinks(): void {
+          loadOnce(inviteLinksLoaded, async () => {
+            const inviteLinksEl = group.querySelector<HTMLElement>(".invite-links-list");
+            if (!inviteLinksEl) return;
+            try {
+              const { links } = await apiGet<{ links: InviteLink[] }>(
+                `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/invite-links`,
+              );
+              renderInviteLinks(inviteLinksEl, ws.workspace, links, reloadInviteLinks);
+            } catch {
+              inviteLinksEl.innerHTML = `<p class="muted">Failed to load invite links.</p>`;
+              throw new Error("invite-links");
+            }
+          });
+        }
 
         function loadDetail() {
           const membersEl = group.querySelector<HTMLElement>(".members");
@@ -705,6 +807,8 @@ export const prerender = false;
               throw new Error("github");
             }
           });
+
+          loadInviteLinks();
         }
 
         const { setOpen } = wireExpandGroup(group, loadDetail);
@@ -764,8 +868,22 @@ export const prerender = false;
         const urlInput = group.querySelector<HTMLInputElement>(".invite-link-url");
         const copyBtn = group.querySelector<HTMLButtonElement>(".invite-link-copy");
         const linkStatusEl = group.querySelector<HTMLElement>(".invite-link-status");
+        const labelInput = group.querySelector<HTMLInputElement>(".invite-link-label");
+        const scopeInputs = Array.from(
+          group.querySelectorAll<HTMLInputElement>(".invite-link-scope"),
+        );
         generateBtn?.addEventListener("click", () => {
           void (async () => {
+            const label = labelInput?.value.trim() ?? "";
+            const scopes = scopeInputs.filter((s) => s.checked).map((s) => s.value);
+            if (scopes.length === 0) {
+              if (linkStatusEl) {
+                linkStatusEl.dataset.state = "error";
+                linkStatusEl.textContent = "Pick at least one scope.";
+                linkStatusEl.hidden = false;
+              }
+              return;
+            }
             generateBtn.disabled = true;
             if (linkStatusEl) linkStatusEl.hidden = true;
             if (urlInput) urlInput.hidden = true;
@@ -777,7 +895,7 @@ export const prerender = false;
                   method: "POST",
                   credentials: "include",
                   headers: { "Content-Type": "application/json" },
-                  body: "{}",
+                  body: JSON.stringify({ label: label || undefined, scopes }),
                 },
               );
               if (!res.ok) {
@@ -792,6 +910,8 @@ export const prerender = false;
                 urlInput.hidden = false;
               }
               if (copyBtn) copyBtn.hidden = false;
+              if (labelInput) labelInput.value = "";
+              reloadInviteLinks();
             } catch (err) {
               if (linkStatusEl) {
                 linkStatusEl.dataset.state = "error";

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -93,6 +93,7 @@ export const prerender = false;
         pageId: string | null;
         label: string | null;
         scopes: string[];
+        kind?: "token" | "member";
         createdAt: string;
         expiresAt: string;
       }
@@ -575,7 +576,7 @@ export const prerender = false;
              ${links
                .map(
                  (link) => `<li class="${ADMIN_MINI_LIST_ITEM}" data-id="${escapeHtml(link.id)}">
-                   <span>${link.label ? escapeHtml(link.label) : `<span class="muted">unlabeled</span>`} · ${escapeHtml(link.scopes.join(", "))} · expires ${escapeHtml(formatDate(link.expiresAt) ?? link.expiresAt)}</span>
+                   <span>${link.label ? escapeHtml(link.label) : `<span class="muted">unlabeled</span>`} · ${escapeHtml(link.kind === "member" ? "member" : link.scopes.join(", "))} · expires ${escapeHtml(formatDate(link.expiresAt) ?? link.expiresAt)}</span>
                    <button type="button" class="invite-link-revoke ${ADMIN_BTN} ${ADMIN_BTN_DANGER}" data-id="${escapeHtml(link.id)}">Revoke</button>
                  </li>`,
                )

--- a/apps/web/src/pages/api/enrollments/join.ts
+++ b/apps/web/src/pages/api/enrollments/join.ts
@@ -1,0 +1,12 @@
+/**
+ * Same-origin proxy for `POST /auth/enrollments/join` (issue #869 phase B).
+ * Route stays thin — see `proxyEnrollmentJoinRequest` in `../../../lib/api-proxy`
+ * for why this needs its own route rather than going through `/api/[...path]`.
+ */
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { proxyEnrollmentJoinRequest } from "../../../lib/api-proxy";
+
+export const prerender = false;
+
+export const POST: APIRoute = ({ request }) => proxyEnrollmentJoinRequest(env, request);

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -94,7 +94,8 @@ import Footer from "../components/Footer.astro";
       .command button {
         flex-shrink: 0;
       }
-      button {
+      button,
+      a.button {
         font-size: var(--text-micro);
         letter-spacing: 0.06em;
         border: 1px solid var(--line);
@@ -104,11 +105,30 @@ import Footer from "../components/Footer.astro";
         color: var(--accent);
         cursor: pointer;
         font-family: inherit;
+        text-decoration: none;
+        display: inline-block;
       }
       button:hover,
-      button:focus-visible {
+      button:focus-visible,
+      a.button:hover,
+      a.button:focus-visible {
         border-color: var(--accent);
         outline: none;
+      }
+      #join-actions {
+        margin: 24px 0;
+      }
+      #join-btn,
+      #join-signin {
+        font-size: var(--text-ui);
+        padding: 10px 18px;
+        border-color: var(--accent);
+        color: var(--fg);
+        background: var(--accent);
+      }
+      #join-btn:disabled {
+        opacity: 0.6;
+        cursor: default;
       }
       .security {
         margin-top: 26px;
@@ -125,8 +145,8 @@ import Footer from "../components/Footer.astro";
   <body>
     <main>
       <div class="brandbar"><Brand /></div>
-      <h1>Accept your invite to uploads.sh</h1>
-      <p>
+      <h1 id="heading">Accept your invite to uploads.sh</h1>
+      <p id="lead">
         Host files and screenshots straight from your terminal — upload, get a public link, attach
         them to a pull request.
       </p>
@@ -152,7 +172,11 @@ import Footer from "../components/Footer.astro";
           </li>
         </ol>
       </section>
-      <p class="security">
+      <section id="join-actions" hidden>
+        <a id="join-signin" class="button" hidden>Sign in to join</a>
+        <button id="join-btn" type="button" hidden>Join workspace</button>
+      </section>
+      <p class="security" id="security-note">
         Treat this link like a password — it's single-use and stops working once you log in.
       </p>
       <Footer compact />
@@ -164,15 +188,22 @@ import Footer from "../components/Footer.astro";
         return element;
       }
 
+      const heading = requireElement<HTMLElement>("#heading");
+      const lead = requireElement<HTMLElement>("#lead");
       const meta = requireElement<HTMLElement>("#meta");
       const instructions = requireElement<HTMLElement>("#instructions");
       const loginCmd = requireElement<HTMLElement>("#login-cmd");
       const loginCopy = requireElement<HTMLButtonElement>("#login-copy");
+      const joinActions = requireElement<HTMLElement>("#join-actions");
+      const joinSignin = requireElement<HTMLAnchorElement>("#join-signin");
+      const joinBtn = requireElement<HTMLButtonElement>("#join-btn");
+      const securityNote = requireElement<HTMLElement>("#security-note");
 
       const url = new URL(location.href);
       const pageId = url.searchParams.get("id") ?? "";
       // The one-time code rides in the URL fragment, which browsers never send to the
-      // server. Read it, then scrub it from the address bar; the CLI still redeems it.
+      // server. Read it, then scrub it from the address bar; the CLI still redeems it
+      // (token-kind), and the join flow (member-kind) keeps it in memory for the POST.
       const code = new URLSearchParams(url.hash.replace(/^#/, "")).get("code") ?? "";
       if (url.hash) history.replaceState(null, "", url.pathname + url.search);
 
@@ -180,6 +211,91 @@ import Footer from "../components/Footer.astro";
         const command = `uploads login --code ${code}`;
         loginCmd.textContent = command;
         loginCopy.dataset.copy = command;
+      }
+
+      /** `/login?callbackURL=` back to this exact invite (code fragment included, so
+       * the join flow can resume immediately on return) — same pattern login.astro
+       * itself uses for its own `?callbackURL=` param. */
+      function signInHref(): string {
+        const returnTo = `${location.origin}/invite?id=${encodeURIComponent(pageId)}#code=${encodeURIComponent(code)}`;
+        return `/login?callbackURL=${encodeURIComponent(returnTo)}`;
+      }
+
+      async function setUpJoinFlow(workspace: string) {
+        heading.textContent = `Join ${workspace} on uploads.sh`;
+        lead.textContent = `You've been invited to join the ${workspace} workspace.`;
+        securityNote.textContent = "Treat this link like a password — it's single-use.";
+        joinActions.hidden = false;
+
+        let signedIn = false;
+        try {
+          const session = await fetch("/api/auth/get-session", {
+            credentials: "include",
+            cache: "no-store",
+          });
+          signedIn = session.ok && (await session.json().catch(() => null)) !== null;
+        } catch {
+          signedIn = false;
+        }
+
+        if (!signedIn) {
+          joinSignin.href = signInHref();
+          joinSignin.hidden = false;
+          return;
+        }
+
+        joinBtn.textContent = `Join ${workspace}`;
+        joinBtn.hidden = false;
+        joinBtn.addEventListener("click", async () => {
+          joinBtn.disabled = true;
+          joinBtn.textContent = "Joining…";
+          try {
+            const response = await fetch("/api/enrollments/join", {
+              method: "POST",
+              credentials: "include",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ code }),
+            });
+            if (response.status === 401) {
+              location.href = signInHref();
+              return;
+            }
+            const payload = (await response.json().catch(() => null)) as {
+              workspace?: string;
+              alreadyMember?: boolean;
+              error?: { code?: string; message?: string };
+            } | null;
+            if (!response.ok) {
+              joinActions.hidden = true;
+              if (payload?.error?.code === "member_cap_reached") {
+                meta.textContent =
+                  payload.error.message ?? "This workspace has reached its member limit.";
+              } else {
+                meta.textContent = "This invite is invalid or has expired.";
+              }
+              meta.dataset.state = "closed";
+              return;
+            }
+            joinActions.hidden = true;
+            meta.textContent = payload?.alreadyMember
+              ? `You're already a member of ${workspace}.`
+              : `You're a member of ${workspace}.`;
+            meta.dataset.state = "ready";
+            const link = document.createElement("a");
+            link.href = `/account/workspaces/${encodeURIComponent(workspace)}`;
+            link.textContent = `Go to ${workspace} →`;
+            link.className = "button";
+            link.style.marginTop = "16px";
+            link.style.display = "inline-block";
+            joinActions.hidden = false;
+            joinActions.replaceChildren(link);
+          } catch {
+            joinBtn.disabled = false;
+            joinBtn.textContent = `Join ${workspace}`;
+            meta.textContent = "Couldn't reach uploads.sh — try again.";
+            meta.dataset.state = "closed";
+          }
+        });
       }
 
       async function checkInvitation() {
@@ -193,6 +309,7 @@ import Footer from "../components/Footer.astro";
           used: boolean;
           expiresAt: string;
           workspace: string;
+          kind?: "token" | "member";
         };
         if (invitation.used) {
           meta.textContent = "This invite has already been used.";
@@ -204,6 +321,14 @@ import Footer from "../components/Footer.astro";
           timeStyle: "short",
         });
         const where = invitation.workspace ? `the ${invitation.workspace} workspace` : "uploads.sh";
+
+        if (invitation.kind === "member") {
+          meta.textContent = `Expires ${when}`;
+          meta.dataset.state = "ready";
+          await setUpJoinFlow(invitation.workspace);
+          return;
+        }
+
         meta.textContent = `You'll join ${where} · expires ${when}`;
         meta.dataset.state = "ready";
         instructions.hidden = false;

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -182,6 +182,13 @@ import Footer from "../components/Footer.astro";
       <Footer compact />
     </main>
     <script>
+      import {
+        codeFromHash,
+        loginHref as buildLoginHref,
+        readStashedCode,
+        stashCode as stashCodeIn,
+      } from "../lib/invite-code";
+
       function requireElement<T extends Element>(selector: string): T {
         const element = document.querySelector<T>(selector);
         if (!element) throw new Error(`invite page is missing ${selector}`);
@@ -201,11 +208,21 @@ import Footer from "../components/Footer.astro";
 
       const url = new URL(location.href);
       const pageId = url.searchParams.get("id") ?? "";
+
       // The one-time code rides in the URL fragment, which browsers never send to the
       // server. Read it, then scrub it from the address bar; the CLI still redeems it
-      // (token-kind), and the join flow (member-kind) keeps it in memory for the POST.
-      const code = new URLSearchParams(url.hash.replace(/^#/, "")).get("code") ?? "";
+      // (token-kind) straight from the fragment.
+      let code = codeFromHash(url.hash);
       if (url.hash) history.replaceState(null, "", url.pathname + url.search);
+
+      if (!code && pageId) {
+        // No fragment — this may be the return trip from /login, where the
+        // join flow (member-kind) stashed the code in sessionStorage instead
+        // of putting it back in a URL (see stashCode below). A private
+        // window or disabled storage just means the code doesn't resume;
+        // nothing was ever exposed in a URL either way.
+        code = readStashedCode(sessionStorage, pageId);
+      }
 
       if (/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) {
         const command = `uploads login --code ${code}`;
@@ -213,12 +230,35 @@ import Footer from "../components/Footer.astro";
         loginCopy.dataset.copy = command;
       }
 
-      /** `/login?callbackURL=` back to this exact invite (code fragment included, so
-       * the join flow can resume immediately on return) — same pattern login.astro
-       * itself uses for its own `?callbackURL=` param. */
-      function signInHref(): string {
-        const returnTo = `${location.origin}/invite?id=${encodeURIComponent(pageId)}#code=${encodeURIComponent(code)}`;
-        return `/login?callbackURL=${encodeURIComponent(returnTo)}`;
+      /** `/login?callbackURL=` back to this exact invite — deliberately WITHOUT the
+       * code, fragment or otherwise: `callbackURL` travels through a server-visible
+       * query string (magic-link emails, OAuth state), so a single-use bearer code
+       * must never ride in it. `stashCode()` below is how the join flow resumes the
+       * code on return instead. */
+      function loginHref(): string {
+        return buildLoginHref(location.origin, pageId);
+      }
+
+      /** Stashes `code` in sessionStorage (private-window/storage-disabled safe —
+       * returns false rather than throwing) so it survives the round trip through
+       * /login without ever appearing in a URL. Callers must NOT fall back to
+       * putting the code in the URL when this returns false. */
+      function stashCode(): boolean {
+        return stashCodeIn(sessionStorage, pageId, code);
+      }
+
+      /** Prepares the code to survive sign-in, then either navigates to /login or,
+       * if storage isn't available, shows guidance instead of silently leaking the
+       * code into the URL. */
+      function goToSignIn(): void {
+        if (code && !stashCode()) {
+          joinActions.hidden = true;
+          meta.textContent =
+            "Couldn't prepare this invite for sign-in — after you log in, open the original invite link again.";
+          meta.dataset.state = "closed";
+          return;
+        }
+        location.href = loginHref();
       }
 
       async function setUpJoinFlow(workspace: string) {
@@ -239,7 +279,15 @@ import Footer from "../components/Footer.astro";
         }
 
         if (!signedIn) {
-          joinSignin.href = signInHref();
+          // `href="#"` only for keyboard/focus semantics — the actual navigation
+          // goes through `goToSignIn()` so the code is stashed (or the guidance
+          // state shown) before the browser leaves this page, never via a real
+          // `href` a user could copy or middle-click and leak the code through.
+          joinSignin.href = "#";
+          joinSignin.addEventListener("click", (event) => {
+            event.preventDefault();
+            goToSignIn();
+          });
           joinSignin.hidden = false;
           return;
         }
@@ -257,7 +305,7 @@ import Footer from "../components/Footer.astro";
               body: JSON.stringify({ code }),
             });
             if (response.status === 401) {
-              location.href = signInHref();
+              goToSignIn();
               return;
             }
             const payload = (await response.json().catch(() => null)) as {
@@ -265,6 +313,16 @@ import Footer from "../components/Footer.astro";
               alreadyMember?: boolean;
               error?: { code?: string; message?: string };
             } | null;
+            if (response.status === 503 && payload?.error?.code === "cap_check_unavailable") {
+              // Retryable — the join wasn't denied, the cap check just
+              // couldn't run. Keep the button live rather than closing out
+              // the invite like an actual denial.
+              joinBtn.disabled = false;
+              joinBtn.textContent = `Join ${workspace}`;
+              meta.textContent = payload.error?.message ?? "Couldn't reach uploads.sh — try again.";
+              meta.dataset.state = "closed";
+              return;
+            }
             if (!response.ok) {
               joinActions.hidden = true;
               if (payload?.error?.code === "member_cap_reached") {

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -182,6 +182,7 @@ import Footer from "../components/Footer.astro";
       <Footer compact />
     </main>
     <script>
+      import { getSession } from "../lib/auth-client";
       import {
         codeFromHash,
         loginHref as buildLoginHref,
@@ -267,16 +268,16 @@ import Footer from "../components/Footer.astro";
         securityNote.textContent = "Treat this link like a password — it's single-use.";
         joinActions.hidden = false;
 
-        let signedIn = false;
-        try {
-          const session = await fetch("/api/auth/get-session", {
-            credentials: "include",
-            cache: "no-store",
-          });
-          signedIn = session.ok && (await session.json().catch(() => null)) !== null;
-        } catch {
-          signedIn = false;
-        }
+        // Same-origin ("" — SAME_ORIGIN_AUTH_BASE): the browser only ever
+        // needs this page's own `/api/auth/get-session` proxy, never a
+        // configured auth-worker origin. `unavailable` (outage or a
+        // malformed response) folds into "not signed in" here, same as the
+        // plain `fetch()` this replaced — no distinct outage state exists
+        // on this page for the session check, so the sign-in prompt is
+        // still the right fallback rather than leaving the join button
+        // hidden with no way forward.
+        const sessionResult = await getSession("");
+        const signedIn = sessionResult.kind === "signed_in";
 
         if (!signedIn) {
           // `href="#"` only for keyboard/focus semantics — the actual navigation

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -187,6 +187,7 @@ import Footer from "../components/Footer.astro";
         codeFromHash,
         loginHref as buildLoginHref,
         readStashedCode,
+        safeSessionStorage,
         stashCode as stashCodeIn,
       } from "../lib/invite-code";
 
@@ -222,7 +223,7 @@ import Footer from "../components/Footer.astro";
         // of putting it back in a URL (see stashCode below). A private
         // window or disabled storage just means the code doesn't resume;
         // nothing was ever exposed in a URL either way.
-        code = readStashedCode(sessionStorage, pageId);
+        code = readStashedCode(safeSessionStorage(), pageId);
       }
 
       if (/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) {
@@ -245,7 +246,7 @@ import Footer from "../components/Footer.astro";
        * /login without ever appearing in a URL. Callers must NOT fall back to
        * putting the code in the URL when this returns false. */
       function stashCode(): boolean {
-        return stashCodeIn(sessionStorage, pageId, code);
+        return stashCodeIn(safeSessionStorage(), pageId, code);
       }
 
       /** Prepares the code to survive sign-in, then either navigates to /login or,

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -807,6 +807,36 @@ section.card .ws-note {
 .settings-section .command {
   margin-top: 8px;
 }
+/* Issue #869 phase B: the People page's outstanding invite-link list. */
+.invite-link-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  max-width: 28rem;
+}
+.invite-link-list:empty {
+  display: none;
+}
+.invite-link-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: var(--text-meta);
+}
+.invite-link-row:last-child {
+  border-bottom: none;
+}
+.invite-link-row__label {
+  color: var(--fg);
+  flex: 1;
+  min-width: 0;
+}
+.invite-link-row__expiry {
+  white-space: nowrap;
+}
 /* Joined control: one outer border, hairline between input and action. */
 .input-group {
   display: flex;


### PR DESCRIPTION
Closes #869 — both follow-ups from the `/console` retirement (#868).

## 1. Link management in `/admin` (issue item 2)

- New `GET /admin-ui/workspaces/:name/invite-links` and `DELETE /admin-ui/workspaces/:name/invite-links/:id`, backed by `listOpenEnrollments` / `revokeEnrollment` in auth-db. Listings never include `code_hash`; the show-once URL behavior is unchanged (plaintext codes are never stored).
- The `/admin` generate flow now takes an optional label and files:read/files:write scope checkboxes, and each workspace's detail panel shows the outstanding (unredeemed, unexpired) links with revoke buttons.
- Hardening: the mint route's existence check moved from a raw `REGISTRY.get` to `loadEditableWorkspace`, so soft-deleted workspaces 404 instead of minting.

## 2. Workspace-admin join links (issue item 1)

Design decision: redeeming a workspace-admin link creates **membership**, not a CLI token. The existing enrollment exchange mints `auth_tokens` rows and never touches the member cap, so it cannot carry this feature.

- Migration adds `auth_enrollments.kind` (`'token'` default, `'member'` for these links). The token exchange rejects member-kind codes and the join path rejects token-kind codes, both with the uniform `invalid_enrollment` shape.
- `POST/GET/DELETE /v1/workspaces/:workspace/invite-links(/:id)` gated by `sessionAdminGate()` (session-only, matching the People page's invite management).
- Redemption: `POST /auth/enrollments/join` (session-authed, rate-limited, same body hygiene as the exchange endpoint) atomically claims the single-use enrollment, then the auth worker's new `POST /internal/join` adds the redeemer as a `member`-role org member. The claim is restored if the add fails, if transport to the auth worker fails, or if the redeemer was already a member (so a curious existing member can't burn a shared link).
- Member cap (free-plan 3-member cap included) enforced at **mint** (mirroring email invites) and again at **redemption**. The redemption-time check fails closed: the membership insert is a single atomic conditional `INSERT … SELECT … WHERE NOT EXISTS(membership) AND under-cap`, which also closes the concurrent-join TOCTOU, and a cap-lookup outage returns a retryable 503 instead of admitting the member. The email-invite path's pre-existing fail-open behavior is unchanged (regression-tested).
- `/invite` page branches on `kind`: member links get a "Join <workspace>" flow with sign-in-and-return. The single-use code stays out of server-visible URLs — on the sign-in round trip it's stashed in `sessionStorage`, never folded into `callbackURL` (which would have leaked it into request logs, magic-link emails, and OAuth state).
- People page: workspace admins get an "Invite links" block — generate with optional label, show-once URL with copy, outstanding list with revoke.

## Review

Two independent review passes (Opus + Codex adversarial) ran over the diff; all findings are fixed in the final commit — details in the commit message of 32f7296e. Both reviews specifically cleared the authz matrix, cross-workspace revoke isolation, single-use claim atomicity, secret handling in list endpoints, XSS on the HTML-string surfaces, and the migration backfill.

`pnpm test`: 349 files / 5375 tests passing; typecheck, lint, and format clean.

No screenshots attached — the UI additions need a signed-in local session to capture; happy to add before/afters on request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace admins can create, view, copy, and revoke one-time member invite links.
  - Invite links support optional labels and display expiration details.
  - Recipients can join a workspace directly after signing in.
  - Member limits are checked during link creation and redemption.
  - Existing token-based invitations continue to work separately.

- **Bug Fixes**
  - Invite codes are kept out of login callback URLs and securely cleared after use.
  - Improved handling for expired, invalid, unavailable, and capacity-limited invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->