### PR TITLE
fix(auth): grant offline_access so OAuth clients get refresh tokens

### DIFF
--- a/apps/api/migrations/20260831120000_oauth_client_offline_access.sql
+++ b/apps/api/migrations/20260831120000_oauth_client_offline_access.sql
@@ -1,0 +1,16 @@
+-- Issue #911: refresh tokens are only issued when the grant carries
+-- offline_access, which no client was registered for. New registrations get
+-- it via clientRegistrationDefaultScopes (apps/auth/src/auth.ts); this
+-- backfills every existing oauth_client row so already-registered clients
+-- (OpenCode, Cursor, MCP Inspector, ...) can hold refresh tokens without
+-- re-registering. `scopes` is a JSON TEXT array; json_insert('$[#]')
+-- appends. Rows already carrying the scope (none today, but the migration
+-- must be re-runnable against previews) are skipped.
+UPDATE oauth_client
+SET scopes = json_insert(scopes, '$[#]', 'offline_access')
+WHERE scopes IS NOT NULL
+  AND json_valid(scopes)
+  AND NOT EXISTS (
+    SELECT 1 FROM json_each(oauth_client.scopes)
+    WHERE json_each.value = 'offline_access'
+  );

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -97,8 +97,24 @@ export function isCliSessionUserAgent(ua?: string | null): boolean {
  */
 export const OAUTH_SCOPES = ["files:read", "files:write", "files:delete"] as const;
 
+/**
+ * Issue #911: `@better-auth/oauth-provider` only issues a refresh token when
+ * the grant's scopes include `offline_access` (see createUserTokens in the
+ * plugin) — without it every OAuth/MCP client got a 1h access token and a
+ * forced interactive re-auth on expiry. Registered by default on every
+ * self-registered client, unioned into authorize requests by
+ * oauth-grant-scopes.ts (clients copy `scope` from the resource metadata,
+ * which advertises only files:*), and backfilled onto existing clients by
+ * migration 20260831120000_oauth_client_offline_access.sql.
+ */
+export const OAUTH_OFFLINE_ACCESS_SCOPE = "offline_access";
+
 /** Default scopes granted to a dynamically registered client that requests none. */
-const OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES = ["files:read", "files:write"] as const;
+const OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES = [
+  "files:read",
+  "files:write",
+  OAUTH_OFFLINE_ACCESS_SCOPE,
+] as const;
 
 /**
  * Extra scopes a CIMD/DCR client may request (consent still required). Better
@@ -705,7 +721,7 @@ function buildAuth(
       oauthProvider({
         loginPage: `${webOrigin}/login`,
         consentPage: `${webOrigin}/oauth/consent`,
-        scopes: [...OAUTH_SCOPES],
+        scopes: [...OAUTH_SCOPES, OAUTH_OFFLINE_ACCESS_SCOPE],
         clientRegistrationDefaultScopes: [...OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES],
         // Better Auth 1.7 persists every self-registered client (DCR and
         // CIMD alike) with scope = defaultScopes ∪ allowedScopes, DISCARDING

--- a/apps/auth/src/oauth-grant-scopes.test.ts
+++ b/apps/auth/src/oauth-grant-scopes.test.ts
@@ -44,6 +44,35 @@ describe("restrictOAuthQueryScopes", () => {
       scope: "",
     });
   });
+
+  // Issue #911: MCP clients copy `scope=` from the resource metadata
+  // (files:* only), so offline_access — required for a refresh token —
+  // must be unioned in server-side for clients registered with it.
+  const WITH_OFFLINE = [...SELF_REGISTERED, "offline_access"] as const;
+
+  it("unions offline_access into a files:* request when the client is registered for it", () => {
+    expect(restrictOAuthQueryScopes({ scope: "files:read files:write" }, WITH_OFFLINE)).toEqual({
+      scope: "files:read files:write offline_access",
+    });
+  });
+
+  it("keeps an already-requested offline_access without duplicating it", () => {
+    expect(
+      restrictOAuthQueryScopes({ scope: "files:read offline_access" }, WITH_OFFLINE),
+    ).toBeUndefined();
+  });
+
+  it("does not union offline_access for a client not registered for it", () => {
+    expect(
+      restrictOAuthQueryScopes({ scope: "files:read files:write" }, SELF_REGISTERED),
+    ).toBeUndefined();
+  });
+
+  it("does not mint an offline_access-only grant from a nothing-grantable request", () => {
+    expect(restrictOAuthQueryScopes({ scope: "openid admin" }, WITH_OFFLINE)).toEqual({
+      scope: "",
+    });
+  });
 });
 
 describe("restrictOAuthConsentBody", () => {

--- a/apps/auth/src/oauth-grant-scopes.test.ts
+++ b/apps/auth/src/oauth-grant-scopes.test.ts
@@ -73,6 +73,12 @@ describe("restrictOAuthQueryScopes", () => {
       scope: "",
     });
   });
+
+  it("rejects an explicit offline_access-only request (no refresh-token-only grants)", () => {
+    expect(restrictOAuthQueryScopes({ scope: "offline_access" }, WITH_OFFLINE)).toEqual({
+      scope: "",
+    });
+  });
 });
 
 describe("restrictOAuthConsentBody", () => {

--- a/apps/auth/src/oauth-grant-scopes.ts
+++ b/apps/auth/src/oauth-grant-scopes.ts
@@ -33,9 +33,14 @@ const OFFLINE_ACCESS = "offline_access";
 function filterScopeString(scope: string, allowedScopes: readonly string[]): string | undefined {
   const requested = scope.split(/\s+/).filter(Boolean);
   const allow = new Set(allowedScopes);
-  const permitted = requested.filter((id) => KNOWN_SCOPES.has(id) && allow.has(id));
+  let permitted = requested.filter((id) => KNOWN_SCOPES.has(id) && allow.has(id));
   const grantsResourceScope = permitted.some((id) => id !== OFFLINE_ACCESS);
-  if (grantsResourceScope && allow.has(OFFLINE_ACCESS) && !permitted.includes(OFFLINE_ACCESS)) {
+  if (!grantsResourceScope) {
+    // An offline_access-only request must not survive: it would mint a
+    // refresh-token-only grant with no resource access. Dropping it lands in
+    // the plugin's invalid_scope path like any other nothing-grantable request.
+    permitted = [];
+  } else if (allow.has(OFFLINE_ACCESS) && !permitted.includes(OFFLINE_ACCESS)) {
     permitted.push(OFFLINE_ACCESS);
   }
   const next = permitted.join(" ");

--- a/apps/auth/src/oauth-grant-scopes.ts
+++ b/apps/auth/src/oauth-grant-scopes.ts
@@ -12,12 +12,32 @@
  * Known ids stay in lockstep with `OAUTH_SCOPES` in auth.ts (duplicated
  * rather than imported: auth.ts wires this module from `hooks.before`).
  */
-const KNOWN_SCOPES: ReadonlySet<string> = new Set(["files:read", "files:write", "files:delete"]);
+const KNOWN_SCOPES: ReadonlySet<string> = new Set([
+  "files:read",
+  "files:write",
+  "files:delete",
+  "offline_access",
+]);
+
+/**
+ * Issue #911: the plugin only issues a refresh token when the grant carries
+ * `offline_access`, but MCP clients build `scope=` from the resource
+ * metadata's `scopes_supported` (files:* only) and so never request it.
+ * Union it in server-side for any client registered with it — but only when
+ * the filtered request still grants a real resource scope, so a
+ * nothing-grantable request keeps its RFC 6749 §3.3 `invalid_scope` and an
+ * offline_access-only grant can't be minted from garbage.
+ */
+const OFFLINE_ACCESS = "offline_access";
 
 function filterScopeString(scope: string, allowedScopes: readonly string[]): string | undefined {
   const requested = scope.split(/\s+/).filter(Boolean);
   const allow = new Set(allowedScopes);
   const permitted = requested.filter((id) => KNOWN_SCOPES.has(id) && allow.has(id));
+  const grantsResourceScope = permitted.some((id) => id !== OFFLINE_ACCESS);
+  if (grantsResourceScope && allow.has(OFFLINE_ACCESS) && !permitted.includes(OFFLINE_ACCESS)) {
+    permitted.push(OFFLINE_ACCESS);
+  }
   const next = permitted.join(" ");
   return next === requested.join(" ") ? undefined : next;
 }

--- a/apps/auth/src/oauth.test.ts
+++ b/apps/auth/src/oauth.test.ts
@@ -81,9 +81,17 @@ describe("dynamic client registration", () => {
     );
     // Better Auth 1.7 returns RFC 7591-compliant 201 Created for DCR (was 200).
     expect(res.status).toBe(201);
-    const body = (await res.json()) as { client_id?: string; redirect_uris?: string[] };
+    const body = (await res.json()) as {
+      client_id?: string;
+      redirect_uris?: string[];
+      scope?: string;
+    };
     expect(typeof body.client_id).toBe("string");
     expect(body.redirect_uris).toEqual(["https://client.example.com/callback"]);
+    // Issue #911: without offline_access in the registered scopes the plugin
+    // never issues a refresh token, forcing interactive re-auth at access
+    // token expiry.
+    expect(body.scope?.split(" ")).toContain("offline_access");
   });
 
   // Better Auth 1.7 defaults DCR clients without `application_type` to "web",
@@ -359,16 +367,8 @@ describe("refresh token rotation reuse grace", () => {
       updatedAt: new Date(),
     });
     // The plugin only issues refresh tokens when the grant carries
-    // offline_access (introspect createUserTokens), and validates a refresh
-    // grant's scopes against the client's registered list — grant the client
-    // offline_access directly (DCR discards requested scope; see the
-    // clientRegistrationAllowedScopes comment in auth.ts).
-    (env.DB as FakeD1Database).__sqlite
-      .prepare("UPDATE oauth_client SET scopes = ? WHERE client_id = ?")
-      .run(
-        JSON.stringify(["files:read", "files:write", "files:delete", "offline_access"]),
-        clientId,
-      );
+    // offline_access (issue #911) — registration defaults now include it,
+    // so the DCR client above can hold one with no extra setup.
     const rawToken = "reuse-grace-raw-refresh-token";
     await orm.insert(schema.oauthRefreshToken).values({
       id: crypto.randomUUID(),

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -444,6 +444,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
         "files:read": "Read your files",
         "files:write": "Upload and modify files",
         "files:delete": "Delete files",
+        offline_access: "Stay connected without signing in again",
       };
 
       // Hand-rolled lucide-style icons (stroke=currentColor, strokeWidth=2,
@@ -455,6 +456,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
           '<path d="M12 3v12"></path><path d="m7 8 5-5 5 5"></path><path d="M5 21h14"></path>',
         "files:delete":
           '<path d="M3 6h18"></path><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path><path d="M10 11v6"></path><path d="M14 11v6"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>',
+        // refresh-cw: the grant stays alive via refresh tokens (issue #911).
+        offline_access: '<path d="M21 12a9 9 0 1 1-2.64-6.36"></path><path d="M21 3v6h-6"></path>',
       };
       const UNKNOWN_SCOPE_ICON = '<path d="M12 2 4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5Z"></path>';
       const SCOPE_CHIP_TONE: Record<string, string> = {


### PR DESCRIPTION
Closes #911. Follows #909 (rotation reuse grace) and #910 (regression test).

## Problem

`@better-auth/oauth-provider` only issues a refresh token when the grant's scopes include `offline_access`. This AS never granted it — it wasn't in the scope list, DCR clients weren't registered with it, and the downscope hook stripped it from requests. Every OAuth/MCP client (OpenCode, Cursor, MCP Inspector) got a 1h access token and a forced interactive re-auth at expiry.

## Changes

- **Registration**: `offline_access` added to `clientRegistrationDefaultScopes` and the provider scope list — every self-registered client can now hold it.
- **Authorize/consent rewrite** (`oauth-grant-scopes.ts`): union `offline_access` into the request for clients registered with it. MCP clients copy `scope=` from the resource metadata, which stays `files:*` only, so they'd never ask on their own. The union is skipped when the filtered request grants no real resource scope, preserving `invalid_scope` for nothing-grantable requests.
- **Backfill migration** (`20260831120000_oauth_client_offline_access.sql`): appends `offline_access` to existing `oauth_client.scopes` JSON so already-registered clients don't need to re-register. Applies to prod via the D1 migrations workflow on merge.
- **Consent page**: description ("Stay connected without signing in again") + refresh icon for the new scope chip.
- **Tests**: the #910 reuse-grace test now runs on registration defaults alone (DCR → refresh issuance → rotation replay, end to end); DCR test asserts `offline_access` in the registered scope; four new unit tests for the union behavior.

Connected-apps revoke (#890/#891) already stamps `revoked` on refresh-token rows, so revocation kills the refresh path as intended.

## Testing

- `pnpm test` — 5573 passed
- `tsc --noEmit` (auth) and `astro check` (web) clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth clients now support offline access, enabling refresh tokens and continued connections without signing in again.
  * Newly registered clients include offline access by default.
  * Existing eligible clients are updated to support offline access.
  * OAuth consent screens display a clear description and icon for offline access.

* **Bug Fixes**
  * Improved scope handling to prevent invalid or offline-access-only grants while preserving standard invalid-scope behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->