### PR TITLE
feat(auth): observability for OAuth refresh-grant failures and rotation replays

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -10,7 +10,7 @@ import { dash } from "@better-auth/infra";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { betterAuth } from "better-auth";
-import { APIError, createAuthMiddleware } from "better-auth/api";
+import { APIError, createAuthMiddleware, isAPIError } from "better-auth/api";
 import { and, asc, eq, isNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import {
@@ -41,6 +41,7 @@ import { sendAuthEmail } from "./email";
 import { localDemoEnabled, localDemoPlugin } from "./local-demo";
 import { memberCapDenial } from "./member-cap";
 import { notifyAdminsOfMemberJoin } from "./notify-member-join";
+import { buildTokenGrantAfterHandler, captureRefreshTokenPriorState } from "./oauth-observability";
 import { createDurableRateLimitStorage, type RateLimitNamespaceLike } from "./rate-limit";
 import * as schema from "./schema";
 import { stripePluginOrNone } from "./stripe-plugin";
@@ -314,8 +315,23 @@ function authBeforeHook(
   return createAuthMiddleware(async (ctx) => {
     const oauthOverride = await applyOAuthClientInterop(ctx, registeredScopesForClientId);
     if (oauthOverride) return oauthOverride;
+    // Issue #912: snapshot the presented refresh token's D1 rotation state
+    // BEFORE the plugin's own /oauth2/token handler runs — see
+    // oauth-observability.ts's file doc comment for why this can't be done
+    // from the after hook alone. Cheap no-op for every other path/grant_type.
+    await captureRefreshTokenPriorState(db, ctx);
     await enforceLastAdminGuard(ctx, db);
   });
+}
+
+/**
+ * Issue #912: completes the refresh-grant/replay/teardown/no-refresh
+ * classification once the `/oauth2/token` response (success or thrown
+ * `APIError`) is known, and writes the resulting event(s) to Analytics
+ * Engine. See oauth-observability.ts for the full design.
+ */
+function oauthObservabilityAfterHook(env: { AUTH_EVENTS?: AnalyticsEngineDataset }) {
+  return createAuthMiddleware(buildTokenGrantAfterHandler(env, isAPIError));
 }
 
 /**
@@ -439,6 +455,14 @@ export type AuthEnv = GitHubCredentialsEnv &
     STRIPE_SECRET_KEY?: string;
     STRIPE_WEBHOOK_SECRET?: string;
     STRIPE_PRO_PRICE_ID?: string;
+    /**
+     * Issue #912: Analytics Engine dataset for the OAuth refresh-grant/
+     * replay/teardown/no-refresh signals (see oauth-observability.ts).
+     * Optional and purely additive, same contract as apps/api's ANALYTICS/
+     * SLOW_OPS bindings — absent in tests and local dev, and every writer
+     * here treats that as a silent no-op.
+     */
+    AUTH_EVENTS?: AnalyticsEngineDataset;
   };
 
 export type BetterAuthInstance = ReturnType<typeof buildAuth>;
@@ -941,6 +965,7 @@ function buildAuth(
     // single middleware here.
     hooks: {
       before: authBeforeHook(db, registeredScopesForClientId),
+      after: oauthObservabilityAfterHook(env),
     },
     // Fail-closed in production, decoupled from secret resolution (D3/D7):
     // rate limiting is on whenever ENVIRONMENT === "production", regardless

--- a/apps/auth/src/oauth-observability.test.ts
+++ b/apps/auth/src/oauth-observability.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Issue #912: unit coverage for the OAuth refresh-grant/replay/teardown/
+ * no-refresh event classification. `classifyTokenGrantEvents` is pure, so
+ * most cases are driven directly against it; the before→after D1 snapshot
+ * correlation (`captureRefreshTokenPriorState` + `buildTokenGrantAfterHandler`)
+ * is exercised against the real Better Auth `/oauth2/token` handler and the
+ * fake-D1 harness, the same way oauth.test.ts pins the reuse-grace behavior
+ * itself — that's the only way to observe the plugin's actual DB state
+ * transitions without reimplementing them.
+ */
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AuthEnv } from "./auth";
+import { app } from "./index";
+import {
+  __resetPendingRefreshSnapshotsForTest,
+  buildTokenGrantAfterHandler,
+  captureRefreshTokenPriorState,
+  classifyTokenGrantEvents,
+  hashRefreshToken,
+  writeAuthEventPoint,
+  type AuthEvent,
+} from "./oauth-observability";
+import * as schema from "./schema";
+import { createFakeD1 } from "./test/fake-d1";
+
+function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
+  return {
+    DB: createFakeD1(),
+    WEB_ORIGIN: "https://uploads.sh",
+    BETTER_AUTH_URL: "https://uploads.sh",
+    ENVIRONMENT: "development",
+    BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
+    ...overrides,
+  };
+}
+
+describe("writeAuthEventPoint", () => {
+  it("is a silent no-op when AUTH_EVENTS is absent", () => {
+    expect(() => writeAuthEventPoint({}, { name: "oauth_refresh_grant_failure" })).not.toThrow();
+  });
+
+  it("writes one indexed point with the documented blob order", () => {
+    const points: unknown[] = [];
+    writeAuthEventPoint(
+      { AUTH_EVENTS: { writeDataPoint: (p: unknown) => points.push(p) } as never },
+      {
+        name: "oauth_refresh_family_teardown",
+        clientId: "client-1",
+        userId: "user-1",
+        grantType: "refresh_token",
+        errorCode: "invalid_grant",
+      },
+    );
+    expect(points).toEqual([
+      {
+        indexes: ["oauth_refresh_family_teardown"],
+        blobs: [
+          "oauth_refresh_family_teardown",
+          "client-1",
+          "refresh_token",
+          "invalid_grant",
+          "user-1",
+        ],
+        doubles: [],
+      },
+    ]);
+  });
+
+  it("never throws even when the binding itself throws", () => {
+    expect(() =>
+      writeAuthEventPoint(
+        {
+          AUTH_EVENTS: {
+            writeDataPoint: () => {
+              throw new Error("boom");
+            },
+          } as never,
+        },
+        { name: "oauth_refresh_grant_failure" },
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("classifyTokenGrantEvents", () => {
+  it("emits a failure event for a refresh_token grant that errored, with no prior state", () => {
+    expect(
+      classifyTokenGrantEvents({
+        grantType: "refresh_token",
+        clientId: "client-1",
+        success: false,
+        errorCode: "invalid_grant",
+      }),
+    ).toEqual<AuthEvent[]>([
+      {
+        name: "oauth_refresh_grant_failure",
+        clientId: "client-1",
+        grantType: "refresh_token",
+        errorCode: "invalid_grant",
+      },
+    ]);
+  });
+
+  it("emits failure + family teardown when the presented token was already revoked and outside grace", () => {
+    expect(
+      classifyTokenGrantEvents(
+        {
+          grantType: "refresh_token",
+          clientId: "client-1",
+          success: false,
+          errorCode: "invalid_grant",
+        },
+        { clientId: "client-1", userId: "user-1", wasRevoked: true, withinGrace: false },
+      ),
+    ).toEqual<AuthEvent[]>([
+      {
+        name: "oauth_refresh_grant_failure",
+        clientId: "client-1",
+        grantType: "refresh_token",
+        errorCode: "invalid_grant",
+      },
+      { name: "oauth_refresh_family_teardown", clientId: "client-1", userId: "user-1" },
+    ]);
+  });
+
+  it("emits a replay-hit event for a successful refresh grant whose token was already revoked but still within grace", () => {
+    expect(
+      classifyTokenGrantEvents(
+        { grantType: "refresh_token", clientId: "client-1", success: true, hasRefreshToken: true },
+        { clientId: "client-1", userId: "user-1", wasRevoked: true, withinGrace: true },
+      ),
+    ).toEqual<AuthEvent[]>([
+      { name: "oauth_refresh_replay_hit", clientId: "client-1", userId: "user-1" },
+    ]);
+  });
+
+  it("emits nothing extra for an ordinary successful rotation (fresh token, no prior state)", () => {
+    expect(
+      classifyTokenGrantEvents({
+        grantType: "refresh_token",
+        clientId: "client-1",
+        success: true,
+        hasRefreshToken: true,
+      }),
+    ).toEqual([]);
+  });
+
+  it("emits token_grant_no_refresh for any successful grant type missing a refresh_token", () => {
+    expect(
+      classifyTokenGrantEvents({
+        grantType: "authorization_code",
+        clientId: "client-1",
+        success: true,
+        hasRefreshToken: false,
+      }),
+    ).toEqual<AuthEvent[]>([
+      {
+        name: "oauth_token_grant_no_refresh",
+        clientId: "client-1",
+        grantType: "authorization_code",
+      },
+    ]);
+  });
+
+  it("does not emit token_grant_no_refresh for a successful grant that did include one", () => {
+    expect(
+      classifyTokenGrantEvents({
+        grantType: "authorization_code",
+        clientId: "client-1",
+        success: true,
+        hasRefreshToken: true,
+      }),
+    ).toEqual([]);
+  });
+
+  it("can emit both a replay hit and a no-refresh event together", () => {
+    // Pathological but exercises the two independent checks are not
+    // mutually exclusive.
+    expect(
+      classifyTokenGrantEvents(
+        { grantType: "refresh_token", clientId: "client-1", success: true, hasRefreshToken: false },
+        { clientId: "client-1", userId: "user-1", wasRevoked: true, withinGrace: true },
+      ),
+    ).toEqual<AuthEvent[]>([
+      { name: "oauth_refresh_replay_hit", clientId: "client-1", userId: "user-1" },
+      { name: "oauth_token_grant_no_refresh", clientId: "client-1", grantType: "refresh_token" },
+    ]);
+  });
+});
+
+describe("buildTokenGrantAfterHandler", () => {
+  it("classifies a thrown APIError as a failure using the injected isApiError + body.error", async () => {
+    const points: unknown[] = [];
+    const handler = buildTokenGrantAfterHandler(
+      { AUTH_EVENTS: { writeDataPoint: (p: unknown) => points.push(p) } as never },
+      (v): v is never => Boolean(v && typeof v === "object" && "body" in v),
+    );
+    await handler({
+      path: "/oauth2/token",
+      body: { grant_type: "refresh_token", client_id: "client-1", refresh_token: "some-token" },
+      context: { returned: { body: { error: "invalid_scope", error_description: "nope" } } },
+    });
+    expect(points).toHaveLength(1);
+    expect((points[0] as { blobs: string[] }).blobs[0]).toBe("oauth_refresh_grant_failure");
+    expect((points[0] as { blobs: string[] }).blobs[3]).toBe("invalid_scope");
+  });
+
+  it("classifies a successful response missing refresh_token", async () => {
+    const points: unknown[] = [];
+    const handler = buildTokenGrantAfterHandler(
+      { AUTH_EVENTS: { writeDataPoint: (p: unknown) => points.push(p) } as never },
+      () => false,
+    );
+    await handler({
+      path: "/oauth2/token",
+      body: { grant_type: "authorization_code", client_id: "client-1" },
+      context: { returned: { access_token: "abc", token_type: "Bearer" } },
+    });
+    expect(points).toHaveLength(1);
+    expect((points[0] as { blobs: string[] }).blobs[0]).toBe("oauth_token_grant_no_refresh");
+  });
+
+  it("is a no-op for any path other than /oauth2/token", async () => {
+    const points: unknown[] = [];
+    const handler = buildTokenGrantAfterHandler(
+      { AUTH_EVENTS: { writeDataPoint: (p: unknown) => points.push(p) } as never },
+      () => false,
+    );
+    await handler({ path: "/oauth2/authorize", context: { returned: { anything: true } } });
+    expect(points).toHaveLength(0);
+  });
+
+  it("never throws even if the writer/classifier path errors", async () => {
+    const handler = buildTokenGrantAfterHandler(
+      {
+        AUTH_EVENTS: {
+          writeDataPoint: () => {
+            throw new Error("boom");
+          },
+        } as never,
+      },
+      () => false,
+    );
+    await expect(
+      handler({
+        path: "/oauth2/token",
+        body: { grant_type: "authorization_code" },
+        context: { returned: { access_token: "abc" } },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("captureRefreshTokenPriorState + before/after correlation (real handler)", () => {
+  beforeEach(() => {
+    __resetPendingRefreshSnapshotsForTest();
+  });
+
+  /** Mirrors the plugin's defaultHasher: SHA-256, base64url, no padding. */
+  async function hashToken(raw: string): Promise<string> {
+    return hashRefreshToken(raw);
+  }
+
+  async function seedActiveRefreshToken(
+    env: AuthEnv,
+    opts: { clientId: string; userId: string; rawToken: string },
+  ) {
+    const orm = drizzle(env.DB, { schema });
+    await orm.insert(schema.oauthRefreshToken).values({
+      id: crypto.randomUUID(),
+      token: await hashToken(opts.rawToken),
+      clientId: opts.clientId,
+      userId: opts.userId,
+      scopes: ["files:read", "files:write", "offline_access"],
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+    });
+  }
+
+  async function registerClient(env: AuthEnv) {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "observability test",
+          redirect_uris: ["http://127.0.0.1:19876/callback"],
+          token_endpoint_auth_method: "none",
+          grant_types: ["authorization_code", "refresh_token"],
+        }),
+      },
+      env,
+    );
+    const { client_id } = (await res.json()) as { client_id: string };
+    return client_id;
+  }
+
+  async function seedUser(env: AuthEnv) {
+    const orm = drizzle(env.DB, { schema });
+    const userId = crypto.randomUUID();
+    await orm.insert(schema.user).values({
+      id: userId,
+      name: "Observability",
+      email: `observability-${userId}@example.com`,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return userId;
+  }
+
+  async function refresh(env: AuthEnv, clientId: string, token: string) {
+    return app.request(
+      "/api/auth/oauth2/token",
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          client_id: clientId,
+          refresh_token: token,
+        }).toString(),
+      },
+      env,
+    );
+  }
+
+  it("snapshots an unrevoked token as not-within-grace (ordinary first rotation)", async () => {
+    const env = dbEnv();
+    const clientId = await registerClient(env);
+    const userId = await seedUser(env);
+    const rawToken = "capture-before-raw-token";
+    await seedActiveRefreshToken(env, { clientId, userId, rawToken });
+
+    const orm = drizzle(env.DB, { schema });
+    await captureRefreshTokenPriorState(orm, {
+      path: "/oauth2/token",
+      body: { grant_type: "refresh_token", refresh_token: rawToken },
+    });
+
+    // Drive the real rotation through the handler; the snapshot captured
+    // above should reflect the PRE-rotation state (not revoked).
+    const res = await refresh(env, clientId, rawToken);
+    expect(res.status).toBe(200);
+  });
+
+  it("is a no-op for a non-refresh_token grant_type or missing token", async () => {
+    const env = dbEnv();
+    const orm = drizzle(env.DB, { schema });
+    await expect(
+      captureRefreshTokenPriorState(orm, {
+        path: "/oauth2/token",
+        body: { grant_type: "authorization_code" },
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      captureRefreshTokenPriorState(orm, { path: "/oauth2/authorize", body: {} }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("end-to-end: a real replay through the app produces a replay-hit event, not a failure", async () => {
+    const points: { blobs: string[] }[] = [];
+    const env = dbEnv({
+      AUTH_EVENTS: { writeDataPoint: (p: { blobs: string[] }) => points.push(p) } as never,
+    });
+    const clientId = await registerClient(env);
+    const userId = await seedUser(env);
+    const rawToken = "e2e-replay-raw-token";
+    await seedActiveRefreshToken(env, { clientId, userId, rawToken });
+    const orm = drizzle(env.DB, { schema });
+
+    // First refresh: an ordinary rotation. The real hooks (wired in
+    // auth.ts's buildAuth) run automatically inside app.request — no manual
+    // hook calls needed here, that's the point of driving this end-to-end.
+    const first = await refresh(env, clientId, rawToken);
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as { refresh_token: string };
+    // Ordinary rotation: no refresh_token grant failure or replay event.
+    expect(points.map((p) => p.blobs[0])).not.toContain("oauth_refresh_replay_hit");
+    expect(points.map((p) => p.blobs[0])).not.toContain("oauth_refresh_family_teardown");
+
+    // Second presentation of the SAME raw token, still within the 60s grace
+    // (PR #909): the plugin replays the cached pair instead of rotating
+    // again — the after hook should classify this as a replay hit.
+    points.length = 0;
+    const replay = await refresh(env, clientId, rawToken);
+    expect(replay.status).toBe(200);
+    const replayBody = (await replay.json()) as { refresh_token: string };
+    expect(replayBody.refresh_token).toBe(firstBody.refresh_token);
+    expect(points).toHaveLength(1);
+    expect(points[0]?.blobs[0]).toBe("oauth_refresh_replay_hit");
+    expect(points[0]?.blobs[1]).toBe(clientId);
+    expect(points[0]?.blobs[4]).toBe(userId);
+
+    const [row] = await orm
+      .select({
+        wasRevoked: schema.oauthRefreshToken.revoked,
+        rotationReplayExpiresAt: schema.oauthRefreshToken.rotationReplayExpiresAt,
+      })
+      .from(schema.oauthRefreshToken)
+      .where(eq(schema.oauthRefreshToken.token, await hashToken(rawToken)));
+    expect(row?.wasRevoked).toBeTruthy();
+    expect(row?.rotationReplayExpiresAt?.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("end-to-end: a stale reused token (grace expired) is classified as both a failure and a family teardown", async () => {
+    const points: { blobs: string[] }[] = [];
+    const env = dbEnv({
+      AUTH_EVENTS: { writeDataPoint: (p: { blobs: string[] }) => points.push(p) } as never,
+    });
+    const clientId = await registerClient(env);
+    const userId = await seedUser(env);
+    const rawToken = "e2e-teardown-raw-token";
+    const orm = drizzle(env.DB, { schema });
+    // Seed the row already rotated, with its replay grace already expired —
+    // the exact precondition for the plugin's invalidateRefreshFamily branch.
+    await orm.insert(schema.oauthRefreshToken).values({
+      id: crypto.randomUUID(),
+      token: await hashToken(rawToken),
+      clientId,
+      userId,
+      scopes: ["files:read", "files:write", "offline_access"],
+      revoked: new Date(Date.now() - 5000),
+      rotatedAt: new Date(Date.now() - 5000),
+      rotationReplayExpiresAt: new Date(Date.now() - 1000),
+      createdAt: new Date(Date.now() - 10_000),
+      expiresAt: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+    });
+
+    const res = await refresh(env, clientId, rawToken);
+    expect(res.status).toBe(400);
+
+    expect(points.map((p) => p.blobs[0]).sort()).toEqual(
+      ["oauth_refresh_family_teardown", "oauth_refresh_grant_failure"].sort(),
+    );
+    const teardown = points.find((p) => p.blobs[0] === "oauth_refresh_family_teardown");
+    expect(teardown?.blobs[1]).toBe(clientId);
+    expect(teardown?.blobs[4]).toBe(userId);
+    const failure = points.find((p) => p.blobs[0] === "oauth_refresh_grant_failure");
+    expect(failure?.blobs[3]).toBe("invalid_grant");
+  });
+});

--- a/apps/auth/src/oauth-observability.ts
+++ b/apps/auth/src/oauth-observability.ts
@@ -1,0 +1,380 @@
+/**
+ * Issue #912: lightweight Analytics Engine signals for OAuth refresh-grant
+ * failures and rotation-replay hits. `@better-auth/oauth-provider` is a
+ * dependency we don't patch (see auth.ts's long comments on that plugin), so
+ * every signal here is observed from OUTSIDE it, via Better Auth's
+ * `hooks.before`/`hooks.after` on `/oauth2/token` — the same mechanism
+ * `authBeforeHook` already uses for CIMD/DCR interop.
+ *
+ * Four signals, one dataset (`AUTH_EVENTS`, see wrangler.jsonc):
+ *
+ *  - `oauth_refresh_family_teardown` — the RFC 9700 §4.14 refresh-token
+ *    family invalidation the plugin performs when an already-rotated
+ *    refresh token is presented again OUTSIDE the reuse grace
+ *    (`refreshTokenReuseInterval: 60` on `oauthProvider()`, PR #909).
+ *  - `oauth_refresh_replay_hit` — reuse of an already-rotated refresh token
+ *    WITHIN that grace, which the plugin absorbs by replaying the cached
+ *    rotation response instead of tearing down the family. A nonzero rate
+ *    of these alongside zero teardowns is the healthy signature #909 was
+ *    meant to produce (see the issue).
+ *  - `oauth_refresh_grant_failure` — any `/oauth2/token` refresh_token grant
+ *    that ended in an OAuth error, tagged with the RFC 6749 error code
+ *    (`invalid_grant`, `invalid_scope`, ...).
+ *  - `oauth_token_grant_no_refresh` — any successful `/oauth2/token`
+ *    response, of any grant_type, that did NOT include a refresh_token.
+ *    Would have made #911 (offline_access never granted, so no client ever
+ *    got a refresh token) obvious immediately instead of waiting on a user
+ *    report.
+ *
+ * ## Replay vs. teardown
+ *
+ * Both branches share one precondition in the plugin's handler: the
+ * presented refresh token's row is already `revoked`. The only thing that
+ * separates them is whether the plugin's own `rotationReplayExpiresAt`
+ * window (stamped at rotation time) still covers "now" — which only exists
+ * in D1 (`oauth_refresh_token.revoked`/`rotationReplayExpiresAt`), and only
+ * for the instant a request reads it, before its own processing can move
+ * that state forward. So this reads that row TWICE per refresh_token grant:
+ * once in `hooks.before` (via {@link captureRefreshTokenPriorState}, mirroring
+ * the plugin's own default token hash — see {@link hashRefreshToken}) to
+ * snapshot the "was it already revoked, and still inside grace" state
+ * *before* the plugin's handler runs, and once implicitly in `hooks.after`
+ * (via {@link classifyTokenGrantEvents}) once the response is known.
+ *
+ * The before→after correlation is an isolate-local, FIFO, TTL-bounded queue
+ * ({@link pendingRefreshSnapshots}), not any Better-Auth-internal state —
+ * safe against the plugin's own internals changing. Caveats for whoever
+ * reads the resulting counts:
+ *
+ *  - It's per-isolate. Two concurrent refresh requests for the same token
+ *    landing on DIFFERENT isolates (plausible under real load, e.g. two
+ *    OpenCode processes racing from different colos) won't correlate, and
+ *    that specific outcome silently falls back to no replay/teardown event
+ *    at all (the coarser `oauth_refresh_grant_failure` /
+ *    `oauth_token_grant_no_refresh` signals are unaffected — those don't
+ *    need the snapshot).
+ *  - A snapshot older than {@link PENDING_SNAPSHOT_TTL_MS} or beyond
+ *    {@link PENDING_SNAPSHOT_MAX_KEYS} distinct tokens is dropped rather than
+ *    kept forever, so an isolate that never sees the matching after-hook
+ *    (crash mid-request) can't leak memory.
+ *  - This is all best-effort telemetry, not a security control — nothing
+ *    here changes what the plugin actually does with the token.
+ *
+ * Never logs a token value, email, or other PII: client_id, opaque user id,
+ * grant_type, and the OAuth error code are the only identifying fields.
+ */
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import * as schema from "./schema";
+
+/** Matches `@better-auth/oauth-provider`'s default token hasher exactly
+ * (SHA-256, base64url, no padding) — see `defaultHasher`/`storeToken` in the
+ * plugin's dist (`storeTokens` defaults to `"hashed"`, unset by auth.ts's
+ * `oauthProvider()` call). Also mirrored in oauth.test.ts's `hashToken`
+ * helper for the reuse-grace test; keep both in lockstep with the plugin's
+ * default should it ever change. */
+export async function hashRefreshToken(raw: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(raw));
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+export type AuthEventName =
+  | "oauth_refresh_family_teardown"
+  | "oauth_refresh_replay_hit"
+  | "oauth_refresh_grant_failure"
+  | "oauth_token_grant_no_refresh";
+
+export interface AuthEvent {
+  name: AuthEventName;
+  clientId?: string;
+  userId?: string;
+  grantType?: string;
+  errorCode?: string;
+}
+
+/**
+ * Blob positions are a contract with any future SQL read path (mirrors
+ * `SLOW_OP_BLOB_ORDER` in apps/api's slow-op-analytics.ts) — Analytics
+ * Engine has no column names, only ordinals. Append new fields at the END;
+ * never reorder or remove.
+ */
+export const AUTH_EVENT_BLOB_ORDER = [
+  "event",
+  "clientId",
+  "grantType",
+  "errorCode",
+  "userId",
+] as const;
+
+/**
+ * Analytics Engine write side. Null-safe and never throws: tests and local
+ * dev run apps/auth without an `AUTH_EVENTS` binding today (see
+ * wrangler.jsonc), and a write failure must never affect the token
+ * response — same contract as apps/api's `writeSlowOpPoint`/
+ * `writeAdoptionPoint`.
+ */
+export function writeAuthEventPoint(
+  env: { AUTH_EVENTS?: AnalyticsEngineDataset },
+  event: AuthEvent,
+): void {
+  const analytics = env.AUTH_EVENTS;
+  if (!analytics) return;
+  try {
+    analytics.writeDataPoint({
+      // Sampling key: keeps one noisy event type from crowding out the rest.
+      indexes: [event.name],
+      blobs: [
+        event.name,
+        event.clientId ?? "",
+        event.grantType ?? "",
+        event.errorCode ?? "",
+        event.userId ?? "",
+      ],
+      doubles: [],
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(JSON.stringify({ message: "auth event analytics write failed", error: message }));
+  }
+}
+
+/** Snapshot of an `oauth_refresh_token` row's rotation state, read BEFORE
+ * the plugin's own `/oauth2/token` handler runs for this request. */
+export interface RefreshTokenPriorState {
+  clientId: string;
+  userId: string;
+  wasRevoked: boolean;
+  /** True when `rotationReplayExpiresAt` was still in the future at read
+   * time — i.e. this request is inside the `refreshTokenReuseInterval`
+   * grace for whichever earlier request rotated this token. */
+  withinGrace: boolean;
+}
+
+interface QueuedSnapshot extends RefreshTokenPriorState {
+  at: number;
+}
+
+/** See the "Replay vs. teardown" section of the file doc comment. */
+const pendingRefreshSnapshots = new Map<string, QueuedSnapshot[]>();
+const PENDING_SNAPSHOT_TTL_MS = 15_000;
+const PENDING_SNAPSHOT_MAX_KEYS = 200;
+
+function pruneStalePendingSnapshots(now: number): void {
+  for (const [key, queue] of pendingRefreshSnapshots) {
+    const fresh = queue.filter((s) => now - s.at < PENDING_SNAPSHOT_TTL_MS);
+    if (fresh.length === 0) pendingRefreshSnapshots.delete(key);
+    else if (fresh.length !== queue.length) pendingRefreshSnapshots.set(key, fresh);
+  }
+}
+
+function stashRefreshSnapshot(tokenHash: string, state: RefreshTokenPriorState): void {
+  const now = Date.now();
+  pruneStalePendingSnapshots(now);
+  const queue = pendingRefreshSnapshots.get(tokenHash) ?? [];
+  queue.push({ ...state, at: now });
+  pendingRefreshSnapshots.set(tokenHash, queue);
+  while (pendingRefreshSnapshots.size > PENDING_SNAPSHOT_MAX_KEYS) {
+    const oldestKey = pendingRefreshSnapshots.keys().next().value;
+    if (oldestKey === undefined) break;
+    pendingRefreshSnapshots.delete(oldestKey);
+  }
+}
+
+/** FIFO take — pairs with the earliest not-yet-consumed snapshot for this
+ * token hash, so two sequential requests for the same token each get their
+ * own prior-state reading. */
+function takeRefreshSnapshot(tokenHash: string): RefreshTokenPriorState | undefined {
+  const queue = pendingRefreshSnapshots.get(tokenHash);
+  if (!queue || queue.length === 0) return undefined;
+  const next = queue.shift();
+  if (queue.length === 0) pendingRefreshSnapshots.delete(tokenHash);
+  else pendingRefreshSnapshots.set(tokenHash, queue);
+  return next;
+}
+
+/** Test-only escape hatch: clears in-flight snapshot state between cases. */
+export function __resetPendingRefreshSnapshotsForTest(): void {
+  pendingRefreshSnapshots.clear();
+}
+
+type HookCtx = { path: string; body?: unknown };
+
+/**
+ * `hooks.before` half of the pair (see file doc comment). Reads the
+ * presented refresh token's current D1 state ahead of the plugin's own
+ * handler; a no-op (single cheap `!==` check) for every path/grant_type
+ * other than a refresh_token grant at `/oauth2/token`, and for a token this
+ * worker has no row for (unknown/garbage token — the plugin's own
+ * `invalid_grant` covers that; nothing to snapshot). Never throws — a
+ * lookup failure here must not block the token endpoint.
+ */
+export async function captureRefreshTokenPriorState(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  ctx: HookCtx,
+): Promise<void> {
+  if (ctx.path !== "/oauth2/token") return;
+  const body = ctx.body as Record<string, unknown> | undefined;
+  if (body?.grant_type !== "refresh_token") return;
+  const raw = body.refresh_token;
+  if (typeof raw !== "string" || !raw) return;
+  try {
+    const tokenHash = await hashRefreshToken(raw);
+    const [row] = await db
+      .select({
+        clientId: schema.oauthRefreshToken.clientId,
+        userId: schema.oauthRefreshToken.userId,
+        revoked: schema.oauthRefreshToken.revoked,
+        rotationReplayExpiresAt: schema.oauthRefreshToken.rotationReplayExpiresAt,
+      })
+      .from(schema.oauthRefreshToken)
+      .where(eq(schema.oauthRefreshToken.token, tokenHash))
+      .limit(1);
+    if (!row) return;
+    stashRefreshSnapshot(tokenHash, {
+      clientId: row.clientId,
+      userId: row.userId,
+      wasRevoked: Boolean(row.revoked),
+      withinGrace: Boolean(
+        row.rotationReplayExpiresAt && row.rotationReplayExpiresAt.getTime() > Date.now(),
+      ),
+    });
+  } catch {
+    // Best-effort: a D1 hiccup here must never block the token endpoint.
+  }
+}
+
+export interface TokenGrantOutcome {
+  grantType?: string;
+  clientId?: string;
+  success: boolean;
+  /** RFC 6749 `error` value (e.g. `invalid_grant`), only set when `!success`. */
+  errorCode?: string;
+  /** Only meaningful when `success`: did the response body carry a
+   * `refresh_token`? */
+  hasRefreshToken?: boolean;
+}
+
+/**
+ * Pure classification: turns one `/oauth2/token` outcome (plus the optional
+ * before-hook snapshot for refresh_token grants) into zero or more events.
+ * Exported and kept side-effect-free so it's directly unit-testable without
+ * driving the full HTTP/D1 stack.
+ */
+export function classifyTokenGrantEvents(
+  outcome: TokenGrantOutcome,
+  priorRefreshState?: RefreshTokenPriorState,
+): AuthEvent[] {
+  const events: AuthEvent[] = [];
+
+  if (outcome.grantType === "refresh_token") {
+    if (!outcome.success) {
+      events.push({
+        name: "oauth_refresh_grant_failure",
+        clientId: outcome.clientId,
+        grantType: outcome.grantType,
+        errorCode: outcome.errorCode,
+      });
+      // Family teardown: the presented token was already revoked AND its
+      // reuse grace had already expired at read time — exactly the branch
+      // in the plugin's handler that calls invalidateRefreshFamily before
+      // throwing invalid_grant.
+      if (priorRefreshState?.wasRevoked && !priorRefreshState.withinGrace) {
+        events.push({
+          name: "oauth_refresh_family_teardown",
+          clientId: priorRefreshState.clientId,
+          userId: priorRefreshState.userId,
+        });
+      }
+    } else if (priorRefreshState?.wasRevoked && priorRefreshState.withinGrace) {
+      // Presented an already-rotated token still inside the reuse grace:
+      // the plugin replayed the cached rotation response instead of
+      // minting a fresh pair.
+      events.push({
+        name: "oauth_refresh_replay_hit",
+        clientId: priorRefreshState.clientId,
+        userId: priorRefreshState.userId,
+      });
+    }
+  }
+
+  if (outcome.success && outcome.hasRefreshToken === false) {
+    events.push({
+      name: "oauth_token_grant_no_refresh",
+      clientId: outcome.clientId,
+      grantType: outcome.grantType,
+    });
+  }
+
+  return events;
+}
+
+/** Shape of the `after`-hook `ctx` this needs beyond `HookCtx`: the
+ * endpoint's outcome, mirroring what Better Auth's dispatcher stashes on
+ * `ctx.context.returned` — either the success response body, or the thrown
+ * `APIError` itself (Better Auth runs `hooks.after` on both paths; see
+ * `runAfterHooks`/`dispatchAuthEndpoint` in better-auth's `api/dispatch`). */
+type AfterHookCtx = HookCtx & { context: { returned?: unknown } };
+
+/**
+ * Builds the `hooks.after` handler that completes the classification and
+ * writes events. Takes a plain `isError`/`errorBody` extractor rather than
+ * importing `isAPIError` itself so this module has no dependency on
+ * `better-auth/api` beyond the type the caller already imports — keeps this
+ * file trivially unit-testable (see oauth-observability.test.ts) without
+ * constructing a real `APIError`.
+ */
+export function buildTokenGrantAfterHandler(
+  env: { AUTH_EVENTS?: AnalyticsEngineDataset },
+  isApiError: (value: unknown) => boolean,
+) {
+  return async (ctx: AfterHookCtx): Promise<void> => {
+    if (ctx.path !== "/oauth2/token") return;
+    try {
+      const body = ctx.body as Record<string, unknown> | undefined;
+      const grantType = typeof body?.grant_type === "string" ? body.grant_type : undefined;
+      const clientId = typeof body?.client_id === "string" ? body.client_id : undefined;
+
+      let priorState: RefreshTokenPriorState | undefined;
+      const rawRefreshToken = body?.refresh_token;
+      if (grantType === "refresh_token" && typeof rawRefreshToken === "string" && rawRefreshToken) {
+        priorState = takeRefreshSnapshot(await hashRefreshToken(rawRefreshToken));
+      }
+
+      const returned = ctx.context.returned;
+      let outcome: TokenGrantOutcome;
+      if (isApiError(returned)) {
+        const errorBody = (returned as { body?: { error?: unknown } }).body;
+        outcome = {
+          grantType,
+          clientId,
+          success: false,
+          errorCode: typeof errorBody?.error === "string" ? errorBody.error : undefined,
+        };
+      } else if (returned && typeof returned === "object") {
+        const responseBody = returned as { refresh_token?: unknown };
+        outcome = {
+          grantType,
+          clientId,
+          success: true,
+          hasRefreshToken: typeof responseBody.refresh_token === "string",
+        };
+      } else {
+        // Nothing to classify (no response captured on this ctx).
+        return;
+      }
+
+      for (const event of classifyTokenGrantEvents(outcome, priorState)) {
+        writeAuthEventPoint(env, event);
+      }
+    } catch (err) {
+      // Observability must never break the token endpoint.
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        JSON.stringify({ message: "oauth observability after-hook failed", error: message }),
+      );
+    }
+  };
+}

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -142,6 +142,21 @@
       "service": "uploads-api",
     },
   ],
+  // Issue #912: OAuth refresh-grant/replay/teardown/no-refresh signals (see
+  // src/oauth-observability.ts). This worker had no Analytics Engine
+  // binding before this — follows apps/api's ANALYTICS/SLOW_OPS pattern
+  // (wrangler.jsonc there). Purely additive: every writer treats an absent
+  // binding as a silent no-op, so deleting this block just turns the
+  // signals off. Datasets auto-create on first write; no read binding
+  // needed here (a future /admin/metrics tile would read it the same way
+  // apps/api's analytics-engine.ts reads ANALYTICS/SLOW_OPS, via the SQL
+  // API + an account token).
+  "analytics_engine_datasets": [
+    {
+      "binding": "AUTH_EVENTS",
+      "dataset": "uploads_auth_events",
+    },
+  ],
   // Rate limiting (2026-08-23 incident follow-up): Better Auth's limiter is
   // backed by one `RateLimitCounter` Durable Object per rate-limit key —
   // `rateLimit.customStorage` in src/auth.ts, class in src/rate-limit-do.ts,
@@ -221,6 +236,15 @@
       {
         "binding": "API",
         "service": "uploads-api",
+      },
+    ],
+    // Separate preview dataset (apps/api's own previews block does the same
+    // for ANALYTICS/SLOW_OPS) — keeps preview traffic out of the prod
+    // signal.
+    "analytics_engine_datasets": [
+      {
+        "binding": "AUTH_EVENTS",
+        "dataset": "uploads_auth_events_preview",
       },
     ],
     // Repeated verbatim because `previews` bindings do not inherit. No


### PR DESCRIPTION
Closes #912.

## What this adds

Four lightweight Analytics Engine signals for `/oauth2/token`, all observed from OUTSIDE `@better-auth/oauth-provider` (a dependency we don't patch) via Better Auth's `hooks.before`/`hooks.after` — the same mechanism `authBeforeHook` already used for CIMD/DCR interop:

- **`oauth_refresh_family_teardown`** — the RFC 9700 §4.14 refresh-token family invalidation the plugin performs when an already-rotated refresh token is presented again *outside* the reuse grace.
- **`oauth_refresh_replay_hit`** — reuse of an already-rotated refresh token *within* the 60s grace from PR #909 (the plugin replays the cached rotation response instead of tearing down the family). Per the issue: nonzero replay counts + zero teardowns is the healthy signature.
- **`oauth_refresh_grant_failure`** — any refresh_token grant that ended in an OAuth error, tagged with the RFC 6749 error code (`invalid_grant`, `invalid_scope`, ...).
- **`oauth_token_grant_no_refresh`** — any successful `/oauth2/token` response, of any grant_type, missing a `refresh_token`. Would have made #911 obvious immediately.

## Event schema

One dataset, `AUTH_EVENTS` (new binding — apps/auth had no Analytics Engine dataset before this; follows apps/api's `ANALYTICS`/`SLOW_OPS` pattern in `wrangler.jsonc`). Each point:

- `indexes`: `[eventName]` (sampling key)
- `blobs`, ordinal contract (`AUTH_EVENT_BLOB_ORDER`, append-only): `[event, clientId, grantType, errorCode, userId]`
- `doubles`: `[]`

Never logs a token value or email — only `client_id`, an opaque `userId`, `grant_type`, and the OAuth error code.

Writes are null-safe (`writeAuthEventPoint`): an absent `AUTH_EVENTS` binding (tests, local dev) is a silent no-op, and a write failure is caught and logged, never thrown — matches `writeSlowOpPoint`'s contract in apps/api.

## Design: distinguishing replay from teardown

Both branches share one precondition in the plugin's own handler: the presented refresh token's row is already `revoked`. The only thing that separates them is whether the plugin's `rotationReplayExpiresAt` window still covers "now" — state that only exists in D1, and only for the instant a request reads it (its own processing moves it forward).

So this reads `oauth_refresh_token` twice per refresh_token grant:
1. In `hooks.before` (`captureRefreshTokenPriorState`), mirroring the plugin's own default token hash (SHA-256/base64url — matches oauth.test.ts's own `hashToken` helper) to snapshot `revoked`/`rotationReplayExpiresAt` *before* the plugin's handler runs.
2. In `hooks.after` (`buildTokenGrantAfterHandler`), once the response (success body or thrown `APIError`) is known — Better Auth runs `hooks.after` on both paths.

The before→after correlation is an isolate-local, FIFO, TTL-bounded queue (`pendingRefreshSnapshots` in `apps/auth/src/oauth-observability.ts`), not any Better-Auth-internal state.

## Caveats for the reviewer

- **Per-isolate correlation.** Two concurrent refresh requests for the *same* token landing on different isolates (plausible under real load — two OpenCode processes racing from different colos) won't correlate; that specific outcome silently drops the replay/teardown classification (the coarser failure/no-refresh signals are unaffected, they don't need the snapshot).
- **Best-effort, not a security control.** Nothing here changes what the plugin actually does with the token — this is telemetry only.
- **No read path yet.** No `/admin/metrics` tile — reading `AUTH_EVENTS` would follow the same SQL-API pattern as `apps/api/src/analytics-engine.ts` reads `ANALYTICS`/`SLOW_OPS`, left for a follow-up once there's a tile to hang it on. In the meantime this is queryable via the Analytics Engine SQL API against the `uploads_auth_events` dataset.
- **`hashRefreshToken` mirrors an internal, unversioned plugin default** (`storeTokens: "hashed"`, unset by our `oauthProvider()` call). If a future Better Auth release changes that default or we ever set `storeTokens` explicitly, the snapshot lookup silently stops matching rows (falls back to no replay/teardown signal, not a crash) — same fragility class as the reuse-grace test's own `hashToken` helper already accepted.

## Testing

- `apps/auth/src/oauth-observability.test.ts`: unit coverage for the pure classifier (`classifyTokenGrantEvents`), the AE writer's null-safety, the after-handler's APIError/success branching, and two end-to-end cases driven against the real Better Auth `/oauth2/token` handler + fake-D1 (a genuine replay produces exactly one `oauth_refresh_replay_hit`; a stale reused token past its grace produces both `oauth_refresh_grant_failure` and `oauth_refresh_family_teardown`).
- `pnpm vitest run --config vitest.projects.ts --project @uploads/auth`: 30 files / 434 tests passing.
- `pnpm test` (root): 361 files / 5592 tests passing.
- `pnpm exec tsc --noEmit` in apps/auth: clean (after `wrangler types` regenerates `worker-configuration.d.ts` for the new `AUTH_EVENTS` binding — gitignored, not committed).

No changeset (internal worker change, not a published package).
