### PR TITLE
refactor(admin): share wire types between workers and admin pages

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,8 @@
     "./github-comment-render": "./src/github-comment-render.ts",
     "./github-promote-service": "./src/github-promote-service.ts",
     "./github-attach-service": "./src/github-attach-service.ts",
-    "./github-repo-binding": "./src/github-repo-binding.ts"
+    "./github-repo-binding": "./src/github-repo-binding.ts",
+    "./admin-ui": "./src/routes/admin-ui.ts"
   },
   "scripts": {
     "dev": "wrangler dev",
@@ -54,6 +55,7 @@
     "@types/node": "^26.1.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10",
-    "wrangler": "^4.125.0"
+    "wrangler": "^4.125.0",
+    "@uploads/auth": "workspace:^"
   }
 }

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -710,6 +710,7 @@ describe("workspace limits editing", () => {
         maxUploadsPerPeriod: 3000,
         maxUploadBytes: null,
         maxVideoUploadBytes: null,
+        maxMembers: null,
       },
       usage: { bytes: 128, uploads: 5 },
     });

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -198,6 +198,16 @@ async function allOrgSummaries(env: Env): Promise<Map<string, OrgSummary>> {
   return map;
 }
 
+/** One row of the `/admin-ui/workspaces` list: the KV workspace + its org counts. */
+function workspaceSummaryResponse(name: string, summary: OrgSummary | undefined) {
+  return {
+    workspace: name,
+    organization: summary?.organization ?? null,
+    memberCount: summary?.memberCount ?? 0,
+    pendingInviteCount: summary?.pendingInviteCount ?? 0,
+  };
+}
+
 /**
  * Proxies a request to `path` over the AUTH service binding (Lane 1's
  * `/internal/oauth-clients*` routes) and passes the status code + JSON body
@@ -438,6 +448,7 @@ async function limitsResponse(env: Env, name: string, record: WorkspaceRecord) {
     maxUploadsPerPeriod: record.maxUploadsPerPeriod ?? null,
     maxUploadBytes: record.maxUploadBytes ?? null,
     maxVideoUploadBytes: record.maxVideoUploadBytes ?? null,
+    maxMembers: record.maxMembers ?? null,
   };
   let usage: { bytes: number; uploads: number } | null = null;
   try {
@@ -489,6 +500,24 @@ function validateByoBucketPatch(body: unknown): boolean {
   }
   return value;
 }
+
+/**
+ * Wire types for the `/admin-ui/*` responses, inferred from the serializers
+ * above so the operator pages in apps/web (`src/pages/admin/*`) import the
+ * shape they actually receive instead of re-declaring it. Type-only — nothing
+ * here is imported at runtime across workers.
+ */
+export type AdminWorkspaceSummary = ReturnType<typeof workspaceSummaryResponse>;
+export type AdminLimitsResponse = Awaited<ReturnType<typeof limitsResponse>>;
+export type AdminPlanResponse = ReturnType<typeof planResponse> &
+  Awaited<ReturnType<typeof adminSubscriptionInfo>>;
+export type AdminStorageResponse = ReturnType<typeof adminStorageResponse>;
+export type AdminGithubLink = ReturnType<typeof repoLinkResponse>;
+export type { MetricsOverview } from "../metrics-overview";
+export type { OrgInvite, OrgMember } from "../org-workspaces";
+export type { OpenEnrollment } from "../auth-db";
+/** `/admin-ui/oauth-clients*` passes the auth worker's body through unchanged. */
+export type { SerializedOauthClient } from "@uploads/auth/oauth-client-serialize";
 
 export const adminUi = new Hono<SessionVars>()
   .use("/*", sessionAuth, requireSessionUser, requireAdminUser)
@@ -542,15 +571,7 @@ export const adminUi = new Hono<SessionVars>()
     } while (cursor);
 
     const summaries = await allOrgSummaries(c.env);
-    const workspaces = names.map((name) => {
-      const summary = summaries.get(name);
-      return {
-        workspace: name,
-        organization: summary?.organization ?? null,
-        memberCount: summary?.memberCount ?? 0,
-        pendingInviteCount: summary?.pendingInviteCount ?? 0,
-      };
-    });
+    const workspaces = names.map((name) => workspaceSummaryResponse(name, summaries.get(name)));
     return c.json({ workspaces });
   })
 

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "exports": {
+    "./oauth-client-serialize": "./src/oauth-client-serialize.ts"
+  },
   "scripts": {
     "dev": "wrangler dev --persist-to ../api/.wrangler/state",
     "deploy": "node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js deploy",

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -13,6 +13,13 @@ import { memberCapDenial, resolveMemberCapStrict } from "./member-cap";
 import { notifyAdminsOfMemberJoin } from "./notify-member-join";
 import { notifyAdminsOfUsageAlert } from "./notify-usage-alert";
 import * as schema from "./schema";
+import {
+  isOfficial,
+  serializeClient,
+  toEpochMs,
+  type OauthClientRow,
+  type OauthClientStats,
+} from "./oauth-client-serialize";
 import type { UsageAlertCap, UsageAlertEvent, UsageAlertThreshold } from "@uploads/email";
 
 const USAGE_ALERT_CAPS = new Set<UsageAlertCap>(["storage", "uploads"]);
@@ -143,25 +150,6 @@ function isAllowedRedirectUrl(value: string): boolean {
   return url.hash === "";
 }
 
-type OauthClientRow = typeof schema.oauthClient.$inferSelect;
-
-/** Reads the `official` flag out of the client's metadata JSON blob. */
-function isOfficial(row: OauthClientRow): boolean {
-  const metadata = row.metadata as Record<string, unknown> | null;
-  return Boolean(metadata && metadata.official === true);
-}
-
-function toEpochMs(value: Date | number | null | undefined): number | null {
-  if (value === null || value === undefined) return null;
-  return value instanceof Date ? value.getTime() : value;
-}
-
-type OauthClientStats = {
-  consentCount: number;
-  activeTokenCount: number;
-  lastConsentAt: number | null;
-};
-
 async function statsForClient(
   db: ReturnType<typeof drizzle<typeof schema>>,
   clientId: string,
@@ -187,26 +175,6 @@ async function statsForClient(
     consentCount: consentRow?.consentCount ?? 0,
     activeTokenCount: tokenRow?.activeTokenCount ?? 0,
     lastConsentAt: toEpochMs(consentRow?.lastConsentAt ?? null),
-  };
-}
-
-function serializeClient(row: OauthClientRow, stats: OauthClientStats) {
-  return {
-    clientId: row.clientId,
-    name: row.name ?? row.clientId,
-    type: row.type,
-    public: Boolean(row.public),
-    disabled: Boolean(row.disabled),
-    official: isOfficial(row),
-    redirectUris: row.redirectUris ?? [],
-    scopes: row.scopes ?? [],
-    uri: row.uri,
-    icon: row.icon,
-    userId: row.userId,
-    skipConsent: Boolean(row.skipConsent),
-    createdAt: toEpochMs(row.createdAt),
-    updatedAt: toEpochMs(row.updatedAt),
-    ...stats,
   };
 }
 

--- a/apps/auth/src/oauth-client-serialize.ts
+++ b/apps/auth/src/oauth-client-serialize.ts
@@ -1,0 +1,52 @@
+/**
+ * The wire shape of an OAuth client registration, shared by every
+ * `/internal/oauth-clients*` route in internal-routes.ts.
+ *
+ * Split out of that router so apps/web's operator pages can `import type` the
+ * serialized shape they actually receive (through apps/api's 1:1
+ * `/admin-ui/oauth-clients*` proxy) instead of re-declaring it. Keep this
+ * module free of worker bindings — the ambient `Env` of whichever app imports
+ * it wins, so anything touching `Env` would not typecheck from apps/web.
+ */
+import * as schema from "./schema";
+
+export type OauthClientRow = typeof schema.oauthClient.$inferSelect;
+
+/** Reads the `official` flag out of the client's metadata JSON blob. */
+export function isOfficial(row: OauthClientRow): boolean {
+  const metadata = row.metadata as Record<string, unknown> | null;
+  return Boolean(metadata && metadata.official === true);
+}
+
+export function toEpochMs(value: Date | number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  return value instanceof Date ? value.getTime() : value;
+}
+
+export type OauthClientStats = {
+  consentCount: number;
+  activeTokenCount: number;
+  lastConsentAt: number | null;
+};
+
+export function serializeClient(row: OauthClientRow, stats: OauthClientStats) {
+  return {
+    clientId: row.clientId,
+    name: row.name ?? row.clientId,
+    type: row.type,
+    public: Boolean(row.public),
+    disabled: Boolean(row.disabled),
+    official: isOfficial(row),
+    redirectUris: row.redirectUris ?? [],
+    scopes: row.scopes ?? [],
+    uri: row.uri,
+    icon: row.icon,
+    userId: row.userId,
+    skipConsent: Boolean(row.skipConsent),
+    createdAt: toEpochMs(row.createdAt),
+    updatedAt: toEpochMs(row.updatedAt),
+    ...stats,
+  };
+}
+
+export type SerializedOauthClient = ReturnType<typeof serializeClient>;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@uploads/api": "workspace:^",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10",
     "wrangler": "^4.125.0"

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -61,6 +61,16 @@ export const prerender = false;
       type LoadOnceFlag,
       wireExpandGroup,
     } from "../../lib/admin-ui";
+    import type {
+      AdminGithubLink,
+      AdminLimitsResponse,
+      AdminPlanResponse,
+      AdminStorageResponse,
+      AdminWorkspaceSummary,
+      OpenEnrollment,
+      OrgInvite,
+      OrgMember,
+    } from "@uploads/api/admin-ui";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("workspaces-list")) return;
@@ -71,38 +81,6 @@ export const prerender = false;
       const workspacesStatus = requireElement<HTMLElement>("#workspaces-status", "admin");
       const workspacesList = requireElement<HTMLElement>("#workspaces-list", "admin");
 
-      interface WorkspaceSummary {
-        workspace: string;
-        organization: { id: string; slug: string; name: string } | null;
-        memberCount: number;
-        pendingInviteCount: number;
-      }
-      interface Member {
-        id: string;
-        email: string;
-        name: string;
-        role: string;
-      }
-      interface Invite {
-        id: string;
-        email: string;
-        role: string | null;
-        status: string;
-      }
-      interface InviteLink {
-        id: string;
-        pageId: string | null;
-        label: string | null;
-        scopes: string[];
-        kind?: "token" | "member";
-        createdAt: string;
-        // Issue #876: nullable (a non-expiring `kind: 'member'` link);
-        // maxUses/useCount are meaningful for `kind: 'member'` only.
-        expiresAt: string | null;
-        maxUses?: number | null;
-        useCount?: number;
-      }
-
       async function apiGet<T>(path: string): Promise<T> {
         const res = await fetch(`${apiOrigin}${path}`, {
           credentials: "include",
@@ -112,52 +90,26 @@ export const prerender = false;
         return (await res.json()) as T;
       }
 
-      interface Limits {
-        maxStorageBytes: number | null;
-        maxUploadsPerPeriod: number | null;
-        maxUploadBytes: number | null;
-        maxVideoUploadBytes: number | null;
-        maxMembers: number | null;
-      }
-      interface LimitsResponse {
-        workspace: string;
-        limits: Limits;
-        usage: { bytes: number; uploads: number } | null;
-      }
-
       // Issue #445: subscription enrichment, additive to the plan
       // GET/PATCH response shape (see apps/api/src/routes/admin-ui.ts's
       // adminSubscriptionInfo). `stripeCustomerId` is admin-ui-only — never
       // sent to /me — and only present when a subscription row exists.
-      interface AdminSubscription {
-        status: string;
-        periodEnd: string | null;
-        cancelAtPeriodEnd: boolean;
-        stripeCustomerId: string | null;
-      }
-      interface PlanResponse {
-        workspace: string;
-        plan: "free" | "pro";
-        available: boolean;
-        planApplied: boolean;
-        limits: Limits;
-        overrides: string[];
-        planSource: "stripe" | "admin" | "none";
-        subscription: AdminSubscription | null;
-      }
-
       const PLAN_OPTIONS: { id: "free" | "pro"; label: string }[] = [
         { id: "free", label: "Free" },
         { id: "pro", label: "Pro (unavailable to self-serve)" },
       ];
 
-      const PLAN_SOURCE_LABEL: Record<PlanResponse["planSource"], string> = {
+      const PLAN_SOURCE_LABEL: Record<AdminPlanResponse["planSource"], string> = {
         stripe: "Stripe-backed",
         admin: "Admin-set (comped)",
         none: "None",
       };
 
-      function renderPlanSelector(host: HTMLElement, workspace: string, data: PlanResponse): void {
+      function renderPlanSelector(
+        host: HTMLElement,
+        workspace: string,
+        data: AdminPlanResponse,
+      ): void {
         const options = PLAN_OPTIONS.map(
           (opt) =>
             `<option value="${opt.id}"${opt.id === data.plan ? " selected" : ""}>${escapeHtml(opt.label)}</option>`,
@@ -220,7 +172,7 @@ export const prerender = false;
                 } | null;
                 throw new Error(payload?.error?.message || `save failed: ${res.status}`);
               }
-              const updated = (await res.json()) as PlanResponse;
+              const updated = (await res.json()) as AdminPlanResponse;
               renderPlanSelector(host, workspace, updated);
               const freshStatus = host.querySelector<HTMLElement>(".plan-status");
               if (freshStatus) {
@@ -247,7 +199,11 @@ export const prerender = false;
         { label: "MB", mult: 1_000_000 },
         { label: "GB", mult: 1_000_000_000 },
       ];
-      const LIMIT_FIELDS: { key: keyof Limits; label: string; byte: boolean }[] = [
+      const LIMIT_FIELDS: {
+        key: keyof AdminLimitsResponse["limits"];
+        label: string;
+        byte: boolean;
+      }[] = [
         { key: "maxStorageBytes", label: "Storage", byte: true },
         { key: "maxUploadsPerPeriod", label: "Uploads / month", byte: false },
         { key: "maxUploadBytes", label: "Max file size", byte: true },
@@ -269,7 +225,11 @@ export const prerender = false;
         return `${value} ${unit}`;
       }
 
-      function renderLimitsForm(host: HTMLElement, workspace: string, data: LimitsResponse): void {
+      function renderLimitsForm(
+        host: HTMLElement,
+        workspace: string,
+        data: AdminLimitsResponse,
+      ): void {
         const rows = LIMIT_FIELDS.map((f) => {
           const raw = data.limits[f.key];
           const unlimited = raw === null;
@@ -363,7 +323,7 @@ export const prerender = false;
                 } | null;
                 throw new Error(payload?.error?.message || `save failed: ${res.status}`);
               }
-              const updated = (await res.json()) as LimitsResponse;
+              const updated = (await res.json()) as AdminLimitsResponse;
               renderLimitsForm(host, workspace, updated);
               const freshStatus = host.querySelector<HTMLElement>(".limit-status");
               if (freshStatus) {
@@ -423,37 +383,77 @@ export const prerender = false;
       // value, only masked/presence fields — see workspace-storage.ts) plus
       // `configuredBy` (admin-ui-only, like `stripeCustomerId` on the plan
       // response above).
-      /** A saved-but-inactive lane (spec: "Configure, then switch") — read-only here, never a credential value. */
-      interface StorageLaneResponse {
-        laneId: string;
-        role: "standby" | "fallback";
-        bucket: string;
-        publicBaseUrl?: string;
-        verifiedAt?: string;
-        lastActiveAt?: string;
-        accountIdMasked?: string;
-        accessKeyIdLast4?: string;
-      }
+      /**
+       * Outstanding invite links for a workspace, with a revoke button per
+       * row. `onRevoke` fires after a successful DELETE so the caller can
+       * refresh the list. A failed DELETE renders an inline status message
+       * instead of throwing.
+       */
+      function renderInviteLinks(
+        host: HTMLElement,
+        workspace: string,
+        links: OpenEnrollment[],
+        onRevoke: () => void,
+      ): void {
+        host.innerHTML = links.length
+          ? `<h4 class="${ADMIN_DETAIL_HEADING}">Invite links</h4>
+           <ul class="invite-links-items ${ADMIN_MINI_LIST}">
+             ${links
+               .map((link) => {
+                 const expiry = link.expiresAt
+                   ? `expires ${formatDate(link.expiresAt) ?? link.expiresAt}`
+                   : "never expires";
+                 const uses =
+                   link.kind === "member"
+                     ? ` · ${link.useCount ?? 0}${link.maxUses ? `/${link.maxUses}` : ""} joins`
+                     : "";
+                 return `<li class="${ADMIN_MINI_LIST_ITEM}" data-id="${escapeHtml(link.id)}">
+                   <span>${link.label ? escapeHtml(link.label) : `<span class="muted">unlabeled</span>`} · ${escapeHtml(link.kind === "member" ? "member" : link.scopes.join(", "))} · ${escapeHtml(expiry)}${escapeHtml(uses)}</span>
+                   <button type="button" class="invite-link-revoke ${ADMIN_BTN} ${ADMIN_BTN_DANGER}" data-id="${escapeHtml(link.id)}">Revoke</button>
+                 </li>`;
+               })
+               .join("")}
+           </ul>
+           <div class="invite-links-status text-(length:--text-micro)" role="status" aria-live="polite" hidden></div>`
+          : `<p class="muted">No outstanding invite links.</p>`;
 
-      interface StorageResponse {
-        workspace: string;
-        mode: "shared" | "byo";
-        byoBucketEnabled: boolean;
-        bucket?: string;
-        accountIdMasked?: string;
-        accessKeyIdLast4?: string;
-        publicBaseUrl?: string;
-        configuredAt?: string;
-        verifiedAt?: string;
-        configuredBy: string | null;
-        activeLaneId?: string;
-        lanes?: StorageLaneResponse[];
+        const statusEl = host.querySelector<HTMLElement>(".invite-links-status");
+        host.querySelectorAll<HTMLButtonElement>(".invite-link-revoke").forEach((btn) => {
+          btn.addEventListener("click", () => {
+            void (async () => {
+              const id = btn.dataset.id;
+              if (!id) return;
+              btn.disabled = true;
+              try {
+                const res = await fetch(
+                  `${apiOrigin}/admin-ui/workspaces/${encodeURIComponent(workspace)}/invite-links/${encodeURIComponent(id)}`,
+                  { method: "DELETE", credentials: "include" },
+                );
+                if (!res.ok) {
+                  const payload = (await res.json().catch(() => null)) as {
+                    error?: { message?: string };
+                  } | null;
+                  throw new Error(payload?.error?.message || `revoke failed: ${res.status}`);
+                }
+                onRevoke();
+              } catch (err) {
+                btn.disabled = false;
+                if (statusEl) {
+                  statusEl.dataset.state = "error";
+                  statusEl.textContent =
+                    err instanceof Error && err.message ? err.message : "Couldn't revoke the link.";
+                  statusEl.hidden = false;
+                }
+              }
+            })();
+          });
+        });
       }
 
       function renderStorageForm(
         host: HTMLElement,
         workspace: string,
-        data: StorageResponse,
+        data: AdminStorageResponse,
       ): void {
         const provenance =
           data.mode === "byo"
@@ -527,7 +527,7 @@ export const prerender = false;
                 } | null;
                 throw new Error(payload?.error?.message || `save failed: ${res.status}`);
               }
-              const updated = (await res.json()) as StorageResponse;
+              const updated = (await res.json()) as AdminStorageResponse;
               renderStorageForm(host, workspace, updated);
               const freshStatus = host.querySelector<HTMLElement>(".storage-status");
               if (freshStatus) {
@@ -551,86 +551,7 @@ export const prerender = false;
         });
       }
 
-      interface GithubLink {
-        repo: string;
-        workspace: string;
-        source: string;
-        installationId: number | null;
-        createdAt: string;
-      }
-      interface GithubLinksResponse {
-        workspace: string;
-        links: GithubLink[];
-      }
-
-      /**
-       * Outstanding invite links for a workspace, with a revoke button per
-       * row. `onRevoke` fires after a successful DELETE so the caller can
-       * refresh the list. A failed DELETE renders an inline status message
-       * instead of throwing.
-       */
-      function renderInviteLinks(
-        host: HTMLElement,
-        workspace: string,
-        links: InviteLink[],
-        onRevoke: () => void,
-      ): void {
-        host.innerHTML = links.length
-          ? `<h4 class="${ADMIN_DETAIL_HEADING}">Invite links</h4>
-           <ul class="invite-links-items ${ADMIN_MINI_LIST}">
-             ${links
-               .map((link) => {
-                 const expiry = link.expiresAt
-                   ? `expires ${formatDate(link.expiresAt) ?? link.expiresAt}`
-                   : "never expires";
-                 const uses =
-                   link.kind === "member"
-                     ? ` · ${link.useCount ?? 0}${link.maxUses ? `/${link.maxUses}` : ""} joins`
-                     : "";
-                 return `<li class="${ADMIN_MINI_LIST_ITEM}" data-id="${escapeHtml(link.id)}">
-                   <span>${link.label ? escapeHtml(link.label) : `<span class="muted">unlabeled</span>`} · ${escapeHtml(link.kind === "member" ? "member" : link.scopes.join(", "))} · ${escapeHtml(expiry)}${escapeHtml(uses)}</span>
-                   <button type="button" class="invite-link-revoke ${ADMIN_BTN} ${ADMIN_BTN_DANGER}" data-id="${escapeHtml(link.id)}">Revoke</button>
-                 </li>`;
-               })
-               .join("")}
-           </ul>
-           <div class="invite-links-status text-(length:--text-micro)" role="status" aria-live="polite" hidden></div>`
-          : `<p class="muted">No outstanding invite links.</p>`;
-
-        const statusEl = host.querySelector<HTMLElement>(".invite-links-status");
-        host.querySelectorAll<HTMLButtonElement>(".invite-link-revoke").forEach((btn) => {
-          btn.addEventListener("click", () => {
-            void (async () => {
-              const id = btn.dataset.id;
-              if (!id) return;
-              btn.disabled = true;
-              try {
-                const res = await fetch(
-                  `${apiOrigin}/admin-ui/workspaces/${encodeURIComponent(workspace)}/invite-links/${encodeURIComponent(id)}`,
-                  { method: "DELETE", credentials: "include" },
-                );
-                if (!res.ok) {
-                  const payload = (await res.json().catch(() => null)) as {
-                    error?: { message?: string };
-                  } | null;
-                  throw new Error(payload?.error?.message || `revoke failed: ${res.status}`);
-                }
-                onRevoke();
-              } catch (err) {
-                btn.disabled = false;
-                if (statusEl) {
-                  statusEl.dataset.state = "error";
-                  statusEl.textContent =
-                    err instanceof Error && err.message ? err.message : "Couldn't revoke the link.";
-                  statusEl.hidden = false;
-                }
-              }
-            })();
-          });
-        });
-      }
-
-      function renderGithubLinks(host: HTMLElement, links: GithubLink[]): void {
+      function renderGithubLinks(host: HTMLElement, links: AdminGithubLink[]): void {
         host.innerHTML = links.length
           ? `<h4 class="github-links-heading ${ADMIN_DETAIL_HEADING}">GitHub repos claimed</h4>
            <ul class="github-links-list list-none m-0 p-0 grid gap-1">
@@ -644,7 +565,7 @@ export const prerender = false;
           : "";
       }
 
-      function renderWorkspace(ws: WorkspaceSummary): HTMLElement {
+      function renderWorkspace(ws: AdminWorkspaceSummary): HTMLElement {
         const group = document.createElement("tbody");
         group.className = "admin-row-group workspace";
         const org = ws.organization ? ws.organization.name : "no organization yet";
@@ -732,7 +653,7 @@ export const prerender = false;
             const inviteLinksEl = group.querySelector<HTMLElement>(".invite-links-list");
             if (!inviteLinksEl) return;
             try {
-              const { links } = await apiGet<{ links: InviteLink[] }>(
+              const { links } = await apiGet<{ links: OpenEnrollment[] }>(
                 `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/invite-links`,
               );
               renderInviteLinks(inviteLinksEl, ws.workspace, links, reloadInviteLinks);
@@ -759,10 +680,10 @@ export const prerender = false;
             loadOnce(membersLoaded, async () => {
               try {
                 const [{ members }, { invites }] = await Promise.all([
-                  apiGet<{ members: Member[] }>(
+                  apiGet<{ members: OrgMember[] }>(
                     `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/members`,
                   ),
-                  apiGet<{ invites: Invite[] }>(
+                  apiGet<{ invites: OrgInvite[] }>(
                     `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/invites`,
                   ),
                 ]);
@@ -787,7 +708,7 @@ export const prerender = false;
             const planEl = group.querySelector<HTMLElement>(".plan");
             if (!planEl) return;
             try {
-              const planData = await apiGet<PlanResponse>(
+              const planData = await apiGet<AdminPlanResponse>(
                 `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/plan`,
               );
               renderPlanSelector(planEl, ws.workspace, planData);
@@ -801,7 +722,7 @@ export const prerender = false;
             const limitsEl = group.querySelector<HTMLElement>(".limits");
             if (!limitsEl) return;
             try {
-              const limitsData = await apiGet<LimitsResponse>(
+              const limitsData = await apiGet<AdminLimitsResponse>(
                 `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/limits`,
               );
               renderLimitsForm(limitsEl, ws.workspace, limitsData);
@@ -815,7 +736,7 @@ export const prerender = false;
             const storageEl = group.querySelector<HTMLElement>(".storage");
             if (!storageEl) return;
             try {
-              const storageData = await apiGet<StorageResponse>(
+              const storageData = await apiGet<AdminStorageResponse>(
                 `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/storage`,
               );
               renderStorageForm(storageEl, ws.workspace, storageData);
@@ -829,7 +750,7 @@ export const prerender = false;
             const githubLinksEl = group.querySelector<HTMLElement>(".github-links");
             if (!githubLinksEl) return;
             try {
-              const { links } = await apiGet<GithubLinksResponse>(
+              const { links } = await apiGet<{ links: AdminGithubLink[] }>(
                 `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/github-links`,
               );
               renderGithubLinks(githubLinksEl, links);
@@ -986,7 +907,7 @@ export const prerender = false;
       async function loadWorkspaces() {
         const tableWrap = document.getElementById("workspaces-table-wrap");
         try {
-          const { workspaces } = await apiGet<{ workspaces: WorkspaceSummary[] }>(
+          const { workspaces } = await apiGet<{ workspaces: AdminWorkspaceSummary[] }>(
             "/admin-ui/workspaces",
           );
           workspacesStatus.hidden = true;

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -463,6 +463,7 @@ const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
     import { ADMIN_TD, ADMIN_TD_NUM, escapeHtml } from "../../lib/admin-ui";
     import { formatBytes } from "../../lib/workspace-ui";
+    import type { MetricsOverview } from "@uploads/api/admin-ui";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("metrics-tiles")) return;
@@ -471,49 +472,6 @@ const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
       const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
       const status = requireElement<HTMLElement>("#metrics-status", "admin metrics");
       const content = requireElement<HTMLElement>("#metrics-content", "admin metrics");
-
-      interface DayPoint {
-        day: string;
-        count: number;
-        bytes: number;
-      }
-      interface SignupPoint {
-        day: string;
-        count: number;
-      }
-      interface WorkspaceRow {
-        workspace: string;
-        uploads: number;
-        bytes: number;
-        lastActive: string;
-      }
-      interface MultiIdentityWorkspaceRow {
-        workspace: string;
-        users: number;
-      }
-      // Mirrors apps/api/src/metrics-overview.ts's MetricsOverview exactly.
-      // `totals.workspaces` is workspaces with >=1 recorded upload — not the
-      // registration count (idle workspaces have no workspace_usage row).
-      // `totals.orgs` is the registration figure. `totals.storedBytes` is
-      // current absolute stored bytes; `totals.bytes` is bytes uploaded
-      // within the selected window, not stored bytes.
-      interface Overview {
-        window: { days: number; since: string };
-        totals: {
-          users: number;
-          orgs: number;
-          workspaces: number;
-          storedBytes: number;
-          activeWorkspaces7d: number;
-          activeWorkspaces30d: number;
-          uploads: number;
-          bytes: number;
-        };
-        series: { uploads: DayPoint[]; users: SignupPoint[]; orgs: SignupPoint[] };
-        features: Record<string, number>;
-        workspaces: WorkspaceRow[];
-        multiIdentityWorkspaces: MultiIdentityWorkspaceRow[];
-      }
 
       let days = 30;
 
@@ -816,7 +774,7 @@ const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
         wrap?.addEventListener("focusout", hide);
       }
 
-      function render(overview: Overview): void {
+      function render(overview: MetricsOverview): void {
         const tile = (id: string, value: string) => {
           const el = document.getElementById(id);
           if (el) el.textContent = value;
@@ -1034,7 +992,7 @@ const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
           });
           if (seq !== loadSeq) return;
           if (!res.ok) throw new Error(`request failed: ${res.status}`);
-          const overview = (await res.json()) as Overview;
+          const overview = (await res.json()) as MetricsOverview;
           if (seq !== loadSeq) return;
           render(overview);
           status.hidden = true;

--- a/apps/web/src/pages/admin/oauth.astro
+++ b/apps/web/src/pages/admin/oauth.astro
@@ -131,6 +131,7 @@ export const prerender = false;
       ADMIN_TD_NUM,
       escapeHtml,
     } from "../../lib/admin-ui";
+    import type { SerializedOauthClient } from "@uploads/api/admin-ui";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("oauth-list-body")) return;
@@ -142,26 +143,6 @@ export const prerender = false;
       const oauthListBody = requireElement<HTMLElement>("#oauth-list-body", "admin oauth");
       const tableWrap = requireElement<HTMLElement>("#oauth-table-wrap", "admin oauth");
 
-      interface OAuthClient {
-        clientId: string;
-        name: string | null;
-        type: string;
-        public: boolean;
-        disabled: boolean;
-        official: boolean;
-        redirectUris: string[];
-        scopes: string[];
-        uri: string | null;
-        icon: string | null;
-        userId: string | null;
-        skipConsent: boolean;
-        createdAt: number;
-        updatedAt: number;
-        consentCount: number;
-        activeTokenCount: number;
-        lastConsentAt: number | null;
-      }
-
       async function apiGet<T>(path: string): Promise<T> {
         const res = await fetch(`${apiOrigin}${path}`, {
           credentials: "include",
@@ -171,7 +152,7 @@ export const prerender = false;
         return (await res.json()) as T;
       }
 
-      function badges(client: OAuthClient): string {
+      function badges(client: SerializedOauthClient): string {
         const parts: string[] = [];
         if (client.official)
           parts.push(`<span class="pill is-admin text-primary border-primary">Official</span>`);
@@ -182,7 +163,7 @@ export const prerender = false;
         return parts.join(" ") || `<span class="muted">-</span>`;
       }
 
-      function renderClient(client: OAuthClient): HTMLElement {
+      function renderClient(client: SerializedOauthClient): HTMLElement {
         const row = document.createElement("tr");
         row.className = "admin-row";
         const href = `/admin/oauth/${encodeURIComponent(client.clientId)}`;
@@ -194,7 +175,7 @@ export const prerender = false;
           </td>
           <td class="optional mono muted ${ADMIN_TD} ${ADMIN_CELL_MONO} ${ADMIN_CELL_MUTED}">${escapeHtml(client.clientId)}</td>
           <td class="optional muted ${ADMIN_TD} ${ADMIN_CELL_MUTED}">${client.scopes.map(escapeHtml).join(", ") || "-"}</td>
-          <td class="optional muted ${ADMIN_TD} ${ADMIN_CELL_MUTED}">${new Date(client.createdAt).toLocaleDateString()}</td>
+          <td class="optional muted ${ADMIN_TD} ${ADMIN_CELL_MUTED}">${client.createdAt ? new Date(client.createdAt).toLocaleDateString() : "-"}</td>
           <td class="num optional ${ADMIN_TD_NUM}">${client.consentCount}</td>
           <td class="actions ${ADMIN_TD_ACTIONS}">${badges(client)}</td>
         `;
@@ -202,9 +183,11 @@ export const prerender = false;
       }
 
       async function loadClients() {
-        let clients: OAuthClient[];
+        let clients: SerializedOauthClient[];
         try {
-          ({ clients } = await apiGet<{ clients: OAuthClient[] }>("/admin-ui/oauth-clients"));
+          ({ clients } = await apiGet<{ clients: SerializedOauthClient[] }>(
+            "/admin-ui/oauth-clients",
+          ));
         } catch {
           oauthStatus.hidden = false;
           oauthStatus.textContent = "Failed to load OAuth apps.";
@@ -288,7 +271,7 @@ export const prerender = false;
                 `create failed: ${res.status}`;
               throw new Error(message);
             }
-            const client = (await res.json()) as OAuthClient;
+            const client = (await res.json()) as SerializedOauthClient;
 
             createClientIdInput.value = client.clientId;
             createResult.hidden = false;

--- a/apps/web/src/pages/admin/oauth/[clientId].astro
+++ b/apps/web/src/pages/admin/oauth/[clientId].astro
@@ -196,6 +196,7 @@ if (!clientId) return Astro.redirect("/admin/oauth");
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../../lib/account-shell";
     import { escapeHtml } from "../../../lib/admin-ui";
+    import type { SerializedOauthClient } from "@uploads/api/admin-ui";
 
     onAstroPageLoad(() => {
       const detailEl = document.getElementById("oauth-detail");
@@ -204,26 +205,6 @@ if (!clientId) return Astro.redirect("/admin/oauth");
       const w = window as unknown as { __UPLOADS_API_ORIGIN__: string };
       const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
       const clientId = decodeURIComponent(location.pathname.split("/").pop() ?? "");
-
-      interface OAuthClient {
-        clientId: string;
-        name: string;
-        type: string;
-        public: boolean;
-        disabled: boolean;
-        official: boolean;
-        redirectUris: string[];
-        scopes: string[];
-        uri: string | null;
-        icon: string | null;
-        userId: string | null;
-        skipConsent: boolean;
-        createdAt: number;
-        updatedAt: number;
-        consentCount: number;
-        activeTokenCount: number;
-        lastConsentAt: number | null;
-      }
 
       function errorMessage(payload: unknown, fallback: string): string {
         if (payload && typeof payload === "object") {
@@ -281,9 +262,9 @@ if (!clientId) return Astro.redirect("/admin/oauth");
         "admin oauth detail",
       );
 
-      let current: OAuthClient | null = null;
+      let current: SerializedOauthClient | null = null;
 
-      function badges(client: OAuthClient): string {
+      function badges(client: SerializedOauthClient): string {
         const parts: string[] = [];
         if (client.official)
           parts.push(`<span class="pill is-admin text-primary border-primary">Official</span>`);
@@ -294,7 +275,7 @@ if (!clientId) return Astro.redirect("/admin/oauth");
         return parts.join(" ");
       }
 
-      function render(client: OAuthClient): void {
+      function render(client: SerializedOauthClient): void {
         current = client;
         document.title = `${client.name} · OAuth apps · Admin · uploads.sh`;
         nameEl.textContent = client.name;
@@ -310,7 +291,9 @@ if (!clientId) return Astro.redirect("/admin/oauth");
         lastConsentEl.textContent = client.lastConsentAt
           ? new Date(client.lastConsentAt).toLocaleString()
           : "Never";
-        createdEl.textContent = new Date(client.createdAt).toLocaleString();
+        createdEl.textContent = client.createdAt
+          ? new Date(client.createdAt).toLocaleString()
+          : "Unknown";
         disableToggleBtn.textContent = client.disabled ? "Enable" : "Disable";
         deleteBtn.disabled = client.official;
         deleteHintEl.hidden = !client.official;
@@ -353,7 +336,7 @@ if (!clientId) return Astro.redirect("/admin/oauth");
             return;
           }
           if (!res.ok) throw new Error(`request failed: ${res.status}`);
-          const client = (await res.json()) as OAuthClient;
+          const client = (await res.json()) as SerializedOauthClient;
           statusEl.hidden = true;
           detail.hidden = false;
           render(client);
@@ -422,7 +405,7 @@ if (!clientId) return Astro.redirect("/admin/oauth");
               const payload = await res.json().catch(() => null);
               throw new Error(errorMessage(payload, `save failed: ${res.status}`));
             }
-            const client = (await res.json()) as OAuthClient;
+            const client = (await res.json()) as SerializedOauthClient;
             render(client);
             editForm.hidden = true;
             actionStatus.dataset.state = "ready";
@@ -458,7 +441,7 @@ if (!clientId) return Astro.redirect("/admin/oauth");
               const payload = await res.json().catch(() => null);
               throw new Error(errorMessage(payload, `update failed: ${res.status}`));
             }
-            const client = (await res.json()) as OAuthClient;
+            const client = (await res.json()) as SerializedOauthClient;
             render(client);
           } catch (err) {
             actionStatus.dataset.state = "error";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@types/node':
         specifier: ^26.1.0
         version: 26.1.0
+      '@uploads/auth':
+        specifier: workspace:^
+        version: link:../auth
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -246,6 +249,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@uploads/api':
+        specifier: workspace:^
+        version: link:../api
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary
Follow-up to #895. The admin pages hand-wrote duplicate response interfaces and cast `res.json() as T`, so server/client drift was invisible to TypeScript — the null-name DCR bug got through exactly that gap.

- Producers export inferred response types (`ReturnType` of the real serializers): `apps/api/src/routes/admin-ui.ts` gains `SerializedOauthClient`, `AdminWorkspaceSummary`, `AdminLimitsResponse`, `AdminPlanResponse`, `AdminStorageResponse`, `MetricsOverview`, etc.
- `serializeClient` moved from `internal-routes.ts` to a new Env-free `apps/auth/src/oauth-client-serialize.ts` — shared modules must not reference the ambient per-app `Env` global or the importing app's declaration wins and typecheck breaks. Re-exported through `@uploads/api/admin-ui` so page imports match the fetch URL.
- Admin pages (`oauth`, `oauth/[clientId]`, `index`, `metrics`) drop 18 local interfaces for `import type` — type-only, zero runtime coupling. `admin/users` untouched (already parses via `auth-client`).

## Latent bugs the compiler caught
- `limitsResponse` never returned `maxMembers`, so the admin Limits form's Members input always rendered blank — fixed server-side, test assertion updated.
- `createdAt` is `number | null` (`toEpochMs`) but both OAuth pages did `new Date(client.createdAt)` — now guarded (`-` / `Unknown`).

## Testing
- 5498 tests pass; `typecheck` clean in web (0 errors / 211 files), api, auth; lint clean.