### PR TITLE
fix(auth): add 60s refresh-token rotation reuse grace

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -742,6 +742,18 @@ function buildAuth(
         enforcePerClientResources: false,
         allowDynamicClientRegistration: true,
         allowUnauthenticatedClientRegistration: true,
+        // Refresh tokens rotate on every refresh, and the plugin's default
+        // reuse grace is 0 — a second use of a just-rotated token (a network
+        // retry whose first attempt landed, or two processes of the same
+        // client sharing one stored token, e.g. multiple OpenCode sessions)
+        // is treated as theft and tears down the ENTIRE refresh-token family
+        // per RFC 9700 §4.14, forcing a full interactive re-auth. Within this
+        // window the plugin instead replays the stored rotation response
+        // (`rotationReplayResponse`), so concurrent refreshers all end up
+        // with the same valid token pair. 60s matches the order of Auth0's
+        // recommended rotation leeway and is far too short to matter for
+        // actual stolen-token replay.
+        refreshTokenReuseInterval: 60,
         // Explicit abuse ceiling on the public /oauth2/register endpoint —
         // pinned here rather than the plugin's library default so it's
         // auditable and can't silently drift. Enforced only when Better


### PR DESCRIPTION
## Summary

A user reported OpenCode's MCP connection to `agents.uploads.sh` demanding re-authentication less than a day after signing in, while the CLI (device-flow session token) stayed signed in.

Token lifetimes were not the cause — the OAuth provider issues 1h access tokens and 30d refresh tokens. The culprit is refresh-token rotation with **zero reuse grace** (Better Auth's base `oauthProvider()` default): every refresh revokes the old token, and any reuse of a just-rotated token — a network retry whose first attempt actually landed, or two processes of the same client sharing one stored token (multiple OpenCode sessions) — is treated as theft and tears down the entire refresh-token family per RFC 9700 §4.14, forcing a full interactive re-auth.

## Change

Set `refreshTokenReuseInterval: 60` on the `oauthProvider()` config. Within that window the plugin replays the stored rotation response (`rotationReplayResponse`, columns already in our schema) instead of invalidating the family, so concurrent refreshers converge on the same valid token pair.

Precedent:
- Better Auth's own `mcp()` plugin defaults this to 30s; only the base provider defaults to strict 0 (see also better-auth/better-auth#8512).
- Auth0 ("rotation overlap period"/leeway) and Okta ship the same grace-window concept for exactly this multi-process/native-client case.
- OpenCode has open issues in this failure class (anomalyco/opencode#21702, #13998).

The 60s window only forgives the immediately-prior token and is far too short to matter for real stolen-token replay.

## Testing

- `tsc --noEmit` clean in `apps/auth`
- `pnpm test` — 5568 passed
