### PR TITLE
feat(api,web): multi-use and non-expiring workspace join links

### DIFF
--- a/apps/api/migrations/20260827170000_auth_enrollments_multi_use.sql
+++ b/apps/api/migrations/20260827170000_auth_enrollments_multi_use.sql
@@ -1,0 +1,48 @@
+-- Issue #876: multi-use, non-expiring member-kind join links.
+--
+-- `max_uses` (NULL = unlimited) and `use_count` replace `used_at` as the
+-- lifecycle stamp for `kind = 'member'` rows — see auth-db.ts's
+-- `claimMemberEnrollment`/`releaseEnrollmentClaim`, now an atomic
+-- conditional increment/decrement instead of the single-winner `used_at`
+-- UPDATE. `kind = 'token'` rows are untouched: `used_at` keeps its exact
+-- pre-#876 single-use meaning; `max_uses`/`use_count` stay unused (NULL/0)
+-- for them.
+--
+-- `expires_at` also becomes nullable — a non-expiring member-kind link has
+-- no expiry at all (NULL), not a far-future date. Token-kind minting paths
+-- keep requiring an explicit TTL; this only widens the column for the rows
+-- that need it. SQLite can't drop a NOT NULL constraint with a plain ALTER,
+-- so the table is rebuilt (standard 4-step SQLite pattern).
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE auth_enrollments_new (
+  id TEXT PRIMARY KEY,
+  workspace TEXT NOT NULL,
+  code_hash TEXT NOT NULL UNIQUE,
+  label TEXT,
+  scopes TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT,
+  token_expires_at TEXT NOT NULL,
+  used_at TEXT,
+  page_id TEXT,
+  kind TEXT NOT NULL DEFAULT 'token',
+  max_uses INTEGER,
+  use_count INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT INTO auth_enrollments_new
+  (id, workspace, code_hash, label, scopes, created_at, expires_at, token_expires_at,
+   used_at, page_id, kind, max_uses, use_count)
+SELECT id, workspace, code_hash, label, scopes, created_at, expires_at, token_expires_at,
+       used_at, page_id, kind, NULL, 0
+FROM auth_enrollments;
+
+DROP TABLE auth_enrollments;
+ALTER TABLE auth_enrollments_new RENAME TO auth_enrollments;
+
+CREATE INDEX auth_enrollments_code_idx ON auth_enrollments (code_hash, used_at, expires_at);
+CREATE UNIQUE INDEX auth_enrollments_page_id_idx
+  ON auth_enrollments (page_id) WHERE page_id IS NOT NULL;
+
+PRAGMA foreign_keys=ON;

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -32,9 +32,20 @@ export function isWorkspaceScope(value: unknown): value is WorkspaceScope {
 // Invite code lifetime. 2h gives a human time to onboard after receiving the
 // link out-of-band, while keeping the single-use secret short-lived. Override
 // per-invite with --expires-in up to MAX_ENROLLMENT_SECONDS (see routes/admin).
+// `kind: 'token'` links only — `kind: 'member'` join links (issue #876) use
+// the DEFAULT/MIN/MAX_MEMBER_LINK_SECONDS trio below instead.
 export const DEFAULT_ENROLLMENT_SECONDS = 2 * 60 * 60;
 export const DEFAULT_TOKEN_SECONDS = 90 * 24 * 60 * 60;
 export const MAX_TOKEN_SECONDS = 365 * 24 * 60 * 60;
+
+// Issue #876: `kind: 'member'` join-link expiry, deliberately longer-lived
+// and admin-configurable than the CLI-enrollment defaults above — these
+// links get dropped in a team chat and read days later, not redeemed
+// immediately. `expiresIn: "never"`/`null` at mint time bypasses this range
+// entirely (NULL `expires_at`, see `createEnrollment`).
+export const DEFAULT_MEMBER_LINK_SECONDS = 7 * 24 * 60 * 60;
+export const MIN_MEMBER_LINK_SECONDS = 60 * 60;
+export const MAX_MEMBER_LINK_SECONDS = 90 * 24 * 60 * 60;
 /** How stale last_used_at must be before a successful auth rewrites it. */
 export const LAST_USED_TOUCH_SECONDS = 60 * 60;
 
@@ -75,16 +86,26 @@ interface EnrollmentRecord {
   label: string | null;
   scopes: string;
   created_at: string;
-  expires_at: string;
+  // Nullable since issue #876: a non-expiring `kind: 'member'` link has no
+  // expiry at all. `kind: 'token'` rows always have one — the minting paths
+  // for that kind still require an explicit TTL.
+  expires_at: string | null;
   token_expires_at: string;
   used_at: string | null;
   page_id: string | null;
   kind: EnrollmentKind;
+  // Issue #876: `kind: 'member'` lifecycle columns. NULL/0 (and untouched)
+  // for `kind: 'token'` rows, which keep using `used_at` exactly as before.
+  max_uses: number | null;
+  use_count: number;
 }
 
-/** One outstanding (unredeemed, unexpired) invite-link enrollment, as
- * surfaced to the admin panel — deliberately excludes `code_hash`: a listed
- * link's URL can never be reconstructed, only revoked. */
+/** One outstanding (unredeemed/not-exhausted, unexpired) invite-link
+ * enrollment, as surfaced to the admin panel and the People page —
+ * deliberately excludes `code_hash`: a listed link's URL can never be
+ * reconstructed, only revoked. `expiresAt` is nullable (issue #876:
+ * non-expiring `kind: 'member'` links); `maxUses`/`useCount` are meaningful
+ * for `kind: 'member'` only (always `null`/`0` for `kind: 'token'`). */
 export interface OpenEnrollment {
   id: string;
   pageId: string | null;
@@ -92,7 +113,9 @@ export interface OpenEnrollment {
   scopes: FileScope[];
   kind: EnrollmentKind;
   createdAt: string;
-  expiresAt: string;
+  expiresAt: string | null;
+  maxUses: number | null;
+  useCount: number;
 }
 
 export function parseScopes(value: string): FileScope[] {
@@ -263,24 +286,41 @@ export async function createEnrollment(
     scopes: FileScope[];
     /** Defaults to `'token'` — the only kind that existed before #869 phase B. */
     kind?: EnrollmentKind;
-    enrollmentSeconds?: number;
+    /**
+     * Seconds until the enrollment code expires. `null` mints a
+     * non-expiring row (`expires_at = NULL`) — issue #876, `kind: 'member'`
+     * only; callers minting `kind: 'token'` links never pass `null`.
+     * Omitted defaults to `DEFAULT_ENROLLMENT_SECONDS`.
+     */
+    enrollmentSeconds?: number | null;
     tokenSeconds?: number;
+    /**
+     * `kind: 'member'` only (issue #876): caps how many times the link can
+     * be redeemed. `null`/omitted = unlimited. Always stored as `null` for
+     * `kind: 'token'` regardless of what's passed.
+     */
+    maxUses?: number | null;
     now?: Date;
   },
 ): Promise<{
   id: string;
   pageId: string;
   code: string;
-  expiresAt: string;
+  expiresAt: string | null;
   tokenExpiresAt: string;
 }> {
   const now = input.now ?? new Date();
-  const expiresAt = new Date(
-    now.getTime() + (input.enrollmentSeconds ?? DEFAULT_ENROLLMENT_SECONDS) * 1000,
-  );
+  const expiresAt =
+    input.enrollmentSeconds === null
+      ? null
+      : new Date(
+          now.getTime() + (input.enrollmentSeconds ?? DEFAULT_ENROLLMENT_SECONDS) * 1000,
+        ).toISOString();
   const tokenExpiresAt = new Date(
     now.getTime() + (input.tokenSeconds ?? DEFAULT_TOKEN_SECONDS) * 1000,
   );
+  const kind = input.kind ?? "token";
+  const maxUses = kind === "member" ? (input.maxUses ?? null) : null;
   const code = randomSecret("upe_", 18);
   const pageId = randomSecret("upi_", 12);
   const enrollmentId = id();
@@ -288,8 +328,8 @@ export async function createEnrollment(
     .prepare(
       `INSERT INTO auth_enrollments
        (id, workspace, code_hash, label, scopes, created_at, expires_at, token_expires_at, used_at,
-        page_id, kind)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)`,
+        page_id, kind, max_uses, use_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, 0)`,
     )
     .bind(
       enrollmentId,
@@ -298,26 +338,34 @@ export async function createEnrollment(
       input.label ?? null,
       JSON.stringify(input.scopes),
       now.toISOString(),
-      expiresAt.toISOString(),
+      expiresAt,
       tokenExpiresAt.toISOString(),
       pageId,
-      input.kind ?? "token",
+      kind,
+      maxUses,
     )
     .run();
   return {
     id: enrollmentId,
     pageId,
     code,
-    expiresAt: expiresAt.toISOString(),
+    expiresAt,
     tokenExpiresAt: tokenExpiresAt.toISOString(),
   };
 }
 
 /**
- * Outstanding (unredeemed, unexpired) invite-link enrollments for a
- * workspace, newest first — backs the admin panel's invite-link list. Never
- * selects `code_hash`; the plaintext code is never stored either, so a
- * listed link's URL can't be reconstructed (show-once stays show-once).
+ * Outstanding invite-link enrollments for a workspace, newest first — backs
+ * the admin panel's and the People page's invite-link lists. Never selects
+ * `code_hash`; the plaintext code is never stored either, so a listed link's
+ * URL can't be reconstructed (show-once stays show-once).
+ *
+ * "Outstanding" (issue #876): unexpired (`expires_at IS NULL` — non-expiring
+ * — or in the future) AND not exhausted. Exhaustion means different things
+ * per `kind`: a `'token'` row is exhausted once `used_at` is set (unchanged
+ * single-use semantics); a `'member'` row is exhausted only once
+ * `use_count` reaches `max_uses` (unlimited when `max_uses IS NULL`) —
+ * `used_at` is never touched for `'member'` rows any more.
  */
 export async function listOpenEnrollments(
   db: D1Queryable,
@@ -330,16 +378,30 @@ export async function listOpenEnrollments(
 ): Promise<OpenEnrollment[]> {
   const result = await db
     .prepare(
-      `SELECT id, page_id, label, scopes, kind, created_at, expires_at
+      `SELECT id, page_id, label, scopes, kind, created_at, expires_at, max_uses, use_count
        FROM auth_enrollments
-       WHERE workspace = ? AND used_at IS NULL AND expires_at > ?${kind ? " AND kind = ?" : ""}
+       WHERE workspace = ?
+         AND (expires_at IS NULL OR expires_at > ?)
+         AND (
+           (kind = 'member' AND (max_uses IS NULL OR use_count < max_uses))
+           OR (kind != 'member' AND used_at IS NULL)
+         )
+         ${kind ? "AND kind = ?" : ""}
        ORDER BY created_at DESC`,
     )
     .bind(...(kind ? [workspace, now.toISOString(), kind] : [workspace, now.toISOString()]))
     .all<
       Pick<
         EnrollmentRecord,
-        "id" | "page_id" | "label" | "scopes" | "kind" | "created_at" | "expires_at"
+        | "id"
+        | "page_id"
+        | "label"
+        | "scopes"
+        | "kind"
+        | "created_at"
+        | "expires_at"
+        | "max_uses"
+        | "use_count"
       >
     >();
   return result.results.map((row) => ({
@@ -350,6 +412,8 @@ export async function listOpenEnrollments(
     kind: row.kind,
     createdAt: row.created_at,
     expiresAt: row.expires_at,
+    maxUses: row.max_uses,
+    useCount: row.use_count,
   }));
 }
 
@@ -377,39 +441,74 @@ export async function revokeEnrollment(
   return (result.meta?.changes ?? 0) > 0;
 }
 
+/**
+ * Public (unauthenticated) status lookup for `/invite`'s "is this link still
+ * good" check, by the non-secret `page_id` — never the code or its hash.
+ * `expiresAt` is nullable (issue #876: a non-expiring `kind: 'member'` link).
+ * `used` means "no longer redeemable": for `kind: 'token'` that's still
+ * `used_at IS NOT NULL` (unchanged single-use meaning); for `kind: 'member'`
+ * it's exhaustion (`use_count >= max_uses`, never true when `max_uses` is
+ * `NULL`) — `used_at` is never set for `'member'` rows any more, so a
+ * still-live multi-use link never shows "already used" just because someone
+ * else already joined through it.
+ */
 export async function findEnrollmentPage(
   db: D1Queryable,
   pageId: string,
   now = new Date(),
-): Promise<{ workspace: string; expiresAt: string; used: boolean; kind: EnrollmentKind } | null> {
+): Promise<{
+  workspace: string;
+  expiresAt: string | null;
+  used: boolean;
+  kind: EnrollmentKind;
+} | null> {
   if (!/^upi_[A-Za-z0-9_-]{16}$/.test(pageId)) return null;
   const record = await db
     .prepare(
-      `SELECT workspace, expires_at, used_at, kind FROM auth_enrollments
-       WHERE page_id = ? AND expires_at > ? LIMIT 1`,
+      `SELECT workspace, expires_at, used_at, kind, max_uses, use_count FROM auth_enrollments
+       WHERE page_id = ? AND (expires_at IS NULL OR expires_at > ?) LIMIT 1`,
     )
     .bind(pageId, now.toISOString())
-    .first<Pick<EnrollmentRecord, "workspace" | "expires_at" | "used_at" | "kind">>();
-  return record
-    ? {
-        workspace: record.workspace,
-        expiresAt: record.expires_at,
-        used: record.used_at !== null,
-        kind: record.kind,
-      }
-    : null;
+    .first<
+      Pick<
+        EnrollmentRecord,
+        "workspace" | "expires_at" | "used_at" | "kind" | "max_uses" | "use_count"
+      >
+    >();
+  if (!record) return null;
+  const used =
+    record.kind === "member"
+      ? record.max_uses !== null && record.use_count >= record.max_uses
+      : record.used_at !== null;
+  return {
+    workspace: record.workspace,
+    expiresAt: record.expires_at,
+    used,
+    kind: record.kind,
+  };
 }
 
 /**
- * Claims an outstanding `kind: 'member'` invite link for redemption (issue
- * #869 phase B) — the single-use, race-safe first half of `POST
- * /auth/enrollments/join` (`routes/auth.ts`): a conditional UPDATE that only
- * the first concurrent redeemer wins, done BEFORE the caller adds the member,
- * so a lost race is indistinguishable from any other invalid code. Returns
- * `null` for an unknown/expired/already-used/wrong-kind code — same uniform
- * failure shape callers collapse to `INVALID_ENROLLMENT`. The returned
- * `codeHash` is what {@link releaseEnrollmentClaim} needs to restore the
- * claim; recomputing it there would mean hashing the code twice.
+ * Claims an outstanding `kind: 'member'` invite link for redemption — the
+ * race-safe first half of `POST /auth/enrollments/join` (`routes/auth.ts`):
+ * an atomic conditional `UPDATE … SET use_count = use_count + 1` that only
+ * succeeds while the link is still redeemable, done BEFORE the caller adds
+ * the member, so a lost race (cap already hit) is indistinguishable from any
+ * other invalid code.
+ *
+ * Issue #876: this used to be a single-winner `used_at` stamp (`kind:
+ * 'member'` links were single-use). It's now a conditional increment, so
+ * concurrent redemptions of the same link are legal — each one only wins if
+ * `use_count < max_uses` (or `max_uses IS NULL`, unlimited) still holds at
+ * UPDATE time; D1/SQLite's single-writer serialization means a concurrent
+ * loser's WHERE re-evaluates against the just-written row and correctly
+ * fails once the cap is reached. The per-redemption member-cap gate is a
+ * separate, unrelated check — the atomic insert in `/internal/join`.
+ *
+ * Returns `null` for an unknown/expired/exhausted/revoked/wrong-kind code —
+ * same uniform failure shape callers collapse to `INVALID_ENROLLMENT`. The
+ * returned `codeHash` is what {@link releaseEnrollmentClaim} needs to
+ * release the claim; recomputing it there would mean hashing the code twice.
  */
 export async function claimMemberEnrollment(
   db: D1Queryable,
@@ -418,11 +517,12 @@ export async function claimMemberEnrollment(
 ): Promise<{ id: string; workspace: string; codeHash: string } | null> {
   const nowIso = now.toISOString();
   const codeHash = await sha256Hex(code);
+  const REDEEMABLE = `kind = 'member'
+       AND (expires_at IS NULL OR expires_at > ?)
+       AND (max_uses IS NULL OR use_count < max_uses)`;
   const enrollment = await db
     .prepare(
-      `SELECT id, workspace FROM auth_enrollments
-       WHERE code_hash = ? AND used_at IS NULL AND expires_at > ? AND kind = 'member'
-       LIMIT 1`,
+      `SELECT id, workspace FROM auth_enrollments WHERE code_hash = ? AND ${REDEEMABLE} LIMIT 1`,
     )
     .bind(codeHash, nowIso)
     .first<{ id: string; workspace: string }>();
@@ -430,10 +530,10 @@ export async function claimMemberEnrollment(
 
   const claim = await db
     .prepare(
-      `UPDATE auth_enrollments SET used_at = ?
-       WHERE id = ? AND code_hash = ? AND used_at IS NULL AND expires_at > ? AND kind = 'member'`,
+      `UPDATE auth_enrollments SET use_count = use_count + 1
+       WHERE id = ? AND code_hash = ? AND ${REDEEMABLE}`,
     )
-    .bind(nowIso, enrollment.id, codeHash, nowIso)
+    .bind(enrollment.id, codeHash, nowIso)
     .run();
   if ((claim.meta?.changes ?? 0) !== 1) return null;
 
@@ -441,11 +541,12 @@ export async function claimMemberEnrollment(
 }
 
 /**
- * Restores a claim {@link claimMemberEnrollment} made (`used_at = NULL`),
- * scoped by both `id` and `code_hash` so it can only ever touch the row it
- * claimed. Shared by every `/auth/enrollments/join` path where the
- * redemption didn't actually happen (or didn't consume a seat) — the link
- * isn't permanently burned for something that never occurred.
+ * Releases (decrements) a claim {@link claimMemberEnrollment} made, scoped
+ * by both `id` and `code_hash` so it can only ever touch the row it claimed,
+ * and by `use_count > 0` so it can never underflow. Shared by every `/auth/
+ * enrollments/join` path where the redemption didn't actually happen (or
+ * didn't consume a seat) — the link isn't permanently burned (nor a seat
+ * permanently lost) for something that never occurred.
  */
 export async function releaseEnrollmentClaim(
   db: D1Queryable,
@@ -453,7 +554,10 @@ export async function releaseEnrollmentClaim(
   codeHash: string,
 ): Promise<void> {
   await db
-    .prepare(`UPDATE auth_enrollments SET used_at = NULL WHERE id = ? AND code_hash = ?`)
+    .prepare(
+      `UPDATE auth_enrollments SET use_count = use_count - 1
+       WHERE id = ? AND code_hash = ? AND use_count > 0`,
+    )
     .bind(id, codeHash)
     .run();
 }

--- a/apps/api/src/routes/admin-enrollments-email.test.ts
+++ b/apps/api/src/routes/admin-enrollments-email.test.ts
@@ -18,6 +18,7 @@ const MIGRATIONS = [
   "migrations/20260712230000_token_minting_user.sql",
   "migrations/20260817180000_token_last_used.sql",
   "migrations/20260827160000_auth_enrollments_kind.sql",
+  "migrations/20260827170000_auth_enrollments_multi_use.sql",
 ];
 
 const RECORD = {

--- a/apps/api/src/routes/admin-workspace-required.test.ts
+++ b/apps/api/src/routes/admin-workspace-required.test.ts
@@ -21,9 +21,11 @@ import { admin } from "./admin";
 const ADMIN_TOKEN = "test-admin-token";
 const MIGRATIONS = [
   "migrations/20260710120000_auth.sql",
+  "migrations/20260711120000_invite_pages.sql",
   "migrations/20260712230000_token_minting_user.sql",
   "migrations/20260817180000_token_last_used.sql",
   "migrations/20260827160000_auth_enrollments_kind.sql",
+  "migrations/20260827170000_auth_enrollments_multi_use.sql",
 ];
 
 const RECORD = {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -329,7 +329,11 @@ export const admin = new Hono<{ Bindings: Env }>()
       const webOrigin = c.env.WEB_ORIGIN || deriveWebOrigin(c.req.url);
       const link = inviteMagicLink(webOrigin, enrollment.pageId, enrollment.code);
       try {
-        await c.env.EMAIL.send(inviteEmail(email, name, link, enrollment.expiresAt));
+        // Non-null: this route always mints `kind: 'token'` with a numeric
+        // `enrollmentSeconds` (never `null`), so `expiresAt` is always set —
+        // the nullable type on `createEnrollment`'s return is for issue
+        // #876's non-expiring `kind: 'member'` links only.
+        await c.env.EMAIL.send(inviteEmail(email, name, link, enrollment.expiresAt!));
         emailed = true;
         // Audit only non-secret metadata — never the code, magic link, or URL.
         console.log(

--- a/apps/api/src/routes/workspace-members.ts
+++ b/apps/api/src/routes/workspace-members.ts
@@ -55,10 +55,12 @@ import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from
 import { Hono, type Context, type MiddlewareHandler } from "hono";
 import {
   createEnrollment,
-  DEFAULT_ENROLLMENT_SECONDS,
+  DEFAULT_MEMBER_LINK_SECONDS,
   DEFAULT_TOKEN_SECONDS,
   labelValue,
   listOpenEnrollments,
+  MAX_MEMBER_LINK_SECONDS,
+  MIN_MEMBER_LINK_SECONDS,
   revokeEnrollment,
 } from "../auth-db";
 import { dbFor } from "../db-session";
@@ -270,6 +272,39 @@ async function requireLiveWorkspace(env: Env, name: string): Promise<void> {
 }
 
 /**
+ * Validates the mint body's `expiresIn` (issue #876): `undefined` → caller
+ * applies `DEFAULT_MEMBER_LINK_SECONDS`; `"never"` or `null` → non-expiring
+ * (`createEnrollment`'s `enrollmentSeconds: null`); a positive integer
+ * within `[MIN_MEMBER_LINK_SECONDS, MAX_MEMBER_LINK_SECONDS]` → that many
+ * seconds. Anything else (a string other than `"never"`, a non-integer, an
+ * out-of-range number) is `{ ok: false }`.
+ */
+function validExpiresIn(
+  value: unknown,
+): { ok: true; value: number | null | undefined } | { ok: false } {
+  if (value === undefined) return { ok: true, value: undefined };
+  if (value === null || value === "never") return { ok: true, value: null };
+  if (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= MIN_MEMBER_LINK_SECONDS &&
+    value <= MAX_MEMBER_LINK_SECONDS
+  ) {
+    return { ok: true, value };
+  }
+  return { ok: false };
+}
+
+/** Validates the mint body's `maxUses`: `undefined`/`null` → unlimited; a positive integer → that cap. */
+function validMaxUses(value: unknown): { ok: true; value: number | null } | { ok: false } {
+  if (value === undefined || value === null) return { ok: true, value: null };
+  if (typeof value === "number" && Number.isInteger(value) && value >= 1) {
+    return { ok: true, value };
+  }
+  return { ok: false };
+}
+
+/**
  * `sessionAdminGate`'s `MembersVars["memberOrg"]["slug"]` IS the workspace
  * name (the 1:1 org<->workspace mapping `org-workspaces.ts` documents), so
  * every invite-link handler below reuses it instead of re-reading (and
@@ -305,11 +340,27 @@ export async function inviteLinkMintHandler(c: Context<MembersVars>) {
   });
   await liveWorkspace;
 
-  const body = await c.req.json<{ label?: unknown }>().catch(() => ({}) as { label?: unknown });
+  const body = await c.req
+    .json<{ label?: unknown; expiresIn?: unknown; maxUses?: unknown }>()
+    .catch(() => ({}) as { label?: unknown; expiresIn?: unknown; maxUses?: unknown });
   const label = labelValue(body.label);
   if (label === null) {
     throw new ValidationError("label must be between 1 and 100 characters", {
       code: "invalid_label",
+    });
+  }
+  const expiresIn = validExpiresIn(body.expiresIn);
+  if (!expiresIn.ok) {
+    throw new ValidationError(
+      `expiresIn must be "never", null, or an integer number of seconds between ` +
+        `${MIN_MEMBER_LINK_SECONDS} and ${MAX_MEMBER_LINK_SECONDS}`,
+      { code: "invalid_expires_in" },
+    );
+  }
+  const maxUses = validMaxUses(body.maxUses);
+  if (!maxUses.ok) {
+    throw new ValidationError("maxUses must be null or a positive integer", {
+      code: "invalid_max_uses",
     });
   }
 
@@ -324,8 +375,10 @@ export async function inviteLinkMintHandler(c: Context<MembersVars>) {
     label,
     scopes: [],
     kind: "member",
-    enrollmentSeconds: DEFAULT_ENROLLMENT_SECONDS,
+    enrollmentSeconds:
+      expiresIn.value === undefined ? DEFAULT_MEMBER_LINK_SECONDS : expiresIn.value,
     tokenSeconds: DEFAULT_TOKEN_SECONDS,
+    maxUses: maxUses.value,
   });
 
   const webOrigin = c.env.WEB_ORIGIN || deriveWebOrigin(c.req.url);
@@ -339,6 +392,8 @@ export async function inviteLinkMintHandler(c: Context<MembersVars>) {
       label: label ?? null,
       url,
       expiresAt: enrollment.expiresAt,
+      maxUses: maxUses.value,
+      useCount: 0,
     },
     201,
   );

--- a/apps/api/test/auth-db-enrollment-claim-sqlite.test.ts
+++ b/apps/api/test/auth-db-enrollment-claim-sqlite.test.ts
@@ -7,6 +7,11 @@
  * sqlite-backed (real SQL, not the hand-rolled `FakeD1` in
  * `auth-db.test.ts`) so the `kind = 'member'` / `code_hash` scoping is
  * exercised for real.
+ *
+ * Issue #876: `claimMemberEnrollment` moved from a single-winner `used_at`
+ * stamp to a conditional `use_count` increment — this file's "single-use"
+ * coverage below now exercises the `max_uses = 1` case explicitly, plus new
+ * coverage for unlimited/capped multi-use and concurrent redemption.
  */
 import { describe, expect, it } from "vitest";
 import { claimMemberEnrollment, createEnrollment, releaseEnrollmentClaim } from "../src/auth-db";
@@ -18,6 +23,7 @@ const MIGRATIONS = [
   "migrations/20260712230000_token_minting_user.sql",
   "migrations/20260817180000_token_last_used.sql",
   "migrations/20260827160000_auth_enrollments_kind.sql",
+  "migrations/20260827170000_auth_enrollments_multi_use.sql",
 ];
 
 function db() {
@@ -33,12 +39,82 @@ describe("claimMemberEnrollment", () => {
     expect(claim).toEqual({ id: link.id, workspace: "acme", codeHash: expect.any(String) });
   });
 
-  it("is single-use: a second claim of the same code fails", async () => {
+  it("is unlimited by default: the same code claims repeatedly", async () => {
     const d1 = db();
     const link = await createEnrollment(d1, { workspace: "acme", scopes: [], kind: "member" });
 
     expect(await claimMemberEnrollment(d1, link.code)).not.toBeNull();
+    expect(await claimMemberEnrollment(d1, link.code)).not.toBeNull();
+    expect(await claimMemberEnrollment(d1, link.code)).not.toBeNull();
+  });
+
+  it("respects an explicit max_uses cap — the (max_uses+1)th claim fails", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      maxUses: 2,
+    });
+
+    expect(await claimMemberEnrollment(d1, link.code)).not.toBeNull();
+    expect(await claimMemberEnrollment(d1, link.code)).not.toBeNull();
     expect(await claimMemberEnrollment(d1, link.code)).toBeNull();
+  });
+
+  it("max_uses: 1 behaves like the pre-#876 single-use link", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      maxUses: 1,
+    });
+
+    expect(await claimMemberEnrollment(d1, link.code)).not.toBeNull();
+    expect(await claimMemberEnrollment(d1, link.code)).toBeNull();
+  });
+
+  it("two concurrent claims of an unlimited link both win", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, { workspace: "acme", scopes: [], kind: "member" });
+
+    const [a, b] = await Promise.all([
+      claimMemberEnrollment(d1, link.code),
+      claimMemberEnrollment(d1, link.code),
+    ]);
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+  });
+
+  it("two concurrent claims of a max_uses: 1 link — only one wins", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      maxUses: 1,
+    });
+
+    const [a, b] = await Promise.all([
+      claimMemberEnrollment(d1, link.code),
+      claimMemberEnrollment(d1, link.code),
+    ]);
+    const successes = [a, b].filter((v) => v !== null);
+    expect(successes).toHaveLength(1);
+  });
+
+  it("claims a non-expiring member link (expires_at NULL)", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      enrollmentSeconds: null,
+    });
+    expect(
+      await claimMemberEnrollment(d1, link.code, new Date("2099-01-01T00:00:00.000Z")),
+    ).not.toBeNull();
   });
 
   it("rejects a token-kind code — never exchangeable for membership", async () => {
@@ -67,26 +143,53 @@ describe("claimMemberEnrollment", () => {
 });
 
 describe("releaseEnrollmentClaim", () => {
-  it("restores used_at so the link is claimable again", async () => {
+  it("decrements use_count so the link is claimable again under its cap", async () => {
     const d1 = db();
-    const link = await createEnrollment(d1, { workspace: "acme", scopes: [], kind: "member" });
+    const link = await createEnrollment(d1, {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      maxUses: 1,
+    });
 
     const claim = await claimMemberEnrollment(d1, link.code);
     expect(claim).not.toBeNull();
+    expect(await claimMemberEnrollment(d1, link.code)).toBeNull(); // exhausted
+
     await releaseEnrollmentClaim(d1, claim!.id, claim!.codeHash);
 
     const reclaim = await claimMemberEnrollment(d1, link.code);
     expect(reclaim).toEqual(claim);
   });
 
-  it("is scoped to (id, code_hash) — a mismatched hash restores nothing", async () => {
+  it("is scoped to (id, code_hash) — a mismatched hash releases nothing", async () => {
+    const d1 = db();
+    const link = await createEnrollment(d1, {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      maxUses: 1,
+    });
+    const claim = await claimMemberEnrollment(d1, link.code);
+    expect(claim).not.toBeNull();
+
+    await releaseEnrollmentClaim(d1, claim!.id, "not-the-real-hash");
+    // Still exhausted — the mismatched-hash release didn't touch the row.
+    expect(await claimMemberEnrollment(d1, link.code)).toBeNull();
+  });
+
+  it("never underflows use_count below zero", async () => {
     const d1 = db();
     const link = await createEnrollment(d1, { workspace: "acme", scopes: [], kind: "member" });
     const claim = await claimMemberEnrollment(d1, link.code);
     expect(claim).not.toBeNull();
 
-    await releaseEnrollmentClaim(d1, claim!.id, "not-the-real-hash");
-    // Still claimed — the mismatched-hash release didn't touch the row.
-    expect(await claimMemberEnrollment(d1, link.code)).toBeNull();
+    // Release twice — the second is a no-op (use_count > 0 guard), not -1.
+    await releaseEnrollmentClaim(d1, claim!.id, claim!.codeHash);
+    await releaseEnrollmentClaim(d1, claim!.id, claim!.codeHash);
+
+    // A fresh max_uses:1 claim path would still see use_count at 0, not -1 —
+    // exercised indirectly via a normal claim succeeding.
+    expect(await claimMemberEnrollment(d1, link.code)).not.toBeNull();
   });
 });

--- a/apps/api/test/auth-db.test.ts
+++ b/apps/api/test/auth-db.test.ts
@@ -54,7 +54,8 @@ class FakeD1 {
     if (sql.startsWith("SELECT workspace, expires_at, used_at")) {
       const [pageId, now] = values as string[];
       const enrollment = this.enrollments.find(
-        (row) => row.page_id === pageId && (row.expires_at as string) > now,
+        (row) =>
+          row.page_id === pageId && (row.expires_at === null || (row.expires_at as string) > now),
       );
       return enrollment
         ? {
@@ -62,6 +63,8 @@ class FakeD1 {
             expires_at: enrollment.expires_at,
             used_at: enrollment.used_at,
             kind: enrollment.kind,
+            max_uses: enrollment.max_uses,
+            use_count: enrollment.use_count,
           }
         : null;
     }
@@ -106,6 +109,7 @@ class FakeD1 {
         tokenExpiresAt,
         pageId,
         kind,
+        maxUses,
       ] = values;
       this.enrollments.push({
         id,
@@ -119,6 +123,8 @@ class FakeD1 {
         used_at: null,
         page_id: pageId,
         kind,
+        max_uses: maxUses,
+        use_count: 0,
       });
       return result(1);
     }
@@ -178,13 +184,19 @@ class FakeD1 {
     if (sql.startsWith("SELECT id, page_id, label, scopes, kind, created_at, expires_at")) {
       const [workspace, now, kind] = values as string[];
       return this.enrollments
-        .filter(
-          (row) =>
+        .filter((row) => {
+          const notExpired = row.expires_at === null || (row.expires_at as string) > now;
+          const notExhausted =
+            row.kind === "member"
+              ? row.max_uses === null || (row.use_count as number) < (row.max_uses as number)
+              : row.used_at === null;
+          return (
             row.workspace === workspace &&
-            row.used_at === null &&
-            (row.expires_at as string) > now &&
-            (kind === undefined || row.kind === kind),
-        )
+            notExpired &&
+            notExhausted &&
+            (kind === undefined || row.kind === kind)
+          );
+        })
         .sort((a, b) => (b.created_at as string).localeCompare(a.created_at as string))
         .map((row) => ({
           id: row.id,
@@ -194,6 +206,8 @@ class FakeD1 {
           kind: row.kind,
           created_at: row.created_at,
           expires_at: row.expires_at,
+          max_uses: row.max_uses,
+          use_count: row.use_count,
         }));
     }
     throw new Error(`unsupported all: ${sql}`);
@@ -237,7 +251,9 @@ describe("D1 enrollment exchange", () => {
     expect(enrollment.pageId).toMatch(/^upi_[A-Za-z0-9_-]{16}$/);
     expect(fake.enrollments[0]?.page_id).toBe(enrollment.pageId);
     expect(JSON.stringify(fake.enrollments)).not.toContain(enrollment.code);
-    expect(Date.parse(enrollment.expiresAt) - now.getTime()).toBe(
+    // kind: 'token' (the default here) always sets expiresAt — nullable is
+    // for issue #876's non-expiring kind: 'member' links only.
+    expect(Date.parse(enrollment.expiresAt!) - now.getTime()).toBe(
       DEFAULT_ENROLLMENT_SECONDS * 1000,
     );
     expect(Date.parse(enrollment.tokenExpiresAt) - now.getTime()).toBe(
@@ -436,6 +452,90 @@ describe("listOpenEnrollments", () => {
     const tokenOnly = await listOpenEnrollments(database(fake), "acme", now, "token");
     expect(tokenOnly).toHaveLength(1);
     expect(tokenOnly[0]?.kind).toBe("token");
+  });
+
+  // Issue #876: a non-expiring member-kind link (expires_at NULL) stays
+  // outstanding forever — the `expires_at IS NULL` branch, not just "> now".
+  it("includes a non-expiring member-kind link regardless of now", async () => {
+    const fake = new FakeD1();
+    const link = await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      enrollmentSeconds: null,
+    });
+    const farFuture = new Date("2099-01-01T00:00:00.000Z");
+    const links = await listOpenEnrollments(database(fake), "acme", farFuture, "member");
+    expect(links).toHaveLength(1);
+    expect(links[0]?.id).toBe(link.id);
+    expect(links[0]?.expiresAt).toBeNull();
+  });
+
+  // Issue #876: an exhausted (use_count >= max_uses) member-kind link drops
+  // out of the outstanding list, same as a single-use token-kind link does
+  // once used_at is set.
+  it("excludes an exhausted member-kind link but keeps one under its cap", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    await createEnrollment(database(fake), { workspace: "acme", scopes: [], kind: "member", now });
+    fake.enrollments[0].max_uses = 2;
+    fake.enrollments[0].use_count = 2;
+
+    await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      now: new Date(now.getTime() + 1000),
+    });
+    fake.enrollments[1].max_uses = 2;
+    fake.enrollments[1].use_count = 1;
+
+    const links = await listOpenEnrollments(database(fake), "acme", now, "member");
+    expect(links).toHaveLength(1);
+    expect(links[0]?.useCount).toBe(1);
+    expect(links[0]?.maxUses).toBe(2);
+  });
+});
+
+describe("createEnrollment — issue #876 multi-use/non-expiring member links", () => {
+  it("mints a non-expiring link when enrollmentSeconds is null", async () => {
+    const fake = new FakeD1();
+    const enrollment = await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      enrollmentSeconds: null,
+    });
+    expect(enrollment.expiresAt).toBeNull();
+    expect(fake.enrollments[0]?.expires_at).toBeNull();
+  });
+
+  it("defaults max_uses to unlimited (null) for a member link", async () => {
+    const fake = new FakeD1();
+    await createEnrollment(database(fake), { workspace: "acme", scopes: [], kind: "member" });
+    expect(fake.enrollments[0]?.max_uses).toBeNull();
+    expect(fake.enrollments[0]?.use_count).toBe(0);
+  });
+
+  it("stores an explicit max_uses for a member link", async () => {
+    const fake = new FakeD1();
+    await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: [],
+      kind: "member",
+      maxUses: 5,
+    });
+    expect(fake.enrollments[0]?.max_uses).toBe(5);
+  });
+
+  it("ignores maxUses for a token-kind link — always stored null", async () => {
+    const fake = new FakeD1();
+    await createEnrollment(database(fake), {
+      workspace: "acme",
+      scopes: ["files:read"],
+      maxUses: 5,
+    });
+    expect(fake.enrollments[0]?.max_uses).toBeNull();
   });
 });
 

--- a/apps/api/test/observability-retention.test.ts
+++ b/apps/api/test/observability-retention.test.ts
@@ -15,6 +15,8 @@ const MIGRATIONS = [
   "migrations/20260711120000_invite_pages.sql",
   "migrations/20260715120000_uploads_cli_observability.sql",
   "migrations/20260722180100_auth_enrollments_expires_at_idx.sql",
+  "migrations/20260827160000_auth_enrollments_kind.sql",
+  "migrations/20260827170000_auth_enrollments_multi_use.sql",
 ];
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -40,24 +42,31 @@ function insertEnrollment(
   sqlite: SqliteD1,
   row: {
     id: string;
-    expiresAt: string;
+    expiresAt: string | null;
     usedAt?: string | null;
     codeHash?: string;
+    kind?: "token" | "member";
+    maxUses?: number | null;
+    useCount?: number;
   },
 ) {
   sqlite.db
     .prepare(
       `INSERT INTO auth_enrollments (
-        id, workspace, code_hash, label, scopes, created_at, expires_at, token_expires_at, used_at
-      ) VALUES (?, 'default', ?, NULL, '["files:write"]', ?, ?, ?, ?)`,
+        id, workspace, code_hash, label, scopes, created_at, expires_at, token_expires_at, used_at,
+        kind, max_uses, use_count
+      ) VALUES (?, 'default', ?, NULL, '["files:write"]', ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       row.id,
       row.codeHash ?? `hash_${row.id}`,
+      row.expiresAt ?? new Date().toISOString(),
       row.expiresAt,
-      row.expiresAt,
-      row.expiresAt,
+      row.expiresAt ?? new Date().toISOString(),
       row.usedAt ?? null,
+      row.kind ?? "token",
+      row.maxUses ?? null,
+      row.useCount ?? 0,
     );
 }
 
@@ -134,6 +143,56 @@ describe("runObservabilityRetention", () => {
         .prepare("SELECT id FROM auth_enrollments ORDER BY id")
         .all() as Array<{ id: string }>;
       expect(remaining.map((r) => r.id)).toEqual(["enr_live_unused", "enr_used_recent"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  // Issue #876: `kind: 'member'` rows never set `used_at`, so a fully
+  // redeemed but still-live multi-use link, and a standing non-expiring
+  // link, must both survive the purge — the sweep only bases its DELETE on
+  // `expires_at`/`used_at`, and `expires_at IS NULL` never satisfies
+  // `expires_at < cutoff`.
+  it("never purges a live non-expiring or still-under-cap member link", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-07-22T12:00:00.000Z");
+      const past = new Date(
+        now.getTime() - (ENROLLMENT_RETENTION_DAYS + 2) * MS_PER_DAY,
+      ).toISOString();
+      const liveExpires = new Date(now.getTime() + 2 * MS_PER_DAY).toISOString();
+
+      insertEnrollment(sqlite, {
+        id: "enr_member_never_expires",
+        expiresAt: null,
+        kind: "member",
+        maxUses: null,
+        useCount: 5,
+      });
+      insertEnrollment(sqlite, {
+        id: "enr_member_exhausted_but_live",
+        expiresAt: liveExpires,
+        kind: "member",
+        maxUses: 3,
+        useCount: 3,
+      });
+      // Sanity control: an old, expired token-kind row still purges.
+      insertEnrollment(sqlite, {
+        id: "enr_token_expired_old",
+        expiresAt: past,
+        usedAt: null,
+      });
+
+      const result = await runObservabilityRetention(env(database(sqlite)), now);
+      expect(result.enrollmentsDeleted).toBe(1);
+
+      const remaining = sqlite.db
+        .prepare("SELECT id FROM auth_enrollments ORDER BY id")
+        .all() as Array<{ id: string }>;
+      expect(remaining.map((r) => r.id)).toEqual([
+        "enr_member_exhausted_but_live",
+        "enr_member_never_expires",
+      ]);
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/routes-auth-join.test.ts
+++ b/apps/api/test/routes-auth-join.test.ts
@@ -16,6 +16,7 @@ const MIGRATIONS = [
   "migrations/20260712230000_token_minting_user.sql",
   "migrations/20260817180000_token_last_used.sql",
   "migrations/20260827160000_auth_enrollments_kind.sql",
+  "migrations/20260827170000_auth_enrollments_multi_use.sql",
 ];
 
 const USER = { id: "u-joiner", email: "joiner@example.com", name: "Joiner" };
@@ -73,11 +74,25 @@ function makeEnv(opts: EnvOpts = {}) {
 
 const sessionHeaders = { cookie: "session=x", "content-type": "application/json" };
 
-async function mintMemberLink(db: SqliteD1, workspace = "acme") {
+// Issue #876: member-kind links default to unlimited use. `maxUses` defaults
+// to 1 here (not the createEnrollment default) so every pre-existing
+// regression test below — written against the pre-#876 single-use
+// semantics — keeps exercising the same "the link is burned/not burned"
+// behavior unchanged. Multi-use/unlimited/non-expiring get their own tests
+// further down, which pass `maxUses`/`expiresIn` explicitly.
+async function mintMemberLink(
+  db: SqliteD1,
+  workspace = "acme",
+  opts: { maxUses?: number | null; enrollmentSeconds?: number | null } = {},
+) {
   return createEnrollment(database(db) as unknown as D1Database, {
     workspace,
     scopes: [],
     kind: "member",
+    // `??` would collapse an explicit `maxUses: null` (unlimited) into the
+    // 1-use default below — use `in` so callers can request unlimited.
+    maxUses: "maxUses" in opts ? opts.maxUses : 1,
+    ...(opts.enrollmentSeconds !== undefined ? { enrollmentSeconds: opts.enrollmentSeconds } : {}),
   });
 }
 
@@ -413,6 +428,73 @@ describe("POST /auth/enrollments/join", () => {
       makeEnv({ db, inviteAllowed: false }),
     );
     expect(res.status).toBe(429);
+  });
+
+  // Issue #876: an unlimited-use link (createEnrollment's default when
+  // maxUses is omitted) redeems successfully for two different users.
+  it("redeems a multi-use link twice, by different users", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db, "acme", { maxUses: null });
+    const first = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(first.status).toBe(200);
+
+    const otherUser = { id: "u-other", email: "other@example.com", name: "Other" };
+    const second = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db, sessionUser: otherUser }),
+    );
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual({ workspace: "acme", alreadyMember: false });
+  });
+
+  // Issue #876: a link with an explicit max_uses fails uniformly (same
+  // INVALID_ENROLLMENT shape as unknown/expired) once exhausted.
+  it("uniformly fails an exhausted max_uses link", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db, "acme", { maxUses: 2 });
+    const otherUser = { id: "u-other", email: "other@example.com", name: "Other" };
+
+    const first = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(first.status).toBe(200);
+    const second = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db, sessionUser: otherUser }),
+    );
+    expect(second.status).toBe(200);
+
+    const third = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db, sessionUser: { id: "u-third", email: "third@example.com", name: "Third" } }),
+    );
+    expect(third.status).toBe(400);
+    expect(((await third.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_enrollment",
+    );
+  });
+
+  // Issue #876: a non-expiring member link (`expiresIn: "never"` at mint,
+  // `expires_at IS NULL`) redeems normally, arbitrarily far in the future.
+  it("redeems a non-expiring link", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const link = await mintMemberLink(db, "acme", { enrollmentSeconds: null });
+    const res = await app.request(
+      "/auth/enrollments/join",
+      { method: "POST", headers: sessionHeaders, body: JSON.stringify({ code: link.code }) },
+      makeEnv({ db }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ workspace: "acme", alreadyMember: false });
   });
 
   it("uses the same 1KB/single-key/prefix hygiene as exchange", async () => {

--- a/apps/api/test/routes-workspace-members.test.ts
+++ b/apps/api/test/routes-workspace-members.test.ts
@@ -22,6 +22,7 @@ const MIGRATIONS = [
   "migrations/20260712230000_token_minting_user.sql",
   "migrations/20260817180000_token_last_used.sql",
   "migrations/20260827160000_auth_enrollments_kind.sql",
+  "migrations/20260827170000_auth_enrollments_multi_use.sql",
 ];
 
 const ADMIN = { id: "u-admin", email: "admin@example.com", name: "Admin" };
@@ -536,6 +537,147 @@ describe("POST /v1/workspaces/:workspace/invite-links", () => {
     expect(JSON.stringify(body)).not.toContain("code_hash");
   });
 
+  // Issue #876: default expiry is 7 days (not the CLI-enrollment 2h
+  // default), and default max uses is unlimited (null, useCount 0).
+  it("defaults to a 7-day expiry and unlimited uses when expiresIn/maxUses are omitted", async () => {
+    const before = Date.now();
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      expiresAt: string;
+      maxUses: number | null;
+      useCount: number;
+    };
+    const deltaMs = Date.parse(body.expiresAt) - before;
+    // Within a few seconds of exactly 7 days — tolerant of test wall-clock drift.
+    expect(Math.abs(deltaMs - 7 * 24 * 60 * 60 * 1000)).toBeLessThan(10_000);
+    expect(body.maxUses).toBeNull();
+    expect(body.useCount).toBe(0);
+  });
+
+  it('mints a non-expiring link when expiresIn is "never"', async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ expiresIn: "never" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as { expiresAt: string | null }).expiresAt).toBeNull();
+  });
+
+  it("mints a non-expiring link when expiresIn is null", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ expiresIn: null }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as { expiresAt: string | null }).expiresAt).toBeNull();
+  });
+
+  it("mints a link with an explicit expiresIn (seconds) and maxUses", async () => {
+    const before = Date.now();
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ expiresIn: 3600, maxUses: 5 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { expiresAt: string; maxUses: number };
+    expect(Math.abs(Date.parse(body.expiresAt) - before - 3600 * 1000)).toBeLessThan(10_000);
+    expect(body.maxUses).toBe(5);
+  });
+
+  it("400s for an expiresIn below the minimum", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ expiresIn: 60 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_expires_in",
+    );
+  });
+
+  it("400s for an expiresIn above the maximum", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ expiresIn: 91 * 24 * 60 * 60 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_expires_in",
+    );
+  });
+
+  it("400s for a non-integer/non-'never' expiresIn", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ expiresIn: "sometime" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "invalid_expires_in",
+    );
+  });
+
+  it("400s for a zero or negative maxUses", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ maxUses: 0 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe("invalid_max_uses");
+  });
+
   it("defaults label to null when omitted", async () => {
     const env = makeEnv();
     const res = await app.request(
@@ -730,6 +872,52 @@ describe("GET /v1/workspaces/:workspace/invite-links + DELETE .../:id", () => {
     expect(body.links.map((l) => l.label).sort()).toEqual(["one", "two"]);
     // code_hash (or the plaintext code) is never exposed by the list.
     expect(JSON.stringify(body)).not.toContain("code_hash");
+  });
+
+  // Issue #876: the list surfaces maxUses/useCount/nullable expiresAt so a
+  // standing link is auditable at a glance.
+  it("includes maxUses, useCount, and a nullable expiresAt per link", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ label: "capped", maxUses: 3 }),
+      },
+      makeEnv({ db }),
+    );
+    await app.request(
+      "/v1/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ label: "standing", expiresIn: "never" }),
+      },
+      makeEnv({ db }),
+    );
+
+    const res = await app.request(
+      "/v1/workspaces/acme/invite-links",
+      { headers: sessionHeaders },
+      makeEnv({ db }),
+    );
+    const body = (await res.json()) as {
+      links: {
+        label: string | null;
+        maxUses: number | null;
+        useCount: number;
+        expiresAt: string | null;
+      }[];
+    };
+    const capped = body.links.find((l) => l.label === "capped");
+    const standing = body.links.find((l) => l.label === "standing");
+    expect(capped).toEqual(
+      expect.objectContaining({ maxUses: 3, useCount: 0, expiresAt: expect.any(String) }),
+    );
+    expect(standing).toEqual(
+      expect.objectContaining({ maxUses: null, useCount: 0, expiresAt: null }),
+    );
   });
 
   // Review finding 5 explicitly leaves list/revoke unguarded — useful during

--- a/apps/web/src/content/docs/reference.mdx
+++ b/apps/web/src/content/docs/reference.mdx
@@ -75,9 +75,9 @@ uploads --help        # everything else
   directly via `/oembed`, passing the page URL as its `url` query param.
 - **Getting access.** Sign in and create your own workspace with a linked GitHub account, or get
   invited to an existing one. A workspace admin can invite by email from the workspace's People page,
-  or generate a join link there — anyone signed in who opens it joins the workspace, once. Join links
-  expire after 2 hours and an admin can revoke one before it's used. Questions? Reach out via
-  <a href={REPO}>the GitHub repo</a>.
+  or generate a join link there — anyone signed in who opens it joins the workspace. Join links can be
+  multi-use and set to expire in 1–90 days or never, and an admin can revoke one anytime. Questions?
+  Reach out via <a href={REPO}>the GitHub repo</a>.
 - **Everything lands in your workspace.** Files are stored under a prefix for your workspace, and
   PR/issue attachments get stable, predictable paths, so re-attaching an updated screenshot replaces
   the old URL's spot instead of littering.

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -800,9 +800,22 @@ export async function updateWorkspaceMemberRole(
  * Distinct from `inviteToWorkspace`'s email invites (no recipient needed)
  * and from `/admin`'s CLI-token links (this workspace's own People page can
  * only see/revoke its own `kind: 'member'` links, never a token-kind one).
+ *
+ * Issue #876: `expiresAt` is nullable (a `"never"`-expiring standing link),
+ * and links carry `maxUses`/`useCount` — multi-use by default (unlimited)
+ * unless the mint form sets a cap.
  */
 export type CreateInviteLinkResult =
-  | { kind: "ok"; id: string; pageId: string; label: string | null; url: string; expiresAt: string }
+  | {
+      kind: "ok";
+      id: string;
+      pageId: string;
+      label: string | null;
+      url: string;
+      expiresAt: string | null;
+      maxUses: number | null;
+      useCount: number;
+    }
   | {
       kind: "unavailable";
       reason: RequestFailure | "server" | "forbidden" | "invalid" | "member_cap";
@@ -810,12 +823,22 @@ export type CreateInviteLinkResult =
       message?: string;
     };
 
-/** POST /v1/workspaces/:name/invite-links */
+/**
+ * POST /v1/workspaces/:name/invite-links
+ *
+ * `expiresIn` — seconds (validated server-side to 1h..90d), `"never"` for a
+ * non-expiring standing link, or omitted for the server default (7 days).
+ * `maxUses` — a positive integer cap, or omitted for unlimited.
+ */
 export async function createInviteLink(
   apiOrigin: string,
   name: string,
-  label?: string,
+  opts: { label?: string; expiresIn?: number | "never"; maxUses?: number } = {},
 ): Promise<CreateInviteLinkResult> {
+  const body: Record<string, unknown> = {};
+  if (opts.label) body.label = opts.label;
+  if (opts.expiresIn !== undefined) body.expiresIn = opts.expiresIn;
+  if (opts.maxUses !== undefined) body.maxUses = opts.maxUses;
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/invite-links`,
     {
@@ -823,7 +846,7 @@ export async function createInviteLink(
       credentials: "include",
       cache: "no-store",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(label ? { label } : {}),
+      body: JSON.stringify(body),
     },
   );
   if (result.kind === "unavailable") return result;
@@ -833,38 +856,45 @@ export async function createInviteLink(
   }
   if (response.status === 400) return { kind: "unavailable", reason: "invalid" };
   if (!response.ok) return { kind: "unavailable", reason: "server" };
-  const body = (await response.json().catch(() => null)) as {
+  const respBody = (await response.json().catch(() => null)) as {
     id?: string;
     pageId?: string;
     label?: string | null;
     url?: string;
-    expiresAt?: string;
+    expiresAt?: string | null;
+    maxUses?: number | null;
+    useCount?: number;
   } | null;
   if (
-    !body ||
-    typeof body.id !== "string" ||
-    typeof body.pageId !== "string" ||
-    typeof body.url !== "string" ||
-    typeof body.expiresAt !== "string"
+    !respBody ||
+    typeof respBody.id !== "string" ||
+    typeof respBody.pageId !== "string" ||
+    typeof respBody.url !== "string" ||
+    (respBody.expiresAt !== null && typeof respBody.expiresAt !== "string")
   ) {
     return { kind: "unavailable", reason: "server" };
   }
   return {
     kind: "ok",
-    id: body.id,
-    pageId: body.pageId,
-    label: typeof body.label === "string" ? body.label : null,
-    url: body.url,
-    expiresAt: body.expiresAt,
+    id: respBody.id,
+    pageId: respBody.pageId,
+    label: typeof respBody.label === "string" ? respBody.label : null,
+    url: respBody.url,
+    expiresAt: respBody.expiresAt ?? null,
+    maxUses: typeof respBody.maxUses === "number" ? respBody.maxUses : null,
+    useCount: typeof respBody.useCount === "number" ? respBody.useCount : 0,
   };
 }
 
+/** Issue #876: `expiresAt` nullable (standing, non-expiring link); `maxUses`/`useCount` — see `renderInviteLinksHtml`. */
 export interface WorkspaceInviteLink {
   id: string;
   pageId: string | null;
   label: string | null;
   createdAt: string;
-  expiresAt: string;
+  expiresAt: string | null;
+  maxUses: number | null;
+  useCount: number;
 }
 
 export type WorkspaceInviteLinksResult =

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -120,26 +120,39 @@ describe("renderInvitesHtml", () => {
 });
 
 describe("renderInviteLinksHtml", () => {
-  it("renders a labeled row with expiry and revoke", () => {
+  it("renders a labeled row with expiry, uses, and revoke", () => {
     const html = renderInviteLinksHtml([
-      { id: "l1", label: "for the design team", expiresAt: "2026-08-27T18:00:00.000Z" },
+      {
+        id: "l1",
+        label: "for the design team",
+        expiresAt: "2026-08-27T18:00:00.000Z",
+        maxUses: null,
+        useCount: 3,
+      },
     ]);
     expect(html).toContain('data-link-id="l1"');
     expect(html).toContain("for the design team");
     expect(html).toContain("invite-link-row__revoke");
     expect(html).toContain("expires");
+    expect(html).toContain("3 joins");
   });
 
   it("falls back to a generic label when none was set", () => {
     const html = renderInviteLinksHtml([
-      { id: "l1", label: null, expiresAt: "2026-08-27T18:00:00.000Z" },
+      { id: "l1", label: null, expiresAt: "2026-08-27T18:00:00.000Z", maxUses: null, useCount: 0 },
     ]);
     expect(html).toContain("Unlabeled link");
   });
 
   it("escapes the label", () => {
     const html = renderInviteLinksHtml([
-      { id: "l1", label: "<script>alert(1)</script>", expiresAt: "2026-08-27T18:00:00.000Z" },
+      {
+        id: "l1",
+        label: "<script>alert(1)</script>",
+        expiresAt: "2026-08-27T18:00:00.000Z",
+        maxUses: null,
+        useCount: 0,
+      },
     ]);
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
@@ -147,6 +160,42 @@ describe("renderInviteLinksHtml", () => {
 
   it("returns empty string for no links", () => {
     expect(renderInviteLinksHtml([])).toBe("");
+  });
+
+  // Issue #876
+  it("shows 'never expires' for a non-expiring link", () => {
+    const html = renderInviteLinksHtml([
+      { id: "l1", label: "standing", expiresAt: null, maxUses: null, useCount: 1 },
+    ]);
+    expect(html).toContain("never expires");
+    expect(html).not.toContain("expires never");
+  });
+
+  it("shows N/max joins for a capped link", () => {
+    const html = renderInviteLinksHtml([
+      {
+        id: "l1",
+        label: "capped",
+        expiresAt: "2026-08-27T18:00:00.000Z",
+        maxUses: 10,
+        useCount: 3,
+      },
+    ]);
+    expect(html).toContain("3/10 joins");
+  });
+
+  it("singularizes one join", () => {
+    const html = renderInviteLinksHtml([
+      {
+        id: "l1",
+        label: "solo",
+        expiresAt: "2026-08-27T18:00:00.000Z",
+        maxUses: null,
+        useCount: 1,
+      },
+    ]);
+    expect(html).toContain("1 join");
+    expect(html).not.toContain("1 joins");
   });
 });
 

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -263,23 +263,36 @@ export function renderInvitesHtml(
  * Issue #869 phase B: the People page's outstanding `kind: 'member'`
  * join-link list — a plain `<ul>`, not the people table (these aren't
  * teammates or pending email invites, just live shareable links). Each row
- * shows the label (or a generic fallback) and expiry, plus a revoke button
- * matching the `text-btn` treatment `renderInvitesHtml`'s revoke uses.
- * `[]` → `""` (caller renders its own empty state).
+ * shows the label (or a generic fallback), expiry, and use count, plus a
+ * revoke button matching the `text-btn` treatment `renderInvitesHtml`'s
+ * revoke uses. `[]` → `""` (caller renders its own empty state).
+ *
+ * Issue #876: `expiresAt` nullable — a standing link shows "never expires".
+ * Uses show as "N joins" (unlimited) or "N/max joins" (capped) so a
+ * multi-use link is auditable at a glance.
  */
 export function renderInviteLinksHtml(
-  links: { id: string; label: string | null; expiresAt: string }[],
+  links: {
+    id: string;
+    label: string | null;
+    expiresAt: string | null;
+    maxUses: number | null;
+    useCount: number;
+  }[],
 ): string {
   return links
     .map((link) => {
       const label = link.label ? escapeHtml(link.label) : "Unlabeled link";
-      const when = new Date(link.expiresAt).toLocaleString([], {
-        dateStyle: "medium",
-        timeStyle: "short",
-      });
+      const when = link.expiresAt
+        ? new Date(link.expiresAt).toLocaleString([], { dateStyle: "medium", timeStyle: "short" })
+        : "never expires";
+      const uses =
+        link.maxUses === null
+          ? `${link.useCount} ${link.useCount === 1 ? "join" : "joins"}`
+          : `${link.useCount}/${link.maxUses} joins`;
       return `<li class="invite-link-row">
   <span class="invite-link-row__label">${label}</span>
-  <span class="invite-link-row__expiry text-muted-foreground">expires ${escapeHtml(when)}</span>
+  <span class="invite-link-row__expiry text-muted-foreground">${link.expiresAt ? `expires ${escapeHtml(when)}` : escapeHtml(when)} · ${escapeHtml(uses)}</span>
   <button type="button" class="text-btn invite-link-row__revoke" data-link-id="${escapeHtml(link.id)}" data-link-label="${label}">Revoke</button>
 </li>`;
     })

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -97,13 +97,32 @@ if (cookie.trim()) {
     <div class="settings-section" id="ws-invite-links-section" hidden>
       <h2>Invite links</h2>
       <p class="settings-note muted">
-        Anyone with the link can join this workspace once — no email required.
+        Anyone with the link can join this workspace — no email required.
       </p>
       <form class="ws-form" id="ws-invite-link-form">
         <div class="input-group">
           <label class="input-group__field">
             <span class="sr-only">Label (optional)</span>
             <input type="text" name="label" maxlength="100" placeholder="Label (optional)" />
+          </label>
+          <label class="input-group__field">
+            <span class="sr-only">Expires</span>
+            <select name="expiresIn">
+              <option value="86400">Expires in 1 day</option>
+              <option value="604800" selected>Expires in 7 days</option>
+              <option value="2592000">Expires in 30 days</option>
+              <option value="never">Never expires</option>
+            </select>
+          </label>
+          <label class="input-group__field">
+            <span class="sr-only">Max uses (optional)</span>
+            <input
+              type="number"
+              name="maxUses"
+              min="1"
+              step="1"
+              placeholder="Max uses (optional)"
+            />
           </label>
           <button type="submit" class="input-group__action">Generate link</button>
         </div>
@@ -411,15 +430,31 @@ if (cookie.trim()) {
           if (!stillHere()) return;
           const form = event.currentTarget as HTMLFormElement;
           const labelInput = form.querySelector<HTMLInputElement>('input[name="label"]');
+          // Not querySelector<HTMLSelectElement>: worker-configuration.d.ts's
+          // HTMLRewriter ambient `Element` redeclares `remove()`, which makes
+          // HTMLSelectElement fail the `T extends Element` constraint (see
+          // the role-select handler below). Fetch as HTMLElement and cast.
+          const expiresInSelect = form.querySelector<HTMLElement>(
+            'select[name="expiresIn"]',
+          ) as unknown as HTMLSelectElement | null;
+          const maxUsesInput = form.querySelector<HTMLInputElement>('input[name="maxUses"]');
           const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
           const label = labelInput?.value.trim() || undefined;
+          const expiresInRaw = expiresInSelect?.value ?? "604800";
+          const expiresIn = expiresInRaw === "never" ? "never" : Number(expiresInRaw);
+          const maxUsesRaw = maxUsesInput?.value.trim();
+          const maxUses = maxUsesRaw ? Number(maxUsesRaw) : undefined;
           if (!submit) return;
 
           inviteLinkStatus.hidden = false;
           inviteLinkStatus.textContent = "Generating link…";
           inviteLinkUrl.hidden = true;
           submit.disabled = true;
-          const result = await createInviteLink(apiOrigin, workspaceName, label);
+          const result = await createInviteLink(apiOrigin, workspaceName, {
+            label,
+            expiresIn,
+            maxUses,
+          });
           if (!stillHere()) return;
           submit.disabled = false;
 
@@ -429,6 +464,7 @@ if (cookie.trim()) {
             inviteLinkUrlCopy.dataset.copy = result.url;
             inviteLinkUrl.hidden = false;
             if (labelInput) labelInput.value = "";
+            if (maxUsesInput) maxUsesInput.value = "";
             void loadInviteLinks();
             return;
           }

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -96,7 +96,11 @@ export const prerender = false;
         scopes: string[];
         kind?: "token" | "member";
         createdAt: string;
-        expiresAt: string;
+        // Issue #876: nullable (a non-expiring `kind: 'member'` link);
+        // maxUses/useCount are meaningful for `kind: 'member'` only.
+        expiresAt: string | null;
+        maxUses?: number | null;
+        useCount?: number;
       }
 
       async function apiGet<T>(path: string): Promise<T> {
@@ -575,12 +579,19 @@ export const prerender = false;
           ? `<h4 class="${ADMIN_DETAIL_HEADING}">Invite links</h4>
            <ul class="invite-links-items ${ADMIN_MINI_LIST}">
              ${links
-               .map(
-                 (link) => `<li class="${ADMIN_MINI_LIST_ITEM}" data-id="${escapeHtml(link.id)}">
-                   <span>${link.label ? escapeHtml(link.label) : `<span class="muted">unlabeled</span>`} · ${escapeHtml(link.kind === "member" ? "member" : link.scopes.join(", "))} · expires ${escapeHtml(formatDate(link.expiresAt) ?? link.expiresAt)}</span>
+               .map((link) => {
+                 const expiry = link.expiresAt
+                   ? `expires ${formatDate(link.expiresAt) ?? link.expiresAt}`
+                   : "never expires";
+                 const uses =
+                   link.kind === "member"
+                     ? ` · ${link.useCount ?? 0}${link.maxUses ? `/${link.maxUses}` : ""} joins`
+                     : "";
+                 return `<li class="${ADMIN_MINI_LIST_ITEM}" data-id="${escapeHtml(link.id)}">
+                   <span>${link.label ? escapeHtml(link.label) : `<span class="muted">unlabeled</span>`} · ${escapeHtml(link.kind === "member" ? "member" : link.scopes.join(", "))} · ${escapeHtml(expiry)}${escapeHtml(uses)}</span>
                    <button type="button" class="invite-link-revoke ${ADMIN_BTN} ${ADMIN_BTN_DANGER}" data-id="${escapeHtml(link.id)}">Revoke</button>
-                 </li>`,
-               )
+                 </li>`;
+               })
                .join("")}
            </ul>
            <div class="invite-links-status text-(length:--text-micro)" role="status" aria-live="polite" hidden></div>`

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -266,7 +266,9 @@ import Footer from "../components/Footer.astro";
       async function setUpJoinFlow(workspace: string) {
         heading.textContent = `Join ${workspace} on uploads.sh`;
         lead.textContent = `You've been invited to join the ${workspace} workspace.`;
-        securityNote.textContent = "Treat this link like a password — it's single-use.";
+        // Issue #876: member-kind links may be multi-use, so this no longer
+        // claims "single-use" — just the general "treat it like a secret" advice.
+        securityNote.textContent = "Treat this link like a password.";
         joinActions.hidden = false;
 
         // Same-origin ("" — SAME_ORIGIN_AUTH_BASE): the browser only ever
@@ -367,29 +369,35 @@ import Footer from "../components/Footer.astro";
         if (!response.ok) throw new Error("invalid");
         const invitation = (await response.json()) as {
           used: boolean;
-          expiresAt: string;
+          // Issue #876: nullable — a non-expiring `kind: 'member'` link.
+          expiresAt: string | null;
           workspace: string;
           kind?: "token" | "member";
         };
         if (invitation.used) {
-          meta.textContent = "This invite has already been used.";
+          meta.textContent =
+            invitation.kind === "member"
+              ? "This invite link is no longer accepting new members."
+              : "This invite has already been used.";
           meta.dataset.state = "closed";
           return;
         }
-        const when = new Date(invitation.expiresAt).toLocaleString([], {
-          dateStyle: "medium",
-          timeStyle: "short",
-        });
+        const when = invitation.expiresAt
+          ? new Date(invitation.expiresAt).toLocaleString([], {
+              dateStyle: "medium",
+              timeStyle: "short",
+            })
+          : null;
         const where = invitation.workspace ? `the ${invitation.workspace} workspace` : "uploads.sh";
 
         if (invitation.kind === "member") {
-          meta.textContent = `Expires ${when}`;
+          meta.textContent = when ? `Expires ${when}` : "This link never expires.";
           meta.dataset.state = "ready";
           await setUpJoinFlow(invitation.workspace);
           return;
         }
 
-        meta.textContent = `You'll join ${where} · expires ${when}`;
+        meta.textContent = when ? `You'll join ${where} · expires ${when}` : `You'll join ${where}`;
         meta.dataset.state = "ready";
         instructions.hidden = false;
       }


### PR DESCRIPTION
## Summary

Follow-up to #869 / #872. `kind: 'member'` workspace join links were single-use with a fixed 2-hour expiry, both inherited from the CLI-enrollment defaults — awkward for the stated use case (drop a link in team chat: the first clicker burns it, and anyone reading the chat later gets a dead link).

This makes `kind: 'member'` links multi-use, admin-configurable expiry (including non-expiring), and visible usage. `kind: 'token'` (CLI enrollment/onboarding) links are untouched — exact pre-existing single-use/required-TTL semantics.

## Semantics change

- **Schema** (`auth_enrollments`): adds `max_uses INTEGER` (NULL = unlimited) and `use_count INTEGER NOT NULL DEFAULT 0`; `expires_at` becomes nullable. `kind: 'member'` rows stop using `used_at` as their lifecycle stamp — it stays `NULL` forever for that kind now. `kind: 'token'` rows are byte-for-byte unaffected (still single-use via `used_at`, still require an explicit TTL).
- **Redemption**: `claimMemberEnrollment`/`releaseEnrollmentClaim` move from a single-winner `used_at` UPDATE to an atomic conditional `use_count` increment/decrement (`WHERE ... AND (max_uses IS NULL OR use_count < max_uses)`). Concurrent redemptions of the same link are now legal — the per-redemption member-cap gate is the separate, unrelated atomic insert in `/internal/join`, unchanged. All of #872's retry/fail-closed/alreadyMember semantics are preserved verbatim (retry-once on transport failure, no restore when the outcome is unknown, no restore for `alreadyMember` on the retry path).
- **Mint** (`POST /v1/workspaces/:workspace/invite-links`): new `expiresIn` (seconds, validated 1h–90d, or `"never"`/`null` for non-expiring) and `maxUses` (positive int, or omitted for unlimited). Default expiry moves from 2h to 7 days for this kind only.
- **Retention sweep**: unaffected in behavior, but verified by a new test — a non-expiring or still-under-cap `kind: 'member'` link is never purged (its `expires_at IS NULL` never satisfies `expires_at < cutoff`, and it never sets `used_at`).
- **UI**: People page mint form gets an expiry select (1d/7d/30d/never) and an optional max-uses field; the outstanding list shows "N joins" / "N/max joins" and "never expires". The `/admin` invite-links list shows the same fields read-only. `/invite` handles a nullable `expiresAt`, drops the "single-use" claim from the member-link security note, and distinguishes "already used" (token-kind) from "no longer accepting new members" (an exhausted multi-use link) so a still-live multi-use link never shows stale "already used" copy.
- **Docs**: `reference.mdx`'s join-link sentence updated to match.

## Verification

- `pnpm test` (root, whole monorepo): 350 files / 5420 tests passed.
- `pnpm typecheck` (Node 24): clean across all packages.
- `pnpm types`: clean.
- `pnpm check` (lint + format): clean (pre-existing warnings only, no new ones).

No changeset (platform release, per AGENTS.md).

Closes #876.
