### PR TITLE
feat: notify workspace admins when a member joins

### DIFF
--- a/apps/api/migrations/20260829120000_auth_user_notify_member_join.sql
+++ b/apps/api/migrations/20260829120000_auth_user_notify_member_join.sql
@@ -1,0 +1,5 @@
+-- Per-user notification preference: email me when someone joins a workspace
+-- I administer. Default 1 (on) so existing admins keep getting notified; users
+-- opt out on /account/profile. Declared as a better-auth additionalField in
+-- apps/auth/src/auth.ts so /api/auth/update-user can write it.
+ALTER TABLE user ADD COLUMN notify_member_join INTEGER NOT NULL DEFAULT 1;

--- a/apps/api/src/admin-email-preview.ts
+++ b/apps/api/src/admin-email-preview.ts
@@ -5,6 +5,7 @@
 import {
   renderEnrollmentInvitationEmail,
   renderMagicLinkEmail,
+  renderMemberJoinAdminNoticeEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
   renderWelcomeEmail,
@@ -15,6 +16,7 @@ export const EMAIL_PREVIEW_TYPES = [
   { id: "magic-link", label: "Magic sign-in link", category: "Auth" },
   { id: "org-invitation", label: "Workspace invitation", category: "Auth" },
   { id: "member-joined", label: "Member joined notify", category: "Auth" },
+  { id: "member-join-admin-notice", label: "Admin: member joined notify", category: "Auth" },
   { id: "welcome", label: "Welcome / next steps", category: "Auth" },
   { id: "enrollment-invitation", label: "Enrollment invitation", category: "Invites" },
 ] as const;
@@ -71,6 +73,16 @@ function renderPreview(type: EmailPreviewType, origin: string) {
         from: AUTH_FROM,
         ...renderMemberJoinedEmail({
           organizationName: "preview-workspace",
+          memberEmail: "new-member@example.com",
+          webOrigin: origin,
+        }),
+      };
+    case "member-join-admin-notice":
+      return {
+        from: AUTH_FROM,
+        ...renderMemberJoinAdminNoticeEmail({
+          organizationName: "preview-workspace",
+          organizationSlug: "preview-workspace",
           memberEmail: "new-member@example.com",
           webOrigin: origin,
         }),

--- a/apps/auth/src/admin-last-guard.test.ts
+++ b/apps/auth/src/admin-last-guard.test.ts
@@ -56,6 +56,7 @@ async function seedUser(
     banExpires: overrides.banExpires ?? null,
     cliOnboardedAt: overrides.cliOnboardedAt ?? null,
     stripeCustomerId: overrides.stripeCustomerId ?? null,
+    notifyMemberJoin: overrides.notifyMemberJoin ?? true,
   };
   await orm.insert(schema.user).values(user);
   return user;

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -34,6 +34,7 @@ import {
 import { sendAuthEmail } from "./email";
 import { localDemoEnabled, localDemoPlugin } from "./local-demo";
 import { memberCapDenial } from "./member-cap";
+import { notifyAdminsOfMemberJoin } from "./notify-member-join";
 import { createDurableRateLimitStorage, type RateLimitNamespaceLike } from "./rate-limit";
 import * as schema from "./schema";
 import { stripePluginOrNone } from "./stripe-plugin";
@@ -659,6 +660,18 @@ function buildAuth(
               to: user.email,
               template: "welcome",
               context: { workspaceName: org.name },
+            });
+
+            // Notify the workspace's other admins/owners. The inviter already
+            // got the tailored `member-joined` email above, so exclude them to
+            // avoid a double-send; the joiner is always excluded by the helper.
+            await notifyAdminsOfMemberJoin(env, db, {
+              organizationId: org.id,
+              organizationName: org.name,
+              organizationSlug: org.slug,
+              joinerUserId: user.id,
+              joinerEmail: user.email,
+              excludeUserIds: invitation.inviterId ? [invitation.inviterId] : [],
             });
           },
         },

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -648,6 +648,18 @@ function buildAuth(
               }
             }
 
+            // Notify the workspace's other admins/owners. The inviter already
+            // got the tailored `member-joined` email above, so exclude them to
+            // avoid a double-send; the joiner is always excluded by the helper.
+            await notifyAdminsOfMemberJoin(env, db, {
+              organizationId: org.id,
+              organizationName: org.name,
+              organizationSlug: org.slug,
+              joinerUserId: user.id,
+              joinerEmail: user.email,
+              excludeUserIds: invitation.inviterId ? [invitation.inviterId] : [],
+            });
+
             // Welcome only on the invitee's first membership.
             if (!user.email) return;
             const memberships = await db
@@ -660,18 +672,6 @@ function buildAuth(
               to: user.email,
               template: "welcome",
               context: { workspaceName: org.name },
-            });
-
-            // Notify the workspace's other admins/owners. The inviter already
-            // got the tailored `member-joined` email above, so exclude them to
-            // avoid a double-send; the joiner is always excluded by the helper.
-            await notifyAdminsOfMemberJoin(env, db, {
-              organizationId: org.id,
-              organizationName: org.name,
-              organizationSlug: org.slug,
-              joinerUserId: user.id,
-              joinerEmail: user.email,
-              excludeUserIds: invitation.inviterId ? [invitation.inviterId] : [],
             });
           },
         },

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -820,6 +820,12 @@ function buildAuth(
     user: {
       additionalFields: {
         cliOnboardedAt: { type: "date", required: false, input: false },
+        notifyMemberJoin: {
+          type: "boolean",
+          required: false,
+          input: true,
+          defaultValue: true,
+        },
       },
     },
     session: {

--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -74,30 +74,40 @@ function render(args: SendAuthEmailArgs, webOrigin: string): RenderedEmail {
  * Auth hooks/callbacks stay fire-and-forget.
  */
 export async function sendAuthEmail(env: SendAuthEmailEnv, args: SendAuthEmailArgs): Promise<void> {
-  const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
-  const { subject, text, html } = render(args, webOrigin);
-  const isDev = env.ENVIRONMENT !== "production";
-  const magicLink = args.template === "magic-link" && isDev ? ` Link: ${args.context.url}` : "";
-
-  if (!env.EMAIL) {
-    // Invitation accept URLs are always logged so self-hosted operators without
-    // Email Sending can copy them. Magic-link URLs stay dev-only (secrets).
-    const inviteLink =
-      args.template === "invitation" && typeof args.context.url === "string"
-        ? ` Link: ${args.context.url}`
-        : "";
-    console.warn(
-      `[auth email] no EMAIL binding — not sent. To: ${args.to}. "${subject}".${inviteLink || magicLink}`,
-    );
-    return;
-  }
-
   try {
-    await env.EMAIL.send({ to: args.to, from: FROM, subject, text, html });
-    console.log(`[auth email] sent "${subject}" to ${args.to}${magicLink}`);
+    const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
+    const { subject, text, html } = render(args, webOrigin);
+    const isDev = env.ENVIRONMENT !== "production";
+    const magicLink = args.template === "magic-link" && isDev ? ` Link: ${args.context.url}` : "";
+
+    if (!env.EMAIL) {
+      // Invitation accept URLs are always logged so self-hosted operators without
+      // Email Sending can copy them. Magic-link URLs stay dev-only (secrets).
+      const inviteLink =
+        args.template === "invitation" && typeof args.context.url === "string"
+          ? ` Link: ${args.context.url}`
+          : "";
+      console.warn(
+        `[auth email] no EMAIL binding — not sent. To: ${args.to}. "${subject}".${inviteLink || magicLink}`,
+      );
+      return;
+    }
+
+    try {
+      await env.EMAIL.send({ to: args.to, from: FROM, subject, text, html });
+      console.log(`[auth email] sent "${subject}" to ${args.to}${magicLink}`);
+    } catch (err) {
+      console.error(
+        `[auth email] send failed for "${subject}" to ${args.to}`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
   } catch (err) {
+    // Belt-and-suspenders: render() (or anything else above) throwing must
+    // not propagate — callers (e.g. notifyAdminsOfMemberJoin's send loop)
+    // rely on this being genuinely fire-and-forget.
     console.error(
-      `[auth email] send failed for "${subject}" to ${args.to}`,
+      `[auth email] failed to prepare email "${args.template}" for ${args.to}`,
       err instanceof Error ? err.message : String(err),
     );
   }

--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -6,6 +6,7 @@
 
 import {
   renderMagicLinkEmail,
+  renderMemberJoinAdminNoticeEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
   renderWelcomeEmail,
@@ -44,6 +45,11 @@ export type SendAuthEmailArgs =
     }
   | {
       to: string;
+      template: "member-join-admin-notice";
+      context: { organizationName: string; organizationSlug: string; memberEmail: string };
+    }
+  | {
+      to: string;
       template: "welcome";
       context: { workspaceName?: string };
     };
@@ -56,6 +62,8 @@ function render(args: SendAuthEmailArgs, webOrigin: string): RenderedEmail {
       return renderOrgInvitationEmail({ ...args.context, webOrigin });
     case "member-joined":
       return renderMemberJoinedEmail({ ...args.context, webOrigin });
+    case "member-join-admin-notice":
+      return renderMemberJoinAdminNoticeEmail({ ...args.context, webOrigin });
     case "welcome":
       return renderWelcomeEmail({ ...args.context, webOrigin });
   }

--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -74,40 +74,43 @@ function render(args: SendAuthEmailArgs, webOrigin: string): RenderedEmail {
  * Auth hooks/callbacks stay fire-and-forget.
  */
 export async function sendAuthEmail(env: SendAuthEmailEnv, args: SendAuthEmailArgs): Promise<void> {
+  const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
+
+  // render() must not propagate — callers (e.g. notifyAdminsOfMemberJoin's
+  // send loop) rely on this being genuinely fire-and-forget.
+  let rendered: RenderedEmail;
   try {
-    const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
-    const { subject, text, html } = render(args, webOrigin);
-    const isDev = env.ENVIRONMENT !== "production";
-    const magicLink = args.template === "magic-link" && isDev ? ` Link: ${args.context.url}` : "";
-
-    if (!env.EMAIL) {
-      // Invitation accept URLs are always logged so self-hosted operators without
-      // Email Sending can copy them. Magic-link URLs stay dev-only (secrets).
-      const inviteLink =
-        args.template === "invitation" && typeof args.context.url === "string"
-          ? ` Link: ${args.context.url}`
-          : "";
-      console.warn(
-        `[auth email] no EMAIL binding — not sent. To: ${args.to}. "${subject}".${inviteLink || magicLink}`,
-      );
-      return;
-    }
-
-    try {
-      await env.EMAIL.send({ to: args.to, from: FROM, subject, text, html });
-      console.log(`[auth email] sent "${subject}" to ${args.to}${magicLink}`);
-    } catch (err) {
-      console.error(
-        `[auth email] send failed for "${subject}" to ${args.to}`,
-        err instanceof Error ? err.message : String(err),
-      );
-    }
+    rendered = render(args, webOrigin);
   } catch (err) {
-    // Belt-and-suspenders: render() (or anything else above) throwing must
-    // not propagate — callers (e.g. notifyAdminsOfMemberJoin's send loop)
-    // rely on this being genuinely fire-and-forget.
     console.error(
       `[auth email] failed to prepare email "${args.template}" for ${args.to}`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return;
+  }
+  const { subject, text, html } = rendered;
+  const isDev = env.ENVIRONMENT !== "production";
+  const magicLink = args.template === "magic-link" && isDev ? ` Link: ${args.context.url}` : "";
+
+  if (!env.EMAIL) {
+    // Invitation accept URLs are always logged so self-hosted operators without
+    // Email Sending can copy them. Magic-link URLs stay dev-only (secrets).
+    const inviteLink =
+      args.template === "invitation" && typeof args.context.url === "string"
+        ? ` Link: ${args.context.url}`
+        : "";
+    console.warn(
+      `[auth email] no EMAIL binding — not sent. To: ${args.to}. "${subject}".${inviteLink || magicLink}`,
+    );
+    return;
+  }
+
+  try {
+    await env.EMAIL.send({ to: args.to, from: FROM, subject, text, html });
+    console.log(`[auth email] sent "${subject}" to ${args.to}${magicLink}`);
+  } catch (err) {
+    console.error(
+      `[auth email] send failed for "${subject}" to ${args.to}`,
       err instanceof Error ? err.message : String(err),
     );
   }

--- a/apps/auth/src/internal-metrics.test.ts
+++ b/apps/auth/src/internal-metrics.test.ts
@@ -43,6 +43,7 @@ describe("GET /internal/metrics", () => {
       banExpires: null,
       cliOnboardedAt: null,
       stripeCustomerId: null,
+      notifyMemberJoin: true,
     } as schema.AuthUser);
   }
 

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -131,6 +131,7 @@ describe("DB-backed behavior", () => {
       banExpires: overrides.banExpires ?? null,
       cliOnboardedAt: overrides.cliOnboardedAt ?? null,
       stripeCustomerId: overrides.stripeCustomerId ?? null,
+      notifyMemberJoin: overrides.notifyMemberJoin ?? true,
     };
     await orm.insert(schema.user).values(user);
     return user;
@@ -151,6 +152,12 @@ describe("DB-backed behavior", () => {
     await orm.insert(schema.organization).values(org);
     return org;
   }
+
+  it("defaults notify_member_join to on for a seeded user", async () => {
+    const user = await seedUser();
+    const [row] = await orm.select().from(schema.user).where(eq(schema.user.id, user.id));
+    expect(row.notifyMemberJoin).toBe(true);
+  });
 
   describe("POST /internal/promote-admin", () => {
     it("promotes an existing user to admin", async () => {

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -1,7 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthEnv } from "./auth";
 import { internal } from "./internal-routes";
 import * as schema from "./schema";
@@ -1618,6 +1618,34 @@ describe("DB-backed behavior", () => {
         .from(schema.member)
         .where(and(eq(schema.member.organizationId, org.id), eq(schema.member.userId, user.id)));
       expect(member).toMatchObject({ role: "member" });
+    });
+
+    it("emails workspace admins when a new member joins via /internal/join", async () => {
+      const org = await seedOrg();
+      const admin = await seedUser();
+      const joiner = await seedUser();
+      await orm.insert(schema.member).values({
+        id: crypto.randomUUID(),
+        organizationId: org.id,
+        userId: admin.id,
+        role: "admin",
+        createdAt: new Date(),
+      });
+      const send = vi.fn().mockResolvedValue({});
+
+      const res = await app().request(
+        "/internal/join",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ organizationSlug: org.slug, userId: joiner.id }),
+        },
+        dbEnv({ EMAIL: { send } }),
+      );
+
+      expect(res.status).toBe(201);
+      const recipients = send.mock.calls.map((c) => c[0].to);
+      expect(recipients).toEqual([admin.email]);
     });
 
     it("no-ops gracefully for an already-existing member", async () => {

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -10,6 +10,7 @@ import { Hono } from "hono";
 import { OAUTH_SCOPES, type AuthEnv } from "./auth";
 import { sendAuthEmail } from "./email";
 import { memberCapDenial, resolveMemberCapStrict } from "./member-cap";
+import { notifyAdminsOfMemberJoin } from "./notify-member-join";
 import * as schema from "./schema";
 
 function errorJson(code: string, message: string) {
@@ -1003,6 +1004,13 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       .run();
 
     if ((insert.meta?.changes ?? 0) === 1) {
+      await notifyAdminsOfMemberJoin(c.env, db, {
+        organizationId: org.id,
+        organizationName: org.name,
+        organizationSlug: org.slug,
+        joinerUserId: userId,
+        joinerEmail: user.email,
+      });
       return c.json({ alreadyMember: false }, 201);
     }
 

--- a/apps/auth/src/member-cap.test.ts
+++ b/apps/auth/src/member-cap.test.ts
@@ -71,6 +71,7 @@ describe("memberCapDenial", () => {
       banExpires: null,
       cliOnboardedAt: null,
       stripeCustomerId: null,
+      notifyMemberJoin: true,
     });
     return userId;
   }
@@ -295,6 +296,7 @@ describe("POST /internal/invite at cap", () => {
       banExpires: null,
       cliOnboardedAt: null,
       stripeCustomerId: null,
+      notifyMemberJoin: true,
     });
     await orm.insert(schema.member).values({
       id: crypto.randomUUID(),

--- a/apps/auth/src/notify-member-join.test.ts
+++ b/apps/auth/src/notify-member-join.test.ts
@@ -1,0 +1,143 @@
+import { drizzle } from "drizzle-orm/d1";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmailBinding } from "./email";
+import { notifyAdminsOfMemberJoin } from "./notify-member-join";
+import * as schema from "./schema";
+import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
+
+describe("notifyAdminsOfMemberJoin", () => {
+  let db: FakeD1Database;
+  let orm: ReturnType<typeof drizzle<typeof schema>>;
+
+  beforeEach(async () => {
+    db = createFakeD1();
+    orm = drizzle(db, { schema });
+    await orm.insert(schema.organization).values({
+      id: orgId,
+      name: "Acme",
+      slug: "acme",
+      logo: null,
+      createdAt: new Date(),
+      metadata: null,
+      stripeCustomerId: null,
+    });
+  });
+
+  async function seedUser(over: Partial<schema.AuthUser> = {}): Promise<schema.AuthUser> {
+    const u: schema.AuthUser = {
+      id: over.id ?? crypto.randomUUID(),
+      name: "U",
+      email: over.email ?? `u-${crypto.randomUUID()}@example.com`,
+      emailVerified: true,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      role: "user",
+      banned: null,
+      banReason: null,
+      banExpires: null,
+      cliOnboardedAt: null,
+      stripeCustomerId: null,
+      notifyMemberJoin: over.notifyMemberJoin ?? true,
+    };
+    await orm.insert(schema.user).values(u);
+    return u;
+  }
+
+  async function seedMember(organizationId: string, userId: string, role: string): Promise<void> {
+    await orm.insert(schema.member).values({
+      id: crypto.randomUUID(),
+      organizationId,
+      userId,
+      role,
+      createdAt: new Date(),
+    });
+  }
+
+  function emailCapture(): { EMAIL: EmailBinding; send: ReturnType<typeof vi.fn> } {
+    const send = vi.fn().mockResolvedValue({});
+    return { EMAIL: { send }, send };
+  }
+
+  const orgId = "org-1";
+  const baseEnv = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "production" as const };
+
+  it("emails admins and owners, not plain members or the joiner", async () => {
+    const admin = await seedUser();
+    const owner = await seedUser();
+    const plain = await seedUser();
+    const joiner = await seedUser();
+    await seedMember(orgId, admin.id, "admin");
+    await seedMember(orgId, owner.id, "owner");
+    await seedMember(orgId, plain.id, "member");
+    await seedMember(orgId, joiner.id, "owner"); // joiner even as owner is excluded
+    const { EMAIL, send } = emailCapture();
+
+    await notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, orm, {
+      organizationId: orgId,
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      joinerUserId: joiner.id,
+      joinerEmail: joiner.email,
+    });
+
+    const recipients = send.mock.calls.map((c) => c[0].to).sort();
+    expect(recipients).toEqual([admin.email, owner.email].sort());
+  });
+
+  it("skips recipients who turned the preference off", async () => {
+    const admin = await seedUser({ notifyMemberJoin: false });
+    const joiner = await seedUser();
+    await seedMember(orgId, admin.id, "admin");
+    const { EMAIL, send } = emailCapture();
+    await notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, orm, {
+      organizationId: orgId,
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      joinerUserId: joiner.id,
+      joinerEmail: joiner.email,
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("excludes extra excludeUserIds (the inviter)", async () => {
+    const inviter = await seedUser();
+    const otherAdmin = await seedUser();
+    const joiner = await seedUser();
+    await seedMember(orgId, inviter.id, "admin");
+    await seedMember(orgId, otherAdmin.id, "admin");
+    const { EMAIL, send } = emailCapture();
+    await notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, orm, {
+      organizationId: orgId,
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      joinerUserId: joiner.id,
+      joinerEmail: joiner.email,
+      excludeUserIds: [inviter.id],
+    });
+    const recipients = send.mock.calls.map((c) => c[0].to);
+    expect(recipients).toEqual([otherAdmin.email]);
+  });
+
+  it("never throws when the DB read fails", async () => {
+    const poison = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("boom");
+        },
+      },
+    ) as never;
+    const { EMAIL, send } = emailCapture();
+    await expect(
+      notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, poison, {
+        organizationId: orgId,
+        organizationName: "Acme",
+        organizationSlug: "acme",
+        joinerUserId: "j",
+        joinerEmail: "j@example.com",
+      }),
+    ).resolves.toBeUndefined();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/auth/src/notify-member-join.ts
+++ b/apps/auth/src/notify-member-join.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, notInArray } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { sendAuthEmail, type SendAuthEmailEnv } from "./email";
 import * as schema from "./schema";
@@ -25,10 +25,12 @@ export async function notifyAdminsOfMemberJoin(
   db: DrizzleD1Database<typeof schema>,
   opts: NotifyAdminsOfMemberJoinOpts,
 ): Promise<void> {
-  const excluded = new Set([opts.joinerUserId, ...(opts.excludeUserIds ?? [])]);
+  // Joiner (always) and the inviter (invite path) are excluded in SQL, so the
+  // query returns exactly the recipients to mail.
+  const excludedUserIds = [opts.joinerUserId, ...(opts.excludeUserIds ?? [])];
   try {
     const rows = await db
-      .select({ userId: schema.member.userId, email: schema.user.email })
+      .select({ email: schema.user.email })
       .from(schema.member)
       .innerJoin(schema.user, eq(schema.member.userId, schema.user.id))
       .where(
@@ -36,21 +38,28 @@ export async function notifyAdminsOfMemberJoin(
           eq(schema.member.organizationId, opts.organizationId),
           inArray(schema.member.role, ["admin", "owner"]),
           eq(schema.user.notifyMemberJoin, true),
+          notInArray(schema.member.userId, excludedUserIds),
         ),
       );
 
-    for (const row of rows) {
-      if (excluded.has(row.userId) || !row.email) continue;
-      await sendAuthEmail(env, {
-        to: row.email,
-        template: "member-join-admin-notice",
-        context: {
-          organizationName: opts.organizationName,
-          organizationSlug: opts.organizationSlug,
-          memberEmail: opts.joinerEmail,
-        },
-      });
-    }
+    // Independent sends — fire them concurrently rather than serializing the
+    // whole join response behind N sequential email round trips. sendAuthEmail
+    // never rejects, so plain Promise.all is safe.
+    await Promise.all(
+      rows
+        .filter((row) => row.email)
+        .map((row) =>
+          sendAuthEmail(env, {
+            to: row.email,
+            template: "member-join-admin-notice",
+            context: {
+              organizationName: opts.organizationName,
+              organizationSlug: opts.organizationSlug,
+              memberEmail: opts.joinerEmail,
+            },
+          }),
+        ),
+    );
   } catch (err) {
     console.error(
       "[notify-member-join] recipient lookup failed",

--- a/apps/auth/src/notify-member-join.ts
+++ b/apps/auth/src/notify-member-join.ts
@@ -1,0 +1,60 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { sendAuthEmail, type SendAuthEmailEnv } from "./email";
+import * as schema from "./schema";
+
+export interface NotifyAdminsOfMemberJoinOpts {
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+  joinerUserId: string;
+  joinerEmail: string;
+  /** Extra userIds to skip (e.g. the inviter on the email-invite path). */
+  excludeUserIds?: string[];
+}
+
+/**
+ * Emails a workspace's admins/owners that a new member joined. Recipients are
+ * members with role admin/owner whose `notifyMemberJoin` preference is on,
+ * minus the joiner and any `excludeUserIds`. Fire-and-forget: `sendAuthEmail`
+ * never throws, and the recipient lookup is wrapped so a DB failure can't fail
+ * the join that triggered this.
+ */
+export async function notifyAdminsOfMemberJoin(
+  env: SendAuthEmailEnv,
+  db: DrizzleD1Database<typeof schema>,
+  opts: NotifyAdminsOfMemberJoinOpts,
+): Promise<void> {
+  const excluded = new Set([opts.joinerUserId, ...(opts.excludeUserIds ?? [])]);
+  try {
+    const rows = await db
+      .select({ userId: schema.member.userId, email: schema.user.email })
+      .from(schema.member)
+      .innerJoin(schema.user, eq(schema.member.userId, schema.user.id))
+      .where(
+        and(
+          eq(schema.member.organizationId, opts.organizationId),
+          inArray(schema.member.role, ["admin", "owner"]),
+          eq(schema.user.notifyMemberJoin, true),
+        ),
+      );
+
+    for (const row of rows) {
+      if (excluded.has(row.userId) || !row.email) continue;
+      await sendAuthEmail(env, {
+        to: row.email,
+        template: "member-join-admin-notice",
+        context: {
+          organizationName: opts.organizationName,
+          organizationSlug: opts.organizationSlug,
+          memberEmail: opts.joinerEmail,
+        },
+      });
+    }
+  } catch (err) {
+    console.error(
+      "[notify-member-join] recipient lookup failed",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -54,6 +54,12 @@ export const user = sqliteTable("user", {
    * better-auth-plugin.md). Paired migration:
    * `migrations/20260722190000_stripe_subscription.sql`. */
   stripeCustomerId: text("stripe_customer_id"),
+  /** Per-user pref: email me when someone joins a workspace I administer.
+   * Default on. Declared as a better-auth additionalField (src/auth.ts) so
+   * /api/auth/update-user writes it and the session returns it. */
+  notifyMemberJoin: integer("notify_member_join", { mode: "boolean" })
+    .notNull()
+    .$defaultFn(() => true),
 });
 
 /**

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -21,6 +21,7 @@ import {
   startLocalDemoSession,
   submitOAuthConsent,
   unbanUser,
+  updateNotifyMemberJoin,
   upgradeOrganizationSubscription,
 } from "./auth-client";
 import { BROWSER_REQUEST_TIMEOUT_MS, fetchWithTimeout } from "./request";
@@ -915,6 +916,28 @@ describe("upgradeOrganizationSubscription", () => {
         cancelUrl: "https://uploads.sh/x",
       }),
     ).resolves.toEqual({ ok: false, message: "Couldn't reach the auth service. Try again." });
+  });
+});
+
+describe("updateNotifyMemberJoin", () => {
+  it("POSTs update-user with the boolean and returns true on ok", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const ok = await updateNotifyMemberJoin("", false);
+    expect(ok).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain("/api/auth/update-user");
+    expect(JSON.parse(String(init?.body))).toEqual({ notifyMemberJoin: false });
+    fetchMock.mockRestore();
+  });
+
+  it("returns false on a non-ok response", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("nope", { status: 500 }));
+    expect(await updateNotifyMemberJoin("", true)).toBe(false);
+    fetchMock.mockRestore();
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -54,6 +54,8 @@ export interface SessionUser {
   banned?: boolean | null;
   /** First CLI device-flow session (sticky); de-emphasizes account setup. */
   cliOnboardedAt?: string | Date | null;
+  /** Per-user pref: email me when someone joins a workspace I administer. */
+  notifyMemberJoin?: boolean | null;
 }
 
 /** Operator-facing copy when sign-in is refused for a banned account. */
@@ -282,6 +284,26 @@ export async function linkGitHub(origin: string, callbackURL: string): Promise<b
     callbackURL,
     errorCallbackURL: callbackURL,
   });
+}
+
+/**
+ * Write the "email me when someone joins a workspace I administer" preference
+ * via Better Auth's update-user endpoint (the field is an `input: true`
+ * additionalField). Same-origin through the /api/auth proxy; session cookie
+ * rides along. Returns false on any failure so the toggle can revert.
+ */
+export async function updateNotifyMemberJoin(origin: string, value: boolean): Promise<boolean> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/update-user`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ notifyMemberJoin: value }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -41,6 +41,19 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
     </div>
 
     <div class="settings-section">
+      <h2>Email notifications</h2>
+      <label class="notify-row">
+        <input
+          type="checkbox"
+          id="notify-member-join"
+          checked={initial.user?.notifyMemberJoin ?? true}
+        />
+        <span>Email me when someone joins a workspace I administer.</span>
+      </label>
+      <p id="notify-status" class="muted settings-note" role="status" aria-live="polite"></p>
+    </div>
+
+    <div class="settings-section">
       <h2>Sign-in methods</h2>
       <div id="accounts-status" class="muted detail-status" hidden></div>
       <ul
@@ -135,6 +148,15 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
       gap: 8px;
       margin: 0;
     }
+    .notify-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: var(--text-meta);
+    }
+    .notify-row input {
+      margin: 0;
+    }
   </style>
 
   <script>
@@ -147,6 +169,7 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
       listAccounts,
       listSessions,
       revokeSession,
+      updateNotifyMemberJoin,
       type AuthSession,
     } from "../../lib/auth-client";
     import {
@@ -389,11 +412,32 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
         history.replaceState(null, "", clean.pathname + clean.search + clean.hash);
       }
 
+      const notifyToggle = document.getElementById("notify-member-join") as HTMLInputElement | null;
+      const notifyStatus = document.getElementById("notify-status");
+      notifyToggle?.addEventListener("change", () => {
+        void (async () => {
+          const desired = notifyToggle.checked;
+          notifyToggle.disabled = true;
+          if (notifyStatus) notifyStatus.textContent = "Saving…";
+          const ok = await updateNotifyMemberJoin(authOrigin, desired);
+          if (!ok) {
+            notifyToggle.checked = !desired; // revert
+            if (notifyStatus) notifyStatus.textContent = "Couldn’t save — try again.";
+          } else if (notifyStatus) {
+            notifyStatus.textContent = desired ? "You’ll be notified." : "Notifications off.";
+          }
+          notifyToggle.disabled = false;
+        })();
+      });
+
       onSession((user) => {
         requireElement<HTMLElement>("#acct-email", "account profile").textContent = user.email;
         requireElement<HTMLElement>("#acct-name", "account profile").textContent = user.name || "—";
         requireElement<HTMLElement>("#acct-role", "account profile").textContent =
           user.role || "member";
+        if (notifyToggle && typeof user.notifyMemberJoin === "boolean") {
+          notifyToggle.checked = user.notifyMemberJoin;
+        }
         void loadAccounts();
         void loadSessions();
       });

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -414,17 +414,20 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
 
       const notifyToggle = document.getElementById("notify-member-join") as HTMLInputElement | null;
       const notifyStatus = document.getElementById("notify-status");
+      function setNotifyStatus(message: string): void {
+        if (notifyStatus) notifyStatus.textContent = message;
+      }
       notifyToggle?.addEventListener("change", () => {
         void (async () => {
           const desired = notifyToggle.checked;
           notifyToggle.disabled = true;
-          if (notifyStatus) notifyStatus.textContent = "Saving…";
+          setNotifyStatus("Saving…");
           const ok = await updateNotifyMemberJoin(authOrigin, desired);
           if (!ok) {
             notifyToggle.checked = !desired; // revert
-            if (notifyStatus) notifyStatus.textContent = "Couldn’t save — try again.";
-          } else if (notifyStatus) {
-            notifyStatus.textContent = desired ? "You’ll be notified." : "Notifications off.";
+            setNotifyStatus("Couldn’t save — try again.");
+          } else {
+            setNotifyStatus(desired ? "You’ll be notified." : "Notifications off.");
           }
           notifyToggle.disabled = false;
         })();

--- a/apps/web/src/pages/admin/email.astro
+++ b/apps/web/src/pages/admin/email.astro
@@ -21,6 +21,7 @@ const PREVIEW_TYPES = [
   { id: "magic-link", label: "Magic sign-in link", category: "Auth" },
   { id: "org-invitation", label: "Workspace invitation", category: "Auth" },
   { id: "member-joined", label: "Member joined notify", category: "Auth" },
+  { id: "member-join-admin-notice", label: "Admin: member joined notify", category: "Auth" },
   { id: "welcome", label: "Welcome / next steps", category: "Auth" },
   { id: "enrollment-invitation", label: "Enrollment invitation", category: "Invites" },
 ] as const;

--- a/docs/superpowers/plans/2026-08-29-invite-acceptance-admin-notification.md
+++ b/docs/superpowers/plans/2026-08-29-invite-acceptance-admin-notification.md
@@ -674,7 +674,7 @@ In `apps/auth/src/auth.ts`, add near the other local imports: `import { notifyAd
 
 - [ ] **Step 2: Call the helper in `afterAcceptInvitation`**
 
-In `apps/auth/src/auth.ts`, at the end of the `afterAcceptInvitation` hook body (after the welcome-email block, before the closing `}` at line ~663), add:
+In `apps/auth/src/auth.ts`, place this call so it runs UNCONDITIONALLY on every acceptance — immediately after the inviter `member-joined` block and BEFORE the `if (!user.email) return;` guard. Do NOT put it at the end of the hook: the welcome-email block is preceded by two early returns (`if (!user.email) return;` and the first-membership gate `if (memberships.length !== 1) return;`), so a call placed there would only fire on the joiner's first-ever membership and would skip admins when an existing user joins a second workspace. Add:
 
 ```ts
 // Notify the workspace's other admins/owners. The inviter already

--- a/docs/superpowers/plans/2026-08-29-invite-acceptance-admin-notification.md
+++ b/docs/superpowers/plans/2026-08-29-invite-acceptance-admin-notification.md
@@ -1,0 +1,891 @@
+# Invite-acceptance Admin Notification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Email a workspace's admins/owners when a new member joins (via either join path), gated by a per-user, on-by-default notification preference editable on the account profile page.
+
+**Architecture:** All storage, join logic, and member/user data live in the AUTH worker (`apps/auth`). A new `notifyAdminsOfMemberJoin` helper queries admin/owner members whose preference is on (excluding the joiner, and the inviter on the invite path) and sends a new `@uploads/email` template via the existing `sendAuthEmail`. The preference is one boolean column on `user`, declared as a better-auth `additionalField` so `POST /api/auth/update-user` writes it and the session returns it; the profile page toggles it through that endpoint via the existing same-origin auth proxy.
+
+**Tech Stack:** Cloudflare Workers, Hono, better-auth (organization plugin), Drizzle ORM over D1, `@uploads/email` (card templates + Cloudflare Email Sending), Astro (SSR, bundled TS `<script>`, no React), Vitest with the `createFakeD1` harness.
+
+**Spec:** [`docs/superpowers/specs/2026-08-29-invite-acceptance-admin-notification-design.md`](../specs/2026-08-29-invite-acceptance-admin-notification-design.md)
+
+## Global Constraints
+
+- **Migration chain:** the AUTH worker's D1 tables are migrated from `apps/api/migrations/*.sql` ONLY. The `apps/auth/migrations/` chain is retired (see `apps/auth/src/test/fake-d1.ts`). D1 migrations auto-apply to prod on merge to `main`.
+- **Mail is fire-and-forget:** `sendAuthEmail` never throws; a mail (or recipient-lookup) failure must never fail or roll back a join.
+- **Sender:** always `noreply@uploads.sh` (already enforced by `sendAuthEmail`).
+- **No new web client dependency:** `apps/web` ships no React; account pages are Astro with bundled TS `<script>` blocks using plain `fetch` wrappers in `apps/web/src/lib/auth-client.ts`.
+- **Recipients:** members with role `admin` or `owner`, minus the joiner (and minus the inviter on the invite path). Never notify plain members.
+- **Default:** `notify_member_join` defaults to `1` (on) for new and existing rows.
+- **Copy rule:** no sensational words ("comprehensive", "world-class"). Terminal/product voice matching sibling templates.
+- **Test runner:** plain Vitest, in-process fakes; `pnpm test` at repo root, or `pnpm --filter @uploads/<pkg> test`.
+- **Typecheck:** `pnpm --filter @uploads/auth types`, `pnpm --filter @uploads/web types`, `pnpm --filter @uploads/email types`, `pnpm --filter @uploads/api types` as touched.
+
+---
+
+## File Structure
+
+**Create:**
+
+- `apps/api/migrations/20260829120000_auth_user_notify_member_join.sql` — adds the column.
+- `apps/auth/src/notify-member-join.ts` — the `notifyAdminsOfMemberJoin` helper.
+- `apps/auth/src/notify-member-join.test.ts` — helper unit tests.
+
+**Modify:**
+
+- `apps/auth/src/schema.ts` — add `notifyMemberJoin` to the `user` table.
+- `apps/auth/src/auth.ts` — declare the `additionalField`; call the helper in `afterAcceptInvitation`.
+- `apps/auth/src/internal-routes.ts` — call the helper in the `/internal/join` fresh-insert branch.
+- `apps/auth/src/email.ts` — add the `member-join-admin-notice` arm to `SendAuthEmailArgs` + `render()`.
+- `packages/email/src/invites.ts` — add `renderMemberJoinAdminNoticeEmail`.
+- `packages/email/src/index.ts` — export it.
+- `apps/api/src/admin-email-preview.ts` — register the preview type.
+- `apps/web/src/lib/auth-client.ts` — add `notifyMemberJoin` to `SessionUser`; add `updateNotifyMemberJoin`.
+- `apps/web/src/pages/account/profile.astro` — add the "Email notifications" section + toggle wiring.
+- Test seed helpers (new NOT NULL column ⇒ required in `AuthUser`): `apps/auth/src/internal-routes.test.ts`, `apps/auth/src/member-cap.test.ts`, `apps/auth/src/admin-last-guard.test.ts`, `apps/auth/src/internal-metrics.test.ts`.
+- `apps/auth/src/internal-routes.test.ts` — add a `/internal/join` notification integration test (Task 4).
+
+---
+
+## Task 1: Preference column + schema + additional field
+
+**Files:**
+
+- Create: `apps/api/migrations/20260829120000_auth_user_notify_member_join.sql`
+- Modify: `apps/auth/src/schema.ts:36-57` (user table)
+- Modify: `apps/auth/src/auth.ts:820-824` (`user.additionalFields`)
+- Modify (test seeds): `apps/auth/src/internal-routes.test.ts:119-137`, `apps/auth/src/member-cap.test.ts` (lines ~35-75 and ~270-300), `apps/auth/src/admin-last-guard.test.ts:50-60`, `apps/auth/src/internal-metrics.test.ts` (its `AuthUser` builder)
+
+**Interfaces:**
+
+- Produces: `schema.user.notifyMemberJoin` (Drizzle boolean column, DB `notify_member_join`); `schema.AuthUser` now has a required `notifyMemberJoin: boolean`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/20260829120000_auth_user_notify_member_join.sql`:
+
+```sql
+-- Per-user notification preference: email me when someone joins a workspace
+-- I administer. Default 1 (on) so existing admins keep getting notified; users
+-- opt out on /account/profile. Declared as a better-auth additionalField in
+-- apps/auth/src/auth.ts so /api/auth/update-user can write it.
+ALTER TABLE user ADD COLUMN notify_member_join INTEGER NOT NULL DEFAULT 1;
+```
+
+- [ ] **Step 2: Add the column to the Drizzle schema**
+
+In `apps/auth/src/schema.ts`, inside `export const user = sqliteTable("user", { ... })` (after `stripeCustomerId`, line ~56), add:
+
+```ts
+  /** Per-user pref: email me when someone joins a workspace I administer.
+   * Default on. Declared as a better-auth additionalField (src/auth.ts) so
+   * /api/auth/update-user writes it and the session returns it. */
+  notifyMemberJoin: integer("notify_member_join", { mode: "boolean" })
+    .notNull()
+    .$defaultFn(() => true),
+```
+
+- [ ] **Step 3: Declare the better-auth additional field**
+
+In `apps/auth/src/auth.ts`, in the `user.additionalFields` object (line ~821), add alongside `cliOnboardedAt`:
+
+```ts
+        notifyMemberJoin: {
+          type: "boolean",
+          required: false,
+          input: true,
+          defaultValue: true,
+        },
+```
+
+- [ ] **Step 4: Fix the test seed builders (typecheck driver)**
+
+The column is NOT NULL, so `schema.AuthUser` now requires `notifyMemberJoin`. In each `seedUser`/full-`AuthUser` builder listed under Files, add this line next to `stripeCustomerId`:
+
+```ts
+      notifyMemberJoin: overrides.notifyMemberJoin ?? true,
+```
+
+For builders that construct a bare literal without an `overrides` object (some in `member-cap.test.ts`), add `notifyMemberJoin: true,`.
+
+- [ ] **Step 5: Write a failing test for the default**
+
+Add to `apps/auth/src/internal-routes.test.ts` inside the `DB-backed behavior` describe:
+
+```ts
+it("defaults notify_member_join to on for a seeded user", async () => {
+  const user = await seedUser();
+  const [row] = await orm.select().from(schema.user).where(eq(schema.user.id, user.id));
+  expect(row.notifyMemberJoin).toBe(true);
+});
+```
+
+- [ ] **Step 6: Run it — expect PASS once migration + schema + seed land**
+
+Run: `pnpm --filter @uploads/auth test -- internal-routes`
+Expected: the new test PASSES (fake-D1 applies the new migration; seed defaults to true). If it fails to compile, an `AuthUser` builder still lacks the field — fix per Step 4.
+
+- [ ] **Step 7: Typecheck**
+
+Run: `pnpm --filter @uploads/auth types`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/migrations/20260829120000_auth_user_notify_member_join.sql apps/auth/src/schema.ts apps/auth/src/auth.ts apps/auth/src/*.test.ts
+git commit -m "feat(auth): add notify_member_join user preference column"
+```
+
+---
+
+## Task 2: `member-join-admin-notice` email template
+
+**Files:**
+
+- Modify: `packages/email/src/invites.ts` (add renderer after `renderMemberJoinedEmail`, line ~104)
+- Modify: `packages/email/src/index.ts:10-14`
+- Modify: `apps/api/src/admin-email-preview.ts:5-20,49-95`
+- Test: `packages/email/src/invites.test.ts` (create if absent) or the existing email test file for the package
+
+**Interfaces:**
+
+- Produces: `renderMemberJoinAdminNoticeEmail(ctx: { organizationName: string; organizationSlug: string; memberEmail: string; webOrigin?: string }): RenderedEmail`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/email/src/invites.test.ts` (or append to the package's existing test file):
+
+```ts
+import { describe, expect, it } from "vitest";
+import { renderMemberJoinAdminNoticeEmail } from "./invites";
+
+describe("renderMemberJoinAdminNoticeEmail", () => {
+  it("renders subject, body, manage CTA, and settings footnote", () => {
+    const email = renderMemberJoinAdminNoticeEmail({
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      memberEmail: "new@example.com",
+      webOrigin: "https://uploads.sh",
+    });
+    expect(email.subject).toContain("Acme");
+    expect(email.subject.toLowerCase()).toContain("joined");
+    expect(email.html).toContain("new@example.com");
+    expect(email.html).toContain("https://uploads.sh/account/workspaces/acme/settings");
+    expect(email.html).toContain("https://uploads.sh/account/profile");
+    expect(email.text).toContain("new@example.com");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @uploads/email test -- invites`
+Expected: FAIL — `renderMemberJoinAdminNoticeEmail` is not exported.
+
+- [ ] **Step 3: Implement the renderer**
+
+In `packages/email/src/invites.ts`, after `renderMemberJoinedEmail` (line ~104), add:
+
+```ts
+/** Notify a workspace's admins/owners when a new member joins (either path). */
+export function renderMemberJoinAdminNoticeEmail(ctx: {
+  organizationName: string;
+  organizationSlug: string;
+  memberEmail: string;
+  webOrigin?: string;
+}): RenderedEmail {
+  const origin = (ctx.webOrigin ?? "https://uploads.sh").replace(/\/$/, "");
+  const manageUrl = `${origin}/account/workspaces/${ctx.organizationSlug}/settings`;
+  const settingsUrl = `${origin}/account/profile`;
+  const lead = `${ctx.memberEmail} joined ${ctx.organizationName} on uploads.sh.`;
+  return renderEmailCard({
+    subject: `${ctx.memberEmail} joined ${ctx.organizationName} on uploads.sh`,
+    preheader: lead,
+    eyebrow: "Membership",
+    title: "New member joined",
+    bodyHtml: `${strong(ctx.memberEmail)} joined ${strong(ctx.organizationName)} on uploads.sh.`,
+    text: [
+      lead,
+      "",
+      `Manage members: ${manageUrl}`,
+      "",
+      "—",
+      "uploads.sh · a Build Internet project",
+      `Turn this notification off in your account settings: ${settingsUrl}`,
+    ].join("\n"),
+    cta: { url: manageUrl, label: "Manage members →" },
+    footNoteHtml: `You administer this workspace. <a href="${settingsUrl}" style="color:#b9b0cf;">Manage notifications</a> to turn this off.`,
+    webOrigin: ctx.webOrigin,
+  });
+}
+```
+
+- [ ] **Step 4: Export it**
+
+In `packages/email/src/index.ts`, add `renderMemberJoinAdminNoticeEmail` to the `./invites` export block:
+
+```ts
+export {
+  renderEnrollmentInvitationEmail,
+  renderMemberJoinAdminNoticeEmail,
+  renderMemberJoinedEmail,
+  renderOrgInvitationEmail,
+} from "./invites";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm --filter @uploads/email test -- invites`
+Expected: PASS.
+
+- [ ] **Step 6: Register the operator preview**
+
+In `apps/api/src/admin-email-preview.ts`:
+
+- Add `renderMemberJoinAdminNoticeEmail` to the `@uploads/email` import (line 5-11).
+- Add to `EMAIL_PREVIEW_TYPES` (after the `member-joined` entry, line 17):
+
+```ts
+  { id: "member-join-admin-notice", label: "Admin: member joined notify", category: "Auth" },
+```
+
+- Add a `renderPreview` case (after the `member-joined` case, line 77):
+
+```ts
+    case "member-join-admin-notice":
+      return {
+        from: AUTH_FROM,
+        ...renderMemberJoinAdminNoticeEmail({
+          organizationName: "preview-workspace",
+          organizationSlug: "preview-workspace",
+          memberEmail: "new-member@example.com",
+          webOrigin: origin,
+        }),
+      };
+```
+
+- [ ] **Step 7: Typecheck email + api**
+
+Run: `pnpm --filter @uploads/email types && pnpm --filter @uploads/api types`
+Expected: clean (the `renderPreview` switch is now exhaustive over the extended `EmailPreviewType`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/email/src/invites.ts packages/email/src/index.ts packages/email/src/invites.test.ts apps/api/src/admin-email-preview.ts
+git commit -m "feat(email): add member-join admin notice template"
+```
+
+---
+
+## Task 3: `notifyAdminsOfMemberJoin` helper + email dispatch arm
+
+**Files:**
+
+- Create: `apps/auth/src/notify-member-join.ts`
+- Create: `apps/auth/src/notify-member-join.test.ts`
+- Modify: `apps/auth/src/email.ts:33-49` (union), `apps/auth/src/email.ts:51-62` (`render`), import (line 7-13)
+
+**Interfaces:**
+
+- Consumes: `sendAuthEmail` (`apps/auth/src/email.ts`), `schema.member`, `schema.user` (`apps/auth/src/schema.ts`).
+- Produces:
+
+  ```ts
+  export interface NotifyAdminsOfMemberJoinOpts {
+    organizationId: string;
+    organizationName: string;
+    organizationSlug: string;
+    joinerUserId: string;
+    joinerEmail: string;
+    excludeUserIds?: string[];
+  }
+  export function notifyAdminsOfMemberJoin(
+    env: SendAuthEmailEnv,
+    db: DrizzleD1Database<typeof schema>,
+    opts: NotifyAdminsOfMemberJoinOpts,
+  ): Promise<void>;
+  ```
+
+- [ ] **Step 1: Add the email dispatch arm**
+
+In `apps/auth/src/email.ts`:
+
+- Import the renderer (line 7-13 block): add `renderMemberJoinAdminNoticeEmail,`.
+- Add to `SendAuthEmailArgs` (after the `member-joined` arm, line 44):
+
+```ts
+  | {
+      to: string;
+      template: "member-join-admin-notice";
+      context: { organizationName: string; organizationSlug: string; memberEmail: string };
+    }
+```
+
+- Add to `render()` switch (after the `member-joined` case, line 58):
+
+```ts
+    case "member-join-admin-notice":
+      return renderMemberJoinAdminNoticeEmail({ ...args.context, webOrigin });
+```
+
+- [ ] **Step 2: Write the failing helper test**
+
+Create `apps/auth/src/notify-member-join.test.ts`:
+
+```ts
+import { drizzle } from "drizzle-orm/d1";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmailBinding } from "./email";
+import { notifyAdminsOfMemberJoin } from "./notify-member-join";
+import * as schema from "./schema";
+import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
+
+describe("notifyAdminsOfMemberJoin", () => {
+  let db: FakeD1Database;
+  let orm: ReturnType<typeof drizzle<typeof schema>>;
+
+  beforeEach(() => {
+    db = createFakeD1();
+    orm = drizzle(db, { schema });
+  });
+
+  async function seedUser(over: Partial<schema.AuthUser> = {}): Promise<schema.AuthUser> {
+    const u: schema.AuthUser = {
+      id: over.id ?? crypto.randomUUID(),
+      name: "U",
+      email: over.email ?? `u-${crypto.randomUUID()}@example.com`,
+      emailVerified: true,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      role: "user",
+      banned: null,
+      banReason: null,
+      banExpires: null,
+      cliOnboardedAt: null,
+      stripeCustomerId: null,
+      notifyMemberJoin: over.notifyMemberJoin ?? true,
+    };
+    await orm.insert(schema.user).values(u);
+    return u;
+  }
+
+  async function seedMember(organizationId: string, userId: string, role: string): Promise<void> {
+    await orm.insert(schema.member).values({
+      id: crypto.randomUUID(),
+      organizationId,
+      userId,
+      role,
+      createdAt: new Date(),
+    });
+  }
+
+  function emailCapture(): { EMAIL: EmailBinding; send: ReturnType<typeof vi.fn> } {
+    const send = vi.fn().mockResolvedValue({});
+    return { EMAIL: { send }, send };
+  }
+
+  const orgId = "org-1";
+  const baseEnv = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "production" as const };
+
+  it("emails admins and owners, not plain members or the joiner", async () => {
+    const admin = await seedUser();
+    const owner = await seedUser();
+    const plain = await seedUser();
+    const joiner = await seedUser();
+    await seedMember(orgId, admin.id, "admin");
+    await seedMember(orgId, owner.id, "owner");
+    await seedMember(orgId, plain.id, "member");
+    await seedMember(orgId, joiner.id, "owner"); // joiner even as owner is excluded
+    const { EMAIL, send } = emailCapture();
+
+    await notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, orm, {
+      organizationId: orgId,
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      joinerUserId: joiner.id,
+      joinerEmail: joiner.email,
+    });
+
+    const recipients = send.mock.calls.map((c) => c[0].to).sort();
+    expect(recipients).toEqual([admin.email, owner.email].sort());
+  });
+
+  it("skips recipients who turned the preference off", async () => {
+    const admin = await seedUser({ notifyMemberJoin: false });
+    const joiner = await seedUser();
+    await seedMember(orgId, admin.id, "admin");
+    const { EMAIL, send } = emailCapture();
+    await notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, orm, {
+      organizationId: orgId,
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      joinerUserId: joiner.id,
+      joinerEmail: joiner.email,
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("excludes extra excludeUserIds (the inviter)", async () => {
+    const inviter = await seedUser();
+    const otherAdmin = await seedUser();
+    const joiner = await seedUser();
+    await seedMember(orgId, inviter.id, "admin");
+    await seedMember(orgId, otherAdmin.id, "admin");
+    const { EMAIL, send } = emailCapture();
+    await notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, orm, {
+      organizationId: orgId,
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      joinerUserId: joiner.id,
+      joinerEmail: joiner.email,
+      excludeUserIds: [inviter.id],
+    });
+    const recipients = send.mock.calls.map((c) => c[0].to);
+    expect(recipients).toEqual([otherAdmin.email]);
+  });
+
+  it("never throws when the DB read fails", async () => {
+    const poison = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("boom");
+        },
+      },
+    ) as never;
+    const { EMAIL, send } = emailCapture();
+    await expect(
+      notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, poison, {
+        organizationId: orgId,
+        organizationName: "Acme",
+        organizationSlug: "acme",
+        joinerUserId: "j",
+        joinerEmail: "j@example.com",
+      }),
+    ).resolves.toBeUndefined();
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `pnpm --filter @uploads/auth test -- notify-member-join`
+Expected: FAIL — `notify-member-join` module not found.
+
+- [ ] **Step 4: Implement the helper**
+
+Create `apps/auth/src/notify-member-join.ts`:
+
+```ts
+import { and, eq, inArray } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { sendAuthEmail, type SendAuthEmailEnv } from "./email";
+import * as schema from "./schema";
+
+export interface NotifyAdminsOfMemberJoinOpts {
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+  joinerUserId: string;
+  joinerEmail: string;
+  /** Extra userIds to skip (e.g. the inviter on the email-invite path). */
+  excludeUserIds?: string[];
+}
+
+/**
+ * Emails a workspace's admins/owners that a new member joined. Recipients are
+ * members with role admin/owner whose `notifyMemberJoin` preference is on,
+ * minus the joiner and any `excludeUserIds`. Fire-and-forget: `sendAuthEmail`
+ * never throws, and the recipient lookup is wrapped so a DB failure can't fail
+ * the join that triggered this.
+ */
+export async function notifyAdminsOfMemberJoin(
+  env: SendAuthEmailEnv,
+  db: DrizzleD1Database<typeof schema>,
+  opts: NotifyAdminsOfMemberJoinOpts,
+): Promise<void> {
+  const excluded = new Set([opts.joinerUserId, ...(opts.excludeUserIds ?? [])]);
+  try {
+    const rows = await db
+      .select({ userId: schema.member.userId, email: schema.user.email })
+      .from(schema.member)
+      .innerJoin(schema.user, eq(schema.member.userId, schema.user.id))
+      .where(
+        and(
+          eq(schema.member.organizationId, opts.organizationId),
+          inArray(schema.member.role, ["admin", "owner"]),
+          eq(schema.user.notifyMemberJoin, true),
+        ),
+      );
+
+    for (const row of rows) {
+      if (excluded.has(row.userId) || !row.email) continue;
+      await sendAuthEmail(env, {
+        to: row.email,
+        template: "member-join-admin-notice",
+        context: {
+          organizationName: opts.organizationName,
+          organizationSlug: opts.organizationSlug,
+          memberEmail: opts.joinerEmail,
+        },
+      });
+    }
+  } catch (err) {
+    console.error(
+      "[notify-member-join] recipient lookup failed",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @uploads/auth test -- notify-member-join email`
+Expected: PASS (helper tests + existing email tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @uploads/auth types`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/auth/src/notify-member-join.ts apps/auth/src/notify-member-join.test.ts apps/auth/src/email.ts
+git commit -m "feat(auth): notifyAdminsOfMemberJoin helper + email dispatch arm"
+```
+
+---
+
+## Task 4: Wire the join-link / enrollment path
+
+**Files:**
+
+- Modify: `apps/auth/src/internal-routes.ts:1005-1007` (`/internal/join` fresh-insert branch), imports
+- Test: `apps/auth/src/internal-routes.test.ts` (DB-backed behavior describe)
+
+**Interfaces:**
+
+- Consumes: `notifyAdminsOfMemberJoin` (Task 3).
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `apps/auth/src/internal-routes.test.ts` in the `DB-backed behavior` describe. It seeds an org, an admin member, and a joining user, then POSTs `/internal/join` and asserts the admin is emailed. Add an `EMAIL` capture to `dbEnv` via its `overrides`:
+
+```ts
+it("emails workspace admins when a new member joins via /internal/join", async () => {
+  const org = await seedOrg();
+  const admin = await seedUser();
+  const joiner = await seedUser();
+  await orm.insert(schema.member).values({
+    id: crypto.randomUUID(),
+    organizationId: org.id,
+    userId: admin.id,
+    role: "admin",
+    createdAt: new Date(),
+  });
+  const send = vi.fn().mockResolvedValue({});
+
+  const res = await app().request(
+    "/internal/join",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ organizationSlug: org.slug, userId: joiner.id }),
+    },
+    dbEnv({ EMAIL: { send } }),
+  );
+
+  expect(res.status).toBe(201);
+  const recipients = send.mock.calls.map((c) => c[0].to);
+  expect(recipients).toEqual([admin.email]);
+});
+```
+
+Ensure `vi` is imported at the top of the file: `import { beforeEach, describe, expect, it, vi } from "vitest";`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @uploads/auth test -- internal-routes`
+Expected: FAIL — no email sent (recipients empty), since the route doesn't notify yet.
+
+- [ ] **Step 3: Wire the call**
+
+In `apps/auth/src/internal-routes.ts`:
+
+- Add the import near the top: `import { notifyAdminsOfMemberJoin } from "./notify-member-join";`
+- In the `/internal/join` handler, replace the fresh-insert branch (line ~1005):
+
+```ts
+if ((insert.meta?.changes ?? 0) === 1) {
+  await notifyAdminsOfMemberJoin(c.env, db, {
+    organizationId: org.id,
+    organizationName: org.name,
+    organizationSlug: org.slug,
+    joinerUserId: userId,
+    joinerEmail: user.email,
+  });
+  return c.json({ alreadyMember: false }, 201);
+}
+```
+
+(`org`, `user`, `db` are already in scope; `c.env` satisfies `SendAuthEmailEnv`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @uploads/auth test -- internal-routes`
+Expected: PASS, including the pre-existing join/cap tests (a no-EMAIL `dbEnv()` still works — `sendAuthEmail` logs).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @uploads/auth types`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/auth/src/internal-routes.ts apps/auth/src/internal-routes.test.ts
+git commit -m "feat(auth): notify admins on join-link membership add"
+```
+
+---
+
+## Task 5: Wire the email-invite accept path
+
+**Files:**
+
+- Modify: `apps/auth/src/auth.ts:634-663` (`afterAcceptInvitation`), import
+
+**Interfaces:**
+
+- Consumes: `notifyAdminsOfMemberJoin` (Task 3).
+
+**Note on testing:** Per this repo's convention (see the issue #580 comment in `apps/auth/src/auth.ts` and `auth.test.ts`), better-auth hooks are not booted in unit tests; the extracted helper is tested directly (Task 3 covers the inviter-exclusion via `excludeUserIds`). This task's verification is a typecheck plus a manual dev check (Step 4). No new unit test is added for the hook wiring itself.
+
+- [ ] **Step 1: Add the import**
+
+In `apps/auth/src/auth.ts`, add near the other local imports: `import { notifyAdminsOfMemberJoin } from "./notify-member-join";`
+
+- [ ] **Step 2: Call the helper in `afterAcceptInvitation`**
+
+In `apps/auth/src/auth.ts`, at the end of the `afterAcceptInvitation` hook body (after the welcome-email block, before the closing `}` at line ~663), add:
+
+```ts
+// Notify the workspace's other admins/owners. The inviter already
+// got the tailored `member-joined` email above, so exclude them to
+// avoid a double-send; the joiner is always excluded by the helper.
+await notifyAdminsOfMemberJoin(env, db, {
+  organizationId: org.id,
+  organizationName: org.name,
+  organizationSlug: org.slug,
+  joinerUserId: user.id,
+  joinerEmail: user.email,
+  excludeUserIds: invitation.inviterId ? [invitation.inviterId] : [],
+});
+```
+
+(`env`, `db`, `org`, `user`, `invitation` are all in the hook's scope. Confirm `org.slug` is present on the hook's `organization` argument — the organization plugin passes the full org row.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @uploads/auth types`
+Expected: clean. If `org.slug` is not typed on the hook argument, read `organization.slug` from the org row via a `db` lookup by `org.id` instead, or use the value already destructured.
+
+- [ ] **Step 4: Manual dev verification**
+
+Run the local auth stack; accept an org invite for a workspace that has a second admin whose `notify_member_join` is on. Confirm the auth worker log shows a `member-join-admin-notice` send to the second admin and NOT to the inviter or the joiner. (No EMAIL binding locally ⇒ `sendAuthEmail` logs the recipient + subject.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/auth/src/auth.ts
+git commit -m "feat(auth): notify admins on invite acceptance"
+```
+
+---
+
+## Task 6: Account settings toggle
+
+**Files:**
+
+- Modify: `apps/web/src/lib/auth-client.ts:47-57` (`SessionUser`), and add `updateNotifyMemberJoin` (near `linkGitHub`, ~line 279)
+- Modify: `apps/web/src/pages/account/profile.astro` (markup + `<script>`)
+- Test: `apps/web/src/lib/auth-client.test.ts` (create if absent) for `updateNotifyMemberJoin`
+
+**Interfaces:**
+
+- Consumes: `authOrigin` (`apps/web/src/lib/auth-client.ts:42`), `fetchWithTimeout` (`./request`).
+- Produces: `SessionUser.notifyMemberJoin?: boolean | null`; `updateNotifyMemberJoin(origin: string, value: boolean): Promise<boolean>`.
+
+- [ ] **Step 1: Add the type field**
+
+In `apps/web/src/lib/auth-client.ts`, in `interface SessionUser` (line 47), add:
+
+```ts
+  /** Per-user pref: email me when someone joins a workspace I administer. */
+  notifyMemberJoin?: boolean | null;
+```
+
+- [ ] **Step 2: Write the failing client-helper test**
+
+Create `apps/web/src/lib/auth-client.test.ts` (or append):
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { updateNotifyMemberJoin } from "./auth-client";
+
+describe("updateNotifyMemberJoin", () => {
+  it("POSTs update-user with the boolean and returns true on ok", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const ok = await updateNotifyMemberJoin("", false);
+    expect(ok).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain("/api/auth/update-user");
+    expect(JSON.parse(String(init?.body))).toEqual({ notifyMemberJoin: false });
+    fetchMock.mockRestore();
+  });
+
+  it("returns false on a non-ok response", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("nope", { status: 500 }));
+    expect(await updateNotifyMemberJoin("", true)).toBe(false);
+    fetchMock.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `pnpm --filter @uploads/web test -- auth-client`
+Expected: FAIL — `updateNotifyMemberJoin` is not exported.
+
+- [ ] **Step 4: Implement the helper**
+
+In `apps/web/src/lib/auth-client.ts`, add (near `linkGitHub`):
+
+```ts
+/**
+ * Write the "email me when someone joins a workspace I administer" preference
+ * via Better Auth's update-user endpoint (the field is an `input: true`
+ * additionalField). Same-origin through the /api/auth proxy; session cookie
+ * rides along. Returns false on any failure so the toggle can revert.
+ */
+export async function updateNotifyMemberJoin(origin: string, value: boolean): Promise<boolean> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/update-user`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ notifyMemberJoin: value }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pnpm --filter @uploads/web test -- auth-client`
+Expected: PASS.
+
+- [ ] **Step 6: Add the settings section markup**
+
+In `apps/web/src/pages/account/profile.astro`, after the "Account" `.settings-section` (closes at line ~41), add a new section. The checkbox initial state comes from the SSR `initial.user`:
+
+```astro
+    <div class="settings-section">
+      <h2>Email notifications</h2>
+      <label class="notify-row">
+        <input
+          type="checkbox"
+          id="notify-member-join"
+          checked={initial.user?.notifyMemberJoin ?? true}
+        />
+        <span>Email me when someone joins a workspace I administer.</span>
+      </label>
+      <p id="notify-status" class="muted settings-note" role="status" aria-live="polite"></p>
+    </div>
+```
+
+- [ ] **Step 7: Wire the toggle in the page `<script>`**
+
+In the `profile.astro` `<script>`, import the helper (add to the `auth-client` import list, line ~143):
+
+```ts
+      updateNotifyMemberJoin,
+```
+
+Inside `onAstroPageLoad(() => { ... })`, after the existing setup, add:
+
+```ts
+const notifyToggle = document.getElementById("notify-member-join") as HTMLInputElement | null;
+const notifyStatus = document.getElementById("notify-status");
+notifyToggle?.addEventListener("change", () => {
+  void (async () => {
+    const desired = notifyToggle.checked;
+    notifyToggle.disabled = true;
+    if (notifyStatus) notifyStatus.textContent = "Saving…";
+    const ok = await updateNotifyMemberJoin(authOrigin, desired);
+    if (!ok) {
+      notifyToggle.checked = !desired; // revert
+      if (notifyStatus) notifyStatus.textContent = "Couldn’t save — try again.";
+    } else if (notifyStatus) {
+      notifyStatus.textContent = desired ? "You’ll be notified." : "Notifications off.";
+    }
+    notifyToggle.disabled = false;
+  })();
+});
+```
+
+And reconcile from the live session inside the existing `onSession((user) => { ... })` callback (line ~392):
+
+```ts
+if (notifyToggle && typeof user.notifyMemberJoin === "boolean") {
+  notifyToggle.checked = user.notifyMemberJoin;
+}
+```
+
+- [ ] **Step 8: Typecheck web**
+
+Run: `pnpm --filter @uploads/web types`
+Expected: clean.
+
+- [ ] **Step 9: Browser verification**
+
+Start the local web + auth stack. Open `/account/profile`, toggle the checkbox off → the `POST /api/auth/update-user` returns 200 and the status reads "Notifications off."; reload → the checkbox stays off (session reflects the stored value). Toggle back on. Capture a screenshot of the new section for the PR.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/web/src/lib/auth-client.ts apps/web/src/lib/auth-client.test.ts apps/web/src/pages/account/profile.astro
+git commit -m "feat(web): account toggle for member-join notifications"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full test suite:** `pnpm test` (or at least `pnpm --filter @uploads/auth test && pnpm --filter @uploads/email test && pnpm --filter @uploads/web test && pnpm --filter @uploads/api test`) — all green.
+- [ ] **Typecheck all touched:** `pnpm --filter @uploads/auth types && pnpm --filter @uploads/email types && pnpm --filter @uploads/web types && pnpm --filter @uploads/api types`.
+- [ ] **Lint/format:** repo pre-commit (oxfmt/prettier) already ran per-commit; confirm no residual diff.
+- [ ] **Changeset:** add a changeset if the repo requires one for these packages (`@uploads/auth`, `@uploads/email`, `@uploads/web`, `@uploads/api`) — follow the repo's changeset convention.
+- [ ] **Manual smoke:** operator `/admin/email` preview of `member-join-admin-notice` renders; a dev join (both paths) logs the expected recipients; the profile toggle round-trips.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** storage (Task 1), helper (Task 3), template (Task 2), both join paths (Tasks 4–5), settings toggle (Task 6), error handling (helper try/catch + fire-and-forget, Task 3), testing (per-task). All spec sections map to a task.
+- **Type consistency:** `notifyMemberJoin` (camel) / `notify_member_join` (DB) used consistently; helper name `notifyAdminsOfMemberJoin`, template id `member-join-admin-notice`, renderer `renderMemberJoinAdminNoticeEmail`, client helper `updateNotifyMemberJoin` — identical across tasks.
+- **Known runtime check:** Task 5 Step 3 flags the one uncertainty (`org.slug` presence on the better-auth hook argument) with a concrete fallback.

--- a/docs/superpowers/specs/2026-08-29-invite-acceptance-admin-notification-design.md
+++ b/docs/superpowers/specs/2026-08-29-invite-acceptance-admin-notification-design.md
@@ -178,18 +178,20 @@ join (invite accept OR join-link redeem)
             └─ for each: sendAuthEmail("member-join-admin-notice")   [never throws]
 
 settings toggle
-  profile.astro form → POST /api/account/notification-prefs (web, session)
-    → POST /internal/user/notification-prefs (auth, session-guarded)
-      → UPDATE user SET notify_member_join = ? WHERE id = <session user>
+  profile.astro checkbox change → updateNotifyMemberJoin(origin, value)
+    → POST /api/auth/update-user (same-origin proxy, session cookie)
+      → better-auth writes user.notifyMemberJoin (input:true additionalField)
 ```
 
 ## Error handling
 
-- All mail is fire-and-forget via `sendAuthEmail` (logs, never throws).
+- All mail is fire-and-forget via `sendAuthEmail` (logs, never throws — the
+  whole body is wrapped so even a template-render error is caught).
 - `notifyAdminsOfMemberJoin` wraps its DB read in try/catch and log-only;
   a failure there must not affect the join response.
-- The prefs write route returns 401 when unauthenticated, 400 on a
-  malformed body, 200 on success.
+- The settings write goes through better-auth's `update-user` endpoint,
+  which requires the session cookie and only writes input-allowed fields on
+  the caller's own user row.
 
 ## Testing (plain vitest + in-process fakes)
 

--- a/docs/superpowers/specs/2026-08-29-invite-acceptance-admin-notification-design.md
+++ b/docs/superpowers/specs/2026-08-29-invite-acceptance-admin-notification-design.md
@@ -52,11 +52,21 @@ notifyMemberJoin: integer("notify_member_join", { mode: "boolean" })
   .$defaultFn(() => true),
 ```
 
-Paired migration in `apps/auth/migrations/` (D1 migrations auto-apply on
-merge to prod):
+Paired migration in **`apps/api/migrations/`** — that is the single D1
+migration chain for the AUTH worker's tables (the old `apps/auth/migrations/`
+chain is retired; see the note in `apps/auth/src/test/fake-d1.ts`). D1
+migrations auto-apply on merge to prod:
 
 ```sql
 ALTER TABLE user ADD COLUMN notify_member_join INTEGER NOT NULL DEFAULT 1;
+```
+
+Also declare it as a better-auth additional field so the framework returns
+it on the session and accepts writes to it (see §5) — in `apps/auth/src/auth.ts`
+`user.additionalFields`:
+
+```ts
+notifyMemberJoin: { type: "boolean", required: false, input: true, defaultValue: true },
 ```
 
 A single typed column (not a JSON blob, not a new table) — queryable and
@@ -130,26 +140,30 @@ existing inviter email stays untouched — it's a different, inviter-specific
 message; excluding the inviter from the admin-notice avoids double-emailing
 them.
 
-### 5. Settings toggle (web, SSR-first, no framework JS)
+### 5. Settings toggle (web, SSR-first, via better-auth update-user)
 
+The write path uses better-auth's built-in `POST /api/auth/update-user`
+endpoint (allowed because `notifyMemberJoin` is declared `input: true` in
+`user.additionalFields`), reached through the app's existing same-origin
+`/api/auth/[...path]` proxy with `credentials: "include"`. No custom
+internal route and no custom web proxy — the field also rides on the
+session object automatically, so the page reads current state directly.
+
+- **Type:** add `notifyMemberJoin?: boolean | null` to `SessionUser`
+  (`apps/web/src/lib/auth-client.ts:47`). Because `session.user` is a
+  passthrough of the better-auth JSON body, the new field arrives with no
+  extra parsing; `loadProfilePageData` already returns `session.user`.
+- **Client helper:** add `updateNotifyMemberJoin(origin, value)` to
+  `apps/web/src/lib/auth-client.ts` — `POST ${authOrigin(origin)}/api/auth/update-user`,
+  `credentials: "include"`, `Content-Type: application/json`, body
+  `{ notifyMemberJoin: value }`; returns ok/failure like the other wrappers.
 - **UI:** add an "Email notifications" `.settings-section` to
   `apps/web/src/pages/account/profile.astro` with a single checkbox
-  ("Email me when someone joins a workspace I administer"), reflecting the
-  user's current `notifyMemberJoin`. Progressive-enhancement form (checkbox
-  - Save button) — no React (signed-in account pages are Astro/SSR).
-- **Same-origin proxy:** new route
-  `apps/web/src/pages/api/account/notification-prefs.ts` (POST), mirroring
-  the `apps/web/src/pages/api/enrollments/join.ts` proxy pattern. Reads the
-  session, forwards to the AUTH internal route.
-- **AUTH write route:** new `POST /internal/user/notification-prefs` in
-  `apps/auth/src/internal-routes.ts`, session/user-guarded, updates
-  `user.notifyMemberJoin` for the authenticated user only. Body:
-  `{ notifyMemberJoin: boolean }`.
-- The current session-user shape (`SessionUser`,
-  `apps/web/src/lib/auth-client.ts:47`) gains `notifyMemberJoin` so the
-  page can render the current state; confirm better-auth surfaces the new
-  column on the session (it selects `user.*`), otherwise fetch it in the
-  page loader.
+  ("Email me when someone joins a workspace I administer"), initial `checked`
+  from `initial.user?.notifyMemberJoin` (defaulting to checked when
+  undefined). The page's bundled `<script>` wires a `change` handler that
+  calls the helper and shows a saved/error status; `onSession` reconciles
+  the checkbox from the live session. No new client dependency.
 
 ## Data flow
 

--- a/docs/superpowers/specs/2026-08-29-invite-acceptance-admin-notification-design.md
+++ b/docs/superpowers/specs/2026-08-29-invite-acceptance-admin-notification-design.md
@@ -1,0 +1,200 @@
+# Invite-acceptance admin notification — design
+
+**Date:** 2026-08-29
+**Branch:** `claude/invite-acceptance-notifications-231346`
+**Status:** Approved design, pre-implementation
+
+## Summary
+
+When a user joins a workspace, notify that workspace's admins/owners by
+email. Each user can turn this notification off in their account settings.
+The notification is **on by default**.
+
+A sibling feature — usage-limit alert emails at 50/90/100% — is explicitly
+**out of scope** and ships as a separate follow-up PR. See "Follow-up" below.
+
+## Requirements
+
+- A new member joining a workspace triggers an email to that workspace's
+  admins and owners.
+- Fires for **both** join paths: better-auth email invites AND
+  join-links / enrollment codes.
+- Recipients: every member with role `admin` or `owner`, **excluding the
+  person who just joined**. On the email-invite path, also exclude the
+  inviter (they already receive the tailored `member-joined` email).
+- Each user has a per-account toggle "Email me when someone joins a
+  workspace I administer", **default on**.
+- Mail is fire-and-forget: a mail failure must never roll back or fail the
+  join.
+
+## Non-goals
+
+- Usage-limit alert emails (separate follow-up PR).
+- Per-workspace notification preferences (this is a per-user preference).
+- Notifying plain members (`role = member`) — admins/owners only.
+- In-app / push notifications — email only.
+
+## Architecture
+
+Storage, join logic, and member/user data all live in the **AUTH worker**
+(`apps/auth`), so the entire feature is implemented there plus the shared
+email package and the web settings surface. No cross-worker preference
+plumbing.
+
+### 1. Preference storage (D1, `user` table)
+
+Add one boolean column to the `user` table in
+`apps/auth/src/schema.ts:36`:
+
+```ts
+notifyMemberJoin: integer("notify_member_join", { mode: "boolean" })
+  .notNull()
+  .$defaultFn(() => true),
+```
+
+Paired migration in `apps/auth/migrations/` (D1 migrations auto-apply on
+merge to prod):
+
+```sql
+ALTER TABLE user ADD COLUMN notify_member_join INTEGER NOT NULL DEFAULT 1;
+```
+
+A single typed column (not a JSON blob, not a new table) — queryable and
+minimal. The follow-up usage-alert PR adds its own column the same way;
+each PR stays self-contained.
+
+### 2. Notification helper (AUTH worker)
+
+New module `apps/auth/src/notify-member-join.ts`:
+
+```ts
+notifyAdminsOfMemberJoin(env, db, {
+  organizationId: string,
+  organizationName: string,
+  joinerUserId: string,
+  joinerEmail: string,
+  excludeUserIds?: string[],   // inviter on the email-invite path
+}): Promise<void>
+```
+
+- One query: `member ⋈ user` where
+  `member.organizationId = organizationId`,
+  `member.role IN ('admin','owner')`,
+  `user.notifyMemberJoin = true`,
+  `user.id NOT IN (joinerUserId, ...excludeUserIds)`.
+- For each recipient, `await sendAuthEmail(env, { to, template:
+"member-join-admin-notice", context })`. `sendAuthEmail` never throws, so
+  the whole helper is safe to `await` inside a join without a rollback risk.
+- Wrap the query in try/catch and log-only, so even a DB read failure can't
+  fail the join.
+
+### 3. Email template (`@uploads/email`)
+
+New `renderMemberJoinAdminNoticeEmail(input)` in
+`packages/email/src/invites.ts`, mirroring `renderMemberJoinedEmail`
+(`invites.ts:88`) and built on `renderEmailCard` (`card.ts:146`):
+
+- Subject: `New member joined <workspace>`
+- Body: `<joiner email> joined <workspace name>.`
+- CTA: manage-members link → `<webOrigin>/account/workspaces/<slug>/settings`
+  (members tab).
+- Footnote: "You're receiving this because you administer this workspace.
+  Manage notifications in your account settings." linking to
+  `<webOrigin>/account/profile`.
+
+Wire it into the dispatcher:
+
+- `apps/auth/src/email.ts` — add the `"member-join-admin-notice"` arm to the
+  `SendAuthEmailArgs` union (line 33) and the `render()` switch (line 51),
+  and import the new renderer.
+- `apps/api/src/admin-email-preview.ts` — register the new type in
+  `EMAIL_PREVIEW_TYPES` and `renderPreview` so operators can preview /
+  self-send it via `/admin/email`.
+- `packages/email/src/index.ts` — export the new renderer.
+
+### 4. Wiring the two join paths
+
+**Join-links / enrollment codes** —
+`apps/auth/src/internal-routes.ts` `/internal/join`, the fresh-insert
+branch at line 1005 (`insert.meta.changes === 1`, returns 201). Before
+returning, call `notifyAdminsOfMemberJoin` with `joinerUserId = userId`,
+`joinerEmail = user.email`, no extra exclusions. `org`, `user`, and `db`
+are already in scope. This path emails nobody today.
+
+**Email invites** — `apps/auth/src/auth.ts` `afterAcceptInvitation`
+(line 634). After the existing inviter `member-joined` email (641-647) and
+the welcome email, call `notifyAdminsOfMemberJoin` with
+`joinerUserId = user.id`, `joinerEmail = user.email`, and
+`excludeUserIds = invitation.inviterId ? [invitation.inviterId] : []`. The
+existing inviter email stays untouched — it's a different, inviter-specific
+message; excluding the inviter from the admin-notice avoids double-emailing
+them.
+
+### 5. Settings toggle (web, SSR-first, no framework JS)
+
+- **UI:** add an "Email notifications" `.settings-section` to
+  `apps/web/src/pages/account/profile.astro` with a single checkbox
+  ("Email me when someone joins a workspace I administer"), reflecting the
+  user's current `notifyMemberJoin`. Progressive-enhancement form (checkbox
+  - Save button) — no React (signed-in account pages are Astro/SSR).
+- **Same-origin proxy:** new route
+  `apps/web/src/pages/api/account/notification-prefs.ts` (POST), mirroring
+  the `apps/web/src/pages/api/enrollments/join.ts` proxy pattern. Reads the
+  session, forwards to the AUTH internal route.
+- **AUTH write route:** new `POST /internal/user/notification-prefs` in
+  `apps/auth/src/internal-routes.ts`, session/user-guarded, updates
+  `user.notifyMemberJoin` for the authenticated user only. Body:
+  `{ notifyMemberJoin: boolean }`.
+- The current session-user shape (`SessionUser`,
+  `apps/web/src/lib/auth-client.ts:47`) gains `notifyMemberJoin` so the
+  page can render the current state; confirm better-auth surfaces the new
+  column on the session (it selects `user.*`), otherwise fetch it in the
+  page loader.
+
+## Data flow
+
+```
+join (invite accept OR join-link redeem)
+  └─ membership row inserted (existing code)
+       └─ notifyAdminsOfMemberJoin(env, db, {...})
+            ├─ SELECT admins/owners with notifyMemberJoin=true, minus joiner (+inviter)
+            └─ for each: sendAuthEmail("member-join-admin-notice")   [never throws]
+
+settings toggle
+  profile.astro form → POST /api/account/notification-prefs (web, session)
+    → POST /internal/user/notification-prefs (auth, session-guarded)
+      → UPDATE user SET notify_member_join = ? WHERE id = <session user>
+```
+
+## Error handling
+
+- All mail is fire-and-forget via `sendAuthEmail` (logs, never throws).
+- `notifyAdminsOfMemberJoin` wraps its DB read in try/catch and log-only;
+  a failure there must not affect the join response.
+- The prefs write route returns 401 when unauthenticated, 400 on a
+  malformed body, 200 on success.
+
+## Testing (plain vitest + in-process fakes)
+
+- `notifyAdminsOfMemberJoin`: emails admins and owners; skips plain
+  members; excludes the joiner; excludes extra `excludeUserIds` (inviter);
+  respects `notifyMemberJoin = false`; sends nothing when no eligible
+  recipients; a thrown DB error is swallowed (no throw).
+- Both call sites: join-link fresh insert triggers the helper with the
+  joiner excluded; invite-accept triggers it with joiner + inviter
+  excluded; an `alreadyMember` result triggers nothing.
+- Email template: renders subject/body/CTA/footnote for representative
+  input (smoke).
+- Prefs write route: persists the new value for the session user; rejects
+  unauthenticated; ignores/400s a malformed body; a user can only change
+  their own row.
+- Migration: column exists with default 1; existing rows read as `true`.
+
+## Follow-up (separate PR, not this one)
+
+Usage-limit alert emails at 50%, 90%, and 100% of a workspace's usage
+limit. This is a distinct notification category with its own
+threshold-crossing detection, de-duplication (fire once per threshold, not
+per upload), billing-period reset, and its own per-user toggle column.
+Design and implementation land in a separate PR; the usage-infrastructure
+exploration notes are captured for that effort.

--- a/docs/superpowers/specs/2026-08-29-invite-acceptance-admin-notification-design.md
+++ b/docs/superpowers/specs/2026-08-29-invite-acceptance-admin-notification-design.md
@@ -132,8 +132,11 @@ returning, call `notifyAdminsOfMemberJoin` with `joinerUserId = userId`,
 are already in scope. This path emails nobody today.
 
 **Email invites** — `apps/auth/src/auth.ts` `afterAcceptInvitation`
-(line 634). After the existing inviter `member-joined` email (641-647) and
-the welcome email, call `notifyAdminsOfMemberJoin` with
+(line 634). Call `notifyAdminsOfMemberJoin` immediately after the existing
+inviter `member-joined` email block and BEFORE the hook's early returns
+(`if (!user.email) return;` and the first-membership gate `if
+(memberships.length !== 1) return;`) so it fires on every acceptance, not
+only the joiner's first membership. Pass
 `joinerUserId = user.id`, `joinerEmail = user.email`, and
 `excludeUserIds = invitation.inviterId ? [invitation.inviterId] : []`. The
 existing inviter email stays untouched — it's a different, inviter-specific

--- a/packages/email/src/card.ts
+++ b/packages/email/src/card.ts
@@ -91,8 +91,13 @@ export function strong(value: string): string {
   return `<strong style="color:${FG};font-weight:600;">${escapeHtml(value)}</strong>`;
 }
 
+/** Normalize a caller-supplied web origin: default when absent, no trailing slash. */
+export function resolveWebOrigin(webOrigin?: string): string {
+  return (webOrigin || DEFAULT_WEB_ORIGIN).replace(/\/$/, "");
+}
+
 function webOriginOf(input: EmailCardInput): string {
-  if (input.webOrigin) return input.webOrigin.replace(/\/$/, "");
+  if (input.webOrigin) return resolveWebOrigin(input.webOrigin);
   if (input.cta?.url) {
     try {
       return new URL(input.cta.url).origin;

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -9,6 +9,7 @@ export {
 export { renderMagicLinkEmail } from "./auth";
 export {
   renderEnrollmentInvitationEmail,
+  renderMemberJoinAdminNoticeEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
 } from "./invites";

--- a/packages/email/src/invites.test.ts
+++ b/packages/email/src/invites.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { renderMemberJoinAdminNoticeEmail } from "./invites";
+
+describe("renderMemberJoinAdminNoticeEmail", () => {
+  it("renders subject, body, manage CTA, and settings footnote", () => {
+    const email = renderMemberJoinAdminNoticeEmail({
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      memberEmail: "new@example.com",
+      webOrigin: "https://uploads.sh",
+    });
+    expect(email.subject).toContain("Acme");
+    expect(email.subject.toLowerCase()).toContain("joined");
+    expect(email.html).toContain("new@example.com");
+    expect(email.html).toContain("https://uploads.sh/account/workspaces/acme/settings");
+    expect(email.html).toContain("https://uploads.sh/account/profile");
+    expect(email.text).toContain("new@example.com");
+  });
+});

--- a/packages/email/src/invites.ts
+++ b/packages/email/src/invites.ts
@@ -102,3 +102,35 @@ export function renderMemberJoinedEmail(ctx: {
     webOrigin: ctx.webOrigin,
   });
 }
+
+/** Notify a workspace's admins/owners when a new member joins (either path). */
+export function renderMemberJoinAdminNoticeEmail(ctx: {
+  organizationName: string;
+  organizationSlug: string;
+  memberEmail: string;
+  webOrigin?: string;
+}): RenderedEmail {
+  const origin = (ctx.webOrigin ?? "https://uploads.sh").replace(/\/$/, "");
+  const manageUrl = `${origin}/account/workspaces/${ctx.organizationSlug}/settings`;
+  const settingsUrl = `${origin}/account/profile`;
+  const lead = `${ctx.memberEmail} joined ${ctx.organizationName} on uploads.sh.`;
+  return renderEmailCard({
+    subject: `${ctx.memberEmail} joined ${ctx.organizationName} on uploads.sh`,
+    preheader: lead,
+    eyebrow: "Membership",
+    title: "New member joined",
+    bodyHtml: `${strong(ctx.memberEmail)} joined ${strong(ctx.organizationName)} on uploads.sh.`,
+    text: [
+      lead,
+      "",
+      `Manage members: ${manageUrl}`,
+      "",
+      "—",
+      "uploads.sh · a Build Internet project",
+      `Turn this notification off in your account settings: ${settingsUrl}`,
+    ].join("\n"),
+    cta: { url: manageUrl, label: "Manage members →" },
+    footNoteHtml: `You administer this workspace. <a href="${settingsUrl}" style="color:#b9b0cf;">Manage notifications</a> to turn this off.`,
+    webOrigin: ctx.webOrigin,
+  });
+}

--- a/packages/email/src/invites.ts
+++ b/packages/email/src/invites.ts
@@ -110,7 +110,7 @@ export function renderMemberJoinAdminNoticeEmail(ctx: {
   memberEmail: string;
   webOrigin?: string;
 }): RenderedEmail {
-  const origin = (ctx.webOrigin ?? "https://uploads.sh").replace(/\/$/, "");
+  const origin = (ctx.webOrigin || "https://uploads.sh").replace(/\/$/, "");
   const manageUrl = `${origin}/account/workspaces/${ctx.organizationSlug}/settings`;
   const settingsUrl = `${origin}/account/profile`;
   const lead = `${ctx.memberEmail} joined ${ctx.organizationName} on uploads.sh.`;
@@ -130,7 +130,7 @@ export function renderMemberJoinAdminNoticeEmail(ctx: {
       `Turn this notification off in your account settings: ${settingsUrl}`,
     ].join("\n"),
     cta: { url: manageUrl, label: "Manage members →" },
-    footNoteHtml: `You administer this workspace. <a href="${settingsUrl}" style="color:#b9b0cf;">Manage notifications</a> to turn this off.`,
+    footNoteHtml: `You administer this workspace. <a href="${escapeHtml(settingsUrl)}" style="color:#b9b0cf;">Manage notifications</a> to turn this off.`,
     webOrigin: ctx.webOrigin,
   });
 }

--- a/packages/email/src/invites.ts
+++ b/packages/email/src/invites.ts
@@ -1,4 +1,4 @@
-import { escapeHtml, renderEmailCard, strong, type RenderedEmail } from "./card";
+import { escapeHtml, renderEmailCard, resolveWebOrigin, strong, type RenderedEmail } from "./card";
 
 const CTA = "Accept invitation →";
 const IGNORE = "If you weren't expecting this, you can ignore this email.";
@@ -110,7 +110,7 @@ export function renderMemberJoinAdminNoticeEmail(ctx: {
   memberEmail: string;
   webOrigin?: string;
 }): RenderedEmail {
-  const origin = (ctx.webOrigin || "https://uploads.sh").replace(/\/$/, "");
+  const origin = resolveWebOrigin(ctx.webOrigin);
   const manageUrl = `${origin}/account/workspaces/${ctx.organizationSlug}/settings`;
   const settingsUrl = `${origin}/account/profile`;
   const lead = `${ctx.memberEmail} joined ${ctx.organizationName} on uploads.sh.`;


### PR DESCRIPTION
## What & why

When someone joins a workspace, the workspace's admins/owners now get a notification email. Each user can turn this off in their account settings; it's **on by default**.

Fires for **both** join paths:
- **Email invites** (`afterAcceptInvitation`) — the notice goes to admins/owners, excluding the joiner and the inviter (who already gets the tailored "your invite was accepted" email). It runs on *every* acceptance, not just a first-time membership.
- **Join links / enrollment codes** (`POST /internal/join`) — this path previously emailed no one.

Recipients are members with role `admin`/`owner` whose preference is on, minus the joiner (+ inviter on the invite path).

## How it's built

- **Preference storage:** one boolean column `notify_member_join` on `user` (default `1`), declared as a better-auth `additionalField` (`input: true`) so it rides on the session and is written via the standard `POST /api/auth/update-user`. Migration lives in `apps/api/migrations/` (the auth worker's D1 chain).
- **Notification helper** (`apps/auth/src/notify-member-join.ts`): one `member ⋈ user` query filtered to admin/owner + preference-on + not-excluded, then sends concurrently. Fire-and-forget — `sendAuthEmail` never throws (now hardened so even a template-render error can't propagate), and the lookup is wrapped so a mail/DB failure can't fail the join.
- **Email template:** new `member-join-admin-notice` card in `@uploads/email`, registered in the operator `/admin/email` preview.
- **Settings toggle:** an "Email notifications" section on `/account/profile` (Astro SSR, no new client JS) that writes through the same-origin auth proxy.

## Tests

- Helper unit tests: admins+owners emailed, plain members and the joiner skipped, inviter excluded, preference-off skipped, DB error swallowed.
- Integration test for the join-link path asserting the admin is the sole recipient.
- Email template render test; `updateNotifyMemberJoin` client-wrapper test (ok / non-ok).
- Full suites green: auth 376, email 17, api 2428, web 910; all touched packages typecheck clean.

## Notes

- Usage-limit alert emails (50/90/100%) were requested alongside this but are intentionally scoped to a **separate follow-up PR**.
- Live-browser round-trip of the toggle wasn't run in-session (the write path is covered by unit tests + static review); worth a quick manual check before merge.
- No changeset — all touched packages are private.

Design + plan: `docs/superpowers/specs/2026-08-29-invite-acceptance-admin-notification-design.md`, `docs/superpowers/plans/2026-08-29-invite-acceptance-admin-notification.md`.
