### PR TITLE
fix(auth): coerce mixed private-use + https DCR redirects to native

### DIFF
--- a/apps/auth/src/cimd-transport.ts
+++ b/apps/auth/src/cimd-transport.ts
@@ -151,7 +151,14 @@ export function defaultRegistrationApplicationType(
   if (body.application_type !== undefined) return undefined;
   const redirectUris = body.redirect_uris;
   if (!Array.isArray(redirectUris) || redirectUris.length === 0) return undefined;
-  if (!redirectUris.every(isNativeStyleRedirectUri)) return undefined;
+  // All native-only shapes, or a private-use scheme anywhere (a web client
+  // cannot have one) alongside only native-valid URIs — same rule as the
+  // explicit-web coercion below.
+  const allNativeOnly = redirectUris.every(isNativeStyleRedirectUri);
+  const privateUseMix =
+    redirectUris.some(isPrivateUseSchemeRedirectUri) &&
+    redirectUris.every(isNativeCompatibleRedirectUri);
+  if (!allNativeOnly && !privateUseMix) return undefined;
   return { ...body, application_type: "native" };
 }
 
@@ -166,14 +173,38 @@ function isPrivateUseSchemeRedirectUri(value: unknown): boolean {
 }
 
 /**
- * Coerce an explicit `application_type: "web"` to `"native"` when every
- * redirect URI is native-only shaped and at least one uses a private-use
- * scheme. No legitimate web client has a custom-scheme callback (e.g.
+ * Valid under Better Auth's NATIVE redirect rules: http on exact loopback,
+ * https on a NON-loopback host (an RFC 8252 §7.2 claimed URI — native
+ * rejects https loopback), or a private-use scheme. Coercing a body with a
+ * URI outside this set would swap one registration error for another.
+ */
+function isNativeCompatibleRedirectUri(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  const isLoopback = NATIVE_HTTP_LOOPBACK_HOSTNAMES.has(
+    url.hostname === "::1" ? "[::1]" : url.hostname,
+  );
+  if (url.protocol === "http:") return isLoopback;
+  if (url.protocol === "https:") return !isLoopback;
+  return true;
+}
+
+/**
+ * Coerce an explicit `application_type: "web"` to `"native"` when at least
+ * one redirect URI uses a private-use scheme and every URI is valid under
+ * native rules. No legitimate web client has a custom-scheme callback (e.g.
  * `cursor://...`); Cursor's MCP client sends "web" here regardless — a known
- * client bug (https://forum.cursor.com/t/cursor-does-not-send-application-type-native-when-registering-mcp-oauth-clients/136907).
- * Web + loopback-only http redirects are deliberately left alone (pinned
- * 400 in oauth.test.ts, better-auth#10913). `undefined` means leave the body
- * alone.
+ * client bug (https://forum.cursor.com/t/cursor-does-not-send-application-type-native-when-registering-mcp-oauth-clients/136907)
+ * — and pairs it with an https redirect, which is fine for native as an
+ * RFC 8252 §7.2 claimed URI (observed in prod 2026-08-30; requiring every
+ * URI to be native-ONLY shaped left Cursor broken). Web + loopback-only http
+ * redirects are deliberately left alone (pinned 400 in oauth.test.ts,
+ * better-auth#10913). `undefined` means leave the body alone.
  */
 export function coerceExplicitWebToNativeForPrivateUseScheme(
   body: Record<string, unknown>,
@@ -181,8 +212,8 @@ export function coerceExplicitWebToNativeForPrivateUseScheme(
   if (body.application_type !== "web") return undefined;
   const redirectUris = body.redirect_uris;
   if (!Array.isArray(redirectUris) || redirectUris.length === 0) return undefined;
-  if (!redirectUris.every(isNativeStyleRedirectUri)) return undefined;
   if (!redirectUris.some(isPrivateUseSchemeRedirectUri)) return undefined;
+  if (!redirectUris.every(isNativeCompatibleRedirectUri)) return undefined;
   return { ...body, application_type: "native" };
 }
 

--- a/apps/auth/src/cimd.test.ts
+++ b/apps/auth/src/cimd.test.ts
@@ -424,6 +424,33 @@ describe("defaultRegistrationApplicationType", () => {
       ).toBeUndefined();
     });
 
+    // Cursor's real prod registration (2026-08-30) pairs cursor:// with an
+    // https redirect — a claimed URI, valid for native (RFC 8252 §7.2).
+    it("coerces web + cursor:// mixed with a non-loopback https redirect", () => {
+      const body = {
+        application_type: "web",
+        redirect_uris: [
+          "cursor://anysphere.cursor-mcp/oauth/callback",
+          "https://cursor.com/api/mcp/oauth/callback",
+        ],
+      };
+      expect(coerceExplicitWebToNativeForPrivateUseScheme(body)).toEqual({
+        ...body,
+        application_type: "native",
+      });
+    });
+
+    // https loopback is invalid for NATIVE clients in Better Auth — coercing
+    // would trade one registration error for another.
+    it("does not coerce when a mixed body includes an https loopback redirect", () => {
+      expect(
+        coerceExplicitWebToNativeForPrivateUseScheme({
+          application_type: "web",
+          redirect_uris: ["cursor://anysphere.cursor-mcp/oauth/callback", "https://localhost/cb"],
+        }),
+      ).toBeUndefined();
+    });
+
     it("does not touch an already-explicit native application_type", () => {
       expect(
         coerceExplicitWebToNativeForPrivateUseScheme({

--- a/apps/auth/src/oauth.test.ts
+++ b/apps/auth/src/oauth.test.ts
@@ -157,6 +157,38 @@ describe("dynamic client registration", () => {
     expect(body.redirect_uris).toEqual(["cursor://anysphere.cursor-mcp/oauth/callback"]);
   });
 
+  // Cursor's real registration (observed in prod 2026-08-30, unlike the
+  // approximation in better-auth#10946) pairs the cursor:// callback with an
+  // https redirect. Native clients may use claimed https URIs (RFC 8252
+  // §7.2), so a private-use scheme ANYWHERE in redirect_uris still means the
+  // client cannot be web — coercion must not require every URI to be
+  // native-only shaped.
+  it("registers Cursor's mixed cursor:// + https DCR body as native", async () => {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          application_type: "web",
+          redirect_uris: [
+            "cursor://anysphere.cursor-mcp/oauth/callback",
+            "https://cursor.com/api/mcp/oauth/callback",
+          ],
+          token_endpoint_auth_method: "none",
+        }),
+      },
+      dbEnv(),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { application_type?: string; redirect_uris?: string[] };
+    expect(body.application_type).toBe("native");
+    expect(body.redirect_uris).toEqual([
+      "cursor://anysphere.cursor-mcp/oauth/callback",
+      "https://cursor.com/api/mcp/oauth/callback",
+    ]);
+  });
+
   // Pins the pnpm patch of @better-auth/oauth-provider (better-auth#10956,
   // porting the upstream fix for better-auth#10946): the dist's native
   // redirect validator rejected host-bearing private-use-scheme redirects


### PR DESCRIPTION
## Summary

Follow-up to #886. Cursor still failed after deploy with the same error. Replaying variants against prod showed why: Cursor's **real** registration pairs `cursor://anysphere.cursor-mcp/oauth/callback` with an **https redirect URI** (the body in better-auth#10946 was an approximation). Both the explicit-web coercion and the omitted-`application_type` default required *every* redirect URI to be a native-only shape, so the https entry made them bail and the body stayed `web` → rejected.

## Fix

A private-use scheme anywhere in `redirect_uris` still makes a web client impossible, and https on a non-loopback host is a valid **native** claimed URI (RFC 8252 §7.2). Both helpers now coerce when any URI is private-use and every URI is valid under native rules. https **loopback** blocks coercion — Better Auth's native validation rejects it, so coercing would just swap one error for another.

Unchanged: web + loopback-only http stays 400 (pinned, better-auth#10913), pure-https bodies stay web, explicit `native` untouched.

## Tests

New e2e reproducing the mixed body (400 before, 201 `native` after — verified failing first), plus coercion unit tests for the mixed and https-loopback cases. `pnpm vitest run` in apps/auth: 401 passed; `tsc --noEmit` clean.