### PR TITLE
fix(uploads): declare every usage field on the MCP output schema

### DIFF
--- a/.changeset/fix-usage-output-schema.md
+++ b/.changeset/fix-usage-output-schema.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Fix `usage`, `reconcile`, and `purge_expired` MCP tools failing with an output validation error. The two-lane storage work added `sharedBytes`, `sharedObjects`, and `storageBudgetBasis` to the usage payload, and the usage route separately stamps `scopes`, `plan`, and `storage`, but the MCP output schema didn't list them, so the strict (`additionalProperties: false`) schema rejected real responses.

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -484,6 +484,8 @@ export interface UsageResult {
   uploadsRemaining?: number;
   /** Bytes still on hosted storage (shared-lane residue). */
   sharedBytes?: number;
+  /** Objects still on hosted storage (shared-lane residue). */
+  sharedObjects?: number;
   /** "shared" = BYO bucket active: the storage cap meters only hosted
    * residue; the customer's own bucket is unmetered. */
   storageBudgetBasis?: "total" | "shared";

--- a/packages/uploads/src/mcp/output-schemas.ts
+++ b/packages/uploads/src/mcp/output-schemas.ts
@@ -254,13 +254,36 @@ export const usageResultSchema: JsonSchema = objectSchema({
   workspace: { type: "string" },
   bytes: { type: "number" },
   objects: { type: "number" },
+  sharedBytes: { type: "number" },
+  sharedObjects: { type: "number" },
   uploadsInPeriod: { type: "number" },
   periodStart: { type: "string" },
   updatedAt: { type: "string" },
+  storageBudgetBasis: { type: "string", enum: ["total", "shared"] },
   maxStorageBytes: { type: "number" },
   storageRemainingBytes: { type: "number" },
   maxUploadsPerPeriod: { type: "number" },
   uploadsRemaining: { type: "number" },
+  // GET /:workspace/usage (routes/workspace-usage.ts) also stamps these on
+  // every response — not part of `usageWithLimits`'s return, so easy to miss.
+  scopes: { type: "array", items: { type: "string" } },
+  plan: { type: "string" },
+  storage: objectSchema(
+    {
+      mode: { type: "string", enum: ["shared", "byo"] },
+      fallbackLanes: { type: "number" },
+      health: objectSchema(
+        {
+          ok: { type: "boolean" },
+          code: { type: "string" },
+          message: { type: "string" },
+          since: { type: "string" },
+        },
+        ["ok"],
+      ),
+    },
+    ["mode", "fallbackLanes", "health"],
+  ),
 });
 
 export const reconcileResultSchema: JsonSchema = objectSchema({

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -1358,6 +1358,97 @@ describe("tools/call list, delete, comment", () => {
   });
 });
 
+describe("tools/call usage, reconcile, purge_expired (output schema drift)", () => {
+  // Regression test for the shipped bug: the two-lane storage work added
+  // `sharedBytes`/`sharedObjects`/`storageBudgetBasis` (and the API route
+  // separately stamps `scopes`/`plan`/`storage`) to the real GET /v1/usage
+  // payload, but `usageResultSchema` in ../src/mcp/output-schemas.ts kept its
+  // narrower field list. Because that schema has `additionalProperties:
+  // false` and the SDK validates `structuredContent` against it, calling
+  // `usage` — or `reconcile`/`purge_expired`, which embed it — failed at
+  // runtime with "Invalid structured content" even though the handler ran
+  // fine. Returning the FULL real-world shape here (not just the fields the
+  // old schema knew about) is the point: a future field the API adds but the
+  // schema doesn't will fail this test the same way it failed in production.
+  const fullUsage = {
+    workspace: "acme",
+    bytes: 100,
+    objects: 2,
+    sharedBytes: 40,
+    sharedObjects: 1,
+    uploadsInPeriod: 3,
+    periodStart: "2026-08-01",
+    updatedAt: "2026-08-27T00:00:00.000Z",
+    storageBudgetBasis: "shared" as const,
+    maxStorageBytes: 1000,
+    storageRemainingBytes: 900,
+    maxUploadsPerPeriod: 50,
+    uploadsRemaining: 47,
+    scopes: ["files:read", "files:write"],
+    plan: "pro",
+    storage: {
+      mode: "byo" as const,
+      fallbackLanes: 1,
+      health: { ok: true },
+    },
+  };
+
+  function serverWithUsage() {
+    return serverWith({
+      factory: () =>
+        ({
+          usage: async () => fullUsage,
+          reconcile: async () => ({
+            workspace: "acme",
+            bytes: 100,
+            objects: 2,
+            previous: { bytes: 90, objects: 2 },
+            changed: true,
+            usage: fullUsage,
+          }),
+          purgeExpired: async () => ({
+            workspace: "acme",
+            retentionDays: 30,
+            cutoff: "2026-07-28T00:00:00.000Z",
+            deleted: 1,
+            freedBytes: 10,
+            keys: ["a.png"],
+            keysTruncated: false,
+            reconcile: {
+              workspace: "acme",
+              bytes: 100,
+              objects: 2,
+              previous: { bytes: 90, objects: 2 },
+              changed: true,
+              usage: fullUsage,
+            },
+          }),
+        }) as unknown as UploadsClient,
+    });
+  }
+
+  it("usage validates against the real GET /v1/usage response shape", async () => {
+    const { server } = serverWithUsage();
+    const res = await rpc(server, "tools/call", { name: "usage", arguments: {} });
+    expect(res.result.isError).toBe(false);
+    expect(res.result.structuredContent).toEqual(fullUsage);
+  });
+
+  it("reconcile validates when its embedded usage carries the full shape", async () => {
+    const { server } = serverWithUsage();
+    const res = await rpc(server, "tools/call", { name: "reconcile", arguments: {} });
+    expect(res.result.isError).toBe(false);
+    expect(res.result.structuredContent.usage).toEqual(fullUsage);
+  });
+
+  it("purge_expired validates when its nested reconcile.usage carries the full shape", async () => {
+    const { server } = serverWithUsage();
+    const res = await rpc(server, "tools/call", { name: "purge_expired", arguments: {} });
+    expect(res.result.isError).toBe(false);
+    expect(res.result.structuredContent.reconcile.usage).toEqual(fullUsage);
+  });
+});
+
 describe("tools/call get_metadata, set_metadata, find_files", () => {
   it("get_metadata returns the map (or empty) and requires key", async () => {
     const { server, metadataStore } = serverWith();


### PR DESCRIPTION
## What

The MCP `usage`, `reconcile`, and `purge_expired` tools were failing at runtime with an output validation error:

```
Output validation error: Invalid structured content for tool usage:
#: Property "sharedBytes" does not match additional properties schema.
#/sharedBytes: False boolean schema. …
```

Found while spot-checking whether workspace storage usage was being calculated correctly (it is — see below).

## Why

`usageResultSchema` is built by the local `objectSchema()` helper, which sets `additionalProperties: false`. The live `GET /:workspace/usage` response carries **six** fields the schema never declared:

- `sharedBytes`, `sharedObjects`, `storageBudgetBasis` — added to the usage payload by the two-lane storage work
- `scopes`, `plan`, `storage` — stamped onto every response by `routes/workspace-usage.ts` itself, outside `usageWithLimits`'s return, so easy to miss when updating the schema

`reconcileResultSchema` and `purgeExpiredResultSchema` embed `usageResultSchema`, so those two tools broke the same way.

`UsageResult` in `client.ts` was stale in the same direction — it declared `sharedBytes` but not `sharedObjects`, though the API always returns both.

## Preventing the recurrence

Every schema in this file is closed, so any field a handler returns without a matching schema entry breaks its tool in production with no local signal. The added test drives `usage` / `reconcile` / `purge_expired` through the real `createMcpServer` + `AjvJsonSchemaValidator` with a full-shape response, so the next such field fails CI instead.

I audited the rest of `output-schemas.ts` against current handler/API DTOs — `comment`, `promote`, `put`, `list`, `delete`, `metadata`, `find_files`, `metadataFacets`, `repoLinkStatus`, `whoami`, and the gallery schemas were all already correct for what each tool reaches at runtime.

One latent case left alone deliberately: `ListItem` can carry a `metadata` field when `metadata: true` is requested, which isn't declared on `listResultSchema`'s item shape — but the `list` MCP tool never passes that option, so it isn't reachable today. Flagging rather than changing an untriggerable path.

## On the usage numbers themselves

The storage accounting checked out. An independent recount of the `default` workspace (paging `list`, summing real object sizes) came to 31,088,587 bytes against a reported 31 MB. The object count differs by two only because `listObjects` filters `_internal/` keys while the ledger counts them.

## Testing

- `pnpm test` (root): 5390 passed / 350 files
- `packages/uploads`, `@uploads/api`, `@uploads/mcp` typechecks clean
- Root `pnpm typecheck` fails only on `apps/web` (`astro check` needs Node ≥24; this worktree is on 22) — pre-existing and untouched by this change
