### PR TITLE
fix(api,docs): name every worker that needs a secret, and stop the dead-end BYO error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,8 @@ playbook in [docs/previews.md](docs/previews.md); the Workers Builds bot's
 against production bindings.
 
 Operator runbook: [docs/ops.md](docs/ops.md). Daily retention cron on the API
-worker; BYO secrets use `WORKSPACE_SECRETS_KEY`; bare upload keys get `f/<id>/…`.
+worker; BYO secrets use `WORKSPACE_SECRETS_KEY`, set on both `uploads-api` and
+`uploads-mcp`; bare upload keys get `f/<id>/…`.
 
 ### Local Wrangler / agent hygiene
 

--- a/apps/api/src/secrets.ts
+++ b/apps/api/src/secrets.ts
@@ -16,6 +16,25 @@ import { ServiceUnavailableError } from "@uploads/errors";
 
 const PREFIX = "enc:v1:";
 
+/**
+ * No key material is configured on this Worker at all — the KEK was never
+ * installed here. This is a deployment gap, not a per-workspace problem, and
+ * no amount of re-entering credentials in workspace settings fixes it: the
+ * write path re-seals with `uploads-api`'s key, and a Worker without the key
+ * still cannot read the result. Callers distinguish this from a genuine
+ * decrypt failure (a key was present but did not open the ciphertext), where
+ * reconfiguring storage IS the right advice.
+ *
+ * Every Worker that resolves BYO storage needs its own copy of the secret —
+ * `uploads-api` and `uploads-mcp` today. See docs/ops.md#secrets.
+ */
+export class SecretsKeyUnconfiguredError extends Error {
+  constructor() {
+    super("encrypted credential requires WORKSPACE_SECRETS_KEY on this worker");
+    this.name = "SecretsKeyUnconfiguredError";
+  }
+}
+
 /** Current + optional previous master secrets for decrypt during rotation. */
 export type SecretsKeyRing = {
   current?: string;
@@ -104,7 +123,7 @@ export async function decryptSecret(
   }
 
   if (candidates.length === 0) {
-    throw new Error("encrypted credential requires WORKSPACE_SECRETS_KEY");
+    throw new SecretsKeyUnconfiguredError();
   }
 
   const packed = b64urlDecode(value.slice(PREFIX.length));

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -1,4 +1,4 @@
-import { ServiceUnavailableError } from "@uploads/errors";
+import { AppError, ServiceUnavailableError } from "@uploads/errors";
 import {
   createStorage,
   publicAndEmbedUrls,
@@ -7,7 +7,11 @@ import {
   type Files,
   type StorageConfig,
 } from "@uploads/storage";
-import { openCredentialFields, secretsKeyRingFromEnv } from "./secrets";
+import {
+  openCredentialFields,
+  SecretsKeyUnconfiguredError,
+  secretsKeyRingFromEnv,
+} from "./secrets";
 import type { StorageLane, StorageLaneFields, WorkspaceRecord } from "./workspace";
 
 /** Worker env override for the embed CDN base (self-host / disable). */
@@ -62,9 +66,26 @@ async function resolveStorageConfig(env: Env, fields: StorageLaneFields): Promis
       secretAccessKey: fields.secretAccessKey,
     });
   } catch (err) {
-    // Missing/rotated WORKSPACE_SECRETS_KEY, or corrupt ciphertext — surface
-    // as a typed, non-retryable-looking 503 with a settings-page hint instead
-    // of letting the raw decrypt error bubble as an opaque 500.
+    if (err instanceof SecretsKeyUnconfiguredError) {
+      // This Worker holds no KEK at all, so it can read no BYO workspace. That
+      // is an operator problem, and the settings page cannot fix it — a re-seal
+      // there uses uploads-api's key and this Worker still has none. Log it
+      // distinctly so a missing secret is greppable, and tell the caller the
+      // truth instead of sending them round a loop.
+      console.error(
+        JSON.stringify({
+          message: "secrets_key_unconfigured_on_read",
+          hint: "set WORKSPACE_SECRETS_KEY on this worker to the same value uploads-api holds — see docs/ops.md#secrets",
+        }),
+      );
+      throw new ServiceUnavailableError(
+        "workspace storage is unavailable because of a server configuration problem; reconfiguring storage will not fix it",
+        { code: "secrets_key_unconfigured", cause: err },
+      );
+    }
+    // A key was present but did not open the ciphertext (rotation gap, or
+    // corrupt stored data) — surface as a typed 503 with a settings-page hint
+    // instead of letting the raw decrypt error bubble as an opaque 500.
     throw new ServiceUnavailableError(
       "workspace storage credentials could not be decrypted; reconfigure storage in workspace settings",
       { code: "storage_credentials_unreadable", cause: err },
@@ -134,10 +155,17 @@ async function resolveFallbackLane(env: Env, lane: StorageLane): Promise<Storage
   try {
     return await resolveStorageConfig(env, lane);
   } catch (err) {
+    // Skipping is quiet by design at the request level (a stale fallback must
+    // never take down the active lane), but it is never quiet in the logs: a
+    // read that 404s because its only lane was skipped is otherwise
+    // indistinguishable from a genuinely missing object. `code` carries the
+    // typed reason, so `secrets_key_unconfigured` — the whole-worker
+    // misconfiguration — is greppable rather than buried in prose.
     console.error(
       JSON.stringify({
         message: "storage_lane_skipped",
         laneId: lane.id,
+        code: err instanceof AppError ? err.code : undefined,
         reason: err instanceof Error ? err.message : String(err),
       }),
     );

--- a/apps/api/test/storage.test.ts
+++ b/apps/api/test/storage.test.ts
@@ -40,15 +40,46 @@ describe("storageConfig", () => {
     expect(body.error.message).toContain("NOT_A_REAL_BINDING");
   });
 
-  it("throws storage_credentials_unreadable when the ciphertext cannot be decrypted", async () => {
+  it("throws secrets_key_unconfigured when the worker holds no WORKSPACE_SECRETS_KEY", async () => {
     const sealed = await encryptSecret("some-other-master-secret", "AKIA");
     const ws: WorkspaceRecord = {
       ...sharedRecord,
       accessKeyId: sealed,
       secretAccessKey: sealed,
     };
-    // No WORKSPACE_SECRETS_KEY configured at all, so decrypt has no candidate key.
+    // No WORKSPACE_SECRETS_KEY configured at all, so decrypt has no candidate
+    // key. That is a deployment gap on this worker, not a workspace problem.
     const env = {} as unknown as Env;
+
+    await expect(storageConfig(env, ws)).rejects.toMatchObject({
+      code: "secrets_key_unconfigured",
+      status: 503,
+    });
+  });
+
+  it("does not tell the caller to reconfigure storage when the key ring is empty", async () => {
+    const sealed = await encryptSecret("some-other-master-secret", "AKIA");
+    const ws: WorkspaceRecord = {
+      ...sharedRecord,
+      accessKeyId: sealed,
+      secretAccessKey: sealed,
+    };
+    const env = {} as unknown as Env;
+
+    // Re-entering credentials re-seals with uploads-api's key; a worker with no
+    // key still cannot read them. The message must not send anyone there.
+    await expect(storageConfig(env, ws)).rejects.toThrow(/will not fix it/);
+    await expect(storageConfig(env, ws)).rejects.not.toThrow(/workspace settings/);
+  });
+
+  it("throws storage_credentials_unreadable when a key is present but does not open the ciphertext", async () => {
+    const sealed = await encryptSecret("some-other-master-secret", "AKIA");
+    const ws: WorkspaceRecord = {
+      ...sharedRecord,
+      accessKeyId: sealed,
+      secretAccessKey: sealed,
+    };
+    const env = { WORKSPACE_SECRETS_KEY: "wrong-master-secret!!!!" } as unknown as Env;
 
     await expect(storageConfig(env, ws)).rejects.toMatchObject({
       code: "storage_credentials_unreadable",

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -439,33 +439,90 @@ SQLite WAL/SHM files under `.wrangler/state` are what miniflare locks.
 
 ## Secrets
 
-| Secret                           | Purpose                                                                                           |
-| -------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `ADMIN_TOKEN`                    | `/admin/*` — break-glass ops/CI use, not routine admin work (see [admin-tokens](admin-tokens.md)) |
-| `WORKSPACE_SECRETS_KEY`          | **Current** KEK for BYO credentials in KV (`enc:v1:…`)                                            |
-| `WORKSPACE_SECRETS_KEY_PREVIOUS` | **Previous** KEK during rotation only (decrypt fallback, then remove)                             |
+Every secret belongs to one or more **named Workers**, and `wrangler secret put`
+sets it on exactly one of them. A secret that two Workers read must be installed
+on both, with byte-identical values. Nothing in Cloudflare enforces that, so this
+table is the source of truth. Keep it current when a Worker starts or stops
+reading a secret.
+
+| Secret                           | Workers                            | Purpose                                                                                           |
+| -------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `WORKSPACE_SECRETS_KEY`          | **`uploads-api` + `uploads-mcp`**  | **Current** KEK for BYO credentials in KV (`enc:v1:…`)                                            |
+| `WORKSPACE_SECRETS_KEY_PREVIOUS` | **`uploads-api` + `uploads-mcp`**  | **Previous** KEK during rotation only (decrypt fallback, then remove from both)                   |
+| `GITHUB_APP_PRIVATE_KEY`         | **`uploads-api` + `uploads-mcp`**  | GitHub App identity (PKCS#8 PEM). Both Workers post managed comments in-process.                  |
+| `BILLING_INTERNAL_KEY`           | **`uploads-api` + `uploads-auth`** | Shared key gating `POST /internal/billing/plan`. The two values must match.                       |
+| `ADMIN_TOKEN`                    | `uploads-api`                      | `/admin/*` — break-glass ops/CI use, not routine admin work (see [admin-tokens](admin-tokens.md)) |
+| `ANALYTICS_API_TOKEN`            | `uploads-api`                      | Analytics Engine SQL API token for the `/admin/metrics` breakdown panel                           |
+| `GITHUB_APP_WEBHOOK_SECRET`      | `uploads-api`                      | HMAC secret for GitHub App webhook deliveries (`X-Hub-Signature-256`)                             |
+| `OPENAI_APPS_CHALLENGE`          | `uploads-mcp`                      | Domain-verification token served at `/.well-known/openai-apps-challenge`                          |
+| The eight in `secrets.required`  | `uploads-auth`                     | Better Auth, GitHub OAuth, Stripe, billing — listed in `apps/auth/wrangler.jsonc`                 |
+
+`uploads-web` reads no secrets. Absence behavior for each of the above is in
+[Minimal-binding profile](#minimal-binding-profile-self-hosting-uploads754-item-3).
+
+**Why `uploads-mcp` needs the same KEK.** The hosted MCP worker resolves BYO
+storage in-process — it imports `@uploads/api/storage` rather than proxying to
+`uploads-api` — so it opens the same `enc:v1:…` ciphertext with its own copy of
+the key. A shared-lane (binding-mode) workspace never touches the key ring, so a
+missing KEK on `uploads-mcp` is invisible until the first BYO workspace calls a
+storage tool, and then every such call 503s. This gap was live in production
+until 2026-08-27.
 
 ```bash
 # Generate
 openssl rand -base64 32
 
-# First-time install (production, from apps/api)
-pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY
+# First-time install (production) — BOTH workers, the SAME value
+pnpm --filter @uploads/api exec wrangler secret put WORKSPACE_SECRETS_KEY
+pnpm --filter @uploads/mcp exec wrangler secret put WORKSPACE_SECRETS_KEY
 ```
 
+Paste the value identically on both. The KDF hashes the raw string, so one
+trailing newline or space silently breaks decrypt on that Worker only.
+
 `workspace:add --bucket …` encrypts keys when `WORKSPACE_SECRETS_KEY` is in the env. Plaintext legacy values still work until re-written. Decrypt tries **current**, then **previous**, so rotation does not brick BYO workspaces mid-cutover.
+
+**Verify both Workers hold it** (read-only — `wrangler secret list` prints names,
+never values):
+
+```bash
+pnpm --filter @uploads/api exec wrangler secret list
+pnpm --filter @uploads/mcp exec wrangler secret list
+```
+
+If a Worker is missing the key, its logs carry
+`secrets_key_unconfigured_on_read` on the first BYO request, and the API answers
+503 `secrets_key_unconfigured`. That error deliberately does **not** tell the
+user to reconfigure storage: re-entering credentials re-seals them with
+`uploads-api`'s key, and the Worker that lacks the key still cannot read them.
+A 503 `storage_credentials_unreadable` is the different case — a key was
+present but did not open the ciphertext — and reconfiguring does fix that one.
+A skipped fallback lane logs `storage_lane_skipped` with the same `code`.
 
 ### Rotating `WORKSPACE_SECRETS_KEY`
 
 **Putting secrets** is always `wrangler secret put` (the Worker config).
 **Re-sealing records** is an **admin API** so the KEK stays on the worker (not in shell history).
 
+Rotate on **every Worker that reads the key** — `uploads-api` and `uploads-mcp`
+today (see the table above). Rotating only `uploads-api` breaks the hosted MCP
+for every BYO workspace the moment you delete the previous key.
+
 1. Generate a new key: `openssl rand -base64 32` → keep OLD and NEW.
-2. Install both on the worker (from `apps/api`):
+2. Install both on **both** Workers. Use one `secret bulk` call per Worker so
+   each Worker never has a half-rotated pair:
    ```bash
-   pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY_PREVIOUS   # paste OLD
-   pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY            # paste NEW
+   printf 'WORKSPACE_SECRETS_KEY_PREVIOUS=%s
+   WORKSPACE_SECRETS_KEY=%s
+   ' "$OLD" "$NEW" \
+     | pnpm --filter @uploads/api exec wrangler secret bulk
+   printf 'WORKSPACE_SECRETS_KEY_PREVIOUS=%s
+   WORKSPACE_SECRETS_KEY=%s
+   ' "$OLD" "$NEW" \
+     | pnpm --filter @uploads/mcp exec wrangler secret bulk
    ```
+   Do `uploads-api` first, then `uploads-mcp`. Between the two calls both
+   Workers can still decrypt, because each holds OLD as its previous key.
 3. Re-seal registry credentials under the **current** key:
    ```bash
    # dry-run
@@ -476,14 +533,20 @@ pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY
      https://api.uploads.sh/admin/credentials/reencrypt
    # or: pnpm workspace:reencrypt-secrets --dry-run
    ```
-4. Verify BYO / presign. Logs may show `credential_decrypted_with_previous_key`
+   The re-seal runs on `uploads-api` only. It rewrites KV, which both Workers
+   read, so `uploads-mcp` needs no separate re-seal — it only needs the key.
+4. Verify BYO on **both** origins, not just the API. Call a storage-touching
+   hosted-MCP tool (`list`) against a BYO workspace as well as an
+   `api.uploads.sh` read. Logs may show `credential_decrypted_with_previous_key`
    until re-seal finishes.
-5. Drop the previous secret:
+5. Drop the previous secret from **both** Workers:
    ```bash
-   pnpm exec wrangler secret delete WORKSPACE_SECRETS_KEY_PREVIOUS
+   pnpm --filter @uploads/api exec wrangler secret delete WORKSPACE_SECRETS_KEY_PREVIOUS
+   pnpm --filter @uploads/mcp exec wrangler secret delete WORKSPACE_SECRETS_KEY_PREVIOUS
    ```
 
-Do **not** delete PREVIOUS before re-encrypt completes.
+Do **not** delete PREVIOUS before re-encrypt completes, and do not delete it from
+either Worker until step 4 passes on both origins.
 
 ### Auth worker: dedicated D1 → merged D1 cutover (uploads#754 item 1)
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -512,13 +512,9 @@ for every BYO workspace the moment you delete the previous key.
 2. Install both on **both** Workers. Use one `secret bulk` call per Worker so
    each Worker never has a half-rotated pair:
    ```bash
-   printf 'WORKSPACE_SECRETS_KEY_PREVIOUS=%s
-   WORKSPACE_SECRETS_KEY=%s
-   ' "$OLD" "$NEW" \
+   printf 'WORKSPACE_SECRETS_KEY_PREVIOUS=%s\nWORKSPACE_SECRETS_KEY=%s\n' "$OLD" "$NEW" \
      | pnpm --filter @uploads/api exec wrangler secret bulk
-   printf 'WORKSPACE_SECRETS_KEY_PREVIOUS=%s
-   WORKSPACE_SECRETS_KEY=%s
-   ' "$OLD" "$NEW" \
+   printf 'WORKSPACE_SECRETS_KEY_PREVIOUS=%s\nWORKSPACE_SECRETS_KEY=%s\n' "$OLD" "$NEW" \
      | pnpm --filter @uploads/mcp exec wrangler secret bulk
    ```
    Do `uploads-api` first, then `uploads-mcp`. Between the two calls both


### PR DESCRIPTION
## What broke

On 2026-08-27 every BYO-storage workspace got a 503 on every storage-touching hosted-MCP tool. `uploads-mcp` was deployed without `WORKSPACE_SECRETS_KEY` while `uploads-api` had it; both Workers decrypt BYO credentials in-process, so both need the key. Shared-lane workspaces never touch the key ring, which is why the gap stayed latent. The secret is now set and BYO access is confirmed working. This PR fixes the docs and error paths that let the gap hide; the deploy-time guard that prevents recurrence is #875 (merged).

## What changed

- **`docs/ops.md` Secrets table now names the Workers.** Every secret lists which Workers read it, with the shared ones called out (`WORKSPACE_SECRETS_KEY` and `GITHUB_APP_PRIVATE_KEY` on api + mcp, `BILLING_INTERNAL_KEY` on api + auth). The rotation runbook covers both Workers: OLD and NEW land in one `wrangler secret bulk` call per Worker so neither is ever half-rotated, and PREVIOUS is deleted only after a BYO read passes on both origins. Also fixes a `printf` snippet with broken indentation.
- **`apps/api/src/secrets.ts` throws a distinct `SecretsKeyUnconfiguredError`** when no key material is configured, so an empty key ring is distinguishable from a failed decrypt.
- **`apps/api/src/storage.ts` answers the empty-ring case with 503 `secrets_key_unconfigured`** and a message that says this is a server configuration problem. The old message told users to reconfigure storage, which is a dead end for this case: re-entering credentials re-seals them with `uploads-api`'s key, and the Worker without the key still cannot read them. A genuine decrypt failure keeps the old `storage_credentials_unreadable` code and the settings-page advice, which is correct there.
- **`storage_lane_skipped` log lines carry the typed `code`**, so a whole-worker misconfiguration is greppable.

## What to look at

- The catch in `resolveStorageConfig` (`apps/api/src/storage.ts`): the split between the two error cases, and that no key material or internal detail reaches the caller.
- The rotation runbook in `docs/ops.md`: order of operations and the both-Workers verification step.
- Tests in `apps/api/test/storage.test.ts` cover all three paths: empty ring gives `secrets_key_unconfigured`, its message never points at workspace settings, and a wrong-but-present key still gives `storage_credentials_unreadable`.

## Test plan

- `pnpm test` — 350 files, 5389 tests, all passing.
- `pnpm --filter @uploads/api --filter @uploads/mcp --filter @uploads/auth typecheck` — clean. (Root `pnpm typecheck` fails on `apps/web`: `astro check` needs Node >= 24; pre-existing and unrelated.)

No changeset: nothing here changes CLI, client, or npm-package behavior.

Cloudflare Secrets Store was evaluated and not adopted: it fixes value drift between Workers, not the missing-binding failure that caused this outage, and it carries an async-binding rotation trap for our current/previous key ring. The full evaluation is in this description's edit history.
