### PR TITLE
feat(admin): GitHub App badges and media-type upload breakdown on /admin/metrics

### DIFF
--- a/apps/api/src/adoption-queries.ts
+++ b/apps/api/src/adoption-queries.ts
@@ -39,6 +39,8 @@ export interface WorkspaceActivity {
   bytes: number;
   /** Most recent day with an upload, `YYYY-MM-DD`. */
   lastActive: string;
+  /** Whether the workspace has any `github_repo_links` row with a non-null `installation_id`. */
+  githubApp: boolean;
 }
 
 /** Default cap on the per-workspace table. */
@@ -77,21 +79,41 @@ export async function workspaceActivity(
   since: string,
   limit = DEFAULT_LIMIT,
 ): Promise<WorkspaceActivity[]> {
+  const [result, linked] = await Promise.all([
+    db
+      .prepare(
+        `SELECT workspace,
+                SUM(count) AS uploads,
+                SUM(bytes) AS bytes,
+                MAX(day)   AS lastActive
+         FROM daily_metrics
+         WHERE metric = 'upload' AND workspace <> '' AND day >= ?
+         GROUP BY workspace
+         ORDER BY uploads DESC, workspace ASC
+         LIMIT ?`,
+      )
+      .bind(since, limit)
+      .all<Omit<WorkspaceActivity, "githubApp">>(),
+    workspacesWithGithubApp(db),
+  ]);
+  return result.results.map((row) => ({ ...row, githubApp: linked.has(row.workspace) }));
+}
+
+/**
+ * Workspace names with at least one `github_repo_links` row whose
+ * `installation_id` is set — i.e. the workspace has the GitHub App
+ * installed, not merely a self-serve repo link (`installation_id IS NULL`).
+ * One query, joined against callers in JS rather than a SQL join, since the
+ * set of linked workspaces is small and shared by both `workspaceActivity`
+ * and the `workspacesWithGithubApp` total.
+ */
+export async function workspacesWithGithubApp(db: D1Queryable): Promise<Set<string>> {
   const result = await db
     .prepare(
-      `SELECT workspace,
-              SUM(count) AS uploads,
-              SUM(bytes) AS bytes,
-              MAX(day)   AS lastActive
-       FROM daily_metrics
-       WHERE metric = 'upload' AND workspace <> '' AND day >= ?
-       GROUP BY workspace
-       ORDER BY uploads DESC, workspace ASC
-       LIMIT ?`,
+      `SELECT DISTINCT workspace_name FROM github_repo_links WHERE installation_id IS NOT NULL`,
     )
-    .bind(since, limit)
-    .all<WorkspaceActivity>();
-  return result.results;
+    .all<{ workspace_name: string }>();
+  return new Set(result.results.map((row) => row.workspace_name));
 }
 
 /** One row per workspace that uploaded at least once since `since`, with its most recent active day. */

--- a/apps/api/src/analytics-engine.test.ts
+++ b/apps/api/src/analytics-engine.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { breakdownQuery, fetchBreakdown, fetchSlowOps, slowOpsQuery } from "./analytics-engine";
+import {
+  breakdownQuery,
+  fetchBreakdown,
+  fetchSlowOps,
+  fetchUploadClassSeries,
+  slowOpsQuery,
+  uploadClassSeriesQuery,
+} from "./analytics-engine";
 
 function env(overrides: Record<string, unknown> = {}): Env {
   return {
@@ -146,6 +153,87 @@ describe("breakdownQuery non-finite days guard", () => {
 
   it("falls back to a 30-day window when days is Infinity", () => {
     expect(breakdownQuery("surface", Number.POSITIVE_INFINITY)).toContain("INTERVAL '30' DAY");
+  });
+});
+
+describe("uploadClassSeriesQuery", () => {
+  it("buckets contentType (blob3) into image/video/other with a CASE", () => {
+    const sql = uploadClassSeriesQuery(30);
+    expect(sql).toContain("blob3 LIKE 'image/%'");
+    expect(sql).toContain("blob3 LIKE 'video/%'");
+    expect(sql).toContain("ELSE 'other'");
+  });
+
+  it("groups by day and class, scaling by _sample_interval", () => {
+    const sql = uploadClassSeriesQuery(30);
+    expect(sql).toContain("toDate(timestamp) AS day");
+    expect(sql).toContain("_sample_interval");
+    expect(sql).toContain("GROUP BY day, class");
+  });
+
+  it("windows by the requested number of days", () => {
+    expect(uploadClassSeriesQuery(7)).toContain("INTERVAL '7' DAY");
+  });
+
+  it("falls back to a 30-day window when days is not finite", () => {
+    expect(uploadClassSeriesQuery(Number.NaN)).toContain("INTERVAL '30' DAY");
+  });
+});
+
+describe("fetchUploadClassSeries", () => {
+  it("aggregates rows per day across classes", async () => {
+    const impl = jsonFetch({
+      data: [
+        { day: "2026-08-01", class: "image", events: 10 },
+        { day: "2026-08-01", class: "video", events: 2 },
+        { day: "2026-08-01", class: "other", events: 1 },
+        { day: "2026-08-02", class: "image", events: 5 },
+      ],
+    });
+    const result = await fetchUploadClassSeries(env(), 30, impl);
+    expect(result).toEqual({
+      available: true,
+      days: [
+        { day: "2026-08-01", image: 10, video: 2, other: 1 },
+        { day: "2026-08-02", image: 5, video: 0, other: 0 },
+      ],
+    });
+  });
+
+  it("folds an unrecognized class into other", async () => {
+    const impl = jsonFetch({ data: [{ day: "2026-08-01", class: "weird", events: 3 }] });
+    const result = await fetchUploadClassSeries(env(), 30, impl);
+    expect(result).toEqual({
+      available: true,
+      days: [{ day: "2026-08-01", image: 0, video: 0, other: 3 }],
+    });
+  });
+
+  it("reports unavailable when not configured", async () => {
+    const result = await fetchUploadClassSeries(
+      env({ ANALYTICS_API_TOKEN: undefined }),
+      30,
+      jsonFetch({}),
+    );
+    expect(result).toEqual({ available: false, reason: "not_configured" });
+  });
+
+  it("reports unavailable on a non-OK response rather than throwing", async () => {
+    const result = await fetchUploadClassSeries(env(), 30, jsonFetch({ errors: ["nope"] }, 500));
+    expect(result).toEqual({ available: false, reason: "query_failed" });
+  });
+
+  it("reports unavailable when the request throws", async () => {
+    const impl = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const result = await fetchUploadClassSeries(env(), 30, impl);
+    expect(result).toEqual({ available: false, reason: "query_failed" });
+  });
+
+  it("reports unavailable when the response body's data field is not an array", async () => {
+    const result = await fetchUploadClassSeries(env(), 30, jsonFetch({ data: "nope" }));
+    expect(result).toEqual({ available: false, reason: "query_failed" });
   });
 });
 

--- a/apps/api/src/analytics-engine.ts
+++ b/apps/api/src/analytics-engine.ts
@@ -120,6 +120,86 @@ export async function fetchBreakdown(
   }
 }
 
+export interface UploadClassDayPoint {
+  day: string;
+  image: number;
+  video: number;
+  other: number;
+}
+
+export type UploadClassSeriesResult =
+  | { available: true; days: UploadClassDayPoint[] }
+  | { available: false; reason: string };
+
+/**
+ * Per-day upload counts bucketed by media class (image/video/other), from
+ * `uploads_adoption`'s `contentType` blob (see BLOB_COLUMN above). Buckets
+ * with SQL CASE rather than grouping on the raw content type, since the
+ * panel only cares about the three coarse classes, and scales by
+ * `_sample_interval` the same way `breakdownQuery` does.
+ */
+export function uploadClassSeriesQuery(days: number): string {
+  const column = BLOB_COLUMN.contentType;
+  const window = Number.isFinite(days) ? Math.max(1, Math.min(90, Math.floor(days))) : 30;
+  return `SELECT toDate(timestamp) AS day,
+                 CASE
+                   WHEN ${column} LIKE 'image/%' THEN 'image'
+                   WHEN ${column} LIKE 'video/%' THEN 'video'
+                   ELSE 'other'
+                 END AS class,
+                 SUM(_sample_interval) AS events
+          FROM ${DATASET}
+          WHERE timestamp > NOW() - INTERVAL '${window}' DAY
+          GROUP BY day, class
+          ORDER BY day`;
+}
+
+interface UploadClassRow {
+  day: string;
+  class: "image" | "video" | "other" | string;
+  events: number;
+}
+
+export async function fetchUploadClassSeries(
+  env: Env,
+  days: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<UploadClassSeriesResult> {
+  const account = (env as { CLOUDFLARE_ACCOUNT_ID?: string }).CLOUDFLARE_ACCOUNT_ID;
+  const token = (env as { ANALYTICS_API_TOKEN?: string }).ANALYTICS_API_TOKEN;
+  if (!account || !token) return { available: false, reason: "not_configured" };
+
+  try {
+    const res = await fetchImpl(`${SQL_ENDPOINT}/${account}/analytics_engine/sql`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: uploadClassSeriesQuery(days),
+    });
+    if (!res.ok) return { available: false, reason: "query_failed" };
+    const payload = (await res.json()) as { data?: unknown };
+    if (payload.data !== undefined && !Array.isArray(payload.data)) {
+      return { available: false, reason: "query_failed" };
+    }
+    const rows = (payload.data as UploadClassRow[] | undefined) ?? [];
+    const byDay = new Map<string, UploadClassDayPoint>();
+    for (const row of rows) {
+      const point = byDay.get(row.day) ?? { day: row.day, image: 0, video: 0, other: 0 };
+      if (row.class === "image" || row.class === "video" || row.class === "other") {
+        point[row.class] += row.events;
+      } else {
+        point.other += row.events;
+      }
+      byDay.set(row.day, point);
+    }
+    return {
+      available: true,
+      days: [...byDay.values()].sort((a, b) => a.day.localeCompare(b.day)),
+    };
+  } catch {
+    return { available: false, reason: "query_failed" };
+  }
+}
+
 /** Windows the /admin-ui/metrics/slow-ops panel offers — 24 hours or 7 days. */
 export type SlowOpWindow = "24h" | "7d";
 

--- a/apps/api/src/metrics-overview.ts
+++ b/apps/api/src/metrics-overview.ts
@@ -9,6 +9,7 @@
  * that governs `ws:` keys does not apply here.
  */
 
+import { fetchUploadClassSeries, type UploadClassSeriesResult } from "./analytics-engine";
 import { dbFor } from "./db-session";
 import {
   activeWorkspacesSince,
@@ -18,6 +19,7 @@ import {
   platformStorage,
   windowStart,
   workspaceActivity,
+  workspacesWithGithubApp,
   type DayPoint,
   type MultiIdentityWorkspace,
   type WorkspaceActivity,
@@ -50,11 +52,15 @@ export interface MetricsOverview {
     uploads: number;
     /** Bytes uploaded within the selected window — not stored bytes. */
     bytes: number;
+    /** Workspaces with at least one `github_repo_links` row that has the GitHub App installed. */
+    workspacesWithGithubApp: number;
   };
   series: {
     uploads: DayPoint[];
     users: SignupPoint[];
     orgs: SignupPoint[];
+    /** Per-day upload counts by media class, from Analytics Engine. Degrades when AE is unavailable. */
+    uploadClasses: UploadClassSeriesResult;
   };
   features: Record<string, number>;
   workspaces: WorkspaceActivity[];
@@ -80,7 +86,7 @@ const EMPTY_AUTH: AuthMetrics = {
 };
 
 export function overviewCacheKey(days: number): string {
-  return `metrics:overview:v1:${days}`;
+  return `metrics:overview:v2:${days}`;
 }
 
 /**
@@ -122,7 +128,17 @@ export async function buildOverview(
   const since7 = windowStart(7, now);
   const since30 = windowStart(30, now);
 
-  const [uploads, features, table, active30, storage, auth, multiIdentity] = await Promise.all([
+  const [
+    uploads,
+    features,
+    table,
+    active30,
+    storage,
+    auth,
+    multiIdentity,
+    githubApp,
+    uploadClasses,
+  ] = await Promise.all([
     platformSeries(dbFor(env), "upload", since),
     featureTotals(dbFor(env), since),
     workspaceActivity(dbFor(env), since),
@@ -135,6 +151,8 @@ export async function buildOverview(
     platformStorage(dbFor(env)),
     authMetrics(env, since),
     multiIdentityWorkspaces(dbFor(env)),
+    workspacesWithGithubApp(dbFor(env)),
+    fetchUploadClassSeries(env, days),
   ]);
 
   return {
@@ -148,8 +166,9 @@ export async function buildOverview(
       activeWorkspaces30d: active30.length,
       uploads: uploads.reduce((sum, point) => sum + point.count, 0),
       bytes: uploads.reduce((sum, point) => sum + point.bytes, 0),
+      workspacesWithGithubApp: githubApp.size,
     },
-    series: { uploads, users: auth.users, orgs: auth.orgs },
+    series: { uploads, users: auth.users, orgs: auth.orgs, uploadClasses },
     features,
     workspaces: table,
     multiIdentityWorkspaces: multiIdentity,

--- a/apps/api/src/routes/admin-ui-metrics.test.ts
+++ b/apps/api/src/routes/admin-ui-metrics.test.ts
@@ -14,6 +14,7 @@ const MIGRATIONS = [
   "migrations/20260712230000_token_minting_user.sql",
   "migrations/20260817180000_token_last_used.sql",
   "migrations/20260728120000_daily_metrics.sql",
+  "migrations/20260720120000_github_repo_links.sql",
 ];
 const ADMIN_USER = { id: "u-admin", email: "admin@b.com", name: "Admin", role: "admin" };
 const NON_ADMIN_USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
@@ -183,7 +184,7 @@ describe("GET /admin-ui/metrics/overview", () => {
       const env = { AUTH: stubAuth(ADMIN_USER), DB: db, REGISTRY: kv.binding } as unknown as Env;
       await app().request("/admin-ui/metrics/overview?days=30", {}, env);
       expect(kv.puts).toBe(1);
-      expect(kv.store.has("metrics:overview:v1:30")).toBe(true);
+      expect(kv.store.has("metrics:overview:v2:30")).toBe(true);
       const res = await app().request("/admin-ui/metrics/overview?days=30", {}, env);
       expect(res.status).toBe(200);
       expect(kv.puts).toBe(1);

--- a/apps/api/test/adoption-queries-sqlite.test.ts
+++ b/apps/api/test/adoption-queries-sqlite.test.ts
@@ -9,12 +9,14 @@ import {
   platformStorage,
   windowStart,
   workspaceActivity,
+  workspacesWithGithubApp,
 } from "../src/adoption-queries";
 import { SqliteD1, database } from "./helpers/sqlite-d1";
 
 const MIGRATION = "migrations/20260728120000_daily_metrics.sql";
 const USAGE_MIGRATION = "migrations/20260710140000_workspace_usage.sql";
 const SHARED_USAGE_MIGRATION = "migrations/20260822120100_workspace_usage_shared_subset.sql";
+const REPO_LINKS_MIGRATION = "migrations/20260720120000_github_repo_links.sql";
 
 async function seed(db: D1Database): Promise<void> {
   const day = (d: string) => new Date(`${d}T10:00:00Z`);
@@ -65,13 +67,13 @@ describe("platformSeries", () => {
 
 describe("workspaceActivity", () => {
   it("aggregates per workspace and sorts by uploads descending", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1([MIGRATION, REPO_LINKS_MIGRATION]);
     try {
       const db = database(sqlite);
       await seed(db);
       expect(await workspaceActivity(db, "2026-07-01")).toEqual([
-        { workspace: "acme", uploads: 2, bytes: 300, lastActive: "2026-07-28" },
-        { workspace: "beta", uploads: 1, bytes: 50, lastActive: "2026-07-28" },
+        { workspace: "acme", uploads: 2, bytes: 300, lastActive: "2026-07-28", githubApp: false },
+        { workspace: "beta", uploads: 1, bytes: 50, lastActive: "2026-07-28", githubApp: false },
       ]);
     } finally {
       sqlite.close();
@@ -79,12 +81,79 @@ describe("workspaceActivity", () => {
   });
 
   it("never includes the platform sentinel row", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1([MIGRATION, REPO_LINKS_MIGRATION]);
     try {
       const db = database(sqlite);
       await seed(db);
       const rows = await workspaceActivity(db, "2026-07-01");
       expect(rows.some((row) => row.workspace === "")).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("sets githubApp true only for a workspace with a linked, installed repo", async () => {
+    const sqlite = new SqliteD1([MIGRATION, REPO_LINKS_MIGRATION]);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      await db
+        .prepare(
+          `INSERT INTO github_repo_links (repo_full_name, workspace_name, installation_id, source, created_at)
+           VALUES ('acme/repo', 'acme', 42, 'comment', '2026-07-28T00:00:00Z')`,
+        )
+        .run();
+      const rows = await workspaceActivity(db, "2026-07-01");
+      expect(rows.find((r) => r.workspace === "acme")?.githubApp).toBe(true);
+      expect(rows.find((r) => r.workspace === "beta")?.githubApp).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not count a repo link with a null installation_id as the GitHub App", async () => {
+    const sqlite = new SqliteD1([MIGRATION, REPO_LINKS_MIGRATION]);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      await db
+        .prepare(
+          `INSERT INTO github_repo_links (repo_full_name, workspace_name, installation_id, source, created_at)
+           VALUES ('acme/repo', 'acme', NULL, 'comment', '2026-07-28T00:00:00Z')`,
+        )
+        .run();
+      const rows = await workspaceActivity(db, "2026-07-01");
+      expect(rows.find((r) => r.workspace === "acme")?.githubApp).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("workspacesWithGithubApp", () => {
+  it("returns the set of workspace names with a non-null installation_id link", async () => {
+    const sqlite = new SqliteD1([MIGRATION, REPO_LINKS_MIGRATION]);
+    try {
+      const db = database(sqlite);
+      await db
+        .prepare(
+          `INSERT INTO github_repo_links (repo_full_name, workspace_name, installation_id, source, created_at)
+           VALUES ('acme/one', 'acme', 1, 'comment', '2026-07-28T00:00:00Z'),
+                  ('acme/two', 'acme', 2, 'comment', '2026-07-28T00:00:00Z'),
+                  ('beta/one', 'beta', NULL, 'comment', '2026-07-28T00:00:00Z')`,
+        )
+        .run();
+      const result = await workspacesWithGithubApp(db);
+      expect(result).toEqual(new Set(["acme"]));
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns an empty set when no links exist", async () => {
+    const sqlite = new SqliteD1([MIGRATION, REPO_LINKS_MIGRATION]);
+    try {
+      expect(await workspacesWithGithubApp(database(sqlite))).toEqual(new Set());
     } finally {
       sqlite.close();
     }

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -27,6 +27,7 @@ const workspaceActivitySkeleton = renderAdminTableSkeletonRowsHtml(
     { width: "34px", num: true },
     { width: "58px", num: true },
     { width: "76px" },
+    { width: "48px" },
   ],
   5,
 );
@@ -129,6 +130,19 @@ const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
           </dt>
           <dd
             id="tile-workspaces"
+            class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
+          >
+            —
+          </dd>
+        </div>
+        <div class="metrics-tile border border-border rounded-md px-3.5 py-3">
+          <dt
+            class="m-0 text-muted-foreground text-(length:--text-micro) uppercase tracking-[0.06em]"
+          >
+            GitHub App workspaces
+          </dt>
+          <dd
+            id="tile-github-app"
             class="mt-1.5 mb-0 text-foreground text-(length:--text-h3) font-semibold tabular-nums"
           >
             —
@@ -245,6 +259,7 @@ const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
                 <th class={`keep num ${ADMIN_TH_NUM}`} scope="col">Uploads</th>
                 <th class={`keep num ${ADMIN_TH_NUM}`} scope="col">Bytes</th>
                 <th class={`keep ${ADMIN_TH}`} scope="col">Last active</th>
+                <th class={`keep ${ADMIN_TH}`} scope="col">GitHub App</th>
               </tr>
             </thead>
             <tbody set:html={workspaceActivitySkeleton} />
@@ -774,6 +789,237 @@ const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
         wrap?.addEventListener("focusout", hide);
       }
 
+      /** Stacked-bar segment keys, in bottom-to-top draw order. */
+      const UPLOAD_CLASS_KEYS = ["image", "video", "other"] as const;
+      type UploadClassKey = (typeof UPLOAD_CLASS_KEYS)[number];
+      const UPLOAD_CLASS_LABELS: Record<UploadClassKey, string> = {
+        image: "Image",
+        video: "Video",
+        other: "Other",
+      };
+
+      /**
+       * Stacked variant of `drawChart` for `series.uploadClasses` (Analytics
+       * Engine-backed, sampled — see the panel note below the chart): each
+       * day's bar splits into image/video/other segments instead of one
+       * solid fill. Shares drawChart's scale/gridline/tooltip machinery but
+       * can't reuse it directly since niceMax has to cover the *stacked*
+       * total per day, not a single series value, and the tooltip needs a
+       * per-class breakdown rather than one number.
+       */
+      function drawStackedChart(
+        elementId: string,
+        days: { day: string; image: number; video: number; other: number }[],
+        windowDays: number,
+      ): void {
+        const container = document.getElementById(elementId);
+        if (!container) return;
+        container.removeAttribute("aria-busy");
+        if (!days.length) {
+          container.innerHTML = `<p class="muted">No data yet.</p>`;
+          return;
+        }
+
+        const rows = days.map((d) => ({
+          day: d.day,
+          image: Math.max(0, Number(d.image) || 0),
+          video: Math.max(0, Number(d.video) || 0),
+          other: Math.max(0, Number(d.other) || 0),
+        }));
+        const totals = rows.map((r) => r.image + r.video + r.other);
+        const niceMax = niceCeil(Math.max(1, ...totals));
+
+        const W = 480;
+        const H = 200;
+        const marginLeft = 36;
+        const marginRight = 8;
+        const marginTop = 10;
+        const marginBottom = 26;
+        const plotW = W - marginLeft - marginRight;
+        const plotH = H - marginTop - marginBottom;
+        const baseline = marginTop + plotH;
+        const bandWidth = plotW / rows.length;
+        const gap = Math.min(6, Math.max(2, bandWidth * 0.25));
+        const barWidth = Math.max(1, Math.min(24, bandWidth - gap));
+        const labelIdx = pickLabelIndices(rows.length);
+
+        const yTicks = buildYTicks(niceMax);
+        const gridlines = yTicks
+          .map((t) => {
+            const labelValue = Math.round(t);
+            const y = baseline - (labelValue / niceMax) * plotH;
+            return (
+              `<line x1="${marginLeft}" y1="${y}" x2="${W - marginRight}" y2="${y}" class="metrics-gridline" />` +
+              `<text x="${marginLeft - 6}" y="${y}" class="metrics-axis-label" text-anchor="end" dominant-baseline="middle">${escapeHtml(labelValue.toLocaleString())}</text>`
+            );
+          })
+          .join("");
+
+        const bars = rows
+          .map((row, i) => {
+            const x = marginLeft + i * bandWidth + (bandWidth - barWidth) / 2;
+            const dayLabel = escapeHtml(formatDay(row.day));
+            const xLabel = labelIdx.has(i)
+              ? `<text x="${x + barWidth / 2}" y="${H - 8}" class="metrics-axis-label" text-anchor="middle">${dayLabel}</text>`
+              : "";
+
+            // Segments stack bottom-up in UPLOAD_CLASS_KEYS order; only the
+            // topmost segment with any height gets a rounded top, so the
+            // rounding follows whichever class happens to top the stack on
+            // a given day rather than always "video" or always "other".
+            const lastNonZero = [...UPLOAD_CLASS_KEYS].reverse().find((key) => row[key] > 0);
+            let cursor = baseline;
+            const segments = UPLOAD_CLASS_KEYS.map((key) => {
+              const value = row[key];
+              const height = (value / niceMax) * plotH;
+              const y = cursor - height;
+              cursor = y;
+              if (height <= 0) return "";
+              const path =
+                key === lastNonZero
+                  ? roundedTopRectPath(x, y, barWidth, height, 4)
+                  : `M${x},${y} H${x + barWidth} V${y + height} H${x} Z`;
+              return `<path d="${path}" class="metrics-bar-fill metrics-bar-fill--${key}" />`;
+            }).join("");
+
+            const total = totals[i];
+            const ariaParts = UPLOAD_CLASS_KEYS.map(
+              (key) => `${row[key].toLocaleString()} ${UPLOAD_CLASS_LABELS[key].toLowerCase()}`,
+            ).join(", ");
+
+            return `<g class="metrics-bar" data-index="${i}">
+                ${segments}
+                <rect
+                  class="metrics-bar-hit"
+                  data-index="${i}"
+                  x="${x - gap / 2}"
+                  y="${marginTop}"
+                  width="${barWidth + gap}"
+                  height="${plotH}"
+                  tabindex="0"
+                  role="img"
+                  aria-label="${dayLabel}: ${escapeHtml(total.toLocaleString())} uploads (${escapeHtml(ariaParts)})"
+                />
+                ${xLabel}
+              </g>`;
+          })
+          .join("");
+
+        const windowLabel = `last ${windowDays} day${windowDays === 1 ? "" : "s"}`;
+        const legend = UPLOAD_CLASS_KEYS.map(
+          (key) =>
+            `<span class="metrics-legend-item"><span class="metrics-legend-swatch metrics-legend-swatch--${key}"></span>${UPLOAD_CLASS_LABELS[key]}</span>`,
+        ).join("");
+
+        const svg = `<svg class="metrics-chart" viewBox="0 0 ${W} ${H}" role="img" aria-label="Uploads per day by media type, ${windowLabel}">
+            <line x1="${marginLeft}" y1="${baseline}" x2="${W - marginRight}" y2="${baseline}" class="metrics-axis-line" />
+            ${gridlines}
+            ${bars}
+          </svg>`;
+
+        const tableRows = rows
+          .map(
+            (row, i) =>
+              `<tr><td>${escapeHtml(row.day)}</td><td class="num">${escapeHtml(row.image.toLocaleString())}</td><td class="num">${escapeHtml(row.video.toLocaleString())}</td><td class="num">${escapeHtml(row.other.toLocaleString())}</td><td class="num">${escapeHtml(totals[i].toLocaleString())}</td></tr>`,
+          )
+          .join("");
+
+        container.innerHTML = `
+          <div class="metrics-legend">${legend}</div>
+          <div class="metrics-chart-wrap relative">
+            ${svg}
+            <div class="metrics-chart-tooltip" data-visible="false" role="presentation"></div>
+          </div>
+          <table class="sr-only">
+            <caption>Uploads per day by media type</caption>
+            <thead><tr><th scope="col">Day</th><th scope="col">Image</th><th scope="col">Video</th><th scope="col">Other</th><th scope="col">Total</th></tr></thead>
+            <tbody>${tableRows}</tbody>
+          </table>`;
+
+        const wrap = container.querySelector<HTMLElement>(".metrics-chart-wrap");
+        const tooltip = container.querySelector<HTMLElement>(".metrics-chart-tooltip");
+        let liftedGroup: SVGGElement | null = null;
+
+        const groupByIndex = new Map<number, SVGGElement>();
+        wrap?.querySelectorAll<SVGGElement>(".metrics-bar[data-index]").forEach((bar) => {
+          const idx = Number(bar.getAttribute("data-index"));
+          if (!Number.isNaN(idx)) groupByIndex.set(idx, bar);
+        });
+
+        function setLift(index: number | null): void {
+          if (liftedGroup) {
+            liftedGroup.removeAttribute("style");
+            liftedGroup = null;
+          }
+          if (index === null) return;
+          const group = groupByIndex.get(index);
+          if (group) {
+            group.setAttribute("style", "opacity:0.8");
+            liftedGroup = group;
+          }
+        }
+
+        let lastShownIndex: number | null = null;
+
+        function show(index: number): void {
+          const row = rows[index];
+          if (!row || !tooltip) return;
+          const total = totals[index];
+          const height = (total / niceMax) * plotH;
+          const x = marginLeft + index * bandWidth + bandWidth / 2;
+          const y = baseline - height;
+          tooltip.style.left = `${(x / W) * 100}%`;
+          tooltip.style.top = `${(y / H) * 100}%`;
+          tooltip.innerHTML = "";
+          const dayEl = document.createElement("span");
+          dayEl.className = "day";
+          dayEl.textContent = formatDay(row.day);
+          tooltip.appendChild(dayEl);
+          for (const key of UPLOAD_CLASS_KEYS) {
+            const line = document.createElement("div");
+            line.className = "metrics-tooltip-row";
+            const swatch = document.createElement("span");
+            swatch.className = `metrics-legend-swatch metrics-legend-swatch--${key}`;
+            const text = document.createElement("span");
+            text.textContent = `${UPLOAD_CLASS_LABELS[key]} ${row[key].toLocaleString()}`;
+            line.appendChild(swatch);
+            line.appendChild(text);
+            tooltip.appendChild(line);
+          }
+          const totalEl = document.createElement("span");
+          totalEl.className = "value";
+          totalEl.textContent = `Total ${total.toLocaleString()}`;
+          tooltip.appendChild(totalEl);
+          tooltip.dataset.visible = "true";
+          setLift(index);
+          lastShownIndex = index;
+        }
+
+        function hide(): void {
+          if (tooltip) tooltip.dataset.visible = "false";
+          setLift(null);
+          lastShownIndex = null;
+        }
+
+        function indexFromEvent(event: Event): number | null {
+          const el = (event.target as Element | null)?.closest("[data-index]");
+          const raw = el?.getAttribute("data-index");
+          const idx = raw === null || raw === undefined ? NaN : Number(raw);
+          return Number.isNaN(idx) ? null : idx;
+        }
+
+        wrap?.addEventListener("pointermove", (event) => {
+          const idx = indexFromEvent(event);
+          if (idx !== null && idx !== lastShownIndex) show(idx);
+        });
+        wrap?.addEventListener("pointerleave", hide);
+        wrap?.addEventListener("focusin", (event) => {
+          const idx = indexFromEvent(event);
+          if (idx !== null) show(idx);
+        });
+        wrap?.addEventListener("focusout", hide);
+      }
+
       function render(overview: MetricsOverview): void {
         const tile = (id: string, value: string) => {
           const el = document.getElementById(id);
@@ -786,6 +1032,7 @@ const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
         tile("tile-active-7", num(overview.totals.activeWorkspaces7d));
         tile("tile-active-30", num(overview.totals.activeWorkspaces30d));
         tile("tile-uploads", num(overview.totals.uploads));
+        tile("tile-github-app", num(overview.totals.workspacesWithGithubApp));
 
         // `upload`/`delete` are deliberately excluded — they're already the
         // "Uploads in window" tile and the uploads chart above; repeating
@@ -813,10 +1060,10 @@ const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
           ? overview.workspaces
               .map(
                 (row) =>
-                  `<tr class="admin-row"><td class="${ADMIN_TD}">${escapeHtml(row.workspace)}</td><td class="num ${ADMIN_TD_NUM}">${num(row.uploads)}</td><td class="num ${ADMIN_TD_NUM}">${bytes(row.bytes)}</td><td class="${ADMIN_TD}">${escapeHtml(row.lastActive)}</td></tr>`,
+                  `<tr class="admin-row"><td class="${ADMIN_TD}">${escapeHtml(row.workspace)}</td><td class="num ${ADMIN_TD_NUM}">${num(row.uploads)}</td><td class="num ${ADMIN_TD_NUM}">${bytes(row.bytes)}</td><td class="${ADMIN_TD}">${escapeHtml(row.lastActive)}</td><td class="${ADMIN_TD}">${row.githubApp ? `<span class="metrics-gh-badge">GH App</span>` : ""}</td></tr>`,
               )
               .join("")
-          : `<tr class="admin-row"><td colspan="4" class="muted ${ADMIN_TD}">No workspace activity in this window.</td></tr>`;
+          : `<tr class="admin-row"><td colspan="5" class="muted ${ADMIN_TD}">No workspace activity in this window.</td></tr>`;
         const tableBody = table.querySelector<HTMLElement>("tbody");
         if (tableBody) tableBody.innerHTML = rows;
         table.removeAttribute("aria-busy");
@@ -837,12 +1084,41 @@ const slowOpsSkeleton = renderAdminTableSkeletonRowsHtml(
         if (multiIdentityBody) multiIdentityBody.innerHTML = multiIdentityRows;
         multiIdentityTable.removeAttribute("aria-busy");
 
-        drawChart(
-          "chart-uploads",
-          overview.series.uploads.map((p) => ({ day: p.day, value: p.count })),
-          "Uploads per day",
-          overview.window.days,
-        );
+        // uploadClasses is Analytics Engine-sampled while series.uploads is
+        // D1-exact — the two totals may differ slightly; the stacked chart
+        // is rendered whenever class data is available rather than
+        // reconciled against the D1 series.
+        if (overview.series.uploadClasses?.available) {
+          document
+            .getElementById("chart-uploads")
+            ?.parentElement?.querySelector(".metrics-chart-note")
+            ?.remove();
+          drawStackedChart(
+            "chart-uploads",
+            overview.series.uploadClasses.days,
+            overview.window.days,
+          );
+        } else {
+          drawChart(
+            "chart-uploads",
+            overview.series.uploads.map((p) => ({ day: p.day, value: p.count })),
+            "Uploads per day",
+            overview.window.days,
+          );
+          const reason = overview.series.uploadClasses?.reason;
+          const container = document.getElementById("chart-uploads");
+          container?.parentElement?.querySelector(".metrics-chart-note")?.remove();
+          if (container && reason) {
+            const note = document.createElement("p");
+            note.className =
+              "metrics-chart-note m-0 mt-2 text-muted-foreground text-(length:--text-micro)";
+            note.textContent =
+              reason === "not_configured"
+                ? "Media-type breakdown unavailable: Analytics Engine is not configured."
+                : "Media-type breakdown is temporarily unavailable.";
+            container.insertAdjacentElement("afterend", note);
+          }
+        }
         drawChart(
           "chart-signups",
           overview.series.users.map((p) => ({ day: p.day, value: p.count })),

--- a/apps/web/src/styles/admin-metrics.css
+++ b/apps/web/src/styles/admin-metrics.css
@@ -31,6 +31,21 @@
   transition: opacity 0.1s ease;
 }
 
+/* Stacked media-class fills (drawStackedChart) — three theme-aware colors
+   derived from existing tokens rather than new hex values, so they track
+   light/dark without a separate palette. */
+.metrics-chart .metrics-bar-fill--image {
+  fill: var(--accent);
+}
+
+.metrics-chart .metrics-bar-fill--video {
+  fill: var(--green);
+}
+
+.metrics-chart .metrics-bar-fill--other {
+  fill: color-mix(in srgb, var(--muted) 55%, var(--fg));
+}
+
 .metrics-chart .metrics-bar-hit {
   fill: transparent;
   cursor: pointer;
@@ -73,6 +88,78 @@
 .metrics-chart-tooltip .day {
   color: var(--muted);
   margin-right: 4px;
+}
+
+/* Per-class rows inside the stacked chart's tooltip (drawStackedChart's
+   show()) — the day label above, one swatch+count row per media class,
+   then the bold total, all in the same tooltip box as the single-series
+   chart. */
+.metrics-tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--fg);
+}
+
+.metrics-chart-tooltip .value {
+  display: block;
+  margin-top: 2px;
+}
+
+/* Legend above the stacked chart (drawStackedChart) — one swatch + label
+   per media class, matching the fills in .metrics-bar-fill--*. */
+.metrics-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-block-end: 8px;
+  font-size: var(--text-micro);
+  color: var(--muted);
+}
+
+.metrics-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.metrics-legend-swatch {
+  display: inline-block;
+  inline-size: 9px;
+  block-size: 9px;
+  border-radius: 2px;
+}
+
+.metrics-legend-swatch--image {
+  background: var(--accent);
+}
+
+.metrics-legend-swatch--video {
+  background: var(--green);
+}
+
+.metrics-legend-swatch--other {
+  background: color-mix(in srgb, var(--muted) 55%, var(--fg));
+}
+
+/* Fallback-mode note under the single-series uploads chart when
+   series.uploadClasses is unavailable (metrics.astro's render()). */
+.metrics-chart-note {
+  font-style: italic;
+}
+
+/* "GH App" pill in the workspace-activity table (metrics.astro's render()),
+   matching the outline look of .admin-btn/.pill elsewhere in admin. */
+.metrics-gh-badge {
+  display: inline-block;
+  font-size: var(--text-micro);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--line));
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+  white-space: nowrap;
 }
 
 /* Loading placeholder emitted by workspace-ui.ts's skeletonBarHtml (reused by


### PR DESCRIPTION
Adds two operator-facing improvements to `/admin/metrics`.

## GitHub App highlighting

- Each row in the workspace activity table now carries a `githubApp` flag, derived from `github_repo_links` (any link with a non-null `installation_id`). One extra D1 query joined in JS — no GitHub API calls on the hot path.
- New `totals.workspacesWithGithubApp` count, surfaced as a "GitHub App workspaces" stat tile.
- Workspace rows with the App installed show a compact "GH App" pill in a new column.

## Media-type upload breakdown

- New Analytics Engine query buckets `contentType` (blob3) into image / video / other per day, scaled by `_sample_interval`.
- The uploads-over-time chart renders as stacked bars with a legend and per-class tooltip when the class series is available, and falls back to the existing D1 single-series chart otherwise (AE is sampled and 90-day retention, so the two sources are deliberately not reconciled).
- The sr-only accessible table gains per-class columns.
- Overview KV cache key bumped `v1` → `v2` so cached payloads can't miss the new fields.

## Notes

- AE retention caps class history at ~90 days; the allowed windows (7/30/90) all fit. Longer history would need D1 rollups at write time (possible follow-up).


## Testing

- `pnpm --filter @uploads/api test` — 172 files / 2498 tests pass, including new coverage for the `githubApp` join (with/without/null `installation_id`), the totals count, AE query shape, sample-interval scaling, and unavailable-AE degradation.
- `pnpm --filter @uploads/api typecheck` and `pnpm --filter @uploads/web typecheck` clean.

## Screenshot

<img width="760" alt="Admin metrics with GitHub App badges and stacked media-type chart" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/916/127.0.0.1-admin-metrics-after.webp">

Captured on the local stack with seeded workspace/repo-link data; the media-class series uses sample data since local Analytics Engine has no history.
