### PR TITLE
chore(api,mcp): fail the deploy when WORKSPACE_SECRETS_KEY is missing

### DIFF
--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -5,6 +5,21 @@
   "compatibility_date": "2026-07-06",
   "compatibility_flags": ["nodejs_compat"],
   "preview_urls": true,
+  // Deploy-time guard: `wrangler deploy` fails if this secret is not set on
+  // the worker, rather than shipping a build that 503s on every BYO-storage
+  // request. Both this worker and uploads-mcp decrypt workspace credentials
+  // in-process, so both need the same KEK; uploads-mcp shipped without it and
+  // every BYO workspace lost storage until it was noticed. Only the current
+  // key is listed — WORKSPACE_SECRETS_KEY_PREVIOUS is set during a rotation
+  // and removed after, so requiring it would block ordinary deploys.
+  // Secrets that degrade gracefully when unset (GITHUB_APP_PRIVATE_KEY,
+  // GITHUB_APP_WEBHOOK_SECRET, OPENAI_APPS_CHALLENGE) are deliberately absent:
+  // this list is for secrets whose absence silently breaks core function.
+  // Like apps/auth's list, these are worker-level; Workers Builds branch
+  // previews run against production bindings and are unaffected.
+  "secrets": {
+    "required": ["WORKSPACE_SECRETS_KEY"],
+  },
   "vars": {
     // Origin of the invite page that magic links point at. Defaults to the API
     // host without the `api.` prefix; set explicitly for other deployments.

--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -4,6 +4,21 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-07-06",
   "compatibility_flags": ["nodejs_compat"],
+  // Deploy-time guard: `wrangler deploy` fails if this secret is not set on
+  // the worker, rather than shipping a build that 503s on every BYO-storage
+  // request. Both this worker and uploads-api decrypt workspace credentials
+  // in-process, so both need the same KEK; uploads-mcp shipped without it and
+  // every BYO workspace lost storage until it was noticed. Only the current
+  // key is listed — WORKSPACE_SECRETS_KEY_PREVIOUS is set during a rotation
+  // and removed after, so requiring it would block ordinary deploys.
+  // Secrets that degrade gracefully when unset (GITHUB_APP_PRIVATE_KEY,
+  // GITHUB_APP_WEBHOOK_SECRET, OPENAI_APPS_CHALLENGE) are deliberately absent:
+  // this list is for secrets whose absence silently breaks core function.
+  // Like apps/auth's list, these are worker-level; Workers Builds branch
+  // previews run against production bindings and are unaffected.
+  "secrets": {
+    "required": ["WORKSPACE_SECRETS_KEY"],
+  },
   "vars": {
     "WEB_ORIGIN": "https://uploads.sh",
     // OAuth 2.1 authorization server this worker verifies access-token JWTs


### PR DESCRIPTION
## What

Adds `"secrets": { "required": ["WORKSPACE_SECRETS_KEY"] }` to `apps/api` and `apps/mcp`, so `wrangler deploy` fails when that secret is missing instead of shipping a worker that 503s on every BYO-storage request.

## Why

`uploads-mcp` was deployed without `WORKSPACE_SECRETS_KEY` while `uploads-api` had it. Both workers resolve BYO storage in-process and both decrypt workspace credentials with that KEK, so the MCP worker returned:

> workspace storage credentials could not be decrypted; reconfigure storage in workspace settings

on `list`, `put`, metadata, `find_files`, `gallery_add`, and `delete` — for every BYO workspace. Shared-lane workspaces were unaffected, since binding-mode lanes carry no credentials to decrypt, which is why it stayed latent.

The secret has since been set and BYO access is confirmed working. This is the guard so it can't recur — including on the next rotation of that key.

`apps/auth` already uses this mechanism; this brings the other two workers in line.

## Scope

Only `WORKSPACE_SECRETS_KEY` is listed, deliberately:

- `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_WEBHOOK_SECRET`, and `OPENAI_APPS_CHALLENGE` are documented in `env.d.ts` as degrading gracefully when unset ("unset still disables title resolution gracefully", "unset/empty disables the webhook endpoint"). Requiring them would contradict a deliberate design choice.
- `WORKSPACE_SECRETS_KEY_PREVIOUS` is set only during a rotation and removed afterward, so requiring it would block ordinary deploys.

The list is for secrets whose absence silently breaks core function, not every secret a worker reads.

## Verification

Both configs parse and `wrangler deploy --dry-run` succeeds on each.

**One thing I could not verify:** `--dry-run` does not perform the remote check, so the guard itself is not exercised locally. I confirmed this by temporarily adding a deliberately-absent secret name to the required list — the dry run still passed, then reverted it. The mechanism's evidence is that `apps/auth` relies on it in production. The first real deploy of either worker is what exercises it, and both currently have the secret set, so that deploy should pass.

## Related

- Follow-on to #874 (secret-to-worker matrix in `docs/ops.md`, and the dead-end error message).
- A Cloudflare Secrets Store migration was evaluated as the alternative and **not** recommended — it fixes value drift, not missing bindings, so it would not have prevented this. Detail in #874.
