### PR TITLE
fix(auth): accept Cursor's host-bearing cursor:// DCR registration

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -22,6 +22,7 @@ import {
   organization,
 } from "better-auth/plugins";
 import {
+  coerceExplicitWebToNativeForPrivateUseScheme,
   defaultRegistrationApplicationType,
   fetchClientMetadataResource,
   rewriteClientMetadataGrantTypes,
@@ -269,7 +270,8 @@ async function applyOAuthClientInterop(
     const body = ctx.body as Record<string, unknown> | null;
     if (!body) return;
     const withGrantTypes = rewriteClientMetadataGrantTypes(body) ?? body;
-    const next = defaultRegistrationApplicationType(withGrantTypes) ?? withGrantTypes;
+    const withDefaultType = defaultRegistrationApplicationType(withGrantTypes) ?? withGrantTypes;
+    const next = coerceExplicitWebToNativeForPrivateUseScheme(withDefaultType) ?? withDefaultType;
     if (next !== body) return { context: { body: next } };
     return;
   }

--- a/apps/auth/src/cimd-transport.ts
+++ b/apps/auth/src/cimd-transport.ts
@@ -155,6 +155,37 @@ export function defaultRegistrationApplicationType(
   return { ...body, application_type: "native" };
 }
 
+function isPrivateUseSchemeRedirectUri(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const url = new URL(value);
+    return url.protocol !== "http:" && url.protocol !== "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Coerce an explicit `application_type: "web"` to `"native"` when every
+ * redirect URI is native-only shaped and at least one uses a private-use
+ * scheme. No legitimate web client has a custom-scheme callback (e.g.
+ * `cursor://...`); Cursor's MCP client sends "web" here regardless — a known
+ * client bug (https://forum.cursor.com/t/cursor-does-not-send-application-type-native-when-registering-mcp-oauth-clients/136907).
+ * Web + loopback-only http redirects are deliberately left alone (pinned
+ * 400 in oauth.test.ts, better-auth#10913). `undefined` means leave the body
+ * alone.
+ */
+export function coerceExplicitWebToNativeForPrivateUseScheme(
+  body: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (body.application_type !== "web") return undefined;
+  const redirectUris = body.redirect_uris;
+  if (!Array.isArray(redirectUris) || redirectUris.length === 0) return undefined;
+  if (!redirectUris.every(isNativeStyleRedirectUri)) return undefined;
+  if (!redirectUris.some(isPrivateUseSchemeRedirectUri)) return undefined;
+  return { ...body, application_type: "native" };
+}
+
 function shouldRewriteMetadataBody(res: Response): boolean {
   if (res.status !== 200) return false;
   const declared = Number(res.headers.get("content-length"));

--- a/apps/auth/src/cimd.test.ts
+++ b/apps/auth/src/cimd.test.ts
@@ -11,6 +11,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuthEnv } from "./auth";
 import {
+  coerceExplicitWebToNativeForPrivateUseScheme,
   defaultRegistrationApplicationType,
   fetchClientMetadataResource,
   intersectAdvertisedGrantTypes,
@@ -388,5 +389,48 @@ describe("defaultRegistrationApplicationType", () => {
     expect(defaultRegistrationApplicationType({ redirect_uris: "nope" })).toBeUndefined();
     expect(defaultRegistrationApplicationType({ redirect_uris: [42] })).toBeUndefined();
     expect(defaultRegistrationApplicationType({ redirect_uris: ["not a url"] })).toBeUndefined();
+  });
+
+  describe("coerceExplicitWebToNativeForPrivateUseScheme", () => {
+    // Cursor's MCP client: https://forum.cursor.com/t/cursor-does-not-send-application-type-native-when-registering-mcp-oauth-clients/136907
+    it("coerces web + a private-use-scheme redirect to native", () => {
+      const body = {
+        application_type: "web",
+        redirect_uris: ["cursor://anysphere.cursor-mcp/oauth/callback"],
+      };
+      expect(coerceExplicitWebToNativeForPrivateUseScheme(body)).toEqual({
+        ...body,
+        application_type: "native",
+      });
+    });
+
+    // Pinned upstream behavior (better-auth#10913) keeps this a 400 in
+    // oauth.test.ts; the coercion must not intervene here.
+    it("does not coerce web + loopback-only http redirects", () => {
+      expect(
+        coerceExplicitWebToNativeForPrivateUseScheme({
+          application_type: "web",
+          redirect_uris: ["http://127.0.0.1:1234/cb"],
+        }),
+      ).toBeUndefined();
+    });
+
+    it("does not coerce web + an https redirect", () => {
+      expect(
+        coerceExplicitWebToNativeForPrivateUseScheme({
+          application_type: "web",
+          redirect_uris: ["https://client.example.com/callback"],
+        }),
+      ).toBeUndefined();
+    });
+
+    it("does not touch an already-explicit native application_type", () => {
+      expect(
+        coerceExplicitWebToNativeForPrivateUseScheme({
+          application_type: "native",
+          redirect_uris: ["cursor://anysphere.cursor-mcp/oauth/callback"],
+        }),
+      ).toBeUndefined();
+    });
   });
 });

--- a/apps/auth/src/oauth.test.ts
+++ b/apps/auth/src/oauth.test.ts
@@ -130,6 +130,58 @@ describe("dynamic client registration", () => {
     expect(res.status).toBe(400);
   });
 
+  // Cursor's MCP client sends an explicit `application_type: "web"` with a
+  // cursor:// private-use-scheme redirect — a known Cursor bug (no legitimate
+  // web client can register a custom-scheme callback):
+  // https://forum.cursor.com/t/cursor-does-not-send-application-type-native-when-registering-mcp-oauth-clients/136907
+  // The interop coerces this to "native" before the plugin validates it.
+  it("registers Cursor's explicit web + cursor:// DCR body as native", async () => {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          application_type: "web",
+          redirect_uris: ["cursor://anysphere.cursor-mcp/oauth/callback"],
+          token_endpoint_auth_method: "none",
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+        }),
+      },
+      dbEnv(),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { application_type?: string; redirect_uris?: string[] };
+    expect(body.application_type).toBe("native");
+    expect(body.redirect_uris).toEqual(["cursor://anysphere.cursor-mcp/oauth/callback"]);
+  });
+
+  // Pins the pnpm patch of @better-auth/oauth-provider (better-auth#10956,
+  // porting the upstream fix for better-auth#10946): the dist's native
+  // redirect validator rejected host-bearing private-use-scheme redirects
+  // like `cursor://host/path` even for an explicit `application_type:
+  // "native"` client. Delete this test (and patches/@better-auth__oauth-provider@1.7.1.patch)
+  // once a Better Auth release ships #10956 or equivalent.
+  it("registers an explicit native client with a host-bearing cursor:// redirect", async () => {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          application_type: "native",
+          redirect_uris: ["cursor://anysphere.cursor-mcp/oauth/callback"],
+        }),
+      },
+      dbEnv(),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { application_type?: string; redirect_uris?: string[] };
+    expect(body.application_type).toBe("native");
+    expect(body.redirect_uris).toEqual(["cursor://anysphere.cursor-mcp/oauth/callback"]);
+  });
+
   it("leaves registrations with a non-loopback redirect defaulting to web", async () => {
     const res = await app.request(
       "/api/auth/oauth2/register",

--- a/patches/@better-auth__oauth-provider.patch
+++ b/patches/@better-auth__oauth-provider.patch
@@ -1,0 +1,40 @@
+diff --git a/dist/authorize-Crqw4_bR.mjs b/dist/authorize-Crqw4_bR.mjs
+index fdd19eb6333102dd77130d5ed142ad73f853b243..e257065c401f0f7d425784090d08524dc982e2e8 100644
+--- a/dist/authorize-Crqw4_bR.mjs
++++ b/dist/authorize-Crqw4_bR.mjs
+@@ -1642,8 +1642,25 @@ const FORBIDDEN_NATIVE_REDIRECT_SCHEMES = new Set([
+ 	"mailto:",
+ 	"javascript:",
+ 	"data:",
+-	"vbscript:"
++	"vbscript:",
++	// patch(better-auth#10956): union with upstream's NON_PRIVATE_USE_SCHEMES.
++	"http:",
++	"https:",
++	"ws:",
++	"wss:"
+ ]);
++// patch(better-auth#10956, better-auth#10946): accept host-bearing
++// non-reserved custom-scheme redirect URIs (e.g. cursor://host/path) for
++// native clients, alongside the existing authority-free reverse-domain form.
++// Delete once a Better Auth release ships the upstream fix.
++function isHostBearingPrivateUseRedirectUri(uri) {
++	if (FORBIDDEN_NATIVE_REDIRECT_SCHEMES.has(uri.protocol)) return false;
++	if (uri.host.length === 0) return false;
++	return uri.pathname.startsWith("/");
++}
++function isNativePrivateUseRedirectUri(uri) {
++	return isReverseDomainPrivateUseRedirectUri(uri) || isHostBearingPrivateUseRedirectUri(uri);
++}
+ function invalidRedirectUri(description) {
+ 	throw new APIError("BAD_REQUEST", {
+ 		error: "invalid_redirect_uri",
+@@ -1707,7 +1724,7 @@ function validateClientRedirectUri(redirectUri, applicationType) {
+ 		if (!isAllowedNativeHttpLoopback) invalidRedirectUri(`native clients may use http only on the exact loopback hosts localhost, 127.0.0.1, or [::1]: ${redirectUri}`);
+ 		return;
+ 	}
+-	if (FORBIDDEN_NATIVE_REDIRECT_SCHEMES.has(url.protocol) || !isReverseDomainPrivateUseRedirectUri(url)) invalidRedirectUri(`native private-use redirect URI schemes must be well-formed reverse-domain names, omit the naming authority, and must not use a reserved scheme: ${redirectUri}`);
++	if (FORBIDDEN_NATIVE_REDIRECT_SCHEMES.has(url.protocol) || !isNativePrivateUseRedirectUri(url)) invalidRedirectUri(`native private-use redirect URI schemes must not use a reserved scheme; they must be an authority-free reverse-domain URI or a custom-scheme URI with an authority: ${redirectUri}`);
+ }
+ function assertValidRegistrationJwks(jwks) {
+ 	const result = validatePublicClientJwks(jwks);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@better-auth/oauth-provider': 44cdf8c2aeeab967305abd7fa5ecc4cced9191215780a6e7229b2d23e7f5f84e
+
 importers:
 
   .:
@@ -98,13 +101,13 @@ importers:
     dependencies:
       '@better-auth/cimd':
         specifier: ^1.7.1
-        version: 1.7.1(7a89e234d6a62adaf251cc509be38291)
+        version: 1.7.1(c06b14a7b2c994ad107a7df4111cc7d6)
       '@better-auth/infra':
         specifier: ^0.4.1
         version: 0.4.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(better-auth@1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))))(zod@4.4.3)
       '@better-auth/oauth-provider':
         specifier: ^1.7.1
-        version: 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))
+        version: 1.7.1(patch_hash=44cdf8c2aeeab967305abd7fa5ecc4cced9191215780a6e7229b2d23e7f5f84e)(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))
       '@better-auth/stripe':
         specifier: ^1.7.1
         version: 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(better-auth@1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))(stripe@22.3.2(@types/node@26.1.0))
@@ -7917,10 +7920,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@better-auth/cimd@1.7.1(7a89e234d6a62adaf251cc509be38291)':
+  '@better-auth/cimd@1.7.1(c06b14a7b2c994ad107a7df4111cc7d6)':
     dependencies:
       '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
-      '@better-auth/oauth-provider': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))
+      '@better-auth/oauth-provider': 1.7.1(patch_hash=44cdf8c2aeeab967305abd7fa5ecc4cced9191215780a6e7229b2d23e7f5f84e)(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))
       better-auth: 1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))
       better-call: 1.4.0(zod@4.4.3)
 
@@ -7974,7 +7977,7 @@ snapshots:
       '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))':
+  '@better-auth/oauth-provider@1.7.1(patch_hash=44cdf8c2aeeab967305abd7fa5ecc4cced9191215780a6e7229b2d23e7f5f84e)(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.1(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,3 +27,5 @@ minimumReleaseAgeExclude:
   - "@cloudflare/workers-types@5.20260706.1"
   - files-sdk@2.2.4
   - hono@4.12.28
+patchedDependencies:
+  "@better-auth/oauth-provider": patches/@better-auth__oauth-provider.patch


### PR DESCRIPTION
## Two stacked bugs

1. **Cursor's client bug**: Cursor's MCP client sends explicit
   `application_type: "web"` with a `cursor://anysphere.cursor-mcp/oauth/callback`
   redirect, even though no legitimate web client can have a custom-scheme
   callback. This is a known Cursor bug:
   https://forum.cursor.com/t/cursor-does-not-send-application-type-native-when-registering-mcp-oauth-clients/136907
2. **Better Auth's oauth-provider bug**: even once `application_type` is
   `"native"`, the installed `@better-auth/oauth-provider@1.7.1`'s native
   redirect-URI validator only accepts the authority-free reverse-domain
   private-use form (`com.example.app:/callback`) and rejects host-bearing
   custom schemes like `cursor://host/path`. Reported upstream as
   better-auth/better-auth#10946, fixed in the unmerged
   better-auth/better-auth#10956.

## Part A — coercion (`apps/auth/src/cimd-transport.ts`)

Added `coerceExplicitWebToNativeForPrivateUseScheme`, wired into
`applyOAuthClientInterop` in `apps/auth/src/auth.ts` alongside the existing
`defaultRegistrationApplicationType` (PR #885, unchanged).

Coerces `application_type: "web"` to `"native"` only when:
- every `redirect_uris` entry is native-only shaped (http loopback or a
  private-use scheme), **and**
- at least one entry uses a private-use (non-http/https) scheme.

Does **not** coerce:
- web + loopback-only http redirects (pinned 400 test in `oauth.test.ts`,
  better-auth#10913, stays passing)
- web + https redirects
- an already-explicit `application_type: "native"` body

## Part B — pnpm patch (`patches/@better-auth__oauth-provider.patch`)

Ports better-auth/better-auth#10956 into the bundled dist of
`@better-auth/oauth-provider@1.7.1` (the fix is source-only and unmerged
upstream, so it isn't in the published package). Patches
`dist/authorize-Crqw4_bR.mjs` — the only file in the package with the
duplicated validation logic — to accept a native redirect whose scheme is
non-reserved and either matches the existing authority-free reverse-domain
form or is host-bearing (`url.host.length > 0 && url.pathname.startsWith("/")`).

**Retirement condition**: delete `patches/@better-auth__oauth-provider.patch`,
its `pnpm-workspace.yaml` entry, and the pinned test
`"registers an explicit native client with a host-bearing cursor:// redirect"`
in `apps/auth/src/oauth.test.ts` once a Better Auth release ships #10956 or
equivalent.

## Tests

- `apps/auth/src/oauth.test.ts`: e2e registration of Cursor's exact DCR body
  (expects 201, `application_type: "native"`), plus the pinned
  "retire the patch" test for an already-native body with a host-bearing
  `cursor://` redirect.
- `apps/auth/src/cimd.test.ts`: unit tests for
  `coerceExplicitWebToNativeForPrivateUseScheme` — coerces web+cursor://,
  does not coerce web+loopback-http, does not coerce web+https, does not
  touch an already-native body.

## Verification

- `pnpm vitest run` in `apps/auth`: 398/398 passing
- `pnpm exec tsc --noEmit` in `apps/auth`: clean
- `pnpm install` from repo root: clean, patch applies
