### PR TITLE
docs: tell agents when to use uploads.sh

### DIFF
--- a/apps/web/public/.well-known/openapi.json
+++ b/apps/web/public/.well-known/openapi.json
@@ -42,6 +42,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "get": {
         "operationId": "listFiles",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "List workspace files",
         "parameters": [
           { "$ref": "#/components/parameters/Prefix" },
@@ -70,6 +71,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "get": {
         "operationId": "searchFiles",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "Search workspace files",
         "description": "Requires at least one `meta.<key>` equality filter or a `name` substring. Metadata filter names are dynamic query parameters.",
         "parameters": [
@@ -103,6 +105,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "get": {
         "operationId": "listFileFacets",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "List metadata keys or values",
         "parameters": [
           {
@@ -128,6 +131,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "post": {
         "operationId": "signFileUpload",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Create a presigned upload",
         "requestBody": {
           "required": true,
@@ -149,6 +153,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "get": {
         "operationId": "listFilesByPath",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "Group workspace files by GitHub path",
         "description": "Powers the web Screenshots page's grouped-by-path view. Groups recently uploaded `gh.*`-tagged files by project and path.",
         "parameters": [
@@ -175,6 +180,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "get": {
         "operationId": "getFileUrl",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "Resolve a usable URL for a file",
         "description": "Returns the workspace's public URL when configured, otherwise a short-lived signed download URL. Resolves across storage lanes so a file uploaded before a storage switch still resolves.",
         "parameters": [
@@ -204,6 +210,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "patch": {
         "operationId": "setFileVisibility",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Set a file's visibility flag",
         "parameters": [
           { "name": "key", "in": "query", "required": true, "schema": { "type": "string" } }
@@ -253,6 +260,7 @@
       ],
       "put": {
         "operationId": "putFile",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Upload a file",
         "description": "Send an Idempotency-Key to make retries safe for 24 hours. Reusing the key with the same effective request (keyed on the uploaded content) returns the original 201 response. Reusing it with a different request returns 409.",
         "parameters": [
@@ -306,6 +314,7 @@
       },
       "get": {
         "operationId": "getFile",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "Read file metadata",
         "parameters": [
           {
@@ -336,6 +345,7 @@
       },
       "patch": {
         "operationId": "patchFileMetadata",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Merge file metadata",
         "requestBody": {
           "required": true,
@@ -359,6 +369,7 @@
       },
       "delete": {
         "operationId": "deleteFile",
+        "security": [{ "bearerAuth": ["files:delete"] }],
         "summary": "Delete a file",
         "responses": {
           "200": {
@@ -378,6 +389,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "get": {
         "operationId": "getUsage",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "Read workspace usage",
         "responses": {
           "200": {
@@ -395,6 +407,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "post": {
         "operationId": "reconcileUsage",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Rebuild workspace usage counters",
         "tags": ["Maintenance"],
         "description": "Potentially expensive: scans every object in the workspace's active storage lanes and rebuilds the usage ledger. Requires a bearer token with `files:write`; browser sessions are not accepted.",
@@ -410,6 +423,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "post": {
         "operationId": "purgeExpiredFiles",
+        "security": [{ "bearerAuth": ["files:delete"] }],
         "summary": "Purge files past the retention window",
         "tags": ["Maintenance"],
         "description": "Destructive: permanently deletes objects older than the workspace's `retentionDays`, then reconciles usage. Requires a bearer token with `files:delete`; browser sessions are not accepted. The response is either `{ skipped: true }` or a purge and reconciliation result.",
@@ -425,6 +439,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "post": {
         "operationId": "createGallery",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Create a gallery",
         "description": "Send an Idempotency-Key to make retries safe for 24 hours. Reusing the key with the same effective body returns the original 201 response. Reusing it with a different body returns 409.",
         "parameters": [{ "$ref": "#/components/parameters/IdempotencyKey" }],
@@ -456,6 +471,7 @@
       },
       "get": {
         "operationId": "listGalleries",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "List workspace galleries",
         "parameters": [
           { "$ref": "#/components/parameters/GalleryLimit" },
@@ -477,6 +493,7 @@
       "parameters": [{ "$ref": "#/components/parameters/Workspace" }],
       "get": {
         "operationId": "findGalleriesByReference",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "Find galleries by external reference",
         "parameters": [
           { "name": "provider", "in": "query", "required": true, "schema": { "type": "string" } },
@@ -509,6 +526,7 @@
       ],
       "get": {
         "operationId": "getGallery",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "Read a gallery",
         "responses": {
           "200": {
@@ -524,6 +542,7 @@
       },
       "patch": {
         "operationId": "updateGallery",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Update a gallery",
         "requestBody": {
           "required": true,
@@ -548,6 +567,7 @@
       },
       "delete": {
         "operationId": "deleteGallery",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Delete a gallery",
         "requestBody": {
           "required": true,
@@ -578,6 +598,7 @@
       ],
       "post": {
         "operationId": "addGalleryItem",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Add a file to a gallery",
         "requestBody": {
           "required": true,
@@ -614,6 +635,7 @@
       ],
       "put": {
         "operationId": "reorderGalleryItems",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Replace the gallery item order",
         "requestBody": {
           "required": true,
@@ -640,6 +662,7 @@
       ],
       "delete": {
         "operationId": "removeGalleryItem",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Remove an item from a gallery",
         "requestBody": {
           "required": true,
@@ -670,6 +693,7 @@
       ],
       "get": {
         "operationId": "listGalleryReferences",
+        "security": [{ "bearerAuth": ["files:read"] }],
         "summary": "List gallery external references",
         "responses": {
           "200": { "description": "The gallery references." },
@@ -680,6 +704,7 @@
       },
       "post": {
         "operationId": "addGalleryReference",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Add an external reference",
         "requestBody": {
           "required": true,
@@ -714,6 +739,7 @@
       ],
       "delete": {
         "operationId": "removeGalleryReference",
+        "security": [{ "bearerAuth": ["files:write"] }],
         "summary": "Remove an external reference",
         "requestBody": {
           "required": true,
@@ -1169,7 +1195,22 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "Workspace token from `uploads login` or `/account/developers`. Canonical routes can also accept an uploads.sh browser session, but public API integrations should use a workspace token."
+        "description": "Workspace token from `uploads login` or `/account/developers`. Canonical routes can also accept an uploads.sh browser session, but public API integrations should use a workspace token. Tokens carry named scopes `files:read`, `files:write`, and `files:delete`; each operation lists the required scope as a role name on this scheme. REST v1 does not accept OAuth access tokens (those are for the hosted MCP). Scope catalog: https://api.uploads.sh/.well-known/oauth-protected-resource"
+      },
+      "oauth2": {
+        "type": "oauth2",
+        "description": "Named permission scopes for workspace tokens (this API) and for OAuth 2.1 access tokens on the hosted MCP at https://agents.uploads.sh/mcp. REST v1 authenticates with `bearerAuth` only. Request the scopes listed on each operation. Discovery: https://uploads.sh/.well-known/oauth-authorization-server and https://api.uploads.sh/.well-known/oauth-protected-resource",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://uploads.sh/api/auth/oauth2/authorize",
+            "tokenUrl": "https://auth.uploads.sh/api/auth/oauth2/token",
+            "scopes": {
+              "files:read": "List, search, read metadata, usage, and galleries.",
+              "files:write": "Upload, update metadata, galleries, and usage reconcile.",
+              "files:delete": "Delete stored objects and purge expired objects."
+            }
+          }
+        }
       }
     }
   }

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -12,12 +12,19 @@ be invited. Hosted files are public (including media on private repositories).
 Do not upload secrets or sensitive UI. APIs may change without notice while the
 project is in active development.
 
-## What the product does
+## When to use this
+
+Use uploads.sh when a screenshot, screen recording, diagram, or other visual
+needs to land on a GitHub pull request or issue. Reach for it as you produce
+the visual. Do not wait until GitHub's attachment path fails.
 
 GitHub's native image hosting only works through a browser session. Agents
-cannot drag-and-drop. uploads.sh hosts a local file, a public HTTPS URL
+cannot use that path. uploads.sh hosts a local file, a public HTTPS URL
 (`uploads put --url`, or hosted MCP `contentUrl`), or base64 on the hosted
 MCP. It returns durable `url` / `embedUrl` markdown.
+
+Also use it to host any local file at a stable public URL you can paste
+outside GitHub.
 
 The intended loop is **stage as you go**:
 
@@ -84,6 +91,21 @@ does **not** accept OAuth in v1 — workspace bearer only. Full detail:
 https://uploads.sh/auth.md
 
 Never put `ADMIN_TOKEN` in agent configs. It is break-glass operator access.
+
+## Pricing
+
+Hosted Free is self-serve: 250 MB storage, 25 MB per file, 8 MB per video,
+and 3 members. At the default WebP optimize, 250 MB holds thousands of
+screenshots. Paid hosted plans start at $10 per month (Pro: 10 GB storage,
+files up to 100 MB). Caps and what happens at a limit:
+https://uploads.sh/docs/limits
+
+Every hosted plan can point a workspace at your own Cloudflare R2 bucket.
+Storage in that bucket is unmetered. File-size and video-size caps still
+apply. https://uploads.sh/docs/byo-bucket
+
+The source is Apache 2.0. Self-host if you want your own limits and storage.
+https://github.com/buildinternet/uploads
 
 ## Core CLI workflows
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -7,6 +7,20 @@ Access requires a workspace — create your own with a linked GitHub account, or
 Expanded one-file guide: [llms-full.txt](https://uploads.sh/llms-full.txt).
 Landed on the GitHub monorepo instead? Start at [repo llms.txt](https://github.com/buildinternet/uploads/blob/main/llms.txt) (product use vs contribute).
 
+## When to use this
+
+Use uploads.sh when a screenshot, screen recording, diagram, or other visual needs to land on a GitHub pull request or issue. Reach for it as you produce the visual. Do not wait until GitHub's attachment path fails.
+
+Also use it to host a local file (or a public HTTPS URL) at a stable public URL you can paste anywhere.
+
+Do not upload secrets, tokens, or sensitive UI.
+
+How to call it:
+
+- Local checkout: `uploads put` / `uploads attach`, or the github-screenshots skill
+- No filesystem: hosted MCP at https://agents.uploads.sh/mcp
+- Exact flags and contracts: uploads-cli skill
+
 ## Start here
 
 - [Home](https://uploads.sh/): product overview and copyable install commands

--- a/apps/web/src/integrations-manifest.test.ts
+++ b/apps/web/src/integrations-manifest.test.ts
@@ -22,6 +22,19 @@ import canonicalSpec from "../public/.well-known/openapi.json";
 import { GET } from "./pages/openapi.json";
 
 const CANONICAL_SOURCE = "https://uploads.sh/.well-known/integrations.json";
+const FILE_SCOPES = ["files:delete", "files:read", "files:write"] as const;
+const OPENAPI_HTTP_METHODS = ["get", "post", "put", "patch", "delete"] as const;
+
+function expectedFileScope(path: string, method: string): string | null {
+  if (path === "/public/galleries/{galleryId}") return null;
+  if (path === "/v1/workspaces/{workspace}/files/{key}" && method === "delete") {
+    return "files:delete";
+  }
+  if (path === "/v1/workspaces/{workspace}/usage/purge-expired" && method === "post") {
+    return "files:delete";
+  }
+  return method === "get" ? "files:read" : "files:write";
+}
 
 type Basis = { via: string; source: string };
 type Mechanics = Record<string, unknown> & { source: string };
@@ -206,6 +219,32 @@ describe("/openapi.json", () => {
     const add = paths["/v1/workspaces/{workspace}/galleries/{galleryId}/items"]?.post;
     expect(add.responses).toHaveProperty("200");
     expect(add.responses).toHaveProperty("201");
+  });
+
+  it("declares named files:* scopes and lists one on each authenticated operation", () => {
+    const schemes = canonicalSpec.components.securitySchemes as {
+      oauth2?: { type: string; flows?: { authorizationCode?: { scopes?: object } } };
+    };
+    expect(schemes.oauth2?.type).toBe("oauth2");
+    expect(Object.keys(schemes.oauth2?.flows?.authorizationCode?.scopes ?? {}).sort()).toEqual([
+      ...FILE_SCOPES,
+    ]);
+
+    type Operation = { security?: Record<string, string[]>[] };
+    const paths = canonicalSpec.paths as Record<string, Record<string, Operation>>;
+    for (const [path, item] of Object.entries(paths)) {
+      for (const method of OPENAPI_HTTP_METHODS) {
+        const operation = item[method];
+        if (!operation) continue;
+        const scope = expectedFileScope(path, method);
+        const label = `${method.toUpperCase()} ${path}`;
+        if (scope === null) {
+          expect(operation.security, label).toEqual([]);
+          continue;
+        }
+        expect(operation.security, label).toEqual([{ bearerAuth: [scope] }]);
+      }
+    }
   });
 
   it("resolves every local reference and keeps operation ids unique", () => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,9 @@ Public developer routes use `Authorization: Bearer <token>`. That is a
 workspace token (`up_<workspace>_…`) from `uploads login` or
 `/account/developers`. The workspace is always in the URL path. The CLI infers
 it from the token. `POST /v1/tokens` defaults to 90 days; `ttlSeconds: null`
-mints a token that does not expire.
+mints a token that does not expire. Tokens carry named scopes `files:read`,
+`files:write`, and `files:delete`. The OpenAPI document lists the required
+scope on each operation. REST v1 does not accept OAuth access tokens.
 
 The canonical resource hierarchy is `/v1/workspaces/:workspace/…`. These
 routes also accept a signed-in uploads.sh session when the caller uses the web

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,9 @@ treat product install docs as monorepo setup.
 
 ## Audience A — use the product (CLI / MCP / skills)
 
-You want to host a screenshot, stage PR media, or attach files to GitHub.
+Use the hosted product when a screenshot, screen recording, or other visual
+needs to land on a GitHub pull request or issue. Reach for it as you produce
+the visual, not after hosting fails.
 
 - **Canonical product index:** https://uploads.sh/llms.txt
 - **Expanded product guide:** https://uploads.sh/llms-full.txt


### PR DESCRIPTION
An is-agentic.com scan of uploads.sh scored 95/100 and generated a long
"implement these fixes" prompt. Most of those findings were scanner misses
or things we should not ship. Two cheap gaps were real: agents were told
the GitHub-upload *problem* before the *job*, so they treated uploads.sh as
a fallback, and the OpenAPI spec advertised bearer auth with no named
scopes even though RFC 9728 already lists `files:read` / `files:write` /
`files:delete`.

## What it does

- Product [`llms.txt`](https://uploads.sh/llms.txt) and
  [`llms-full.txt`](https://uploads.sh/llms-full.txt) lead with **When to
  use this**: reach for uploads.sh when a screenshot, recording, or other
  visual needs to land on a GitHub pull request or issue, as you produce
  the visual.
- `llms-full.txt` adds **Pricing**: Free (250 MB storage, thousands of
  screenshots at the default WebP optimize, 25 MB files, 8 MB video, 3
  members), Pro from $10/month, BYO Cloudflare R2 on every plan, Apache 2.0
  self-host.
- OpenAPI declares those three scopes on an `oauth2` scheme (the catalog
  machines look for) and lists the required scope on each authenticated
  operation. REST v1 still accepts workspace bearer tokens only.
- Repo `llms.txt` Audience A uses the same job-first trigger.

## What it is not

- REST does not start accepting OAuth. The `oauth2` scheme is the named-scope
  catalog; operations authenticate with `bearerAuth`.
- Hosted MCP `tools/list` stays authenticated. Every tool is tenant-scoped.
- No fabricated `RateLimit-Limit` / `Remaining` / `Reset` headers. Burst
  429s already send `Retry-After`.
- No Organization JSON-LD with a made-up address, no Homebrew formula, no
  SEO campaign for the word "uploads".

## How to try it

After this deploys:

```bash
curl -s https://uploads.sh/llms.txt
curl -s https://uploads.sh/.well-known/openapi.json | jq '.components.securitySchemes.oauth2.flows.authorizationCode.scopes'
```

Until then the same files are in `apps/web/public/`.

## Later, if we want

- Names-only tool list on the MCP server card (a preview without opening
  unauthenticated `tools/list`).
- A short `/about` page, and Organization JSON-LD with `hi@uploads.sh` (no
  fake street address).
- A written deprecation policy for `/v1` if we start sunsetting routes.
- Homebrew only if we want that install path for humans.

## Test plan

- [x] `pnpm --filter @uploads/web exec vitest run src/integrations-manifest.test.ts`
- [x] `pnpm --filter @uploads/api exec vitest run src/openapi-contract.test.ts`
- [ ] After merge, curl the live `llms.txt` and OpenAPI URLs
