### PR TITLE
fix(web): widen docs content area to match releases layout

### DIFF
--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -94,7 +94,7 @@ const fullTitle = `${title} · uploads.sh`;
          here — nesting would shrink the footer to the 1120px shell and leave
          no gap between article end and the footer border. */
       .docs-shell {
-        width: min(1120px, 100%);
+        width: min(1440px, 100%);
         margin: 0 auto;
         padding: 32px 24px 64px;
         flex: 1 0 auto;
@@ -109,7 +109,12 @@ const fullTitle = `${title} · uploads.sh`;
       main.docs-main {
         flex: 1 1 auto;
         min-width: 0;
-        max-width: 720px;
+        /* Fill the column between the nav and TOC rails rather than capping at
+           a fixed width — matches the releases.sh docs, which let the article
+           flex-fill the shell. Prose stays readable via the per-element
+           `--measure` cap below; wide blocks (code, tables, figures) get the
+           extra room. */
+        max-width: none;
       }
       main.docs-main > h1 {
         font-size: var(--text-h1);


### PR DESCRIPTION
## What

The docs/guides content area was cramped even on wide screens. This widens it to match the releases.sh docs layout.

- **Shell** `min(1120px, 100%)` → `min(1440px, 100%)` (releases uses 90rem).
- **Article column** `max-width: 720px` → `max-width: none`, so it flex-fills the space between the left nav and right TOC rails instead of capping short.

Prose stays readable via the existing per-element `--measure` (68ch) cap on `.doc p` / `.doc li`; the extra room goes to wide blocks — code, tables, figures, the GitHub-comment mock. Responsive breakpoints (1180px drops the TOC rail, 880px collapses the nav) are unchanged.

## Before / after

`/docs/comment-config` at a 1600px viewport:

| Before | After |
| --- | --- |
| <img width="440" alt="Docs at 1120px shell — narrow column floating in empty space, code block truncated" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/908/localhost-docs-comment-config-before.webp"> | <img width="440" alt="Docs at 1440px shell — article flex-fills, code block full width" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/908/localhost-docs-comment-config-after.webp"> |

## Verify

Checked at 1600px viewport: shell renders at 1440, the article fills 1160 on a TOC-less page and ~920 with the TOC rail, three-column layout intact, no horizontal overflow.

No changeset — `@uploads/web` is in the changeset ignore list.
