### PR TITLE
fix(auth): default loopback-only DCR clients to application_type native

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -21,7 +21,11 @@ import {
   magicLink,
   organization,
 } from "better-auth/plugins";
-import { fetchClientMetadataResource, rewriteClientMetadataGrantTypes } from "./cimd-transport";
+import {
+  defaultRegistrationApplicationType,
+  fetchClientMetadataResource,
+  rewriteClientMetadataGrantTypes,
+} from "./cimd-transport";
 import { deviceWorkspacePlugin } from "./device-workspace";
 import {
   oauthClientIdFromAuthorizationCode,
@@ -263,8 +267,10 @@ async function applyOAuthClientInterop(
 } | void> {
   if (ctx.path === "/oauth2/register") {
     const body = ctx.body as Record<string, unknown> | null;
-    const next = body ? rewriteClientMetadataGrantTypes(body) : undefined;
-    if (next) return { context: { body: next } };
+    if (!body) return;
+    const withGrantTypes = rewriteClientMetadataGrantTypes(body) ?? body;
+    const next = defaultRegistrationApplicationType(withGrantTypes) ?? withGrantTypes;
+    if (next !== body) return { context: { body: next } };
     return;
   }
   if (ctx.path === "/oauth2/authorize") {

--- a/apps/auth/src/cimd-transport.ts
+++ b/apps/auth/src/cimd-transport.ts
@@ -109,6 +109,52 @@ export function rewriteClientMetadataGrantTypes(
   return { ...metadata, grant_types: next };
 }
 
+/**
+ * Hosts on which Better Auth 1.7 permits a native client's plain-http
+ * redirect URI (RFC 8252 §7.3's exact loopback set).
+ */
+const NATIVE_HTTP_LOOPBACK_HOSTNAMES: ReadonlySet<string> = new Set([
+  "localhost",
+  "127.0.0.1",
+  "[::1]",
+]);
+
+function isNativeStyleRedirectUri(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol === "http:") {
+    return NATIVE_HTTP_LOOPBACK_HOSTNAMES.has(url.hostname === "::1" ? "[::1]" : url.hostname);
+  }
+  // Private-use (reverse-domain) schemes are also a native-only shape; https
+  // is ambiguous, so it never triggers the default.
+  return url.protocol !== "https:";
+}
+
+/**
+ * Default a DCR body's omitted `application_type` to `"native"` when every
+ * redirect URI is a shape only a native client may use (http loopback or a
+ * private-use scheme). Better Auth 1.7 defaults omitted `application_type`
+ * to `"web"` and rejects web clients with loopback redirects, which broke
+ * bare-DCR MCP clients such as opencode (http://127.0.0.1:<port> callback).
+ * `undefined` means leave the body alone — an explicit `application_type`,
+ * any https/ambiguous redirect, or a malformed body all fall through to the
+ * plugin's own validation.
+ */
+export function defaultRegistrationApplicationType(
+  body: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (body.application_type !== undefined) return undefined;
+  const redirectUris = body.redirect_uris;
+  if (!Array.isArray(redirectUris) || redirectUris.length === 0) return undefined;
+  if (!redirectUris.every(isNativeStyleRedirectUri)) return undefined;
+  return { ...body, application_type: "native" };
+}
+
 function shouldRewriteMetadataBody(res: Response): boolean {
   if (res.status !== 200) return false;
   const declared = Number(res.headers.get("content-length"));

--- a/apps/auth/src/cimd.test.ts
+++ b/apps/auth/src/cimd.test.ts
@@ -11,6 +11,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuthEnv } from "./auth";
 import {
+  defaultRegistrationApplicationType,
   fetchClientMetadataResource,
   intersectAdvertisedGrantTypes,
   rewriteClientMetadataGrantTypes,
@@ -335,5 +336,57 @@ describe("dynamic client registration (SEP-837)", () => {
     expect(res.status).toBe(201);
     const body = (await res.json()) as { client_id?: string };
     expect(typeof body.client_id).toBe("string");
+  });
+});
+
+describe("defaultRegistrationApplicationType", () => {
+  it("defaults to native when every redirect is http loopback or a private-use scheme", () => {
+    const body = {
+      client_name: "opencode",
+      redirect_uris: [
+        "http://127.0.0.1:19876/mcp/oauth/callback",
+        "http://localhost:8080/cb",
+        "http://[::1]:9000/cb",
+        "com.example.app:/oauth",
+      ],
+    };
+    expect(defaultRegistrationApplicationType(body)).toEqual({
+      ...body,
+      application_type: "native",
+    });
+    // Input is not mutated.
+    expect(body).not.toHaveProperty("application_type");
+  });
+
+  it("leaves an explicit application_type alone", () => {
+    expect(
+      defaultRegistrationApplicationType({
+        application_type: "web",
+        redirect_uris: ["http://127.0.0.1:1234/cb"],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("leaves bodies with any https or non-loopback http redirect alone", () => {
+    for (const uri of [
+      "https://client.example.com/cb",
+      "https://localhost:1234/cb",
+      "http://example.com/cb",
+      "http://127.0.0.1.evil.com/cb",
+    ]) {
+      expect(
+        defaultRegistrationApplicationType({
+          redirect_uris: ["http://127.0.0.1:1234/cb", uri],
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it("leaves missing, empty, or malformed redirect_uris alone", () => {
+    expect(defaultRegistrationApplicationType({})).toBeUndefined();
+    expect(defaultRegistrationApplicationType({ redirect_uris: [] })).toBeUndefined();
+    expect(defaultRegistrationApplicationType({ redirect_uris: "nope" })).toBeUndefined();
+    expect(defaultRegistrationApplicationType({ redirect_uris: [42] })).toBeUndefined();
+    expect(defaultRegistrationApplicationType({ redirect_uris: ["not a url"] })).toBeUndefined();
   });
 });

--- a/apps/auth/src/oauth.test.ts
+++ b/apps/auth/src/oauth.test.ts
@@ -84,6 +84,69 @@ describe("dynamic client registration", () => {
     expect(typeof body.client_id).toBe("string");
     expect(body.redirect_uris).toEqual(["https://client.example.com/callback"]);
   });
+
+  // Better Auth 1.7 defaults DCR clients without `application_type` to "web",
+  // and web clients reject http loopback redirect URIs outright — which broke
+  // every bare-DCR MCP client with a http://127.0.0.1:<port> callback
+  // (opencode, reported 2026-08-30). The hooks.before interop defaults such
+  // registrations to "native", where RFC 8252 loopback redirects are allowed.
+  it("registers a DCR client with only http loopback redirects as native (opencode regression)", async () => {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "opencode",
+          redirect_uris: ["http://127.0.0.1:19876/mcp/oauth/callback"],
+        }),
+      },
+      dbEnv(),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { application_type?: string; redirect_uris?: string[] };
+    expect(body.application_type).toBe("native");
+    expect(body.redirect_uris).toEqual(["http://127.0.0.1:19876/mcp/oauth/callback"]);
+  });
+
+  // Pins current upstream behavior (better-auth#10913: the web-client check
+  // rejects ALL loopback redirects, even https). If a Better Auth release
+  // starts allowing web+loopback, this test failing is the signal to revisit
+  // — the interop default above stays correct either way.
+  it("still rejects an explicit web client with a http loopback redirect", async () => {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "explicit web",
+          application_type: "web",
+          redirect_uris: ["http://127.0.0.1:19876/callback"],
+        }),
+      },
+      dbEnv(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("leaves registrations with a non-loopback redirect defaulting to web", async () => {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "mixed",
+          redirect_uris: ["https://client.example.com/callback"],
+        }),
+      },
+      dbEnv(),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { application_type?: string };
+    expect(body.application_type).toBe("web");
+  });
 });
 
 describe("JWKS endpoint", () => {


### PR DESCRIPTION
## Summary

A user reported the hosted MCP (agents.uploads.sh) failing OAuth in opencode with:

> web clients require https redirect URIs on non-loopback hosts: http://127.0.0.1:19876/mcp/oauth/callback

Root cause: Better Auth 1.7 defaults DCR registrations that omit `application_type` to `"web"`, and its web-client redirect validation rejects **all** loopback redirect URIs (better-auth/better-auth#10913 — an inverted condition, still unfixed in 1.7.2). Any MCP client doing bare RFC 7591 registration with a `http://127.0.0.1:<port>` callback is rejected. CIMD registrations default to `"native"`, which is why Claude Code and MCP Inspector were unaffected, and the CLI uses device flow.

## Fix

The existing `/oauth2/register` `hooks.before` interop now defaults an omitted `application_type` to `"native"` when every `redirect_uri` is a native-only shape: http on exact loopback hosts (`localhost` / `127.0.0.1` / `[::1]`, RFC 8252 §7.3) or a private-use scheme. Anything else — explicit `application_type`, any https or non-loopback redirect, malformed body — falls through to the plugin's own validation untouched.

This also matches the MCP 2026-07-28 spec, which requires native clients to send `application_type: "native"` — clients that omit it now get the spec-correct classification instead of a rejection.

## Tests

- e2e against the real Better Auth handler: the exact opencode registration shape 400'd before this change and now registers 201 as `native`; explicit `web` + loopback still 400s (pinned with a note referencing better-auth#10913); https-redirect registrations still default to `web`.
- Unit coverage for the helper, including `http://127.0.0.1.evil.com` not counting as loopback and non-mutation of the input body.

`pnpm vitest run` in apps/auth: 392 passed. `tsc --noEmit` clean.