### PR TITLE
fix(admin): handle null-name DCR clients on /admin/oauth

### DIFF
--- a/apps/auth/src/internal-oauth-clients.test.ts
+++ b/apps/auth/src/internal-oauth-clients.test.ts
@@ -155,6 +155,25 @@ describe("GET /internal/oauth-clients", () => {
     expect(created[0].clientId).toBe(secondBody.clientId);
     expect(created[1].clientId).toBe(firstBody.clientId);
   });
+
+  it("falls back to clientId for DCR clients registered without a name", async () => {
+    // DCR (RFC 7591) makes client_name optional, so rows with name = NULL exist.
+    const orm = drizzle(db, { schema });
+    await orm.insert(schema.oauthClient).values({
+      id: "row-dcr",
+      clientId: "dcr-client",
+      redirectUris: ["http://127.0.0.1:33418/callback"],
+      scopes: ["files:read"],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await jsonReq("GET", "/internal/oauth-clients");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { clients: Array<{ clientId: string; name: string }> };
+    const dcr = body.clients.find((c) => c.clientId === "dcr-client");
+    expect(dcr?.name).toBe("dcr-client");
+  });
 });
 
 describe("GET /internal/oauth-clients/:clientId", () => {

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -193,7 +193,7 @@ async function statsForClient(
 function serializeClient(row: OauthClientRow, stats: OauthClientStats) {
   return {
     clientId: row.clientId,
-    name: row.name,
+    name: row.name ?? row.clientId,
     type: row.type,
     public: Boolean(row.public),
     disabled: Boolean(row.disabled),

--- a/apps/web/src/pages/admin/oauth.astro
+++ b/apps/web/src/pages/admin/oauth.astro
@@ -144,7 +144,7 @@ export const prerender = false;
 
       interface OAuthClient {
         clientId: string;
-        name: string;
+        name: string | null;
         type: string;
         public: boolean;
         disabled: boolean;
@@ -189,7 +189,7 @@ export const prerender = false;
         row.innerHTML = `
           <td class="keep ${ADMIN_TD}">
             <a class="admin-row-link group text-inherit no-underline" href="${href}">
-              <span class="primary ${ADMIN_CELL_PRIMARY} group-hover:text-primary group-focus-visible:text-primary">${escapeHtml(client.name)}</span>
+              <span class="primary ${ADMIN_CELL_PRIMARY} group-hover:text-primary group-focus-visible:text-primary">${escapeHtml(client.name ?? client.clientId)}</span>
             </a>
           </td>
           <td class="optional mono muted ${ADMIN_TD} ${ADMIN_CELL_MONO} ${ADMIN_CELL_MUTED}">${escapeHtml(client.clientId)}</td>
@@ -202,23 +202,25 @@ export const prerender = false;
       }
 
       async function loadClients() {
+        let clients: OAuthClient[];
         try {
-          const { clients } = await apiGet<{ clients: OAuthClient[] }>("/admin-ui/oauth-clients");
-          oauthStatus.hidden = true;
-          oauthListBody.innerHTML = "";
-          if (!clients.length) {
-            oauthStatus.hidden = false;
-            oauthStatus.textContent = "No OAuth apps yet.";
-            tableWrap.hidden = true;
-            return;
-          }
-          tableWrap.hidden = false;
-          for (const client of clients) oauthListBody.appendChild(renderClient(client));
+          ({ clients } = await apiGet<{ clients: OAuthClient[] }>("/admin-ui/oauth-clients"));
         } catch {
           oauthStatus.hidden = false;
           oauthStatus.textContent = "Failed to load OAuth apps.";
           tableWrap.hidden = true;
+          return;
         }
+        oauthStatus.hidden = true;
+        oauthListBody.innerHTML = "";
+        if (!clients.length) {
+          oauthStatus.hidden = false;
+          oauthStatus.textContent = "No OAuth apps yet.";
+          tableWrap.hidden = true;
+          return;
+        }
+        tableWrap.hidden = false;
+        for (const client of clients) oauthListBody.appendChild(renderClient(client));
       }
 
       const createForm = requireElement<HTMLFormElement>("#oauth-create-form", "admin oauth");


### PR DESCRIPTION
## Summary
- `/admin/oauth` showed **Failed to load OAuth apps.** whenever any DCR-registered client (Cursor, opencode — possible since #885–#887) had a NULL `name`: `escapeHtml(null)` threw during row render, and the render loop lived inside the fetch `try`, so a render bug read as a load failure.
- `serializeClient` in `apps/auth/src/internal-routes.ts` now falls back to `clientId` when `name` is null (covers the list, detail, create, and update responses).
- The admin page types `name` as nullable, guards the render, and moves rendering out of the fetch `try/catch` so future render errors surface in the console instead of the load-failure message.

## Testing
- New regression test: null-name row serialized with `clientId` fallback.
- Full suite: 5498 passed; lint clean.