### PR TITLE
feat(cli): attach --from-branch recovers staged uploads from renamed branches

### DIFF
--- a/.changeset/brave-branches-promote.md
+++ b/.changeset/brave-branches-promote.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Add `uploads attach --pr <num> --from-branch <old-name>` to promote staged files after a branch is renamed or deleted.

--- a/apps/api/src/github-promote.test.ts
+++ b/apps/api/src/github-promote.test.ts
@@ -96,6 +96,37 @@ async function seedPrivateStaged(seeded: Seeded, prefixId: string, filename: str
 }
 
 describe("promoteBranchAttachments — private prefixes (issue #631)", () => {
+  it("private repo: promotes from the caller-supplied stale branch prefix", async () => {
+    const seeded = await seededEnv({ isPrivate: true });
+    const staleBranch = "renamed/old";
+    const prefixId = await getOrMintPrefixId(seeded.db as unknown as D1Database, REPO, staleBranch);
+    const key = ghPrivateBranchAttachmentKey(prefixId, "stale.png");
+    await seeded.bucket.put(`${PREFIX}${key}`, PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await replaceFileMetadata(seeded.env.DB, WS, key, {
+      "gh.repo": REPO,
+      "gh.kind": "branch",
+      "gh.branch": staleBranch,
+      "gh.staged-at": new Date().toISOString(),
+    });
+
+    const result = await promoteBranchAttachments(seeded.env, seeded.ws, WS, {
+      repo: REPO,
+      num: NUM,
+      branch: staleBranch,
+    });
+
+    const expectedDest = ghPrivateAttachmentKey(
+      prefixId,
+      { repo: REPO, kind: "pull", num: NUM },
+      "stale.png",
+    );
+    expect(result).toEqual({ promoted: [expectedDest], skipped: [] });
+    expect((await getFileMetadata(seeded.env.DB, WS, key))["gh.status"]).toBe("promoted");
+    expect((await getFileMetadata(seeded.env.DB, WS, expectedDest))["gh.branch"]).toBe(staleBranch);
+  });
+
   it("public repo: promotes into the plain destination, byte-identical to pre-#631 behavior", async () => {
     const seeded = await seededEnv({ isPrivate: false });
     await seedPlainStaged(seeded, "hero.png");

--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -73,6 +73,7 @@ export interface PromoteTarget {
   /** "owner/name", already validated by the caller. */
   repo: string;
   num: number;
+  /** Source staging branch, including a stale name supplied through the escape hatch (#918). */
   branch: string;
 }
 

--- a/apps/api/src/github-webhook-auto-promote.test.ts
+++ b/apps/api/src/github-webhook-auto-promote.test.ts
@@ -195,6 +195,20 @@ describe("handleWebhook pull_request auto-promotion", () => {
     expect(bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(true);
   });
 
+  it("keeps PR-open promotion scoped to the current head ref", async () => {
+    const { env, bucket } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedStaged(env, "current.png");
+    await bucket.put(`${PREFIX}gh/acme/web/branch/old-branch/stale.png`, PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+
+    await withMockPost(() => handleWebhook(env, "pull_request", prPayload({ action: "opened" })));
+
+    expect(bucket.store.has(`${PREFIX}${destKey("current.png")}`)).toBe(true);
+    expect(bucket.store.has(`${PREFIX}${destKey("stale.png")}`)).toBe(false);
+  });
+
   it("does not create a comment on a bound PR that never had one", async () => {
     const { env } = await baseEnv();
     await recordRepoLink(env.DB, REPO, WS, "promote");

--- a/apps/api/src/routes/github-promote-route.test.ts
+++ b/apps/api/src/routes/github-promote-route.test.ts
@@ -275,6 +275,31 @@ describe("POST /v1/:workspace/github/promote", () => {
     });
   });
 
+  it("promotes a plain-repo file from a caller-supplied stale branch", async () => {
+    const seeded = await seededEnv();
+    const staleBranch = "renamed/old";
+    const staleKey = `gh/acme/web/branch/renamed-old/stale.png`;
+    await seeded.bucket.put(`${PREFIX}${staleKey}`, PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await replaceFileMetadata(seeded.env.DB, WS, staleKey, {
+      "gh.repo": REPO,
+      "gh.kind": "branch",
+      "gh.branch": staleBranch,
+      "gh.staged-at": new Date().toISOString(),
+      "gh.status": "staged",
+    });
+
+    const res = await post(seeded.env, { repo: REPO, num: NUM, branch: staleBranch });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ promoted: [destKey("stale.png")], skipped: [] });
+    expect((await getFileMetadata(seeded.env.DB, WS, staleKey))["gh.status"]).toBe("promoted");
+    expect((await getFileMetadata(seeded.env.DB, WS, destKey("stale.png")))["gh.branch"]).toBe(
+      staleBranch,
+    );
+  });
+
   it("treats a missing gh.staged-at as fresh (workspace's own data)", async () => {
     const seeded = await seededEnv();
     await seedStaged(seeded, "hero.png", { stagedAt: null });

--- a/apps/api/src/routes/github-promote.ts
+++ b/apps/api/src/routes/github-promote.ts
@@ -29,6 +29,7 @@ const BRANCH_VALUE_MAX = 512;
 interface PromoteBody {
   repo: string;
   num: number;
+  /** Caller-selected source branch; it does not need to match the PR's current head ref. */
   branch: string;
 }
 

--- a/apps/web/src/content/docs/attach-pull-request-images.mdx
+++ b/apps/web/src/content/docs/attach-pull-request-images.mdx
@@ -89,6 +89,16 @@ binding state means and how to fix it.
   body, say, before it was even opened) keeps serving.
 </div>
 
+If you rename or delete the branch before the PR opens, name the old branch explicitly:
+
+```bash
+uploads attach --pr 123 --from-branch old/branch
+```
+
+This command promotes fresh files from the old branch prefix and refreshes the managed comment.
+You can also add local files or existing keys to the same command. The staged files must still be
+inside the 30-day promotion window.
+
 </section>
 
 <section id="before-after">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -321,6 +321,16 @@ no staging reaper (see `docs/deletion.md`); once a file ages out of the promotio
 window it just sits there, still reachable at its original URL, until
 per-workspace retention or an explicit `files:delete` removes it.
 
+If the branch is renamed or deleted before the PR opens, promote from the old
+prefix explicitly:
+
+```bash
+uploads attach --pr 123 --from-branch old/branch
+```
+
+The command also accepts local files or existing object keys. It promotes the
+old branch prefix before it runs the normal attach and managed-comment flow.
+
 On a `gh.*`-tagged upload, the server also stamps `gh.uploader` (GitHub login)
 and `gh.uploader-id` from the user who minted the bearer token. These are
 attribution only, not access control, and the server overrides any

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -39,6 +39,7 @@ export const PUT_LIKE_FLAGS: readonly string[] = [
   "--pr",
   "--issue",
   "--branch",
+  "--from-branch",
   "--comment",
   "--no-comment",
   "--format",

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1094,6 +1094,12 @@ takes effect with zero files and cannot combine with --branch/--issue/
 --no-promote. Promotion never applies to issues. Staged files stay findable
 with "uploads find gh.branch=<branch>" either way.
 
+If the branch was renamed or deleted before the PR opened, pass
+"--from-branch <old-name>" with "--pr <num>". With no file arguments, this
+promotes the stale branch prefix and refreshes the managed comment. With file
+or existing-key arguments, it promotes the stale prefix before the normal
+attach flow.
+
 Options:
   --pr <num>            Attach to this pull request
   --issue <num>         Attach to this issue
@@ -1102,6 +1108,8 @@ Options:
   --promote             No files: promote branch-staged attachments into the
                         resolved PR and refresh the comment; not with
                         --branch/--issue/--no-promote
+  --from-branch <name>  Promote staged attachments from this branch instead of
+                        the current branch; requires a pull-request target
   --no-promote          Skip auto-promoting branch-staged attachments (default path only)
   --move                With an already-uploaded key/URL argument: delete the source
                         object after a successful server-side copy (default: copy)
@@ -1133,6 +1141,7 @@ Examples:
   uploads attach ./artifact.zip --issue 45 --no-comment
   uploads attach ./shot.png --meta path=/settings --state after
   uploads attach ./shot.png --branch
+  uploads attach --pr 123 --from-branch old/branch
   uploads attach ./shot.png --branch feature/new-settings
   uploads attach --promote
 `;
@@ -1694,8 +1703,16 @@ export async function runAttach(
   if (parsed.flags.has("--move") && typeof parsed.flags.get("--move") === "string") {
     throw new UsageError("--move takes no value — place it after the file arguments");
   }
+  if (parsed.flags.has("--from-branch") && !flagString(parsed.flags, "--from-branch")) {
+    throw new UsageError("--from-branch requires a branch name");
+  }
 
-  if (parsed.flags.has("--promote")) {
+  const fromBranch = flagString(parsed.flags, "--from-branch");
+
+  if (
+    parsed.flags.has("--promote") ||
+    (fromBranch !== undefined && parsed.positionals.length === 0)
+  ) {
     if (parsed.positionals.length > 0) {
       throw new UsageError(
         "--promote takes no file arguments — attaching a file to a PR already auto-promotes " +
@@ -1730,6 +1747,12 @@ export async function runAttach(
     if (parsed.flags.has("--comment"))
       throw new UsageError("--branch cannot be combined with --comment");
     return runAttachBranch(ctx, parsed, branchArg, run);
+  }
+  if (fromBranch !== undefined && parsed.flags.has("--issue")) {
+    throw new UsageError("--from-branch cannot be combined with --issue");
+  }
+  if (fromBranch !== undefined && parsed.flags.has("--no-promote")) {
+    throw new UsageError("--from-branch cannot be combined with --no-promote");
   }
 
   const explicitTarget = ghTargetFromFlags(parsed.flags, run);
@@ -1831,10 +1854,13 @@ export async function runAttach(
   let promotion: PromoteBranchAttachmentsResult | undefined;
   let promotedBranch: string | undefined;
   if (target.kind === "pull" && !parsed.flags.has("--no-promote")) {
-    try {
-      promotedBranch = resolveCurrentBranch(run);
-    } catch {
-      promotedBranch = undefined;
+    promotedBranch = fromBranch;
+    if (promotedBranch === undefined) {
+      try {
+        promotedBranch = resolveCurrentBranch(run);
+      } catch {
+        promotedBranch = undefined;
+      }
     }
     if (promotedBranch !== undefined) {
       promotion = await attemptPromoteBranch(ctx.client, target, promotedBranch);
@@ -1843,8 +1869,11 @@ export async function runAttach(
 
   let comment: AttachmentsCommentResult | undefined;
   let commentError: string | undefined;
-  // Skip comment refresh when every upload failed — nothing new from this batch.
-  if (!parsed.flags.has("--no-comment") && uploads.length > 0) {
+  // Existing-key attach syncs server-side, but a stale-branch promotion runs
+  // afterward. Refresh once more so that copy is visible in the same command.
+  const shouldRefreshComment =
+    uploads.length > 0 || (fromBranch !== undefined && attachedExisting.length > 0);
+  if (!parsed.flags.has("--no-comment") && shouldRefreshComment) {
     try {
       comment = await syncAttachmentsComment(ctx.client, target, run, ctx.config.workspace);
     } catch (err) {
@@ -2081,7 +2110,10 @@ async function runAttachPromoteOnly(
   const target =
     explicitTarget ??
     resolveCurrentPullRequest(resolveRepo(flagString(parsed.flags, "--repo"), run), run);
-  const branch = resolveCurrentBranch(run);
+  if (target.kind !== "pull") {
+    throw new UsageError("--from-branch only promotes into a pull request");
+  }
+  const branch = flagString(parsed.flags, "--from-branch") ?? resolveCurrentBranch(run);
 
   const promotion = await attemptPromoteBranch(ctx.client, target, branch);
 

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -931,6 +931,40 @@ function promoteRunner(
 }
 
 describe("runAttach auto-promote (default PR path)", () => {
+  it("promotes from an explicitly named stale branch before attaching an existing key", async () => {
+    const { client, promoteCalls, attachExistingCalls, callOrder } = fakeClient({
+      promote: async () => ({
+        promoted: ["gh/buildinternet/uploads/pull/123/staged.png"],
+        skipped: [],
+      }),
+      attachExisting: {
+        source: { key: "f/old.png" },
+        key: "gh/buildinternet/uploads/pull/123/old.png",
+        url: "https://x.test/gh/buildinternet/uploads/pull/123/old.png",
+        embedUrl: null,
+        moved: false,
+        comment: { posted: true, action: "updated", count: 1 },
+      },
+    });
+    const { run } = promoteRunner({ branch: "renamed-branch" });
+
+    expect(
+      await runAttach(
+        ctxWith(client),
+        ["f/old.png", "--pr", "123", "--from-branch", "original-branch"],
+        false,
+        run,
+      ),
+    ).toBe(0);
+
+    expect(attachExistingCalls).toHaveLength(1);
+    expect(promoteCalls).toEqual([
+      { repo: "buildinternet/uploads", num: 123, branch: "original-branch" },
+    ]);
+    expect(callOrder).toContain("promote");
+    expect(callOrder.indexOf("promote")).toBeLessThan(callOrder.indexOf("comment-gather"));
+  });
+
   it("calls promoteBranchAttachments with the resolved repo/num/branch before the comment sync", async () => {
     const { client, promoteCalls, callOrder } = fakeClient({
       promote: async () => ({
@@ -1113,6 +1147,23 @@ describe("runAttach auto-promote (default PR path)", () => {
 });
 
 describe("runAttach --promote (explicit promote-only mode)", () => {
+  it("uses --from-branch without reading the renamed current branch", async () => {
+    const { client, promoteCalls } = fakeClient({
+      promote: async () => ({ promoted: [], skipped: [] }),
+    });
+    const { run } = promoteRunner({ detached: true });
+
+    expect(
+      await runAttach(
+        ctxWith(client),
+        ["--pr", "77", "--repo", "o/r", "--from-branch", "old/name"],
+        false,
+        run,
+      ),
+    ).toBe(0);
+    expect(promoteCalls).toEqual([{ repo: "o/r", num: 77, branch: "old/name" }]);
+  });
+
   it("promotes staged files with zero file arguments and refreshes the comment", async () => {
     const { client, promoteCalls, callOrder } = fakeClient({
       promote: async () => ({

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -125,6 +125,10 @@ Reach for `attach --branch` explicitly only when you want its extras: uploading
 several files at once with shared flags, or triggering promotion/comment sync as
 a side effect.
 
+Staging keys embed the branch name, so renaming (or deleting) the branch before
+the PR opens strands staged files — recover them with
+`uploads attach --pr <n> --from-branch <old-branch-name>` (see uploads-cli).
+
 ```bash
 uploads screenshot http://localhost:4321/settings --out step1-before.png --state before
 uploads screenshot http://localhost:4321/settings --out step2-after.png --state after

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -147,6 +147,13 @@ once a PR exists for that branch:
 Promotion only applies to PRs, never issues, and both paths degrade silently
 (no error) if the workspace's server doesn't support promotion yet.
 
+**Branch renamed or deleted before the PR existed?** Staged keys embed the
+branch name at stage time, so promotion under the new head ref finds nothing —
+the files sit staged (URLs still work) but never attach. Recover with
+`uploads attach --pr <n> --from-branch <old-branch-name>` (zero file arguments
+is fine): it promotes that stale branch prefix into the PR and refreshes the
+comment. Works for both plain and private-repo staging.
+
 **Promotion needs the repo already bound to the workspace.** Both the webhook
 and the CLI-triggered path above rely on the same repo↔workspace binding used
 by the managed comment (see "Repo binding" below) — any earlier successful


### PR DESCRIPTION
Closes #918.

Branch-staged uploads are keyed by branch name, so a rename or delete before a PR opens strands them: PR-open promotion lists under the new head ref and finds nothing. This adds the escape hatch from the issue (option 2) rather than webhook rename-following.

## Changes

- **CLI**: `uploads attach --pr <n> --from-branch <old-name>` promotes staged files from an arbitrary (stale) branch prefix into the PR, composing with the existing attach-by-key path (#706). Registered in the CLI catalog for completion.
- **API**: the promote route accepts a caller-supplied branch name and reuses `promoteBranchAttachments` end to end — private-prefix lookup for that branch, freshness window, caps, dedupe/shadow logic, `gh.status` flip, and managed-comment re-render.
- **Docs**: rename/delete recovery documented in the attach docs page and `docs/cli.md`.
- **Changeset**: patch for the CLI package.

## Tests

Focused suites (plain-repo stale-branch attach, private-prefix stale-branch attach, PR-open promotion unchanged): 4 files, 129 tests passing. Root `pnpm test` carries 6 pre-existing `s3FetchAdapter` failures in packages/storage that exist on main and are unrelated.
