### PR TITLE
test(storage): env-gated real-AWS live smoke block

### DIFF
--- a/packages/storage/test/s3-live-smoke.test.ts
+++ b/packages/storage/test/s3-live-smoke.test.ts
@@ -9,6 +9,48 @@ const accessKeyId = env.UPLOADS_TEST_R2_ACCESS_KEY_ID;
 const secretAccessKey = env.UPLOADS_TEST_R2_SECRET_ACCESS_KEY;
 const run = accessKeyId && secretAccessKey ? describe : describe.skip;
 
+const awsAccessKeyId = env.UPLOADS_TEST_S3_ACCESS_KEY_ID;
+const awsSecretAccessKey = env.UPLOADS_TEST_S3_SECRET_ACCESS_KEY;
+const awsBucket = env.UPLOADS_TEST_S3_BUCKET;
+const awsEndpoint = env.UPLOADS_TEST_S3_ENDPOINT ?? "https://s3.us-east-1.amazonaws.com";
+const awsRegion =
+  env.UPLOADS_TEST_S3_REGION ??
+  /s3[.-]([a-z0-9-]+)\.amazonaws\.com/.exec(awsEndpoint)?.[1] ??
+  "us-east-1";
+const runAws = awsAccessKeyId && awsSecretAccessKey && awsBucket ? describe : describe.skip;
+
+runAws("live s3 smoke vs real AWS (strict region-scoped signing)", () => {
+  it("upload → head → download → list → delete round-trip", async () => {
+    const files = createStorage({
+      provider: "s3",
+      bucket: awsBucket as string,
+      prefix: "s3-smoke/",
+      endpoint: awsEndpoint,
+      region: awsRegion,
+      forcePathStyle: false,
+      accessKeyId: awsAccessKeyId as string,
+      secretAccessKey: awsSecretAccessKey as string,
+    });
+
+    const key = `live-${Date.now()}.txt`;
+    const body = `s3 smoke ${new Date().toISOString()}`;
+
+    await files.upload(key, new TextEncoder().encode(body), { contentType: "text/plain" });
+
+    const head = await files.head(key);
+    expect(head.size).toBe(body.length);
+
+    const dl = await files.download(key);
+    expect(await dl.text()).toBe(body);
+
+    const listed = await files.list();
+    expect(listed.items.map((f) => f.key)).toContain(key);
+
+    await files.delete(key);
+    expect(await files.exists(key)).toBe(false);
+  }, 30_000);
+});
+
 run("live s3 smoke vs R2 S3 endpoint", () => {
   it("upload → head → download → list → delete round-trip", async () => {
     const files = createStorage({


### PR DESCRIPTION
Adds a second env-gated block to `s3-live-smoke.test.ts` targeting real AWS S3: strict region-scoped SigV4 signing, virtual-hosted addressing (`forcePathStyle` off). Gated on `UPLOADS_TEST_S3_ACCESS_KEY_ID` / `UPLOADS_TEST_S3_SECRET_ACCESS_KEY` / `UPLOADS_TEST_S3_BUCKET` (endpoint/region optional, default us-east-1); skipped in CI.

Verified locally against a real us-east-1 bucket: full upload → head → download → list → delete round-trip passing.

Closes #903.