### PR TITLE
fix(api): harden isInternalOrLiteralHost against alternate IPv4 encodings

### DIFF
--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -593,6 +593,52 @@ describe("verifyStorageConfig — s3 candidates", () => {
     expect(result.checks[0].hint).toMatch(/endpoint/);
   });
 
+  it("fails shape when the endpoint host is an internal IP with a trailing dot (169.254.169.254.)", async () => {
+    const result = await verifyStorageConfig(
+      { ...VALID_S3, endpoint: "https://169.254.169.254." },
+      { createClient: () => new FakeStorageClient() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/endpoint/);
+  });
+
+  it("fails shape when the endpoint host is a hex-encoded internal IP (0x7f.0x0.0x0.0x1)", async () => {
+    const result = await verifyStorageConfig(
+      { ...VALID_S3, endpoint: "https://0x7f.0x0.0x0.0x1" },
+      { createClient: () => new FakeStorageClient() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/endpoint/);
+  });
+
+  it("fails shape when the endpoint host is an octal-encoded internal IP (0177.0.0.1)", async () => {
+    const result = await verifyStorageConfig(
+      { ...VALID_S3, endpoint: "https://0177.0.0.1" },
+      { createClient: () => new FakeStorageClient() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/endpoint/);
+  });
+
+  it("fails shape when the endpoint host is a single-integer IP literal (2130706433)", async () => {
+    const result = await verifyStorageConfig(
+      { ...VALID_S3, endpoint: "https://2130706433" },
+      { createClient: () => new FakeStorageClient() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/endpoint/);
+  });
+
+  // A trailing dot on an otherwise-legit hostname is normalized away rather
+  // than rejected — "example.com." and "example.com" mean the same host.
+  it("passes shape for a legit hostname with a trailing dot (example.com.)", async () => {
+    const result = await verifyStorageConfig(
+      { ...VALID_S3, endpoint: "https://example.com." },
+      { createClient: () => new FakeStorageClient() },
+    );
+    expect(result.checks.find((c) => c.id === "shape")!.ok).toBe(true);
+  });
+
   it("fails shape when the endpoint host is localhost", async () => {
     const result = await verifyStorageConfig(
       { ...VALID_S3, endpoint: "https://localhost" },

--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -620,6 +620,24 @@ describe("verifyStorageConfig — s3 candidates", () => {
     expect(result.checks[0].hint).toMatch(/endpoint/);
   });
 
+  it("fails shape when the endpoint host is a shorthand IPv4 literal (127.1)", async () => {
+    const result = await verifyStorageConfig(
+      { ...VALID_S3, endpoint: "https://127.1" },
+      { createClient: () => new FakeStorageClient() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/endpoint/);
+  });
+
+  it("fails shape when the endpoint host is a three-part IPv4 shorthand (1.2.3)", async () => {
+    const result = await verifyStorageConfig(
+      { ...VALID_S3, endpoint: "https://1.2.3" },
+      { createClient: () => new FakeStorageClient() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/endpoint/);
+  });
+
   it("fails shape when the endpoint host is a single-integer IP literal (2130706433)", async () => {
     const result = await verifyStorageConfig(
       { ...VALID_S3, endpoint: "https://2130706433" },

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -228,18 +228,67 @@ function checkShape(candidate: StorageVerifyCandidate): StorageVerifyCheck {
 }
 
 /**
+ * True when a dotted-decimal label is a plain base-10 octet (no leading
+ * zero padding tricks, no hex/octal prefixes) that a browser/URL parser
+ * would treat the same way we do.
+ */
+function isPlainDecimalOctet(label: string): boolean {
+  return /^\d{1,3}$/.test(label) && Number(label) <= 255;
+}
+
+/**
+ * True when `label` is a numeric-ish IPv4 octet encoding — hex (`0x7f`),
+ * octal (`0177`), or a bare decimal digit string — the kind of thing
+ * browsers and `fetch()` will still resolve as part of an IP literal even
+ * though it doesn't match plain dotted-decimal. We don't need to compute
+ * the resulting address, just recognize the shape so it can be rejected.
+ */
+function looksLikeNumericIPv4Label(label: string): boolean {
+  return (
+    /^0x[0-9a-f]+$/i.test(label) || // hex octet, e.g. 0x7f
+    /^0[0-7]+$/.test(label) || // octal octet, e.g. 0177
+    /^\d+$/.test(label) // plain decimal, including >255 or a single 32-bit integer
+  );
+}
+
+/**
  * True when `host` looks like an internal name or literal address that must
  * never be reached from inside the worker — shared by the `publicBaseUrl`
  * shape check and the s3 `endpoint` shape check.
  */
 function isInternalOrLiteralHost(host: string): boolean {
-  return (
-    host === "localhost" ||
-    host.endsWith(".localhost") ||
-    !host.includes(".") ||
-    /^\d{1,3}(\.\d{1,3}){3}$/.test(host) ||
-    host.startsWith("[")
-  );
+  // A single trailing dot is a valid (if unusual) way to write an absolute
+  // hostname, e.g. "example.com." or "169.254.169.254." — strip exactly one
+  // before checking so it can't be used to slip a literal past the regex
+  // below.
+  const normalized = host.endsWith(".") && host.length > 1 ? host.slice(0, -1) : host;
+
+  if (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    !normalized.includes(".") ||
+    /^\d{1,3}(\.\d{1,3}){3}$/.test(normalized) ||
+    normalized.startsWith("[")
+  ) {
+    return true;
+  }
+
+  // Reject alternate IPv4 encodings (hex/octal octets, or a single
+  // all-digit label standing in for the whole 32-bit address) that some
+  // resolvers still accept but the plain dotted-decimal regex above
+  // misses, e.g. "0x7f.0x0.0x0.0x1", "0177.0.0.1", "2130706433". Fail
+  // closed: if every label looks numeric-ish, treat it as an IP literal
+  // even though we don't fully parse the value.
+  const labels = normalized.split(".");
+  if (
+    labels.length >= 1 &&
+    labels.every(looksLikeNumericIPv4Label) &&
+    !labels.every(isPlainDecimalOctet)
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 /** Shape-checks an s3 candidate's `endpoint`: https origin only, no path/query/fragment, public host. */

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -228,15 +228,6 @@ function checkShape(candidate: StorageVerifyCandidate): StorageVerifyCheck {
 }
 
 /**
- * True when a dotted-decimal label is a plain base-10 octet (no leading
- * zero padding tricks, no hex/octal prefixes) that a browser/URL parser
- * would treat the same way we do.
- */
-function isPlainDecimalOctet(label: string): boolean {
-  return /^\d{1,3}$/.test(label) && Number(label) <= 255;
-}
-
-/**
  * True when `label` is a numeric-ish IPv4 octet encoding — hex (`0x7f`),
  * octal (`0177`), or a bare decimal digit string — the kind of thing
  * browsers and `fetch()` will still resolve as part of an IP literal even
@@ -273,22 +264,14 @@ function isInternalOrLiteralHost(host: string): boolean {
     return true;
   }
 
-  // Reject alternate IPv4 encodings (hex/octal octets, or a single
-  // all-digit label standing in for the whole 32-bit address) that some
-  // resolvers still accept but the plain dotted-decimal regex above
-  // misses, e.g. "0x7f.0x0.0x0.0x1", "0177.0.0.1", "2130706433". Fail
-  // closed: if every label looks numeric-ish, treat it as an IP literal
-  // even though we don't fully parse the value.
-  const labels = normalized.split(".");
-  if (
-    labels.length >= 1 &&
-    labels.every(looksLikeNumericIPv4Label) &&
-    !labels.every(isPlainDecimalOctet)
-  ) {
-    return true;
-  }
-
-  return false;
+  // Reject alternate IPv4 encodings (hex/octal octets, shorthand forms
+  // like "127.1", or a single all-digit label standing in for the whole
+  // 32-bit address) that resolvers still accept but the plain
+  // dotted-decimal regex above misses, e.g. "0x7f.0x0.0x0.0x1",
+  // "0177.0.0.1", "2130706433". All-numeric labels can never form a real
+  // domain (TLDs are never numeric), so fail closed: if every label looks
+  // numeric-ish, treat the host as an IP literal without fully parsing it.
+  return normalized.split(".").every(looksLikeNumericIPv4Label);
 }
 
 /** Shape-checks an s3 candidate's `endpoint`: https origin only, no path/query/fragment, public host. */


### PR DESCRIPTION
## Summary

`isInternalOrLiteralHost` in `apps/api/src/storage-verify.ts` is shared by the `publicBaseUrl` shape check and the BYO `endpoint` check. Two encodings slipped past the dotted-decimal IPv4 match:

1. A trailing-dot host literal, e.g. `169.254.169.254.`
2. Hex/octal IPv4 encodings, e.g. `0x7f.0x0.0x0.0x1`, `0177.0.0.1`, and single-integer forms like `2130706433`

## Approach

Before the existing checks run, the host is normalized:

- Strip exactly one trailing dot (an absolute hostname like `example.com.` and `169.254.169.254.` are otherwise equivalent to their non-dotted form).
- If every dot-separated label looks like a numeric IPv4 encoding (hex `0x...`, octal `0...`, or all-digit) and the host isn't already a plain dotted-decimal literal, treat it as an IP literal and reject.

This fails closed: any host made entirely of numeric-ish labels is rejected as internal/literal, even without fully parsing the resulting address. `example.com.` normalizes to `example.com` and is allowed (a trailing dot on a legit hostname means the same host).

Both callers (`checkEndpointShape` for BYO s3 `endpoint`, `checkPublicBaseUrlShape` for `publicBaseUrl`) share the one helper, so both get the fix.

## Tests

Added cases to `apps/api/src/storage-verify.test.ts`:
- `169.254.169.254.` (trailing dot) — rejected
- `0x7f.0x0.0x0.0x1` (hex) — rejected
- `0177.0.0.1` (octal) — rejected
- `2130706433` (single integer) — rejected
- `example.com.` (legit hostname, trailing dot) — allowed after normalization

`pnpm --filter api test` and the full repo test suite pass (2482 tests, 172 files). `oxfmt` and the repo's pre-commit lint/format/types hooks passed clean.

No changeset — this repo's changesets are CLI-package-only; this change is in `apps/api`.

Closes #901