### PR TITLE
feat(auth): observability for OAuth refresh-grant failures and rotation replays

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -41,6 +41,11 @@ import { sendAuthEmail } from "./email";
 import { localDemoEnabled, localDemoPlugin } from "./local-demo";
 import { memberCapDenial } from "./member-cap";
 import { notifyAdminsOfMemberJoin } from "./notify-member-join";
+import {
+  refreshTokenAfterHook,
+  snapshotBeforeOAuthTokenRequest,
+  type AuthEventsEnv,
+} from "./oauth-observability";
 import { createDurableRateLimitStorage, type RateLimitNamespaceLike } from "./rate-limit";
 import * as schema from "./schema";
 import { stripePluginOrNone } from "./stripe-plugin";
@@ -310,11 +315,19 @@ async function applyOAuthClientInterop(
 function authBeforeHook(
   db: ReturnType<typeof drizzle<typeof schema>>,
   registeredScopesForClientId: (clientId: string | undefined) => Promise<readonly string[]>,
+  env: { DB: D1Database },
 ) {
   return createAuthMiddleware(async (ctx) => {
     const oauthOverride = await applyOAuthClientInterop(ctx, registeredScopesForClientId);
     if (oauthOverride) return oauthOverride;
     await enforceLastAdminGuard(ctx, db);
+    // Issue #912: snapshots a presented refresh token's D1 state ahead of
+    // oauthProvider()'s own /oauth2/token handler — see
+    // oauth-observability.ts's module doc comment for why this rides here
+    // instead of a dedicated hook slot (Better Auth's `hooks.before` takes
+    // exactly one handler). No-op for every path other than a
+    // grant_type=refresh_token request at /oauth2/token.
+    await snapshotBeforeOAuthTokenRequest(ctx, env);
   });
 }
 
@@ -409,7 +422,8 @@ async function enforceLastAdminGuard(
 }
 
 export type AuthEnv = GitHubCredentialsEnv &
-  DashApiKeyEnv & {
+  DashApiKeyEnv &
+  AuthEventsEnv & {
     DB: D1Database;
     EMAIL?: import("./email").EmailBinding;
     BETTER_AUTH_URL?: string;
@@ -936,11 +950,13 @@ function buildAuth(
         },
       },
     },
-    // CIMD/DCR grant_types + authorize/consent scope rewrite, then the
-    // fail-closed last-admin guard. One `hooks.before`: Better Auth takes a
-    // single middleware here.
+    // CIMD/DCR grant_types + authorize/consent scope rewrite, the
+    // fail-closed last-admin guard, then the #912 refresh-token snapshot.
+    // One `hooks.before`: Better Auth takes a single middleware here.
+    // `hooks.after` is #912's other half — see oauth-observability.ts.
     hooks: {
-      before: authBeforeHook(db, registeredScopesForClientId),
+      before: authBeforeHook(db, registeredScopesForClientId, env),
+      after: refreshTokenAfterHook(env),
     },
     // Fail-closed in production, decoupled from secret resolution (D3/D7):
     // rate limiting is on whenever ENVIRONMENT === "production", regardless

--- a/apps/auth/src/oauth-observability.test.ts
+++ b/apps/auth/src/oauth-observability.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Issue #912: OAuth refresh-grant observability. Two layers:
+ *  - Pure unit coverage of `classifyOAuthTokenEvent` (every branch, no I/O).
+ *  - End-to-end coverage driving `/api/auth/oauth2/token` through the real
+ *    handler (same harness as oauth.test.ts's reuse-grace suite) with a fake
+ *    AUTH_EVENTS binding, confirming the right event actually fires for each
+ *    of the four #912 scenarios.
+ */
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { describe, expect, it } from "vitest";
+import type { AuthEnv } from "./auth";
+import { app } from "./index";
+import {
+  classifyOAuthTokenEvent,
+  hashOAuthToken,
+  snapshotPresentedRefreshToken,
+  writeAuthEventPoint,
+  type AuthEventFields,
+  type AuthEventName,
+} from "./oauth-observability";
+import * as schema from "./schema";
+import { createFakeD1 } from "./test/fake-d1";
+
+describe("classifyOAuthTokenEvent", () => {
+  it("classifies a revoked-and-within-grace refresh token as a rotation replay", () => {
+    const event = classifyOAuthTokenEvent({
+      grantType: "refresh_token",
+      failed: false,
+      hasRefreshToken: true,
+      snapshot: { clientId: "c1", userId: "u1", revoked: true, withinReuseInterval: true },
+    });
+    expect(event).toEqual({
+      name: "refresh_rotation_replay",
+      fields: { clientId: "c1", userId: "u1", grantType: "refresh_token" },
+    });
+  });
+
+  it("still classifies as a replay when the reuse-window attempt itself failed", () => {
+    // The plugin's cached rotationReplayResponse can go missing (encryption
+    // failure, storage eviction) even though the presented token IS within
+    // the 60s grace — rare, but "a replay was attempted" is still the #912
+    // signal that matters, not which of the two outcomes the plugin hit.
+    const event = classifyOAuthTokenEvent({
+      grantType: "refresh_token",
+      failed: true,
+      errorCode: "invalid_grant",
+      snapshot: { clientId: "c1", userId: "u1", revoked: true, withinReuseInterval: true },
+    });
+    expect(event?.name).toBe("refresh_rotation_replay");
+  });
+
+  it("classifies a revoked-and-outside-grace refresh token as family invalidation", () => {
+    const event = classifyOAuthTokenEvent({
+      grantType: "refresh_token",
+      failed: true,
+      errorCode: "invalid_grant",
+      snapshot: { clientId: "c1", userId: "u1", revoked: true, withinReuseInterval: false },
+    });
+    expect(event).toEqual({
+      name: "refresh_family_invalidated",
+      fields: { clientId: "c1", userId: "u1", grantType: "refresh_token" },
+    });
+  });
+
+  it("classifies an unknown/foreign refresh token failure by its RFC 6749 error code", () => {
+    const event = classifyOAuthTokenEvent({
+      grantType: "refresh_token",
+      clientId: "c2",
+      failed: true,
+      errorCode: "invalid_scope",
+    });
+    expect(event).toEqual({
+      name: "refresh_grant_failed",
+      fields: { clientId: "c2", grantType: "refresh_token", errorCode: "invalid_scope" },
+    });
+  });
+
+  it("ignores non-refresh-token grant failures (out of #912's scope)", () => {
+    const event = classifyOAuthTokenEvent({
+      grantType: "authorization_code",
+      failed: true,
+      errorCode: "invalid_grant",
+    });
+    expect(event).toBeNull();
+  });
+
+  it("flags a successful refresh grant whose response carries no refresh_token", () => {
+    const event = classifyOAuthTokenEvent({
+      grantType: "refresh_token",
+      clientId: "c3",
+      failed: false,
+      hasRefreshToken: false,
+    });
+    expect(event).toEqual({
+      name: "token_grant_without_refresh",
+      fields: { clientId: "c3", grantType: "refresh_token" },
+    });
+  });
+
+  it("flags a successful authorization_code grant whose response carries no refresh_token (#911's shape)", () => {
+    const event = classifyOAuthTokenEvent({
+      grantType: "authorization_code",
+      clientId: "c4",
+      failed: false,
+      hasRefreshToken: false,
+    });
+    expect(event?.name).toBe("token_grant_without_refresh");
+  });
+
+  it("emits nothing for an ordinary successful grant that does carry a refresh_token", () => {
+    const event = classifyOAuthTokenEvent({
+      grantType: "refresh_token",
+      clientId: "c5",
+      failed: false,
+      hasRefreshToken: true,
+    });
+    expect(event).toBeNull();
+  });
+
+  it("emits nothing for a client_credentials-style grant with no refresh_token expected", () => {
+    const event = classifyOAuthTokenEvent({
+      grantType: "client_credentials",
+      clientId: "c6",
+      failed: false,
+      hasRefreshToken: false,
+    });
+    expect(event).toBeNull();
+  });
+});
+
+describe("writeAuthEventPoint", () => {
+  function fakeDataset() {
+    const points: Array<{ indexes?: string[]; blobs?: string[]; doubles?: number[] }> = [];
+    return {
+      points,
+      dataset: {
+        writeDataPoint: (point: { indexes?: string[]; blobs?: string[]; doubles?: number[] }) => {
+          points.push(point);
+        },
+      } as unknown as AnalyticsEngineDataset,
+    };
+  }
+
+  it("no-ops silently when AUTH_EVENTS is unbound", () => {
+    expect(() =>
+      writeAuthEventPoint({}, "refresh_grant_failed", { errorCode: "invalid_grant" }),
+    ).not.toThrow();
+  });
+
+  it("writes one point per event, blobs in the documented order", () => {
+    const { points, dataset } = fakeDataset();
+    const fields: AuthEventFields = {
+      clientId: "c1",
+      grantType: "refresh_token",
+      errorCode: "invalid_grant",
+      userId: "u1",
+    };
+    writeAuthEventPoint({ AUTH_EVENTS: dataset }, "refresh_grant_failed", fields);
+    expect(points).toHaveLength(1);
+    expect(points[0]?.indexes).toEqual(["refresh_grant_failed"]);
+    expect(points[0]?.blobs).toEqual([
+      "refresh_grant_failed",
+      "c1",
+      "refresh_token",
+      "invalid_grant",
+      "u1",
+    ]);
+  });
+
+  it("never throws when the binding's writeDataPoint itself throws", () => {
+    const dataset = {
+      writeDataPoint: () => {
+        throw new Error("AE quota exceeded");
+      },
+    } as unknown as AnalyticsEngineDataset;
+    expect(() =>
+      writeAuthEventPoint(
+        { AUTH_EVENTS: dataset },
+        "refresh_family_invalidated" as AuthEventName,
+        {},
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("snapshotPresentedRefreshToken", () => {
+  function dbEnv(): AuthEnv {
+    return {
+      DB: createFakeD1(),
+      WEB_ORIGIN: "https://uploads.sh",
+      BETTER_AUTH_URL: "https://uploads.sh",
+      ENVIRONMENT: "development",
+      BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
+    };
+  }
+
+  async function seedClient(orm: ReturnType<typeof drizzle<typeof schema>>, clientId: string) {
+    await orm.insert(schema.oauthClient).values({
+      id: crypto.randomUUID(),
+      clientId,
+      name: "test client",
+      scopes: ["files:read"],
+      grantTypes: ["refresh_token"],
+      redirectUris: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
+  it("returns undefined for a token that isn't in the table", async () => {
+    const env = dbEnv();
+    const orm = drizzle(env.DB, { schema });
+    expect(await snapshotPresentedRefreshToken(orm, "no-such-token")).toBeUndefined();
+  });
+
+  it("reports revoked:false for an active, never-rotated token", async () => {
+    const env = dbEnv();
+    const orm = drizzle(env.DB, { schema });
+    await seedClient(orm, "client-a");
+    const userId = crypto.randomUUID();
+    await orm.insert(schema.oauthRefreshToken).values({
+      id: crypto.randomUUID(),
+      token: await hashOAuthToken("raw-active"),
+      clientId: "client-a",
+      userId,
+      scopes: ["files:read"],
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 3600_000),
+    });
+    const snapshot = await snapshotPresentedRefreshToken(orm, "raw-active");
+    expect(snapshot).toEqual({
+      clientId: "client-a",
+      userId,
+      revoked: false,
+      withinReuseInterval: false,
+    });
+  });
+
+  it("reports withinReuseInterval:true for a token rotated inside the 60s grace", async () => {
+    const env = dbEnv();
+    const orm = drizzle(env.DB, { schema });
+    await seedClient(orm, "client-b");
+    const userId = crypto.randomUUID();
+    await orm.insert(schema.oauthRefreshToken).values({
+      id: crypto.randomUUID(),
+      token: await hashOAuthToken("raw-rotated-recent"),
+      clientId: "client-b",
+      userId,
+      scopes: ["files:read"],
+      revoked: new Date(),
+      rotatedAt: new Date(),
+      rotationReplayExpiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 3600_000),
+    });
+    const snapshot = await snapshotPresentedRefreshToken(orm, "raw-rotated-recent");
+    expect(snapshot).toEqual({
+      clientId: "client-b",
+      userId,
+      revoked: true,
+      withinReuseInterval: true,
+    });
+  });
+
+  it("reports withinReuseInterval:false once the reuse grace has lapsed", async () => {
+    const env = dbEnv();
+    const orm = drizzle(env.DB, { schema });
+    await seedClient(orm, "client-c");
+    const userId = crypto.randomUUID();
+    await orm.insert(schema.oauthRefreshToken).values({
+      id: crypto.randomUUID(),
+      token: await hashOAuthToken("raw-rotated-stale"),
+      clientId: "client-c",
+      userId,
+      scopes: ["files:read"],
+      revoked: new Date(Date.now() - 120_000),
+      rotatedAt: new Date(Date.now() - 120_000),
+      rotationReplayExpiresAt: new Date(Date.now() - 60_000),
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 3600_000),
+    });
+    const snapshot = await snapshotPresentedRefreshToken(orm, "raw-rotated-stale");
+    expect(snapshot).toEqual({
+      clientId: "client-c",
+      userId,
+      revoked: true,
+      withinReuseInterval: false,
+    });
+  });
+});
+
+describe("/oauth2/token end-to-end event emission", () => {
+  function fakeDataset() {
+    const points: Array<{ indexes?: string[]; blobs?: string[] }> = [];
+    return {
+      points,
+      dataset: {
+        writeDataPoint: (point: { indexes?: string[]; blobs?: string[] }) => points.push(point),
+      } as unknown as AnalyticsEngineDataset,
+    };
+  }
+
+  function dbEnv(auth_events: AnalyticsEngineDataset): AuthEnv {
+    return {
+      DB: createFakeD1(),
+      WEB_ORIGIN: "https://uploads.sh",
+      BETTER_AUTH_URL: "https://uploads.sh",
+      ENVIRONMENT: "development",
+      BETTER_AUTH_SECRET: "test-signing-secret-at-least-32-chars-long",
+      AUTH_EVENTS: auth_events,
+    };
+  }
+
+  async function registerClient(env: AuthEnv) {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "observability test",
+          redirect_uris: ["http://127.0.0.1:19877/callback"],
+          token_endpoint_auth_method: "none",
+          grant_types: ["authorization_code", "refresh_token"],
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const { client_id } = (await res.json()) as { client_id: string };
+    return client_id;
+  }
+
+  async function seedUser(env: AuthEnv) {
+    const orm = drizzle(env.DB, { schema });
+    const userId = crypto.randomUUID();
+    await orm.insert(schema.user).values({
+      id: userId,
+      name: "Observability",
+      email: `observability-${userId}@example.com`,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return { orm, userId };
+  }
+
+  async function refresh(env: AuthEnv, clientId: string, token: string) {
+    return app.request(
+      "/api/auth/oauth2/token",
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          client_id: clientId,
+          refresh_token: token,
+        }).toString(),
+      },
+      env,
+    );
+  }
+
+  it("emits refresh_rotation_replay on a reuse within the 60s grace", async () => {
+    const { points, dataset } = fakeDataset();
+    const env = dbEnv(dataset);
+    const clientId = await registerClient(env);
+    const { orm, userId } = await seedUser(env);
+    const rawToken = "observability-raw-token";
+    await orm.insert(schema.oauthRefreshToken).values({
+      id: crypto.randomUUID(),
+      token: await hashOAuthToken(rawToken),
+      clientId,
+      userId,
+      scopes: ["files:read", "files:write", "offline_access"],
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+    });
+
+    const first = await refresh(env, clientId, rawToken);
+    expect(first.status).toBe(200);
+    // First refresh rotates a never-before-seen token: no #912 event.
+    expect(points).toHaveLength(0);
+
+    const replay = await refresh(env, clientId, rawToken);
+    expect(replay.status).toBe(200);
+    expect(points).toHaveLength(1);
+    expect(points[0]?.indexes).toEqual(["refresh_rotation_replay"]);
+    expect(points[0]?.blobs?.[1]).toBe(clientId);
+    expect(points[0]?.blobs?.[4]).toBe(userId);
+  });
+
+  it("emits refresh_family_invalidated on a reuse outside the grace window", async () => {
+    const { points, dataset } = fakeDataset();
+    const env = dbEnv(dataset);
+    const clientId = await registerClient(env);
+    const { orm, userId } = await seedUser(env);
+    await orm.insert(schema.oauthRefreshToken).values({
+      id: crypto.randomUUID(),
+      token: await hashOAuthToken("already-rotated"),
+      clientId,
+      userId,
+      scopes: ["files:read", "offline_access"],
+      revoked: new Date(Date.now() - 120_000),
+      rotatedAt: new Date(Date.now() - 120_000),
+      rotationReplayExpiresAt: new Date(Date.now() - 60_000),
+      createdAt: new Date(Date.now() - 200_000),
+      expiresAt: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+    });
+
+    const res = await refresh(env, clientId, "already-rotated");
+    expect(res.status).toBe(400);
+    expect(points).toHaveLength(1);
+    expect(points[0]?.indexes).toEqual(["refresh_family_invalidated"]);
+    expect(points[0]?.blobs?.[1]).toBe(clientId);
+    expect(points[0]?.blobs?.[4]).toBe(userId);
+  });
+
+  it("emits refresh_grant_failed(invalid_grant) for an unknown refresh token", async () => {
+    const { points, dataset } = fakeDataset();
+    const env = dbEnv(dataset);
+    const clientId = await registerClient(env);
+
+    const res = await refresh(env, clientId, "never-issued-token");
+    expect(res.status).toBe(400);
+    expect(points).toHaveLength(1);
+    expect(points[0]?.indexes).toEqual(["refresh_grant_failed"]);
+    expect(points[0]?.blobs?.[3]).toBe("invalid_grant");
+  });
+
+  it("emits token_grant_without_refresh when the client can't hold offline_access", async () => {
+    // Same shape #911 fixed: a client without offline_access in its
+    // registered scopes gets no refresh_token in the code-exchange response.
+    const { points, dataset } = fakeDataset();
+    const env = dbEnv(dataset);
+    const register = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "no-offline-access client",
+          redirect_uris: ["http://127.0.0.1:19878/callback"],
+          token_endpoint_auth_method: "none",
+          grant_types: ["authorization_code", "refresh_token"],
+        }),
+      },
+      env,
+    );
+    expect(register.status).toBe(201);
+    const { client_id: clientId } = (await register.json()) as { client_id: string };
+    const orm = drizzle(env.DB, { schema });
+    // Downscope this client to a set that excludes offline_access, mirroring
+    // how a pre-#913 client (or one that never requested it) would be seeded.
+    await orm
+      .update(schema.oauthClient)
+      .set({ scopes: ["files:read"] })
+      .where(eq(schema.oauthClient.clientId, clientId));
+
+    const { userId } = await seedUser(env);
+    // Exercising the full authorize→consent leg is out of scope for this
+    // event-emission test — oauth.test.ts's reuse-grace suite already takes
+    // the same "seed the refresh token row directly" shortcut for the token
+    // endpoint. The refresh_token grant hits the identical `createUserTokens`
+    // "no offline_access in scopes" path an authorization_code exchange would.
+    await orm.insert(schema.oauthRefreshToken).values({
+      id: crypto.randomUUID(),
+      token: await hashOAuthToken("no-offline-refresh"),
+      clientId,
+      userId,
+      scopes: ["files:read"],
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+    });
+    const res = await refresh(env, clientId, "no-offline-refresh");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { refresh_token?: string };
+    expect(body.refresh_token).toBeUndefined();
+    expect(points).toHaveLength(1);
+    expect(points[0]?.indexes).toEqual(["token_grant_without_refresh"]);
+  });
+});

--- a/apps/auth/src/oauth-observability.ts
+++ b/apps/auth/src/oauth-observability.ts
@@ -1,0 +1,343 @@
+/**
+ * Issue #912: lightweight Analytics Engine signal for OAuth refresh-grant
+ * health at `/oauth2/token` — a follow-up to #909 (refresh-token rotation
+ * reuse grace) and #911 (offline_access wasn't granted, so no client ever
+ * got a refresh token). Before this, the only detector for either failure
+ * mode was a user report.
+ *
+ * `@better-auth/oauth-provider` is a dependency — this module never patches
+ * it. Everything here observes from OUTSIDE, via two hooks wired onto
+ * `betterAuth({ hooks })` in auth.ts:
+ *
+ *  - `hooks.before` snapshots the presented refresh token's D1 row (revoked
+ *    + rotation-replay-window state) BEFORE the plugin's handler runs. This
+ *    is the only extra query this module ever issues, and it only runs for
+ *    `grant_type=refresh_token` requests at `/oauth2/token` — not on the
+ *    general request path (get-session, sign-in, etc.), which stays exactly
+ *    as cheap as before.
+ *  - `hooks.after` reads the handler's outcome (`ctx.context.returned`,
+ *    either the success JSON body or the thrown `APIError`) plus the
+ *    before-hook's snapshot, classifies the request, and fires at most one
+ *    Analytics Engine data point.
+ *
+ * The before/after snapshot handoff rides on the mutable `ctx` object
+ * `createAuthMiddleware` hands each hook: Better Auth's dispatcher passes
+ * the SAME context through before → handler → after for a single request
+ * (see `dispatchAuthEndpoint` in better-auth's `api/dispatch.mjs`) as long
+ * as no hook rewrites `body`/`query` — this module's before-hook never
+ * does, so the object identity holds. If Better Auth ever changes that and
+ * the stashed snapshot goes missing, `refreshTokenAfterHook` degrades to
+ * treating the request as unclassified rather than throwing or guessing.
+ *
+ * Event payloads are minimal by design (repo rule, and this issue's own
+ * ask): client_id, an opaque userId, the grant type, and an OAuth error
+ * code where relevant. Never a token value, never an email.
+ */
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { APIError, createAuthMiddleware } from "better-auth/api";
+import * as schema from "./schema";
+
+/** Auth worker env slice this module needs — mirrors apps/api's ANALYTICS/SLOW_OPS optionality. */
+export type AuthEventsEnv = {
+  AUTH_EVENTS?: AnalyticsEngineDataset;
+};
+
+/**
+ * Event names this module ever writes. Kept as a literal union (not derived
+ * from the AE call sites) so `classifyOAuthTokenEvent`'s return type alone
+ * documents the full observability surface for #912.
+ */
+export type AuthEventName =
+  /** RFC 9700 §4.14 teardown: a revoked refresh token was reused OUTSIDE the
+   * 60s reuse grace, so the plugin tore down the whole family. */
+  | "refresh_family_invalidated"
+  /** A revoked refresh token was reused WITHIN the 60s reuse grace — #909's
+   * absorption path. Fires whether the plugin replayed a cached response or
+   * (rare — see classifyOAuthTokenEvent) failed anyway. */
+  | "refresh_rotation_replay"
+  /** Any other refresh-grant failure at /oauth2/token, by RFC 6749 error
+   * code (invalid_grant for an unknown/expired/wrong-client token,
+   * invalid_scope, invalid_target, ...). */
+  | "refresh_grant_failed"
+  /** A token grant (authorization_code or refresh_token) succeeded but the
+   * response carried no refresh_token — the exact shape #911 was. */
+  | "token_grant_without_refresh";
+
+/** Fields every AE data point below may carry. Never a token value or email. */
+export type AuthEventFields = {
+  clientId?: string;
+  userId?: string;
+  grantType?: string;
+  errorCode?: string;
+};
+
+/**
+ * Blob ordinal contract for the `uploads_auth_events` dataset — Analytics
+ * Engine has no column names. Append new fields at the END; never reorder
+ * or remove, or historical rows change meaning retroactively (same
+ * convention as apps/api's SLOW_OP_BLOB_ORDER).
+ */
+export const AUTH_EVENT_BLOB_ORDER = [
+  "event",
+  "clientId",
+  "grantType",
+  "errorCode",
+  "userId",
+] as const;
+
+/**
+ * Writes one Analytics Engine data point for an OAuth token-endpoint event.
+ * Never throws and never awaits — an absent AUTH_EVENTS binding (unit
+ * tests, self-hosters, local dev without the binding configured) is a
+ * silent no-op, same contract as apps/api's writeSlowOpPoint/writeAdoptionPoint.
+ */
+export function writeAuthEventPoint(
+  env: AuthEventsEnv,
+  name: AuthEventName,
+  fields: AuthEventFields,
+): void {
+  const analytics = env.AUTH_EVENTS;
+  if (!analytics) return;
+  try {
+    analytics.writeDataPoint({
+      // Sampling key: one noisy client/error combo can't crowd out the rest.
+      indexes: [name],
+      blobs: [
+        name,
+        fields.clientId ?? "",
+        fields.grantType ?? "",
+        fields.errorCode ?? "",
+        fields.userId ?? "",
+      ],
+      doubles: [1],
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(JSON.stringify({ message: "auth event analytics write failed", error: message }));
+  }
+}
+
+/**
+ * SHA-256, base64url, no padding — mirrors `@better-auth/oauth-provider`'s
+ * `defaultHasher`, the storage form its `oauth_refresh_token.token` column
+ * holds under the default (unconfigured) `storeTokens: "hashed"`. Pinned
+ * here, not imported, because the plugin doesn't export it — see the
+ * module doc comment on why this module never patches the plugin.
+ * `refresh token rotation reuse grace` in oauth.test.ts (PR #910) already
+ * relies on the identical mirror for its own D1 assertions.
+ */
+export async function hashOAuthToken(raw: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(raw));
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+/** The presented refresh token's revocation/replay-window state at request start. */
+export type RefreshTokenSnapshot = {
+  clientId: string;
+  userId: string;
+  revoked: boolean;
+  withinReuseInterval: boolean;
+};
+
+/**
+ * Mirrors `isWithinRefreshTokenReuseInterval` in `@better-auth/oauth-provider`:
+ * a row counts as "within the reuse grace" only once it's actually been
+ * rotated (rotatedAt set) and that rotation's replay window hasn't lapsed.
+ */
+function isWithinReuseInterval(row: {
+  rotatedAt: Date | null;
+  rotationReplayExpiresAt: Date | null;
+}): boolean {
+  return (
+    Boolean(row.rotatedAt) &&
+    Boolean(row.rotationReplayExpiresAt) &&
+    (row.rotationReplayExpiresAt as Date) >= new Date()
+  );
+}
+
+/**
+ * Looks up the refresh token a `/oauth2/token` request presented, BEFORE
+ * the plugin's handler processes it. The only extra D1 read this module
+ * ever issues, and only for `grant_type=refresh_token` requests — every
+ * other path (including every other OAuth grant type) is untouched.
+ * Never throws: a lookup failure just means the after-hook can't classify
+ * this request beyond its raw success/failure outcome.
+ */
+export async function snapshotPresentedRefreshToken(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  rawToken: string,
+): Promise<RefreshTokenSnapshot | undefined> {
+  try {
+    const hashed = await hashOAuthToken(rawToken);
+    const [row] = await db
+      .select({
+        clientId: schema.oauthRefreshToken.clientId,
+        userId: schema.oauthRefreshToken.userId,
+        revoked: schema.oauthRefreshToken.revoked,
+        rotatedAt: schema.oauthRefreshToken.rotatedAt,
+        rotationReplayExpiresAt: schema.oauthRefreshToken.rotationReplayExpiresAt,
+      })
+      .from(schema.oauthRefreshToken)
+      .where(eq(schema.oauthRefreshToken.token, hashed))
+      .limit(1);
+    if (!row) return undefined;
+    return {
+      clientId: row.clientId,
+      userId: row.userId,
+      revoked: Boolean(row.revoked),
+      withinReuseInterval: isWithinReuseInterval(row),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Pure classification input — kept independent of `ctx`/`APIError` so tests need no fake middleware context. */
+export type OAuthTokenOutcome = {
+  grantType?: string;
+  clientId?: string;
+  /** True when the handler threw (an RFC 6749 error response). */
+  failed: boolean;
+  /** RFC 6749 `error` field of a failed response, e.g. "invalid_grant". */
+  errorCode?: string;
+  /** True when a successful response body carried a non-empty `refresh_token`. */
+  hasRefreshToken?: boolean;
+  snapshot?: RefreshTokenSnapshot;
+};
+
+/**
+ * Classifies one `/oauth2/token` request into at most one #912 event.
+ * Pure — no I/O, no `ctx` — so oauth-observability.test.ts can cover every
+ * branch directly. `refreshTokenAfterHook` below is the only caller in
+ * production and does nothing but gather this shape and forward the result
+ * to `writeAuthEventPoint`.
+ *
+ * Decision order for `grant_type=refresh_token`:
+ *  1. Presented token was already revoked (from the before-hook snapshot):
+ *     - within the 60s reuse grace → `refresh_rotation_replay` (RFC 9700
+ *       absorption path; the plugin serves a cached rotation response here,
+ *       or — rarely, if the cached replay went missing — fails anyway. The
+ *       "replay was attempted" fact is what matters for #912, not which of
+ *       those two the plugin managed).
+ *     - outside the grace → `refresh_family_invalidated` (the plugin calls
+ *       `invalidateRefreshFamily` before throwing `invalid_grant`).
+ *  2. No snapshot (unknown/foreign/garbage token) and the grant failed →
+ *     `refresh_grant_failed` with whatever RFC 6749 error code came back
+ *     (covers invalid_scope/invalid_target too, not just invalid_grant).
+ *  3. Grant succeeded and the response has no `refresh_token` →
+ *     `token_grant_without_refresh` (the exact #911 shape).
+ *
+ * `authorization_code` grants only ever reach case 3 (no snapshot/replay
+ * logic applies — there's no prior refresh token to reuse).
+ */
+export function classifyOAuthTokenEvent(
+  outcome: OAuthTokenOutcome,
+): { name: AuthEventName; fields: AuthEventFields } | null {
+  const { grantType, snapshot } = outcome;
+  const clientId = outcome.clientId ?? snapshot?.clientId;
+
+  if (grantType === "refresh_token" && snapshot?.revoked) {
+    return snapshot.withinReuseInterval
+      ? {
+          name: "refresh_rotation_replay",
+          fields: { clientId, userId: snapshot.userId, grantType },
+        }
+      : {
+          name: "refresh_family_invalidated",
+          fields: { clientId, userId: snapshot.userId, grantType },
+        };
+  }
+
+  if (outcome.failed) {
+    if (grantType !== "refresh_token") return null;
+    return {
+      name: "refresh_grant_failed",
+      fields: { clientId, grantType, errorCode: outcome.errorCode ?? "unknown" },
+    };
+  }
+
+  if (
+    (grantType === "refresh_token" || grantType === "authorization_code") &&
+    !outcome.hasRefreshToken
+  ) {
+    return { name: "token_grant_without_refresh", fields: { clientId, grantType } };
+  }
+
+  return null;
+}
+
+/**
+ * Shape of the stashed before-hook snapshot. Stored on `ctx.context` (Better
+ * Auth's shared per-request `AuthContext`, holding things like `returned`
+ * and `session`) rather than directly on `ctx` itself: `runBeforeHooks`
+ * (better-auth's `api/dispatch.mjs`) invokes the before-hook with `{
+ * ...context, returnHeaders: true }` — a SHALLOW spread copy — so a field
+ * written straight onto that spread copy is discarded, but `ctx.context` is
+ * a nested object reference the spread preserves, and `runAfterHooks` calls
+ * the after-hook with the original context object directly. Verified
+ * against better-auth 1.7.1's dispatcher; if a future version stops sharing
+ * `ctx.context` across before/after, this degrades to `snapshot: undefined`
+ * (see classifyOAuthTokenEvent's case 2) rather than misclassifying.
+ */
+const SNAPSHOT_KEY = "__uploads_auth_events_snapshot__";
+type SnapshotCarrier = { [SNAPSHOT_KEY]?: RefreshTokenSnapshot };
+
+/**
+ * `hooks.before` half: snapshots the presented refresh token's D1 state
+ * ahead of the plugin's own handler. No-op (and no query) for any request
+ * other than `POST /oauth2/token` with `grant_type=refresh_token`.
+ *
+ * Plain async function, not a `createAuthMiddleware`-wrapped one: Better
+ * Auth's `hooks.before` slot takes exactly one handler, and auth.ts's
+ * `authBeforeHook` already owns it (CIMD/DCR scope rewrite, last-admin
+ * guard). This just needs to run as one more step inside that same
+ * function, sharing its `ctx` — see the call site in auth.ts.
+ */
+export async function snapshotBeforeOAuthTokenRequest(
+  ctx: { path: string; body?: unknown; context: unknown },
+  env: { DB: D1Database },
+): Promise<void> {
+  if (ctx.path !== "/oauth2/token") return;
+  const body = ctx.body as Record<string, unknown> | undefined;
+  if (body?.grant_type !== "refresh_token" || typeof body.refresh_token !== "string") return;
+  const db = drizzle(env.DB, { schema });
+  const snapshot = await snapshotPresentedRefreshToken(db, body.refresh_token);
+  if (snapshot) (ctx.context as SnapshotCarrier)[SNAPSHOT_KEY] = snapshot;
+}
+
+/**
+ * `hooks.after` half: reads the handler's outcome plus the before-hook's
+ * snapshot (if any), classifies, and fires at most one AE point. No-op for
+ * any request other than `POST /oauth2/token`.
+ */
+export function refreshTokenAfterHook(env: AuthEventsEnv) {
+  return createAuthMiddleware(async (ctx) => {
+    if (ctx.path !== "/oauth2/token") return;
+    const body = ctx.body as Record<string, unknown> | undefined;
+    const grantType = typeof body?.grant_type === "string" ? body.grant_type : undefined;
+    const clientId = typeof body?.client_id === "string" ? body.client_id : undefined;
+    const snapshot = (ctx.context as SnapshotCarrier)[SNAPSHOT_KEY];
+    const returned = (ctx.context as unknown as { returned?: unknown }).returned;
+
+    const failed = returned instanceof APIError;
+    const errorCode = failed
+      ? ((returned as APIError).body as { error?: string } | undefined)?.error
+      : undefined;
+    const hasRefreshToken =
+      !failed && Boolean((returned as { refresh_token?: unknown } | undefined)?.refresh_token);
+
+    const event = classifyOAuthTokenEvent({
+      grantType,
+      clientId,
+      failed,
+      errorCode,
+      hasRefreshToken,
+      snapshot,
+    });
+    if (event) writeAuthEventPoint(env, event.name, event.fields);
+  });
+}

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -94,6 +94,18 @@
       "database_id": "5f73946b-edd5-414c-856c-8f9bd3c644ba",
     },
   ],
+  // Issue #912: lightweight signal for OAuth refresh-grant failures and
+  // rotation-replay hits — see src/oauth-observability.ts. Same pattern as
+  // apps/api's ANALYTICS/SLOW_OPS datasets (apps/api/wrangler.jsonc);
+  // writeAuthEventPoint treats an absent binding as a silent no-op, so this
+  // is purely additive and tests/local dev need no binding. Dataset
+  // auto-creates on first write.
+  "analytics_engine_datasets": [
+    {
+      "binding": "AUTH_EVENTS",
+      "dataset": "uploads_auth_events",
+    },
+  ],
   // Plain per-worker secrets (uploads#754 item 2 — moved off the
   // account-level Cloudflare Secrets Store: each of these had exactly one
   // consumer, this worker, so the store's cross-worker propagation never
@@ -214,6 +226,14 @@
         "binding": "DB",
         "database_name": "uploads-preview",
         "database_id": "b8c82095-b471-4e3a-8634-56e0861e43f1",
+      },
+    ],
+    // Separate dataset out of preview traffic, same convention as apps/api's
+    // previews block for ANALYTICS/SLOW_OPS.
+    "analytics_engine_datasets": [
+      {
+        "binding": "AUTH_EVENTS",
+        "dataset": "uploads_auth_events_preview",
       },
     ],
     "send_email": [{ "name": "EMAIL", "allowed_sender_addresses": ["noreply@uploads.sh"] }],


### PR DESCRIPTION
## Summary

Closes #912. Follow-up to #909 (refresh-token rotation reuse grace) and #911 (offline_access grant). Before this, the only detector for a refresh grant silently failing, or a client never getting a refresh token at all, was a user report.

Adds an `AUTH_EVENTS` Analytics Engine binding to `apps/auth` (same pattern as apps/api's `ANALYTICS`/`SLOW_OPS` datasets) and a new `apps/auth/src/oauth-observability.ts` module wired into `betterAuth()`'s `hooks.before`/`hooks.after` at `/oauth2/token`. `@better-auth/oauth-provider` is a dependency and is never patched — this observes from outside via the hook pipeline plus reads of the `oauth_refresh_token` D1 rows the plugin already writes.

## Events emitted

All events write to the `uploads_auth_events` dataset (`uploads_auth_events_preview` in the previews block). Blob ordinal contract (`AUTH_EVENT_BLOB_ORDER` in oauth-observability.ts): `[event, clientId, grantType, errorCode, userId]`. Fields are minimal by design — client_id, an opaque userId, grant_type, and an OAuth error code where relevant. Never a token value or an email.

- **`refresh_family_invalidated`** — RFC 9700 §4.14 teardown: a revoked refresh token was reused *outside* the 60s reuse grace, so the plugin tore down the whole family and forced re-auth. Fields: `clientId`, `userId`, `grantType`.
- **`refresh_rotation_replay`** — a revoked refresh token was reused *within* the 60s reuse grace — confirms #909's absorption path is actually live now that refresh tokens exist (#913). Fields: `clientId`, `userId`, `grantType`.
- **`refresh_grant_failed`** — any other refresh-grant failure at `/oauth2/token`, by RFC 6749 error code (`invalid_grant` for an unknown/expired/wrong-client token, `invalid_scope`, `invalid_target`, ...). Fields: `clientId`, `grantType`, `errorCode`.
- **`token_grant_without_refresh`** — a successful `authorization_code` or `refresh_token` grant whose response carried no `refresh_token` — the exact shape #911 was, and would have made it obvious immediately. Fields: `clientId`, `grantType`.

The healthy signature to watch for (per the issue): nonzero `refresh_rotation_replay` counts with zero `refresh_family_invalidated`.

## How it works / cost

- `hooks.before` snapshots the presented refresh token's D1 row (revoked + rotation-replay-window state) **before** the plugin's own handler runs — the only extra query this adds, and only for `grant_type=refresh_token` requests at `/oauth2/token`. Every other request path (get-session, sign-in, other grant types, ...) is untouched.
- `hooks.after` reads the handler's outcome (`ctx.context.returned` — either the success JSON or the thrown `APIError`) plus that snapshot, classifies, and fires at most one AE point.
- The before→after snapshot handoff rides on `ctx.context` (Better Auth's shared per-request `AuthContext`), not `ctx` itself — `runBeforeHooks` in better-auth's dispatcher invokes the before-hook with a shallow-spread copy of `ctx`, so a field written directly on `ctx` would be discarded; `ctx.context` is a nested reference the spread preserves, and `runAfterHooks` passes the original context through directly. Verified against better-auth 1.7.1's `api/dispatch.mjs`; documented in the module so a future version bump that breaks this degrades to an unclassified event rather than misclassifying.
- `writeAuthEventPoint` never throws and never blocks — an absent `AUTH_EVENTS` binding (unit tests, local dev, self-hosters) is a silent no-op.

## How to query

Analytics Engine has no read binding — reads go through the SQL API (account-scoped, same as apps/api's dataset). Example:

```sql
SELECT blob1 AS event, blob2 AS client_id, blob4 AS error_code, count() AS n
FROM uploads_auth_events
WHERE timestamp > now() - INTERVAL '1' DAY
GROUP BY event, client_id, error_code
ORDER BY n DESC
```

## Testing notes

- New file `apps/auth/src/oauth-observability.test.ts` (20 tests): pure unit coverage of the classification logic (`classifyOAuthTokenEvent`) for every branch, `writeAuthEventPoint`'s no-op/write/never-throws contract, `snapshotPresentedRefreshToken` against the fake-D1 harness, and four end-to-end tests driving real `/api/auth/oauth2/token` requests through the actual handler (same harness as `oauth.test.ts`'s reuse-grace suite) with a fake `AUTH_EVENTS` binding, confirming each of the four events fires in the right scenario.
- `pnpm vitest run --config vitest.projects.ts --project @uploads/auth` — 30 files, 436 tests, all passing.
- `pnpm test` from repo root — 361 files, 5594 tests, all passing (no regressions).
- `pnpm exec tsc --noEmit` in apps/auth — clean.
- `wrangler types` regenerated `worker-configuration.d.ts` (gitignored) and confirms `AUTH_EVENTS: AnalyticsEngineDataset` is now in scope.

## Caveats for review

- The `ctx.context` snapshot-handoff technique (see above) is a documented reliance on better-auth 1.7.1's dispatcher internals — not a patch to the plugin, but worth a second look given how load-bearing it is for the replay/teardown split.
- `refresh_rotation_replay` fires whether the plugin actually served a cached replay response or — rarely, if its stored `rotationReplayResponse` went missing — failed anyway with `invalid_grant`. Both cases mean "a within-grace reuse was attempted," which is the #912 signal; I didn't split them into two events to keep the schema small, called out in the code comment.
- `client_id` is read from the request body only; a client authenticating via HTTP Basic auth instead of a body field won't populate it on some events (falls back to the D1 row's `clientId` when a snapshot exists, which covers the refresh-token cases).