### PR TITLE
feat(api,auth,web): email workspace admins as usage nears its limit

### DIFF
--- a/apps/api/migrations/20260829130000_auth_user_notify_usage_limits.sql
+++ b/apps/api/migrations/20260829130000_auth_user_notify_usage_limits.sql
@@ -1,0 +1,6 @@
+-- Per-user notification preference: email me when a workspace I administer
+-- nears its usage limit (50/90/100% of storage or monthly uploads). Default 1
+-- (on) so existing admins get alerted; users opt out on /account/profile.
+-- Declared as a better-auth additionalField in apps/auth/src/auth.ts so
+-- /api/auth/update-user can write it.
+ALTER TABLE user ADD COLUMN notify_usage_limits INTEGER NOT NULL DEFAULT 1;

--- a/apps/api/src/admin-email-preview.ts
+++ b/apps/api/src/admin-email-preview.ts
@@ -8,6 +8,7 @@ import {
   renderMemberJoinAdminNoticeEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
+  renderUsageAlertEmail,
   renderWelcomeEmail,
 } from "@uploads/email";
 import { ServiceUnavailableError, ValidationError } from "@uploads/errors";
@@ -17,6 +18,7 @@ export const EMAIL_PREVIEW_TYPES = [
   { id: "org-invitation", label: "Workspace invitation", category: "Auth" },
   { id: "member-joined", label: "Member joined notify", category: "Auth" },
   { id: "member-join-admin-notice", label: "Admin: member joined notify", category: "Auth" },
+  { id: "usage-limit-alert", label: "Admin: usage limit alert", category: "Auth" },
   { id: "welcome", label: "Welcome / next steps", category: "Auth" },
   { id: "enrollment-invitation", label: "Enrollment invitation", category: "Invites" },
 ] as const;
@@ -84,6 +86,19 @@ function renderPreview(type: EmailPreviewType, origin: string) {
           organizationName: "preview-workspace",
           organizationSlug: "preview-workspace",
           memberEmail: "new-member@example.com",
+          webOrigin: origin,
+        }),
+      };
+    case "usage-limit-alert":
+      return {
+        from: AUTH_FROM,
+        ...renderUsageAlertEmail({
+          organizationName: "preview-workspace",
+          organizationSlug: "preview-workspace",
+          events: [
+            { cap: "storage", threshold: 90, used: 225_000_000, limit: 250_000_000 },
+            { cap: "uploads", threshold: 50, used: 1500, limit: 3000 },
+          ],
           webOrigin: origin,
         }),
       };

--- a/apps/api/src/admin-email-preview.ts
+++ b/apps/api/src/admin-email-preview.ts
@@ -99,6 +99,7 @@ function renderPreview(type: EmailPreviewType, origin: string) {
             { cap: "storage", threshold: 90, used: 225_000_000, limit: 250_000_000 },
             { cap: "uploads", threshold: 50, used: 1500, limit: 3000 },
           ],
+          plan: "free",
           webOrigin: origin,
         }),
       };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,6 +19,7 @@ import { workspaceMembers } from "./routes/workspace-members";
 import { workspaceSettings } from "./routes/workspace-settings";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
+import { runUsageAlertSweep } from "./usage-alert-sweep";
 import { runObservabilityRetention } from "./observability-retention";
 import { purgeExpiredIdempotencyRequests } from "./idempotency-core";
 import { galleries } from "./routes/galleries";
@@ -262,6 +263,18 @@ export default {
         console.error(
           JSON.stringify({
             message: "idempotency_retention_failed",
+            error: appErr.message,
+            code: appErr.code,
+          }),
+        );
+      }),
+    );
+    ctx.waitUntil(
+      runUsageAlertSweep(env).catch((err) => {
+        const appErr = AppError.from(err);
+        console.error(
+          JSON.stringify({
+            message: "usage_alert_sweep_failed",
             error: appErr.message,
             code: appErr.code,
           }),

--- a/apps/api/src/usage-alert-sweep.test.ts
+++ b/apps/api/src/usage-alert-sweep.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UsageAlertEvent } from "@uploads/email";
+import { runUsageAlertSweep } from "./usage-alert-sweep";
+import { usagePeriodStart } from "./usage";
+
+type UsageSeed = { bytes?: number; uploads?: number };
+
+/** Minimal D1 double for getWorkspaceUsage: prepare().bind(ws).first(). */
+function fakeDb(usage: Record<string, UsageSeed>) {
+  return {
+    prepare() {
+      return {
+        bind(ws: string) {
+          return {
+            async first() {
+              const u = usage[ws];
+              if (!u) return null;
+              return {
+                workspace: ws,
+                bytes: u.bytes ?? 0,
+                objects: 0,
+                shared_bytes: 0,
+                shared_objects: 0,
+                uploads_in_period: u.uploads ?? 0,
+                period_start: usagePeriodStart(),
+                updated_at: new Date().toISOString(),
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+/** KV double: `ws:` records come back for get(key,"json"); markers are text. */
+function fakeRegistry(records: Record<string, unknown>, markers = new Map<string, string>()) {
+  return {
+    markers,
+    async list({ prefix }: { prefix: string }) {
+      const keys = Object.keys(records)
+        .filter((k) => k.startsWith(prefix))
+        .map((name) => ({ name }));
+      return { keys, list_complete: true, cursor: undefined };
+    },
+    async get(key: string, type?: string) {
+      if (type === "json") return records[key] ?? null;
+      return markers.get(key) ?? null;
+    },
+    async put(key: string, value: string) {
+      markers.set(key, value);
+    },
+    async delete(key: string) {
+      markers.delete(key);
+    },
+  };
+}
+
+function fakeAuth() {
+  const posts: Array<{ slug: string; events: UsageAlertEvent[] }> = [];
+  return {
+    posts,
+    fetch: vi.fn(async (_url: string, init: RequestInit) => {
+      posts.push(JSON.parse(String(init.body)));
+      return new Response(null, { status: 200 });
+    }),
+  };
+}
+
+function makeEnv(opts: {
+  records: Record<string, unknown>;
+  usage: Record<string, UsageSeed>;
+  markers?: Map<string, string>;
+}) {
+  const REGISTRY = fakeRegistry(opts.records, opts.markers);
+  const AUTH = fakeAuth();
+  const DB = fakeDb(opts.usage);
+  const env = { REGISTRY, AUTH, DB } as unknown as Env;
+  return { env, REGISTRY, AUTH };
+}
+
+/** Workspace with explicit free-tier-shaped caps (plan-undefined keeps them). */
+function wsRecord(over: Record<string, unknown> = {}) {
+  return {
+    name: "acme",
+    version: 1,
+    maxStorageBytes: 250_000_000,
+    maxUploadsPerPeriod: 3000,
+    ...over,
+  };
+}
+
+describe("runUsageAlertSweep", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("posts a storage crossing once and dedups on re-run", async () => {
+    const setup = {
+      records: { "ws:acme": wsRecord() },
+      usage: { acme: { bytes: 230_000_000 } }, // 92% → band 90
+      markers: new Map<string, string>(),
+    };
+    const { env, AUTH } = makeEnv(setup);
+
+    const r1 = await runUsageAlertSweep(env);
+    expect(r1.crossings).toBe(1);
+    expect(AUTH.posts).toHaveLength(1);
+    expect(AUTH.posts[0]).toEqual({
+      slug: "acme",
+      events: [{ cap: "storage", threshold: 90, used: 230_000_000, limit: 250_000_000 }],
+    });
+    expect(setup.markers.get("usage:alert:acme:storage")).toBe("90");
+
+    // Second sweep, same state → no new email.
+    const env2 = makeEnv(setup).env; // reuse the same markers map
+    const r2 = await runUsageAlertSweep(env2);
+    expect(r2.crossings).toBe(0);
+  });
+
+  it("fires at 100% when uploads hit the cap", async () => {
+    const { env, AUTH } = makeEnv({
+      records: { "ws:acme": wsRecord() },
+      usage: { acme: { uploads: 3000 } }, // 100%
+    });
+    await runUsageAlertSweep(env);
+    expect(AUTH.posts[0].events).toEqual([
+      { cap: "uploads", threshold: 100, used: 3000, limit: 3000 },
+    ]);
+  });
+
+  it("combines both caps into one email when they cross together", async () => {
+    const { env, AUTH } = makeEnv({
+      records: { "ws:acme": wsRecord() },
+      usage: { acme: { bytes: 230_000_000, uploads: 1500 } }, // storage 90, uploads 50
+    });
+    await runUsageAlertSweep(env);
+    expect(AUTH.posts).toHaveLength(1);
+    expect(AUTH.posts[0].events.map((e) => `${e.cap}:${e.threshold}`).sort()).toEqual([
+      "storage:90",
+      "uploads:50",
+    ]);
+  });
+
+  it("re-arms as usage recedes, then re-alerts on a fresh crossing", async () => {
+    const markers = new Map<string, string>([["usage:alert:acme:storage", "90"]]);
+
+    // Receded to 55% (137.5M) — no email, marker drops to 50.
+    const receded = makeEnv({
+      records: { "ws:acme": wsRecord() },
+      usage: { acme: { bytes: 137_500_000 } },
+      markers,
+    });
+    await runUsageAlertSweep(receded.env);
+    expect(receded.AUTH.posts).toHaveLength(0);
+    expect(markers.get("usage:alert:acme:storage")).toBe("50");
+
+    // Climbs back to 92% — re-alerts at 90.
+    const climbed = makeEnv({
+      records: { "ws:acme": wsRecord() },
+      usage: { acme: { bytes: 230_000_000 } },
+      markers,
+    });
+    await runUsageAlertSweep(climbed.env);
+    expect(climbed.AUTH.posts).toHaveLength(1);
+    expect(climbed.AUTH.posts[0].events[0].threshold).toBe(90);
+  });
+
+  it("does not alert below 50% and writes no marker", async () => {
+    const markers = new Map<string, string>();
+    const { env, AUTH } = makeEnv({
+      records: { "ws:acme": wsRecord() },
+      usage: { acme: { bytes: 100_000_000 } }, // 40%
+      markers,
+    });
+    await runUsageAlertSweep(env);
+    expect(AUTH.posts).toHaveLength(0);
+    expect(markers.has("usage:alert:acme:storage")).toBe(false);
+  });
+
+  it("skips legacy/unlimited workspaces (no caps)", async () => {
+    const { env, AUTH } = makeEnv({
+      records: { "ws:legacy": { name: "legacy", version: 1 } }, // no plan, no caps
+      usage: { legacy: { bytes: 999_000_000_000 } },
+    });
+    const r = await runUsageAlertSweep(env);
+    expect(r.workspacesScanned).toBe(1);
+    expect(AUTH.posts).toHaveLength(0);
+  });
+
+  it("skips soft-deleted workspaces and purged tombstones", async () => {
+    const { env, AUTH } = makeEnv({
+      records: {
+        "ws:gone": wsRecord({ name: "gone", deletedAt: "2026-08-01T00:00:00.000Z" }),
+        "ws:dead": { status: "purged", name: "dead", purgedAt: "2026-08-01T00:00:00.000Z" },
+      },
+      usage: { gone: { bytes: 250_000_000 }, dead: { bytes: 250_000_000 } },
+    });
+    await runUsageAlertSweep(env);
+    expect(AUTH.posts).toHaveLength(0);
+  });
+});

--- a/apps/api/src/usage-alert-sweep.test.ts
+++ b/apps/api/src/usage-alert-sweep.test.ts
@@ -56,13 +56,16 @@ function fakeRegistry(records: Record<string, unknown>, markers = new Map<string
   };
 }
 
-function fakeAuth() {
+function fakeAuth(statuses: number[] = []) {
   const posts: Array<{ slug: string; events: UsageAlertEvent[]; plan?: string }> = [];
+  let call = 0;
   return {
     posts,
     fetch: vi.fn(async (_url: string, init: RequestInit) => {
       posts.push(JSON.parse(String(init.body)));
-      return new Response(null, { status: 200 });
+      const status = statuses[call] ?? 200;
+      call += 1;
+      return new Response(null, { status });
     }),
   };
 }
@@ -71,9 +74,10 @@ function makeEnv(opts: {
   records: Record<string, unknown>;
   usage: Record<string, UsageSeed>;
   markers?: Map<string, string>;
+  authStatuses?: number[];
 }) {
   const REGISTRY = fakeRegistry(opts.records, opts.markers);
-  const AUTH = fakeAuth();
+  const AUTH = fakeAuth(opts.authStatuses);
   const DB = fakeDb(opts.usage);
   const env = { REGISTRY, AUTH, DB } as unknown as Env;
   return { env, REGISTRY, AUTH };
@@ -116,6 +120,33 @@ describe("runUsageAlertSweep", () => {
     const env2 = makeEnv(setup).env; // reuse the same markers map
     const r2 = await runUsageAlertSweep(env2);
     expect(r2.crossings).toBe(0);
+  });
+
+  it("does not commit the marker when delivery fails, and retries next sweep", async () => {
+    const markers = new Map<string, string>();
+
+    // First sweep: the auth worker rejects the notification.
+    const failed = makeEnv({
+      records: { "ws:acme": wsRecord() },
+      usage: { acme: { bytes: 230_000_000 } }, // 92% → band 90
+      markers,
+      authStatuses: [500],
+    });
+    const r1 = await runUsageAlertSweep(failed.env);
+    expect(failed.AUTH.posts).toHaveLength(1); // it tried
+    expect(r1.crossings).toBe(0); // but nothing counted as alerted
+    expect(markers.has("usage:alert:acme:storage")).toBe(false); // marker NOT raised
+
+    // Next sweep: the crossing is still fresh, delivery succeeds, marker commits.
+    const ok = makeEnv({
+      records: { "ws:acme": wsRecord() },
+      usage: { acme: { bytes: 230_000_000 } },
+      markers,
+      authStatuses: [200],
+    });
+    await runUsageAlertSweep(ok.env);
+    expect(ok.AUTH.posts).toHaveLength(1);
+    expect(markers.get("usage:alert:acme:storage")).toBe("90");
   });
 
   it("forwards the workspace plan so the email copy can stay plan-accurate", async () => {

--- a/apps/api/src/usage-alert-sweep.test.ts
+++ b/apps/api/src/usage-alert-sweep.test.ts
@@ -57,7 +57,7 @@ function fakeRegistry(records: Record<string, unknown>, markers = new Map<string
 }
 
 function fakeAuth() {
-  const posts: Array<{ slug: string; events: UsageAlertEvent[] }> = [];
+  const posts: Array<{ slug: string; events: UsageAlertEvent[]; plan?: string }> = [];
   return {
     posts,
     fetch: vi.fn(async (_url: string, init: RequestInit) => {
@@ -116,6 +116,15 @@ describe("runUsageAlertSweep", () => {
     const env2 = makeEnv(setup).env; // reuse the same markers map
     const r2 = await runUsageAlertSweep(env2);
     expect(r2.crossings).toBe(0);
+  });
+
+  it("forwards the workspace plan so the email copy can stay plan-accurate", async () => {
+    const { env, AUTH } = makeEnv({
+      records: { "ws:acme": wsRecord({ plan: "pro", maxStorageBytes: 10_000_000_000 }) },
+      usage: { acme: { bytes: 9_500_000_000 } }, // 95%
+    });
+    await runUsageAlertSweep(env);
+    expect(AUTH.posts[0].plan).toBe("pro");
   });
 
   it("fires at 100% when uploads hit the cap", async () => {

--- a/apps/api/src/usage-alert-sweep.ts
+++ b/apps/api/src/usage-alert-sweep.ts
@@ -1,0 +1,184 @@
+/**
+ * Daily usage-limit alert sweep: for every REGISTRY workspace, compare current
+ * storage / monthly-upload usage against the resolved cap and email the
+ * workspace's admins/owners when it crosses a 50 / 90 / 100% band. Invoked from
+ * the Worker scheduled handler alongside the retention sweep.
+ *
+ * Detection is level-based but edge-triggered: a KV marker per (workspace, cap)
+ * stores the highest band already notified, so an email only fires when the
+ * band *rises*. Lowering the marker as usage recedes re-arms the alert — which
+ * is also what makes a plan upgrade (usage % collapses against the bigger cap)
+ * alert again on the new plan. Send + per-user preference filtering happen in
+ * the auth worker (the pref and member roster live only there); this module
+ * only detects and dedups, then POSTs crossings to `/internal/usage-alerts/notify`.
+ */
+import { enforcedMaxStorageBytes, enforcedStorageUsageBytes, resolveBudgetLimits } from "./budget";
+import { dbFor } from "./db-session";
+import { getWorkspaceUsage, usagePeriodStart } from "./usage";
+import { isPurgedTombstone, type PurgedTombstone, type WorkspaceRecord } from "./workspace";
+import type { UsageAlertEvent, UsageAlertThreshold } from "@uploads/email";
+
+const INTERNAL_ORIGIN = "https://auth.internal";
+const THRESHOLDS: readonly UsageAlertThreshold[] = [50, 90, 100];
+/** Storage never resets — keep the marker alive well past the daily cadence. */
+const STORAGE_MARKER_TTL_S = 400 * 24 * 60 * 60;
+/** Upload markers are period-scoped; expire a little after the month rolls. */
+const UPLOADS_MARKER_TTL_S = 40 * 24 * 60 * 60;
+
+export interface UsageAlertSweepResult {
+  workspacesScanned: number;
+  /** Workspaces that crossed at least one new band this run. */
+  workspacesAlerted: number;
+  /** Total cap crossings emailed (a workspace can cross both caps at once). */
+  crossings: number;
+  errors: Array<{ workspace: string; error: string }>;
+}
+
+/** Highest band (50/90/100) the given percentage has reached, else 0. */
+function bandFor(pct: number): number {
+  let band = 0;
+  for (const t of THRESHOLDS) {
+    if (pct >= t) band = t;
+  }
+  return band;
+}
+
+/**
+ * Compare a cap's current usage against its marker. Pushes a crossing when the
+ * band rose; always reconciles the marker to the current band (re-arming on a
+ * recede). Never throws — a KV hiccup on one cap must not abort the sweep.
+ */
+async function evaluateCap(
+  kv: KVNamespace,
+  markerKey: string,
+  ttlSeconds: number,
+  event: { cap: UsageAlertEvent["cap"]; used: number; limit: number },
+  crossed: UsageAlertEvent[],
+): Promise<void> {
+  const pct = (event.used / event.limit) * 100;
+  const current = bandFor(pct);
+  const prevRaw = await kv.get(markerKey);
+  const prev = prevRaw ? parseInt(prevRaw, 10) || 0 : 0;
+
+  if (current > prev) {
+    crossed.push({
+      cap: event.cap,
+      threshold: current as UsageAlertThreshold,
+      used: event.used,
+      limit: event.limit,
+    });
+  }
+
+  if (current === 0) {
+    if (prevRaw !== null) await kv.delete(markerKey);
+    return;
+  }
+  // Refresh every sweep while at/above a band so the marker stays alive for
+  // active workspaces (and lapses via TTL once a workspace goes cold).
+  await kv.put(markerKey, String(current), { expirationTtl: ttlSeconds });
+}
+
+/** POST a workspace's crossings to the auth worker, which filters + sends. */
+async function postUsageAlert(env: Env, slug: string, events: UsageAlertEvent[]): Promise<void> {
+  const res = await env.AUTH.fetch(`${INTERNAL_ORIGIN}/internal/usage-alerts/notify`, {
+    method: "POST",
+    headers: { "x-uploads-internal": "1", "content-type": "application/json" },
+    body: JSON.stringify({ slug, events }),
+  });
+  if (!res.ok) {
+    console.warn(
+      JSON.stringify({
+        message: "usage_alert_notify_failed",
+        workspace: slug,
+        status: res.status,
+      }),
+    );
+  }
+}
+
+export async function runUsageAlertSweep(env: Env): Promise<UsageAlertSweepResult> {
+  const db = dbFor(env);
+  const period = usagePeriodStart();
+  let cursor: string | undefined;
+  const result: UsageAlertSweepResult = {
+    workspacesScanned: 0,
+    workspacesAlerted: 0,
+    crossings: 0,
+    errors: [],
+  };
+
+  do {
+    const page = await env.REGISTRY.list({ prefix: "ws:", cursor, limit: 100 });
+    for (const entry of page.keys) {
+      result.workspacesScanned += 1;
+      const name = entry.name.startsWith("ws:") ? entry.name.slice(3) : entry.name;
+      if (!name) continue;
+
+      try {
+        const record = await env.REGISTRY.get<WorkspaceRecord | PurgedTombstone>(
+          entry.name,
+          "json",
+        );
+        if (!record) continue;
+        if (isPurgedTombstone(record)) continue;
+        // Soft-deleted workspaces are on their way out — don't alert them.
+        if (record.deletedAt) continue;
+
+        const maxStorageBytes = enforcedMaxStorageBytes(record);
+        const { maxUploadsPerPeriod } = resolveBudgetLimits(record);
+        // Legacy/unlimited (plan===undefined and no explicit cap): nothing to
+        // cross. Skip the D1 read entirely when neither cap is set.
+        if (maxStorageBytes === undefined && maxUploadsPerPeriod === undefined) continue;
+
+        const usage = await getWorkspaceUsage(db, name);
+        const crossed: UsageAlertEvent[] = [];
+
+        if (maxStorageBytes !== undefined) {
+          const used = enforcedStorageUsageBytes(record, usage);
+          if (used !== undefined) {
+            await evaluateCap(
+              env.REGISTRY,
+              `usage:alert:${name}:storage`,
+              STORAGE_MARKER_TTL_S,
+              { cap: "storage", used, limit: maxStorageBytes },
+              crossed,
+            );
+          }
+        }
+
+        if (maxUploadsPerPeriod !== undefined) {
+          await evaluateCap(
+            env.REGISTRY,
+            `usage:alert:${name}:uploads:${period}`,
+            UPLOADS_MARKER_TTL_S,
+            { cap: "uploads", used: usage.uploadsInPeriod, limit: maxUploadsPerPeriod },
+            crossed,
+          );
+        }
+
+        if (crossed.length > 0) {
+          await postUsageAlert(env, name, crossed);
+          result.workspacesAlerted += 1;
+          result.crossings += crossed.length;
+        }
+      } catch (err) {
+        result.errors.push({
+          workspace: name,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+
+  console.log(
+    JSON.stringify({
+      message: "usage_alert_sweep",
+      workspacesScanned: result.workspacesScanned,
+      workspacesAlerted: result.workspacesAlerted,
+      crossings: result.crossings,
+      errors: result.errors.length,
+    }),
+  );
+  return result;
+}

--- a/apps/api/src/usage-alert-sweep.ts
+++ b/apps/api/src/usage-alert-sweep.ts
@@ -44,9 +44,13 @@ function bandFor(pct: number): number {
 }
 
 /**
- * Compare a cap's current usage against its marker. Pushes a crossing when the
- * band rose; always reconciles the marker to the current band (re-arming on a
- * recede). Never throws — a KV hiccup on one cap must not abort the sweep.
+ * Compare a cap's current usage against its marker. On a new crossing it pushes
+ * the event and defers the raised marker write onto `pendingRaises` — the caller
+ * commits those only after the notification is accepted, so a failed send is
+ * retried next sweep instead of being suppressed by an already-raised marker.
+ * A non-crossing marker (recede/steady) is reconciled immediately: lowering or
+ * TTL-refreshing it can only make a future alert more likely. Never throws — a
+ * KV hiccup on one cap must not abort the sweep.
  */
 async function evaluateCap(
   kv: KVNamespace,
@@ -54,6 +58,7 @@ async function evaluateCap(
   ttlSeconds: number,
   event: { cap: UsageAlertEvent["cap"]; used: number; limit: number },
   crossed: UsageAlertEvent[],
+  pendingRaises: Array<() => Promise<void>>,
 ): Promise<void> {
   const pct = (event.used / event.limit) * 100;
   const current = bandFor(pct);
@@ -67,6 +72,9 @@ async function evaluateCap(
       used: event.used,
       limit: event.limit,
     });
+    // Hold the raise until delivery is confirmed (see runUsageAlertSweep).
+    pendingRaises.push(() => kv.put(markerKey, String(current), { expirationTtl: ttlSeconds }));
+    return;
   }
 
   if (current === 0) {
@@ -78,13 +86,18 @@ async function evaluateCap(
   await kv.put(markerKey, String(current), { expirationTtl: ttlSeconds });
 }
 
-/** POST a workspace's crossings to the auth worker, which filters + sends. */
+/**
+ * POST a workspace's crossings to the auth worker, which filters + sends.
+ * Returns whether the notification was accepted — a rejection leaves the raised
+ * markers uncommitted so the next sweep retries. A transport error throws to the
+ * caller's per-workspace catch, with the same effect (markers not committed).
+ */
 async function postUsageAlert(
   env: Env,
   slug: string,
   events: UsageAlertEvent[],
   plan: string | undefined,
-): Promise<void> {
+): Promise<boolean> {
   const res = await env.AUTH.fetch(`${INTERNAL_ORIGIN}/internal/usage-alerts/notify`, {
     method: "POST",
     headers: { "x-uploads-internal": "1", "content-type": "application/json" },
@@ -98,7 +111,9 @@ async function postUsageAlert(
         status: res.status,
       }),
     );
+    return false;
   }
+  return true;
 }
 
 export async function runUsageAlertSweep(env: Env): Promise<UsageAlertSweepResult> {
@@ -137,6 +152,7 @@ export async function runUsageAlertSweep(env: Env): Promise<UsageAlertSweepResul
 
         const usage = await getWorkspaceUsage(db, name);
         const crossed: UsageAlertEvent[] = [];
+        const pendingRaises: Array<() => Promise<void>> = [];
 
         if (maxStorageBytes !== undefined) {
           const used = enforcedStorageUsageBytes(record, usage);
@@ -147,6 +163,7 @@ export async function runUsageAlertSweep(env: Env): Promise<UsageAlertSweepResul
               STORAGE_MARKER_TTL_S,
               { cap: "storage", used, limit: maxStorageBytes },
               crossed,
+              pendingRaises,
             );
           }
         }
@@ -158,13 +175,18 @@ export async function runUsageAlertSweep(env: Env): Promise<UsageAlertSweepResul
             UPLOADS_MARKER_TTL_S,
             { cap: "uploads", used: usage.uploadsInPeriod, limit: maxUploadsPerPeriod },
             crossed,
+            pendingRaises,
           );
         }
 
         if (crossed.length > 0) {
-          await postUsageAlert(env, name, crossed, record.plan);
-          result.workspacesAlerted += 1;
-          result.crossings += crossed.length;
+          const delivered = await postUsageAlert(env, name, crossed, record.plan);
+          if (delivered) {
+            // Only now commit the raised markers, so a failed delivery retries.
+            for (const commit of pendingRaises) await commit();
+            result.workspacesAlerted += 1;
+            result.crossings += crossed.length;
+          }
         }
       } catch (err) {
         result.errors.push({

--- a/apps/api/src/usage-alert-sweep.ts
+++ b/apps/api/src/usage-alert-sweep.ts
@@ -79,11 +79,16 @@ async function evaluateCap(
 }
 
 /** POST a workspace's crossings to the auth worker, which filters + sends. */
-async function postUsageAlert(env: Env, slug: string, events: UsageAlertEvent[]): Promise<void> {
+async function postUsageAlert(
+  env: Env,
+  slug: string,
+  events: UsageAlertEvent[],
+  plan: string | undefined,
+): Promise<void> {
   const res = await env.AUTH.fetch(`${INTERNAL_ORIGIN}/internal/usage-alerts/notify`, {
     method: "POST",
     headers: { "x-uploads-internal": "1", "content-type": "application/json" },
-    body: JSON.stringify({ slug, events }),
+    body: JSON.stringify({ slug, events, plan }),
   });
   if (!res.ok) {
     console.warn(
@@ -157,7 +162,7 @@ export async function runUsageAlertSweep(env: Env): Promise<UsageAlertSweepResul
         }
 
         if (crossed.length > 0) {
-          await postUsageAlert(env, name, crossed);
+          await postUsageAlert(env, name, crossed, record.plan);
           result.workspacesAlerted += 1;
           result.crossings += crossed.length;
         }

--- a/apps/auth/src/admin-last-guard.test.ts
+++ b/apps/auth/src/admin-last-guard.test.ts
@@ -57,6 +57,7 @@ async function seedUser(
     cliOnboardedAt: overrides.cliOnboardedAt ?? null,
     stripeCustomerId: overrides.stripeCustomerId ?? null,
     notifyMemberJoin: overrides.notifyMemberJoin ?? true,
+    notifyUsageLimits: overrides.notifyUsageLimits ?? true,
   };
   await orm.insert(schema.user).values(user);
   return user;

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -839,6 +839,12 @@ function buildAuth(
           input: true,
           defaultValue: true,
         },
+        notifyUsageLimits: {
+          type: "boolean",
+          required: false,
+          input: true,
+          defaultValue: true,
+        },
       },
     },
     session: {

--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -57,6 +57,7 @@ export type SendAuthEmailArgs =
         organizationName: string;
         organizationSlug: string;
         events: UsageAlertEvent[];
+        plan?: string;
       };
     }
   | {

--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -9,8 +9,10 @@ import {
   renderMemberJoinAdminNoticeEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
+  renderUsageAlertEmail,
   renderWelcomeEmail,
   type RenderedEmail,
+  type UsageAlertEvent,
 } from "@uploads/email";
 
 const FROM = { name: "uploads.sh", email: "noreply@uploads.sh" } as const;
@@ -50,6 +52,15 @@ export type SendAuthEmailArgs =
     }
   | {
       to: string;
+      template: "usage-limit-alert";
+      context: {
+        organizationName: string;
+        organizationSlug: string;
+        events: UsageAlertEvent[];
+      };
+    }
+  | {
+      to: string;
       template: "welcome";
       context: { workspaceName?: string };
     };
@@ -64,6 +75,8 @@ function render(args: SendAuthEmailArgs, webOrigin: string): RenderedEmail {
       return renderMemberJoinedEmail({ ...args.context, webOrigin });
     case "member-join-admin-notice":
       return renderMemberJoinAdminNoticeEmail({ ...args.context, webOrigin });
+    case "usage-limit-alert":
+      return renderUsageAlertEmail({ ...args.context, webOrigin });
     case "welcome":
       return renderWelcomeEmail({ ...args.context, webOrigin });
   }

--- a/apps/auth/src/internal-metrics.test.ts
+++ b/apps/auth/src/internal-metrics.test.ts
@@ -44,6 +44,7 @@ describe("GET /internal/metrics", () => {
       cliOnboardedAt: null,
       stripeCustomerId: null,
       notifyMemberJoin: true,
+      notifyUsageLimits: true,
     } as schema.AuthUser);
   }
 

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -132,6 +132,7 @@ describe("DB-backed behavior", () => {
       cliOnboardedAt: overrides.cliOnboardedAt ?? null,
       stripeCustomerId: overrides.stripeCustomerId ?? null,
       notifyMemberJoin: overrides.notifyMemberJoin ?? true,
+      notifyUsageLimits: overrides.notifyUsageLimits ?? true,
     };
     await orm.insert(schema.user).values(user);
     return user;
@@ -157,6 +158,77 @@ describe("DB-backed behavior", () => {
     const user = await seedUser();
     const [row] = await orm.select().from(schema.user).where(eq(schema.user.id, user.id));
     expect(row.notifyMemberJoin).toBe(true);
+  });
+
+  it("defaults notify_usage_limits to on for a seeded user", async () => {
+    const user = await seedUser();
+    const [row] = await orm.select().from(schema.user).where(eq(schema.user.id, user.id));
+    expect(row.notifyUsageLimits).toBe(true);
+  });
+
+  describe("POST /internal/usage-alerts/notify", () => {
+    const storageEvent = { cap: "storage", threshold: 90, used: 225_000_000, limit: 250_000_000 };
+    function notify(body: unknown, overrides: Partial<AuthEnv> = {}) {
+      return app().request(
+        "/internal/usage-alerts/notify",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        dbEnv(overrides),
+      );
+    }
+
+    it("400s when slug is missing", async () => {
+      const res = await notify({ events: [storageEvent] });
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "invalid_request" },
+      });
+    });
+
+    it("400s when no valid event is present", async () => {
+      const res = await notify({ slug: "acme", events: [{ cap: "bogus", threshold: 42 }] });
+      expect(res.status).toBe(400);
+    });
+
+    it("404s for an unknown org", async () => {
+      const res = await notify({ slug: "nope", events: [storageEvent] });
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "organization_not_found" },
+      });
+    });
+
+    it("emails admins/owners whose pref is on", async () => {
+      const org = await seedOrg();
+      const admin = await seedUser();
+      const owner = await seedUser();
+      const optedOut = await seedUser({ notifyUsageLimits: false });
+      const plain = await seedUser();
+      for (const [user, role] of [
+        [admin, "admin"],
+        [owner, "owner"],
+        [optedOut, "admin"],
+        [plain, "member"],
+      ] as const) {
+        await orm.insert(schema.member).values({
+          id: crypto.randomUUID(),
+          organizationId: org.id,
+          userId: user.id,
+          role,
+          createdAt: new Date(),
+        });
+      }
+      const send = vi.fn().mockResolvedValue({});
+
+      const res = await notify({ slug: org.slug, events: [storageEvent] }, { EMAIL: { send } });
+
+      expect(res.status).toBe(200);
+      const recipients = send.mock.calls.map((c) => c[0].to).sort();
+      expect(recipients).toEqual([admin.email, owner.email].sort());
+    });
   });
 
   describe("POST /internal/promote-admin", () => {

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -11,7 +11,28 @@ import { OAUTH_SCOPES, type AuthEnv } from "./auth";
 import { sendAuthEmail } from "./email";
 import { memberCapDenial, resolveMemberCapStrict } from "./member-cap";
 import { notifyAdminsOfMemberJoin } from "./notify-member-join";
+import { notifyAdminsOfUsageAlert } from "./notify-usage-alert";
 import * as schema from "./schema";
+import type { UsageAlertCap, UsageAlertEvent, UsageAlertThreshold } from "@uploads/email";
+
+const USAGE_ALERT_CAPS = new Set<UsageAlertCap>(["storage", "uploads"]);
+const USAGE_ALERT_THRESHOLDS = new Set<UsageAlertThreshold>([50, 90, 100]);
+
+/** Validate one usage-alert event from an (internal, trusted) request body. */
+function parseUsageAlertEvent(raw: unknown): UsageAlertEvent | null {
+  if (!raw || typeof raw !== "object") return null;
+  const { cap, threshold, used, limit } = raw as Record<string, unknown>;
+  if (typeof cap !== "string" || !USAGE_ALERT_CAPS.has(cap as UsageAlertCap)) return null;
+  if (
+    typeof threshold !== "number" ||
+    !USAGE_ALERT_THRESHOLDS.has(threshold as UsageAlertThreshold)
+  ) {
+    return null;
+  }
+  if (typeof used !== "number" || !Number.isFinite(used)) return null;
+  if (typeof limit !== "number" || !Number.isFinite(limit) || limit <= 0) return null;
+  return { cap: cap as UsageAlertCap, threshold: threshold as UsageAlertThreshold, used, limit };
+}
 
 function errorJson(code: string, message: string) {
   return { error: { code, message } } as const;
@@ -1031,6 +1052,43 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
           `This workspace includes ${capResolution.cap} members — cap reached.`)
         : "This workspace has reached its member limit.";
     return c.json(errorJson("member_cap_reached", message), 403);
+  })
+  // Usage-limit alerts: the API worker's daily sweep detects a workspace
+  // crossing a 50/90/100% storage or uploads band and calls this to fan the
+  // email out to admins/owners whose `notifyUsageLimits` pref is on. The pref
+  // and the member roster live only here, so filtering + send happen here.
+  .post("/usage-alerts/notify", async (c) => {
+    const body = await c.req
+      .json<{ slug?: unknown; events?: unknown }>()
+      .catch(() => ({}) as { slug?: unknown; events?: unknown });
+    const slug = typeof body.slug === "string" ? body.slug.trim() : "";
+    if (!slug) {
+      return c.json(errorJson("invalid_request", "slug is required"), 400);
+    }
+    const events = Array.isArray(body.events)
+      ? body.events.map(parseUsageAlertEvent).filter((e): e is UsageAlertEvent => e !== null)
+      : [];
+    if (events.length === 0) {
+      return c.json(errorJson("invalid_request", "at least one valid event is required"), 400);
+    }
+
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+
+    await notifyAdminsOfUsageAlert(c.env, db, {
+      organizationId: org.id,
+      organizationName: org.name,
+      organizationSlug: org.slug,
+      events,
+    });
+    return c.json({ ok: true }, 200);
   })
   // Self-serve provisioning (spec 2026-07-14): create an org WITH the caller
   // as owner member, non-idempotent — a taken slug is a 409 the API surfaces

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -1059,8 +1059,8 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
   // and the member roster live only here, so filtering + send happen here.
   .post("/usage-alerts/notify", async (c) => {
     const body = await c.req
-      .json<{ slug?: unknown; events?: unknown }>()
-      .catch(() => ({}) as { slug?: unknown; events?: unknown });
+      .json<{ slug?: unknown; events?: unknown; plan?: unknown }>()
+      .catch(() => ({}) as { slug?: unknown; events?: unknown; plan?: unknown });
     const slug = typeof body.slug === "string" ? body.slug.trim() : "";
     if (!slug) {
       return c.json(errorJson("invalid_request", "slug is required"), 400);
@@ -1071,6 +1071,7 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     if (events.length === 0) {
       return c.json(errorJson("invalid_request", "at least one valid event is required"), 400);
     }
+    const plan = typeof body.plan === "string" ? body.plan : undefined;
 
     const db = drizzle(c.env.DB, { schema });
     const [org] = await db
@@ -1087,6 +1088,7 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       organizationName: org.name,
       organizationSlug: org.slug,
       events,
+      plan,
     });
     return c.json({ ok: true }, 200);
   })

--- a/apps/auth/src/member-cap.test.ts
+++ b/apps/auth/src/member-cap.test.ts
@@ -72,6 +72,7 @@ describe("memberCapDenial", () => {
       cliOnboardedAt: null,
       stripeCustomerId: null,
       notifyMemberJoin: true,
+      notifyUsageLimits: true,
     });
     return userId;
   }
@@ -297,6 +298,7 @@ describe("POST /internal/invite at cap", () => {
       cliOnboardedAt: null,
       stripeCustomerId: null,
       notifyMemberJoin: true,
+      notifyUsageLimits: true,
     });
     await orm.insert(schema.member).values({
       id: crypto.randomUUID(),

--- a/apps/auth/src/notify-usage-alert.test.ts
+++ b/apps/auth/src/notify-usage-alert.test.ts
@@ -1,11 +1,17 @@
 import { drizzle } from "drizzle-orm/d1";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UsageAlertEvent } from "@uploads/email";
 import type { EmailBinding } from "./email";
-import { notifyAdminsOfMemberJoin } from "./notify-member-join";
+import { notifyAdminsOfUsageAlert } from "./notify-usage-alert";
 import * as schema from "./schema";
 import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
 
-describe("notifyAdminsOfMemberJoin", () => {
+const orgId = "org-1";
+const EVENTS: UsageAlertEvent[] = [
+  { cap: "storage", threshold: 90, used: 225_000_000, limit: 250_000_000 },
+];
+
+describe("notifyAdminsOfUsageAlert", () => {
   let db: FakeD1Database;
   let orm: ReturnType<typeof drizzle<typeof schema>>;
 
@@ -45,10 +51,10 @@ describe("notifyAdminsOfMemberJoin", () => {
     return u;
   }
 
-  async function seedMember(organizationId: string, userId: string, role: string): Promise<void> {
+  async function seedMember(userId: string, role: string): Promise<void> {
     await orm.insert(schema.member).values({
       id: crypto.randomUUID(),
-      organizationId,
+      organizationId: orgId,
       userId,
       role,
       createdAt: new Date(),
@@ -60,64 +66,54 @@ describe("notifyAdminsOfMemberJoin", () => {
     return { EMAIL: { send }, send };
   }
 
-  const orgId = "org-1";
   const baseEnv = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "production" as const };
 
-  it("emails admins and owners, not plain members or the joiner", async () => {
+  it("emails admins and owners, not plain members", async () => {
     const admin = await seedUser();
     const owner = await seedUser();
     const plain = await seedUser();
-    const joiner = await seedUser();
-    await seedMember(orgId, admin.id, "admin");
-    await seedMember(orgId, owner.id, "owner");
-    await seedMember(orgId, plain.id, "member");
-    await seedMember(orgId, joiner.id, "owner"); // joiner even as owner is excluded
+    await seedMember(admin.id, "admin");
+    await seedMember(owner.id, "owner");
+    await seedMember(plain.id, "member");
     const { EMAIL, send } = emailCapture();
 
-    await notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, orm, {
+    await notifyAdminsOfUsageAlert({ ...baseEnv, EMAIL }, orm, {
       organizationId: orgId,
       organizationName: "Acme",
       organizationSlug: "acme",
-      joinerUserId: joiner.id,
-      joinerEmail: joiner.email,
+      events: EVENTS,
     });
 
     const recipients = send.mock.calls.map((c) => c[0].to).sort();
     expect(recipients).toEqual([admin.email, owner.email].sort());
+    // The usage template rode through, not some other email.
+    expect(send.mock.calls[0]?.[0].subject).toContain("90%");
   });
 
   it("skips recipients who turned the preference off", async () => {
-    const admin = await seedUser({ notifyMemberJoin: false });
-    const joiner = await seedUser();
-    await seedMember(orgId, admin.id, "admin");
+    const admin = await seedUser({ notifyUsageLimits: false });
+    await seedMember(admin.id, "admin");
     const { EMAIL, send } = emailCapture();
-    await notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, orm, {
+    await notifyAdminsOfUsageAlert({ ...baseEnv, EMAIL }, orm, {
       organizationId: orgId,
       organizationName: "Acme",
       organizationSlug: "acme",
-      joinerUserId: joiner.id,
-      joinerEmail: joiner.email,
+      events: EVENTS,
     });
     expect(send).not.toHaveBeenCalled();
   });
 
-  it("excludes extra excludeUserIds (the inviter)", async () => {
-    const inviter = await seedUser();
-    const otherAdmin = await seedUser();
-    const joiner = await seedUser();
-    await seedMember(orgId, inviter.id, "admin");
-    await seedMember(orgId, otherAdmin.id, "admin");
+  it("does nothing when there are no events", async () => {
+    const admin = await seedUser();
+    await seedMember(admin.id, "admin");
     const { EMAIL, send } = emailCapture();
-    await notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, orm, {
+    await notifyAdminsOfUsageAlert({ ...baseEnv, EMAIL }, orm, {
       organizationId: orgId,
       organizationName: "Acme",
       organizationSlug: "acme",
-      joinerUserId: joiner.id,
-      joinerEmail: joiner.email,
-      excludeUserIds: [inviter.id],
+      events: [],
     });
-    const recipients = send.mock.calls.map((c) => c[0].to);
-    expect(recipients).toEqual([otherAdmin.email]);
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("never throws when the DB read fails", async () => {
@@ -131,12 +127,11 @@ describe("notifyAdminsOfMemberJoin", () => {
     ) as never;
     const { EMAIL, send } = emailCapture();
     await expect(
-      notifyAdminsOfMemberJoin({ ...baseEnv, EMAIL }, poison, {
+      notifyAdminsOfUsageAlert({ ...baseEnv, EMAIL }, poison, {
         organizationId: orgId,
         organizationName: "Acme",
         organizationSlug: "acme",
-        joinerUserId: "j",
-        joinerEmail: "j@example.com",
+        events: EVENTS,
       }),
     ).resolves.toBeUndefined();
     expect(send).not.toHaveBeenCalled();

--- a/apps/auth/src/notify-usage-alert.ts
+++ b/apps/auth/src/notify-usage-alert.ts
@@ -1,0 +1,64 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type { UsageAlertEvent } from "@uploads/email";
+import { sendAuthEmail, type SendAuthEmailEnv } from "./email";
+import * as schema from "./schema";
+
+export interface NotifyAdminsOfUsageAlertOpts {
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+  /** Caps that crossed a new band this sweep (storage and/or uploads). */
+  events: UsageAlertEvent[];
+}
+
+/**
+ * Emails a workspace's admins/owners that it is nearing (or has reached) a
+ * usage limit. Recipients are members with role admin/owner whose
+ * `notifyUsageLimits` preference is on. Fire-and-forget: `sendAuthEmail` never
+ * throws, and the recipient lookup is wrapped so a DB failure can't fail the
+ * caller (the daily usage sweep).
+ */
+export async function notifyAdminsOfUsageAlert(
+  env: SendAuthEmailEnv,
+  db: DrizzleD1Database<typeof schema>,
+  opts: NotifyAdminsOfUsageAlertOpts,
+): Promise<void> {
+  if (opts.events.length === 0) return;
+  try {
+    const rows = await db
+      .select({ email: schema.user.email })
+      .from(schema.member)
+      .innerJoin(schema.user, eq(schema.member.userId, schema.user.id))
+      .where(
+        and(
+          eq(schema.member.organizationId, opts.organizationId),
+          inArray(schema.member.role, ["admin", "owner"]),
+          eq(schema.user.notifyUsageLimits, true),
+        ),
+      );
+
+    // Independent sends, fired concurrently. sendAuthEmail never rejects, so
+    // plain Promise.all is safe.
+    await Promise.all(
+      rows
+        .filter((row) => row.email)
+        .map((row) =>
+          sendAuthEmail(env, {
+            to: row.email,
+            template: "usage-limit-alert",
+            context: {
+              organizationName: opts.organizationName,
+              organizationSlug: opts.organizationSlug,
+              events: opts.events,
+            },
+          }),
+        ),
+    );
+  } catch (err) {
+    console.error(
+      "[notify-usage-alert] recipient lookup failed",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}

--- a/apps/auth/src/notify-usage-alert.ts
+++ b/apps/auth/src/notify-usage-alert.ts
@@ -10,6 +10,8 @@ export interface NotifyAdminsOfUsageAlertOpts {
   organizationSlug: string;
   /** Caps that crossed a new band this sweep (storage and/or uploads). */
   events: UsageAlertEvent[];
+  /** The workspace's billing plan, so remedy copy stays honest for `pro`. */
+  plan?: string;
 }
 
 /**
@@ -51,6 +53,7 @@ export async function notifyAdminsOfUsageAlert(
               organizationName: opts.organizationName,
               organizationSlug: opts.organizationSlug,
               events: opts.events,
+              plan: opts.plan,
             },
           }),
         ),

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -60,6 +60,12 @@ export const user = sqliteTable("user", {
   notifyMemberJoin: integer("notify_member_join", { mode: "boolean" })
     .notNull()
     .$defaultFn(() => true),
+  /** Per-user pref: email me when a workspace I administer nears its usage
+   * limit (50/90/100% of storage or monthly uploads). Default on. Same
+   * additionalField mechanism as notifyMemberJoin. */
+  notifyUsageLimits: integer("notify_usage_limits", { mode: "boolean" })
+    .notNull()
+    .$defaultFn(() => true),
 });
 
 /**

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -22,6 +22,7 @@ import {
   submitOAuthConsent,
   unbanUser,
   updateNotifyMemberJoin,
+  updateNotifyUsageLimits,
   upgradeOrganizationSubscription,
 } from "./auth-client";
 import { BROWSER_REQUEST_TIMEOUT_MS, fetchWithTimeout } from "./request";
@@ -937,6 +938,28 @@ describe("updateNotifyMemberJoin", () => {
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response("nope", { status: 500 }));
     expect(await updateNotifyMemberJoin("", true)).toBe(false);
+    fetchMock.mockRestore();
+  });
+});
+
+describe("updateNotifyUsageLimits", () => {
+  it("POSTs update-user with the boolean and returns true on ok", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const ok = await updateNotifyUsageLimits("", false);
+    expect(ok).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain("/api/auth/update-user");
+    expect(JSON.parse(String(init?.body))).toEqual({ notifyUsageLimits: false });
+    fetchMock.mockRestore();
+  });
+
+  it("returns false on a non-ok response", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("nope", { status: 500 }));
+    expect(await updateNotifyUsageLimits("", true)).toBe(false);
     fetchMock.mockRestore();
   });
 });

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -56,6 +56,8 @@ export interface SessionUser {
   cliOnboardedAt?: string | Date | null;
   /** Per-user pref: email me when someone joins a workspace I administer. */
   notifyMemberJoin?: boolean | null;
+  /** Per-user pref: email me when a workspace I administer nears its usage limit. */
+  notifyUsageLimits?: boolean | null;
 }
 
 /** Operator-facing copy when sign-in is refused for a banned account. */
@@ -299,6 +301,26 @@ export async function updateNotifyMemberJoin(origin: string, value: boolean): Pr
       credentials: "include",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ notifyMemberJoin: value }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write the "email me when a workspace I administer nears its usage limit"
+ * preference via Better Auth's update-user endpoint (an `input: true`
+ * additionalField). Same-origin through the /api/auth proxy; returns false on
+ * any failure so the toggle can revert.
+ */
+export async function updateNotifyUsageLimits(origin: string, value: boolean): Promise<boolean> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/update-user`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ notifyUsageLimits: value }),
     });
     return res.ok;
   } catch {

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -427,8 +427,8 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
       function setNotifyStatus(message: string): void {
         if (notifyStatus) notifyStatus.textContent = message;
       }
-      // Both notification toggles share the one status line and the same
-      // save-and-revert dance; only the persistence call differs.
+      // Both toggles share one status line and the same save-and-revert dance.
+      // Only the persistence call differs.
       function wireNotifyToggle(
         el: HTMLInputElement | null,
         save: (origin: string, value: boolean) => Promise<boolean>,

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -50,6 +50,14 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
         />
         <span>Email me when someone joins a workspace I administer.</span>
       </label>
+      <label class="notify-row">
+        <input
+          type="checkbox"
+          id="notify-usage-limits"
+          checked={initial.user?.notifyUsageLimits ?? true}
+        />
+        <span>Email me when a workspace I administer nears its usage limit.</span>
+      </label>
       <p id="notify-status" class="muted settings-note" role="status" aria-live="polite"></p>
     </div>
 
@@ -170,6 +178,7 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
       listSessions,
       revokeSession,
       updateNotifyMemberJoin,
+      updateNotifyUsageLimits,
       type AuthSession,
     } from "../../lib/auth-client";
     import {
@@ -413,25 +422,35 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
       }
 
       const notifyToggle = document.getElementById("notify-member-join") as HTMLInputElement | null;
+      const usageToggle = document.getElementById("notify-usage-limits") as HTMLInputElement | null;
       const notifyStatus = document.getElementById("notify-status");
       function setNotifyStatus(message: string): void {
         if (notifyStatus) notifyStatus.textContent = message;
       }
-      notifyToggle?.addEventListener("change", () => {
-        void (async () => {
-          const desired = notifyToggle.checked;
-          notifyToggle.disabled = true;
-          setNotifyStatus("Saving…");
-          const ok = await updateNotifyMemberJoin(authOrigin, desired);
-          if (!ok) {
-            notifyToggle.checked = !desired; // revert
-            setNotifyStatus("Couldn’t save — try again.");
-          } else {
-            setNotifyStatus(desired ? "You’ll be notified." : "Notifications off.");
-          }
-          notifyToggle.disabled = false;
-        })();
-      });
+      // Both notification toggles share the one status line and the same
+      // save-and-revert dance; only the persistence call differs.
+      function wireNotifyToggle(
+        el: HTMLInputElement | null,
+        save: (origin: string, value: boolean) => Promise<boolean>,
+      ): void {
+        el?.addEventListener("change", () => {
+          void (async () => {
+            const desired = el.checked;
+            el.disabled = true;
+            setNotifyStatus("Saving…");
+            const ok = await save(authOrigin, desired);
+            if (!ok) {
+              el.checked = !desired; // revert
+              setNotifyStatus("Couldn’t save — try again.");
+            } else {
+              setNotifyStatus(desired ? "Notifications on." : "Notifications off.");
+            }
+            el.disabled = false;
+          })();
+        });
+      }
+      wireNotifyToggle(notifyToggle, updateNotifyMemberJoin);
+      wireNotifyToggle(usageToggle, updateNotifyUsageLimits);
 
       onSession((user) => {
         requireElement<HTMLElement>("#acct-email", "account profile").textContent = user.email;
@@ -440,6 +459,9 @@ const sessionsEmpty = sessionsReady && (initial.sessions?.length ?? 0) === 0;
           user.role || "member";
         if (notifyToggle && typeof user.notifyMemberJoin === "boolean") {
           notifyToggle.checked = user.notifyMemberJoin;
+        }
+        if (usageToggle && typeof user.notifyUsageLimits === "boolean") {
+          usageToggle.checked = user.notifyUsageLimits;
         }
         void loadAccounts();
         void loadSessions();

--- a/apps/web/src/pages/admin/email.astro
+++ b/apps/web/src/pages/admin/email.astro
@@ -22,6 +22,7 @@ const PREVIEW_TYPES = [
   { id: "org-invitation", label: "Workspace invitation", category: "Auth" },
   { id: "member-joined", label: "Member joined notify", category: "Auth" },
   { id: "member-join-admin-notice", label: "Admin: member joined notify", category: "Auth" },
+  { id: "usage-limit-alert", label: "Admin: usage limit alert", category: "Auth" },
   { id: "welcome", label: "Welcome / next steps", category: "Auth" },
   { id: "enrollment-invitation", label: "Enrollment invitation", category: "Invites" },
 ] as const;

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -15,3 +15,9 @@ export {
 } from "./invites";
 export { renderWelcomeEmail } from "./welcome";
 export { renderAbuseReportEmail, type AbuseReportEmailInput } from "./abuse";
+export {
+  renderUsageAlertEmail,
+  type UsageAlertCap,
+  type UsageAlertEvent,
+  type UsageAlertThreshold,
+} from "./usage";

--- a/packages/email/src/usage.test.ts
+++ b/packages/email/src/usage.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { renderUsageAlertEmail } from "./usage";
+
+describe("renderUsageAlertEmail", () => {
+  it("renders a single storage crossing with formatted bytes and CTA", () => {
+    const email = renderUsageAlertEmail({
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      events: [{ cap: "storage", threshold: 90, used: 225_000_000, limit: 250_000_000 }],
+      webOrigin: "https://uploads.sh",
+    });
+    expect(email.subject).toContain("Acme");
+    expect(email.subject).toContain("90%");
+    expect(email.subject.toLowerCase()).toContain("storage");
+    // Decimal byte formatting, not raw bytes.
+    expect(email.html).toContain("225 MB");
+    expect(email.html).toContain("250 MB");
+    expect(email.html).not.toContain("225000000");
+    expect(email.html).toContain("https://uploads.sh/account/workspaces/acme/settings");
+    expect(email.html).toContain("https://uploads.sh/account/profile");
+    expect(email.text).toContain("225 MB of 250 MB");
+  });
+
+  it("says 'reached' (not a percentage) when a cap hits 100%", () => {
+    const email = renderUsageAlertEmail({
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      events: [{ cap: "uploads", threshold: 100, used: 3000, limit: 3000 }],
+    });
+    expect(email.subject.toLowerCase()).toContain("reached");
+    expect(email.subject).not.toContain("%");
+    expect(email.html).toContain("limit reached");
+    // Upload counts are grouped, not byte-formatted.
+    expect(email.text).toContain("3,000 of 3,000 uploads this month");
+  });
+
+  it("covers both caps in one email when they cross together", () => {
+    const email = renderUsageAlertEmail({
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      events: [
+        { cap: "storage", threshold: 90, used: 9_000_000_000, limit: 10_000_000_000 },
+        { cap: "uploads", threshold: 50, used: 1500, limit: 3000 },
+      ],
+    });
+    expect(email.subject.toLowerCase()).toContain("approaching");
+    expect(email.html).toContain("Storage");
+    expect(email.html).toContain("Monthly uploads");
+    expect(email.html).toContain("9 GB");
+    expect(email.html).toContain("1,500 of 3,000 uploads this month");
+  });
+});

--- a/packages/email/src/usage.test.ts
+++ b/packages/email/src/usage.test.ts
@@ -7,6 +7,7 @@ describe("renderUsageAlertEmail", () => {
       organizationName: "Acme",
       organizationSlug: "acme",
       events: [{ cap: "storage", threshold: 90, used: 225_000_000, limit: 250_000_000 }],
+      plan: "free",
       webOrigin: "https://uploads.sh",
     });
     expect(email.subject).toContain("Acme");
@@ -21,17 +22,36 @@ describe("renderUsageAlertEmail", () => {
     expect(email.text).toContain("225 MB of 250 MB");
   });
 
+  it("offers both remedies for a storage crossing on an upgradeable plan", () => {
+    const email = renderUsageAlertEmail({
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      events: [{ cap: "storage", threshold: 90, used: 225_000_000, limit: 250_000_000 }],
+      plan: "free",
+    });
+    expect(email.text).toContain("upgrade to a paid plan");
+    expect(email.text).toContain("connect your own storage bucket");
+    expect(email.text).toContain("To raise your storage limit");
+    // Remedies are clickable in the HTML.
+    expect(email.html).toContain(">upgrade to a paid plan</a>");
+    expect(email.html).toContain(">connect your own storage bucket</a>");
+  });
+
   it("says 'reached' (not a percentage) when a cap hits 100%", () => {
     const email = renderUsageAlertEmail({
       organizationName: "Acme",
       organizationSlug: "acme",
       events: [{ cap: "uploads", threshold: 100, used: 3000, limit: 3000 }],
+      plan: "free",
     });
     expect(email.subject.toLowerCase()).toContain("reached");
     expect(email.subject).not.toContain("%");
     expect(email.html).toContain("limit reached");
     // Upload counts are grouped, not byte-formatted.
     expect(email.text).toContain("3,000 of 3,000 uploads this month");
+    // An external bucket does not lift the upload-count cap, so it isn't offered.
+    expect(email.text).toContain("upgrade to a paid plan");
+    expect(email.text).not.toContain("storage bucket");
   });
 
   it("covers both caps in one email when they cross together", () => {
@@ -42,11 +62,38 @@ describe("renderUsageAlertEmail", () => {
         { cap: "storage", threshold: 90, used: 9_000_000_000, limit: 10_000_000_000 },
         { cap: "uploads", threshold: 50, used: 1500, limit: 3000 },
       ],
+      plan: "free",
     });
     expect(email.subject.toLowerCase()).toContain("approaching");
     expect(email.html).toContain("Storage");
     expect(email.html).toContain("Monthly uploads");
     expect(email.html).toContain("9 GB");
     expect(email.html).toContain("1,500 of 3,000 uploads this month");
+    expect(email.text).toContain("To raise these limits");
+  });
+
+  it("does not offer an upgrade to a workspace already on pro", () => {
+    const email = renderUsageAlertEmail({
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      events: [{ cap: "uploads", threshold: 90, used: 90_000, limit: 100_000 }],
+      plan: "pro",
+    });
+    // No upgrade path and an external bucket doesn't change the upload cap →
+    // the honest next step is the monthly reset.
+    expect(email.text).not.toContain("upgrade to a paid plan");
+    expect(email.text).not.toContain("storage bucket");
+    expect(email.text).toContain("resets at the start of next month");
+  });
+
+  it("still offers the bucket to a pro workspace hitting its storage cap", () => {
+    const email = renderUsageAlertEmail({
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      events: [{ cap: "storage", threshold: 90, used: 9_000_000_000, limit: 10_000_000_000 }],
+      plan: "pro",
+    });
+    expect(email.text).not.toContain("upgrade to a paid plan");
+    expect(email.text).toContain("connect your own storage bucket");
   });
 });

--- a/packages/email/src/usage.ts
+++ b/packages/email/src/usage.ts
@@ -68,6 +68,57 @@ function eventLineText(event: UsageAlertEvent): string {
   return `${capLabel(event.cap)} — ${state} (${usageOf(event)})`;
 }
 
+/** "a", "a or b", "a, b or c". */
+function joinOr(parts: string[]): string {
+  if (parts.length <= 1) return parts[0] ?? "";
+  return `${parts.slice(0, -1).join(", ")} or ${parts[parts.length - 1]}`;
+}
+
+/**
+ * The actionable next step. Which remedies apply depends on the caps that
+ * crossed and the plan:
+ * - Upgrading to a paid plan raises both caps — but only offer it when the
+ *   workspace isn't already on the top paid plan (`pro`).
+ * - Connecting your own storage bucket lifts the *storage* cap only; it does
+ *   not change the monthly upload-count allowance, so only offer it for storage.
+ * When neither applies (a `pro` workspace that hit only its upload cap), the
+ * honest next step is that the count resets next month.
+ */
+function remedy(opts: {
+  hasStorage: boolean;
+  hasUploads: boolean;
+  plan?: string;
+  manageUrl: string;
+}): { html: string; text: string } {
+  const subject =
+    opts.hasStorage && opts.hasUploads
+      ? "these limits"
+      : opts.hasStorage
+        ? "your storage limit"
+        : "your monthly upload limit";
+  const link = (label: string) =>
+    `<a href="${escapeHtml(opts.manageUrl)}" style="color:#b9b0cf;">${label}</a>`;
+
+  const htmlParts: string[] = [];
+  const textParts: string[] = [];
+  if (opts.plan !== "pro") {
+    htmlParts.push(link("upgrade to a paid plan"));
+    textParts.push("upgrade to a paid plan");
+  }
+  if (opts.hasStorage) {
+    htmlParts.push(link("connect your own storage bucket"));
+    textParts.push("connect your own storage bucket");
+  }
+  if (htmlParts.length === 0) {
+    const fallback = "Your monthly upload count resets at the start of next month.";
+    return { html: fallback, text: fallback };
+  }
+  return {
+    html: `To raise ${subject}, ${joinOr(htmlParts)}.`,
+    text: `To raise ${subject}, ${joinOr(textParts)}.`,
+  };
+}
+
 /**
  * Notify a workspace's admins/owners when its storage and/or upload usage
  * crosses a 50 / 90 / 100% band. Sent from the daily usage sweep. One email
@@ -77,6 +128,9 @@ export function renderUsageAlertEmail(ctx: {
   organizationName: string;
   organizationSlug: string;
   events: UsageAlertEvent[];
+  /** The workspace's billing plan, so the remedy copy stays honest (a `pro`
+   * workspace can't "upgrade" further). Absent = treat as upgradeable. */
+  plan?: string;
   webOrigin?: string;
 }): RenderedEmail {
   const origin = resolveWebOrigin(ctx.webOrigin);
@@ -101,8 +155,15 @@ export function renderUsageAlertEmail(ctx: {
     ? `${ctx.organizationName} has reached a usage limit on uploads.sh.`
     : `${ctx.organizationName} is approaching a usage limit on uploads.sh.`;
 
+  const fix = remedy({
+    hasStorage: events.some((e) => e.cap === "storage"),
+    hasUploads: events.some((e) => e.cap === "uploads"),
+    plan: ctx.plan,
+    manageUrl,
+  });
+
   const linesHtml = events.map((e) => `<br>${eventLineHtml(e)}`).join("");
-  const bodyHtml = `${escapeHtml(lead)}${linesHtml}`;
+  const bodyHtml = `${escapeHtml(lead)}${linesHtml}<br><br>${fix.html}`;
 
   return renderEmailCard({
     subject,
@@ -114,6 +175,8 @@ export function renderUsageAlertEmail(ctx: {
       lead,
       "",
       ...events.map(eventLineText),
+      "",
+      fix.text,
       "",
       `Manage this workspace: ${manageUrl}`,
       "",

--- a/packages/email/src/usage.ts
+++ b/packages/email/src/usage.ts
@@ -1,0 +1,128 @@
+import { escapeHtml, renderEmailCard, resolveWebOrigin, strong, type RenderedEmail } from "./card";
+
+/** Which cap a usage alert is about. Storage is cumulative; uploads reset monthly. */
+export type UsageAlertCap = "storage" | "uploads";
+
+/** The bands we alert on, as whole-percent thresholds of a cap. */
+export type UsageAlertThreshold = 50 | 90 | 100;
+
+/**
+ * One cap crossing a new band. `used`/`limit` are raw (bytes for storage,
+ * counts for uploads); the template formats them and derives the displayed
+ * percentage, so senders never format numbers themselves.
+ */
+export interface UsageAlertEvent {
+  cap: UsageAlertCap;
+  threshold: UsageAlertThreshold;
+  used: number;
+  limit: number;
+}
+
+/** Decimal byte units (caps are decimal — 250 MB = 250_000_000). */
+function formatBytes(n: number): string {
+  if (!Number.isFinite(n) || n < 1000) return `${Math.max(0, Math.round(n))} B`;
+  const units = ["kB", "MB", "GB", "TB", "PB"];
+  let value = n;
+  let unit = -1;
+  do {
+    value /= 1000;
+    unit += 1;
+  } while (value >= 1000 && unit < units.length - 1);
+  const rounded =
+    value >= 10 || Number.isInteger(value) ? Math.round(value) : Number(value.toFixed(1));
+  return `${rounded} ${units[unit]}`;
+}
+
+function formatCount(n: number): string {
+  return Math.max(0, Math.round(n)).toLocaleString("en-US");
+}
+
+/** Whole-percent of the cap in use, clamped to [0, 100] for display. */
+function displayPct(event: UsageAlertEvent): number {
+  if (!(event.limit > 0)) return 0;
+  return Math.min(100, Math.max(0, Math.floor((event.used / event.limit) * 100)));
+}
+
+function capNoun(cap: UsageAlertCap): string {
+  return cap === "storage" ? "storage" : "monthly uploads";
+}
+
+function capLabel(cap: UsageAlertCap): string {
+  return cap === "storage" ? "Storage" : "Monthly uploads";
+}
+
+function usageOf(event: UsageAlertEvent): string {
+  return event.cap === "storage"
+    ? `${formatBytes(event.used)} of ${formatBytes(event.limit)}`
+    : `${formatCount(event.used)} of ${formatCount(event.limit)} uploads this month`;
+}
+
+/** One "Storage — 90% used (225 MB of 250 MB)" line for the card body. */
+function eventLineHtml(event: UsageAlertEvent): string {
+  const state = event.threshold >= 100 ? "limit reached" : `${displayPct(event)}% used`;
+  return `${strong(capLabel(event.cap))} — ${escapeHtml(`${state} (${usageOf(event)})`)}`;
+}
+
+function eventLineText(event: UsageAlertEvent): string {
+  const state = event.threshold >= 100 ? "limit reached" : `${displayPct(event)}% used`;
+  return `${capLabel(event.cap)} — ${state} (${usageOf(event)})`;
+}
+
+/**
+ * Notify a workspace's admins/owners when its storage and/or upload usage
+ * crosses a 50 / 90 / 100% band. Sent from the daily usage sweep. One email
+ * covers every cap that crossed a new band in the same sweep (usually one).
+ */
+export function renderUsageAlertEmail(ctx: {
+  organizationName: string;
+  organizationSlug: string;
+  events: UsageAlertEvent[];
+  webOrigin?: string;
+}): RenderedEmail {
+  const origin = resolveWebOrigin(ctx.webOrigin);
+  const manageUrl = `${origin}/account/workspaces/${ctx.organizationSlug}/settings`;
+  const settingsUrl = `${origin}/account/profile`;
+
+  const events = ctx.events.slice(0, 2);
+  const anyReached = events.some((e) => e.threshold >= 100);
+  const single = events.length === 1;
+  const only = events[0];
+
+  // Subject / title / lead vary by whether a hard limit was hit and whether one
+  // cap or both crossed. Single-cap subjects name the cap; multi-cap generalize.
+  const noun = single ? capNoun(only.cap) : "usage";
+  const subject = anyReached
+    ? `${ctx.organizationName} has reached its ${noun} limit on uploads.sh`
+    : single
+      ? `${ctx.organizationName} is at ${displayPct(only)}% of its ${noun} limit on uploads.sh`
+      : `${ctx.organizationName} is approaching its ${noun} limits on uploads.sh`;
+  const title = anyReached ? "Usage limit reached" : "Approaching a usage limit";
+  const lead = anyReached
+    ? `${ctx.organizationName} has reached a usage limit on uploads.sh.`
+    : `${ctx.organizationName} is approaching a usage limit on uploads.sh.`;
+
+  const linesHtml = events.map((e) => `<br>${eventLineHtml(e)}`).join("");
+  const bodyHtml = `${escapeHtml(lead)}${linesHtml}`;
+
+  return renderEmailCard({
+    subject,
+    preheader: lead,
+    eyebrow: "Usage",
+    title,
+    bodyHtml,
+    text: [
+      lead,
+      "",
+      ...events.map(eventLineText),
+      "",
+      `Manage this workspace: ${manageUrl}`,
+      "",
+      "—",
+      "uploads.sh · a Build Internet project",
+      `Turn this notification off in your account settings: ${settingsUrl}`,
+    ].join("\n"),
+    cta: { url: manageUrl, label: "Manage workspace →" },
+    footNoteHtml: `You administer this workspace. <a href="${escapeHtml(settingsUrl)}" style="color:#b9b0cf;">Manage notifications</a> to turn this off.`,
+    webOrigin: ctx.webOrigin,
+  });
+}


### PR DESCRIPTION
The owed follow-up to #880: email a workspace's admins/owners when its usage
nears a limit, gated by a new per-user preference — with actionable copy on how
to raise the limit.

![usage limit alert email](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/881/usage-alert-card.webp)

## What it does

Admins/owners get an email when a workspace crosses **50 / 90 / 100%** of its
**storage** or **monthly-upload** cap, unless they've turned the new
`notify_usage_limits` preference off (default on). The email names the next
step — *"To raise your storage limit, upgrade to a paid plan or connect your
own storage bucket."*

## How it works

- **Detection — daily cron sweep.** `apps/api/src/usage-alert-sweep.ts` runs as
  a fourth scheduled job beside the retention sweep (the existing `0 6 * * *`
  cron). It pages every `ws:` record and compares usage against the resolved
  storage/upload caps. Legacy/unlimited workspaces (no plan, no explicit cap)
  are skipped.
- **Dedup — KV markers.** A marker per `(workspace, cap)` stores the highest
  band already emailed (`usage:alert:<ws>:storage`,
  `usage:alert:<ws>:uploads:<YYYY-MM>`). The email is edge-triggered — it fires
  only when the band *rises* — and the marker re-arms as usage recedes, so a
  plan upgrade (usage % collapses against the bigger cap) re-alerts on the new
  plan. No writes to the workspace record, so no version churn.
- **Send — auth-worker route.** The sweep POSTs crossings to a new internal
  route `POST /internal/usage-alerts/notify`, which resolves the org by slug
  (the workspace name *is* the slug), filters admins/owners by the
  `notify_usage_limits` pref, and sends via `sendAuthEmail`. Preference
  filtering and send stay in the auth worker — the only place the pref and the
  member roster live — exactly as #880 does.
- **Actionable, cap- and plan-aware remedy.** The workspace plan rides along in
  the notify payload so the copy stays honest: an external bucket is offered for
  storage crossings only (it doesn't lift the monthly upload-count cap), and
  "upgrade to a paid plan" is suppressed for workspaces already on `pro` (which
  are instead told the upload count resets next month).
- **Preference — cloned from `notify_member_join`.** A second
  `notify_usage_limits` better-auth `additionalField` + schema column +
  migration, and a second toggle on `/account/profile`.
- **Email.** A shared `renderUsageAlertEmail` template (one email covers both
  caps), registered in the admin email preview (`/admin/email`).

## Testing

- New tests: cron sweep (detection/dedup/re-arm/skips/plan-forwarding), the
  notify helper, the internal route, the email render (including the remedy
  copy for free vs. pro and storage vs. uploads), and the web client update fn.
- Full suites green: **email, auth, api, web**. Typecheck, lint, and format all
  clean.

## Notes

- No changeset — all changes are in ignored `@uploads/*` packages (changesets
  here are CLI-only), same as #880.
- Auth-sensitive (new internal route + per-user pref), so a review is worthwhile.
