### PR TITLE
docs: acknowledge GitHub CLI --attach across site, skills, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ can use in pull requests and issues. On a branch, `uploads put` stages each file
 as soon as it is ready. When the pull request opens, uploads.sh promotes the
 staged files into one managed comment.
 
-GitHub's native image hosting requires a browser session. uploads.sh gives
-agents a command they can run from the same terminal where they build and test
-the change, while the branch is still in progress.
+GitHub's own attachments work from a browser and, since GitHub CLI 2.99
+(September 2026), from `gh … --attach`, but only once a pull request or issue
+exists, and the files stay private to GitHub. uploads.sh gives agents a stable
+public URL from the same terminal where they build and test the change, while
+the branch is still in progress.
 
 Keys are hash-free, so re-uploading the same filename overwrites in place and
 the URL never changes — every embed of it updates at once. Workspaces keep

--- a/VISION.md
+++ b/VISION.md
@@ -18,9 +18,10 @@ human asked, not as a final assembly step, but because capturing evidence is
 part of the loop itself — as unremarkable as committing.
 
 uploads is deliberately infrastructure, not intelligence. It doesn't decide
-what to screenshot or judge whether the change is good. It removes the one step
-agents cannot perform — GitHub's image hosting only works through a browser
-drag-and-drop — and makes the surrounding workflow disappear.
+what to screenshot or judge whether the change is good. It gives every capture a
+public home the moment it exists — before there is a pull request to attach it
+to, and outside GitHub's own hosting, which stays private to GitHub — and makes
+the surrounding workflow disappear.
 
 ## Principles
 

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -18,8 +18,10 @@ Use uploads.sh when a screenshot, screen recording, diagram, or other visual
 needs to land on a GitHub pull request or issue. Reach for it as you produce
 the visual. Do not wait until GitHub's attachment path fails.
 
-GitHub's native image hosting only works through a browser session. Agents
-cannot use that path. uploads.sh hosts a local file, a public HTTPS URL
+GitHub's native image hosting works from a browser and, since GitHub CLI 2.99
+(September 2026), from `gh … --attach` for images and video on an existing PR
+or issue with push access. It has no API, and the file stays private to GitHub.
+uploads.sh hosts a local file, a public HTTPS URL
 (`uploads put --url`, or hosted MCP `contentUrl`), or base64 on the hosted
 MCP. It returns durable `url` / `embedUrl` markdown.
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -27,7 +27,7 @@ How to call it:
 - [Full agent guide (llms-full.txt)](https://uploads.sh/llms-full.txt): install, auth, stage/attach loops, hosted MCP contracts, cautions
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
 - [Changelog](https://uploads.sh/changelog): platform updates and CLI releases, newest first (Atom feed at https://uploads.sh/changelog.xml)
-- [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, pair a before/after with --state, get a URL for any file (local path or `put --url`), capture a screenshot, annotate with callouts/redactions
+- [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, pair a before/after with --state, get a URL for an image or video (local path or `put --url`), capture a screenshot, annotate with callouts/redactions
 - [Docs: annotate a screenshot](https://uploads.sh/docs/attach-pull-request-images#annotate): bake boxes, arrows, labels, freeform strokes, and solid redactions into a capture (`uploads screenshot --annotate` or `uploads annotate`)
 - [Docs: galleries](https://uploads.sh/docs/galleries): create an ordered set of media behind one public link at /g/<id>, add files with uploads put --gallery, and link the gallery to a PR or issue
 - [Docs: GitHub App](https://uploads.sh/docs/github-app): recommended install for bot-posted attachment comments, private-repo PR/issue titles, and zero-CLI promotion of branch-staged screenshots when a PR opens

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -80,7 +80,7 @@ const COLUMNS: FooterColumn[] = [
             <a class="wordmark" href="/">
               uploads.sh
             </a>
-            <p>Screenshot host for coding agents.</p>
+            <p>Screenshot and file host for coding agents.</p>
           </div>
           {COLUMNS.map((column) => (
             <nav aria-label={column.title}>

--- a/apps/web/src/content/changelog/github-cli-attach.md
+++ b/apps/web/src/content/changelog/github-cli-attach.md
@@ -1,0 +1,37 @@
+---
+title: "GitHub CLI can upload media now. Here's where Uploads fits."
+date: 2026-09-01T18:00:00Z
+tags: [platform]
+---
+
+GitHub CLI 2.99 adds a repeatable `--attach` flag to `gh issue` and `gh pr`
+`create`, `edit`, and `comment`. It uploads images and video (up to 10 MB per
+file, video up to 100 MB on paid plans) and rewrites local paths in your
+Markdown to the hosted file. It needs push access, and GitHub Enterprise Server
+isn't supported yet. Read [GitHub's changelog](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/) and
+[the docs](https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli).
+
+Good news. If you have a PR open and one screenshot to drop on it, use `gh`.
+We've updated our docs and agent skills to say so.
+
+What it doesn't change:
+
+- **Before the PR exists.** Agents capture screenshots mid-task. `gh --attach`
+  needs an issue or PR to target. `uploads put` on a branch stages the file,
+  and the PR gets one attachments comment the moment it opens.
+- **One comment that stays current.** Re-upload the same filename and every
+  embed updates. The managed comment rewrites itself on each revision instead
+  of piling up.
+- **Public URLs.** `github.com/user-attachments` links only render inside
+  GitHub. Uploads URLs work in Slack, docs, changelogs, and for any other agent
+  that needs to fetch them. `uploads ingest` mirrors GitHub attachments out
+  when you need that.
+- **Capture and context.** `uploads screenshot` takes the shot, `--annotate`
+  marks it up, before/after pairs render side by side, and every capture
+  carries metadata you can search with `uploads find` or browse on the
+  Screenshots page across projects.
+- **Everyone `gh` leaves out.** Fork contributors and read-only bots, hosted
+  MCP agents with no shell, GitHub Enterprise Server, and files that aren't
+  images or video.
+
+GitHub shipping this validates the workflow. Our job is the rest of the loop.

--- a/apps/web/src/content/changelog/github-cli-attach.md
+++ b/apps/web/src/content/changelog/github-cli-attach.md
@@ -1,37 +1,28 @@
 ---
-title: "GitHub CLI can upload media now. Here's where Uploads fits."
+title: "GitHub CLI can attach media now"
 date: 2026-09-01T18:00:00Z
 tags: [platform]
 ---
 
-GitHub CLI 2.99 adds a repeatable `--attach` flag to `gh issue` and `gh pr`
-`create`, `edit`, and `comment`. It uploads images and video (up to 10 MB per
-file, video up to 100 MB on paid plans) and rewrites local paths in your
-Markdown to the hosted file. It needs push access, and GitHub Enterprise Server
-isn't supported yet. Read [GitHub's changelog](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/) and
-[the docs](https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli).
+As of today, GitHub CLI supports attachments. `gh` 2.99 adds a repeatable
+`--attach` flag for images and video on issues, pull requests, and comments.
+Read [GitHub's changelog](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/).
 
-Good news. If you have a PR open and one screenshot to drop on it, use `gh`.
+Good news. If you have a PR open and a screenshot to drop on it, use `gh`.
 We've updated our docs and agent skills to say so.
 
 What it doesn't change:
 
-- **Before the PR exists.** Agents capture screenshots mid-task. `gh --attach`
-  needs an issue or PR to target. `uploads put` on a branch stages the file,
-  and the PR gets one attachments comment the moment it opens.
+- **Before the PR exists.** Agents capture screenshots mid-task. `uploads put`
+  on a branch stages the file, and the PR gets one attachments comment the
+  moment it opens.
 - **One comment that stays current.** Re-upload the same filename and every
   embed updates. The managed comment rewrites itself on each revision instead
   of piling up.
-- **Public URLs.** `github.com/user-attachments` links only render inside
-  GitHub. Uploads URLs work in Slack, docs, changelogs, and for any other agent
-  that needs to fetch them. `uploads ingest` mirrors GitHub attachments out
-  when you need that.
+- **Public URLs.** GitHub's attachments only render inside GitHub. Uploads URLs
+  work in Slack, docs, changelogs, and for any other agent that needs to fetch
+  them.
 - **Capture and context.** `uploads screenshot` takes the shot, `--annotate`
   marks it up, before/after pairs render side by side, and every capture
   carries metadata you can search with `uploads find` or browse on the
   Screenshots page across projects.
-- **Everyone `gh` leaves out.** Fork contributors and read-only bots, hosted
-  MCP agents with no shell, GitHub Enterprise Server, and files that aren't
-  images or video.
-
-GitHub shipping this validates the workflow. Our job is the rest of the loop.

--- a/apps/web/src/content/changelog/github-cli-attach.md
+++ b/apps/web/src/content/changelog/github-cli-attach.md
@@ -9,7 +9,10 @@ As of today, GitHub CLI supports attachments. `gh` 2.99 adds a repeatable
 Read [GitHub's changelog](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/).
 
 Good news. If you have a PR open and a screenshot to drop on it, use `gh`.
-We've updated our docs and agent skills to say so.
+We've updated our docs and agent skills to say so. Media attached with `gh`
+still lands in Uploads: with the [GitHub App](/docs/github-app#ingest)
+installed, attachments in PR and issue text are imported into the workspace,
+so they show up in the Screenshots view next to CLI captures.
 
 What it doesn't change:
 

--- a/apps/web/src/content/docs/attach-pull-request-images.mdx
+++ b/apps/web/src/content/docs/attach-pull-request-images.mdx
@@ -1,6 +1,6 @@
 ---
 title: Attach & share
-description: Attach screenshots and video to GitHub PRs and issues, get a public URL for any file, capture a screenshot, and bake callouts or redactions onto it with the uploads CLI.
+description: Attach screenshots and video to GitHub PRs and issues, get a public URL for an image or video, capture a screenshot, and bake callouts or redactions onto it with the uploads CLI.
 heading: Attach & share
 tagline: Stage as you work with put. Attach when a PR is already open. Capture, annotate, and share a URL.
 navLabel: Attach & share
@@ -10,7 +10,7 @@ toc:
   - { id: attach, label: Attach files to a PR }
   - { id: staging, label: Stage before a PR exists }
   - { id: before-after, label: Pair a before and after }
-  - { id: put, label: Get a URL for any file }
+  - { id: put, label: Get a URL for a file }
   - { id: screenshot, label: Capture a screenshot }
   - { id: annotate, label: Annotate a screenshot }
 ---
@@ -139,7 +139,7 @@ it falls back to the normal stacked list. Only images pair.
 
 <section id="put">
 
-## Get a URL for any file <a class="anchor" href="#put" aria-label="Link to this section">#</a>
+## Get a URL for a file <a class="anchor" href="#put" aria-label="Link to this section">#</a>
 
 `put` is the simpler building block: upload one file, get back a public URL and Markdown you can
 paste anywhere.

--- a/apps/web/src/content/docs/github-app.mdx
+++ b/apps/web/src/content/docs/github-app.mdx
@@ -100,8 +100,8 @@ just not attached automatically).
 
 ## Imported attachments <a class="anchor" href="#ingest" aria-label="Link to this section">#</a>
 
-When someone drags an image or video into a PR or issue on GitHub itself, the App imports it into the
-workspace automatically. Imported files carry the same `gh.*` metadata as CLI uploads, so they show
+When someone drags an image or video into a PR or issue on GitHub itself, or attaches one with
+`gh --attach`, the App imports it into the workspace automatically. Imported files carry the same `gh.*` metadata as CLI uploads, so they show
 up in search and on the "From GitHub" rail of file pages — and they survive even if GitHub's own
 attachment copy goes away. They never appear in the managed attachments comment; they're an index,
 not a source of truth.

--- a/apps/web/src/content/docs/limits.mdx
+++ b/apps/web/src/content/docs/limits.mdx
@@ -75,7 +75,7 @@ attachment caps never apply.
 - **Videos:** <PlanValue of="proMaxVideo" /> on <PlanValue of="proName" />, even when the repository
   is on a free GitHub plan where direct attachments stop at 10&nbsp;MB.
 - **Formats:** PNG, JPEG, GIF, WebP, AVIF, MP4, and WebM. SVG is not accepted because inline SVG
-  can carry script.
+  can carry script. Support for more file types (PDFs, logs, JSON, zips) is coming.
 
 <div class="note">
   One difference to know: GitHub renders inline video players only for its own uploads. Videos

--- a/apps/web/src/content/docs/limits.mdx
+++ b/apps/web/src/content/docs/limits.mdx
@@ -74,8 +74,8 @@ attachment caps never apply.
   GitHub plan.
 - **Videos:** <PlanValue of="proMaxVideo" /> on <PlanValue of="proName" />, even when the repository
   is on a free GitHub plan where direct attachments stop at 10&nbsp;MB.
-- **Any file type.** GitHub restricts attachments to an allowlist of extensions. uploads.sh hosts
-  whatever your workflow produces.
+- **Formats:** PNG, JPEG, GIF, WebP, AVIF, MP4, and WebM. SVG is not accepted because inline SVG
+  can carry script.
 
 <div class="note">
   One difference to know: GitHub renders inline video players only for its own uploads. Videos

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -723,6 +723,11 @@ const fullTitle = `${title} · uploads.sh`;
       .doc .installed strong {
         color: var(--green);
       }
+      /* Struck-through claim kept for honesty next to its correction (github-screenshots). */
+      .doc del {
+        color: var(--muted);
+        text-decoration-color: color-mix(in srgb, var(--muted) 60%, transparent);
+      }
       /* Contextual callout (e.g. "landed here from a bot comment?" on docs/github-app). */
       .doc .callout {
         margin: 0 0 28px;

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -723,11 +723,6 @@ const fullTitle = `${title} · uploads.sh`;
       .doc .installed strong {
         color: var(--green);
       }
-      /* Struck-through claim kept for honesty next to its correction (github-screenshots). */
-      .doc del {
-        color: var(--muted);
-        text-decoration-color: color-mix(in srgb, var(--muted) 60%, transparent);
-      }
       /* Contextual callout (e.g. "landed here from a bot comment?" on docs/github-app). */
       .doc .callout {
         margin: 0 0 28px;

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -22,9 +22,10 @@ const REPO = "https://github.com/buildinternet/uploads";
       What it does <a class="anchor" href="#what-it-does" aria-label="Link to this section">#</a>
     </h2>
     <p>
-      GitHub has no API for file uploads, so agents can't include screenshots in pull requests and
-      issues. Uploads gives agents a way to host files and show their work. When the pull request
-      opens, all screenshots appear in one tidy comment that updates automatically on each revision.
+      Agents take screenshots long before a pull request exists, and GitHub's own attachments only
+      work inside GitHub. Uploads hosts each file at a stable public URL the moment it's captured.
+      When the pull request opens, all screenshots appear in one tidy comment that updates
+      automatically on each revision.
     </p>
     <p>With the uploads CLI you can:</p>
     <ul>

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -33,7 +33,7 @@ const REPO = "https://github.com/buildinternet/uploads";
         <a href="/docs/attach-pull-request-images">Attach screenshots and video</a> to a GitHub PR, issue,
         or code review — kept in one managed comment.
       </li>
-      <li>Get a stable public URL for any file, on the branch you're already on.</li>
+      <li>Get a stable public URL for any image or clip, on the branch you're already on.</li>
       <li>
         Collect media into a <a href="/docs/galleries">gallery</a> behind one link.
       </li>
@@ -95,8 +95,8 @@ const REPO = "https://github.com/buildinternet/uploads";
       <a class="card" href="/docs/attach-pull-request-images">
         <h3>Attach &amp; share <span class="go">→</span></h3>
         <p>
-          Post files to a PR or issue, get a URL for any file, capture a screenshot, and annotate
-          it.
+          Post files to a PR or issue, get a URL for an image or video, capture a screenshot, and
+          annotate it.
         </p>
       </a>
       <a class="card" href="/docs/github-app">

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -108,22 +108,16 @@ const FAQ_JSON_LD = JSON.stringify({
 
   <section class="lead" id="problem">
     <h2>
-      The problem: no drag-and-drop from a terminal <a
+      The problem: the screenshot exists before the PR does <a
         class="anchor"
         href="#problem"
         aria-label="Link to this section">#</a
       >
     </h2>
     <p>
-      You put a screenshot on a pull request by dragging the file into the comment box. GitHub then
-      hosts it at <code>github.com/user-attachments/…</code>. That only works in a signed-in
-      browser. <del>There is no <code>gh</code> command and no API for it.</del>&#32;
-      <strong>Update, September 2026:</strong>
-      <code>gh</code> now has <code>--attach</code> for images and video.
-    </p>
-    <p>
-      So an agent that just changed your UI has nowhere to put the proof until a PR exists, and even
-      then only inside GitHub. The usual workarounds all hurt:
+      An agent that just changed your UI has a screenshot and nowhere to put it. There is no pull
+      request to attach it to yet, and GitHub's own hosting only works inside GitHub. The usual
+      workarounds all hurt:
     </p>
     <ul>
       <li>

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -53,19 +53,19 @@ const FAQ = [
   },
   {
     q: "Can agents upload video to GitHub pull requests?",
-    a: "Yes. MP4, WebM, and other files upload as-is and get a stable public URL. GitHub only plays videos it hosts itself, so the comment links the file instead of embedding a player.",
+    a: "Yes. MP4, WebM, and GIFs upload as-is and get a stable public URL. GitHub only plays videos it hosts itself, so the comment links the file instead of embedding a player.",
   },
   {
     q: "How do I set up Claude Code to attach screenshots to its pull requests?",
-    a: "Run `uploads install` once. It installs the agent skills (stage-as-you-go workflow, CLI reference, and annotations) and registers the hosted MCP server with Claude Code. After that, the agent runs `uploads put <file>` on the branch as it works. When the PR opens, staged files land in one attachments comment.",
+    a: "Run uploads install once. It installs the agent skills (stage-as-you-go workflow, CLI reference, and annotations) and registers the hosted MCP server with Claude Code. After that, the agent runs uploads put <file> on the branch as it works. When the PR opens, staged files land in one attachments comment.",
   },
   {
     q: "Can I mark up a screenshot before attaching it?",
-    a: "Yes. `uploads screenshot --annotate` bakes boxes, arrows, labels, freeform strokes, and redactions into a capture (CSS selectors on a live page). `uploads annotate` does the same on an existing image with pixel coordinates. See the Attach & share docs and the annotate-screenshots skill.",
+    a: "Yes. uploads screenshot --annotate bakes boxes, arrows, labels, freeform strokes, and redactions into a capture (CSS selectors on a live page). uploads annotate does the same on an existing image with pixel coordinates. See the Attach & share docs and the annotate-screenshots skill.",
   },
   {
     q: "Are uploaded files private?",
-    a: "No. Files are public to anyone with the URL, even media attached to private repos. Don't upload secrets or sensitive UI — use a solid redaction (`uploads annotate` / `screenshot --annotate`) when a capture shows credentials. Create your own workspace (GitHub-linked) or accept an invite from a workspace admin.",
+    a: "No. Files are public to anyone with the URL, even media attached to private repos. Don't upload secrets or sensitive UI — use a solid redaction (uploads annotate / screenshot --annotate) when a capture shows credentials. Create your own workspace (GitHub-linked) or accept an invite from a workspace admin.",
   },
 ];
 

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -44,8 +44,8 @@ const TOC = [
 
 const FAQ = [
   {
-    q: "Why can't my agent upload images to GitHub directly?",
-    a: "GitHub's own image hosting (github.com/user-attachments) only works when you drag a file into the comment box in a signed-in browser. There is no gh command or API for it. So any image an agent puts in a comment must already live at a public URL.",
+    q: "Can't my agent just use gh --attach?",
+    a: "Since September 2026, yes for the simple case. GitHub CLI 2.99 attaches images and video to an issue or pull request you have push access to, up to 10 MB per file. It needs the PR or issue to exist, the file stays private to GitHub, and there is still no API for it. Uploads covers what that leaves out: capturing the screenshot, staging it before the PR opens, one attachments comment that updates on every revision, metadata and search across every capture, and a public URL you can paste anywhere.",
   },
   {
     q: "Do the image URLs change when I re-upload a screenshot?",
@@ -82,7 +82,7 @@ const FAQ_JSON_LD = JSON.stringify({
 
 <DocsLayout
   title="How to get agents to upload screenshots & video to GitHub"
-  description="Agents can't drag-and-drop into GitHub comments. Give Claude Code, CI jobs, and scripts one command that posts screenshots and video to PRs and issues."
+  description="One command for Claude Code, CI jobs, and scripts that captures, hosts, and posts screenshots and video to PRs and issues, before or after the PR exists."
   path="/github-screenshots"
   heading="How to get agents to upload screenshots & video to GitHub"
   tagline="Claude Code, CI jobs, review bots, plain scripts: anything without a browser."
@@ -91,6 +91,30 @@ const FAQ_JSON_LD = JSON.stringify({
   toc={TOC}
 >
   <script type="application/ld+json" slot="head" set:html={FAQ_JSON_LD} />
+
+  <aside class="callout">
+    <p>
+      <strong>Good news (September 2026):</strong> GitHub CLI now has basic upload support. Version 2.99
+      adds a repeatable <code>--attach</code> flag to the issue and pull request create, edit, and comment
+      commands. It takes images and video up to 10 MB per file (video up to 100 MB on paid plans), needs
+      push access, and doesn't cover GitHub Enterprise Server yet. If you have a PR or issue open and
+      one image to drop on it, use it. See&#32;
+      <a
+        href="https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/"
+        >GitHub's changelog</a
+      > and <a
+        href="https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli"
+        >docs</a
+      >.
+    </p>
+    <p>
+      Uploads does the parts <code>gh</code> doesn't: capture the screenshot, stage it before a PR exists,
+      keep one attachments comment current across revisions, tag files with metadata and find them later,
+      browse every capture across projects, and give you a public URL that works outside GitHub. <a
+        href="/changelog#github-cli-attach">Where Uploads still fits</a
+      >.
+    </p>
+  </aside>
 
   <section class="lead" id="problem">
     <h2>
@@ -103,10 +127,14 @@ const FAQ_JSON_LD = JSON.stringify({
     <p>
       You put a screenshot on a pull request by dragging the file into the comment box. GitHub then
       hosts it at <code>github.com/user-attachments/…</code>. That only works in a signed-in
-      browser. There is no <code>gh</code> command and no API for it.
+      browser. <del>There is no <code>gh</code> command and no API for it.</del>&#32;
+      <strong>Update, September 2026:</strong>
+      <code>gh</code> 2.99 adds <code>--attach</code> for images and video on an existing PR or issue.
+      There is still no API, and the hosted file stays private to GitHub.
     </p>
     <p>
-      So an agent that just changed your UI can't show its work. The usual workarounds all hurt:
+      So an agent that just changed your UI has nowhere to put the proof until a PR exists, and even
+      then only inside GitHub. The usual workarounds all hurt:
     </p>
     <ul>
       <li>
@@ -228,6 +256,13 @@ const FAQ_JSON_LD = JSON.stringify({
         >--pr &lt;n&gt;</code
       >, and <code>--repo owner/name</code> for a different repo. Placing the image yourself in a PR description
       or README? <code>--no-comment</code> prints the URL and Markdown without posting.
+    </p>
+    <p class="pointer">
+      One image, one open PR, <code>gh</code> 2.99 and push access? <code
+        >gh pr comment --attach</code
+      >
+      is enough. Uploads earns its keep when the shot needs to exist before the PR does, update in place,
+      carry metadata, or live at a public URL.
     </p>
   </section>
 

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -99,9 +99,10 @@ const FAQ_JSON_LD = JSON.stringify({
       <code>--attach</code> to the issue and pull request commands for images and video (<a
         href="https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/"
         >GitHub's changelog</a
-      >). If you have a PR open and a screenshot to drop on it, use it. This page covers the
-      workflow around that: capturing, staging before a PR exists, and keeping one comment current
-      as the branch changes.
+      >). If you have a PR open and a screenshot to drop on it, use it. With the&#32;
+      <a href="/docs/github-app#ingest">GitHub App</a> installed, those attachments are imported into
+      your workspace's Screenshots view too. This page covers the workflow around that: capturing, staging
+      before a PR exists, and keeping one comment current as the branch changes.
     </p>
   </aside>
 

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -110,9 +110,8 @@ const FAQ_JSON_LD = JSON.stringify({
     <p>
       Uploads does the parts <code>gh</code> doesn't: capture the screenshot, stage it before a PR exists,
       keep one attachments comment current across revisions, tag files with metadata and find them later,
-      browse every capture across projects, and give you a public URL that works outside GitHub. <a
-        href="/changelog#github-cli-attach">Where Uploads still fits</a
-      >.
+      browse every capture across projects, host any file type, and give you a public URL that works outside
+      GitHub. <a href="/changelog#github-cli-attach">Where Uploads still fits</a>.
     </p>
   </aside>
 

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -38,14 +38,14 @@ const TOC = [
   { id: "agents", label: "Teach your agent" },
   { id: "stage", label: "Stage as you go" },
   { id: "attach", label: "PR already open" },
-  { id: "video", label: "Video & everything else" },
+  { id: "video", label: "Video & GIFs" },
   { id: "faq", label: "FAQ" },
 ];
 
 const FAQ = [
   {
     q: "Can't my agent just use gh --attach?",
-    a: "Since September 2026, yes for the simple case. GitHub CLI 2.99 attaches images and video to an issue or pull request you have push access to, up to 10 MB per file. It needs the PR or issue to exist, the file stays private to GitHub, and there is still no API for it. Uploads covers what that leaves out: capturing the screenshot, staging it before the PR opens, one attachments comment that updates on every revision, metadata and search across every capture, and a public URL you can paste anywhere.",
+    a: "Since September 2026, yes, for images and video on an existing issue or pull request. Uploads is for the rest of the loop: capturing the shot, staging it before the PR opens, one comment that updates on every revision, and a public URL you can paste anywhere.",
   },
   {
     q: "Do the image URLs change when I re-upload a screenshot?",
@@ -94,24 +94,14 @@ const FAQ_JSON_LD = JSON.stringify({
 
   <aside class="callout">
     <p>
-      <strong>Good news (September 2026):</strong> GitHub CLI now has basic upload support. Version 2.99
-      adds a repeatable <code>--attach</code> flag to the issue and pull request create, edit, and comment
-      commands. It takes images and video up to 10 MB per file (video up to 100 MB on paid plans), needs
-      push access, and doesn't cover GitHub Enterprise Server yet. If you have a PR or issue open and
-      one image to drop on it, use it. See&#32;
-      <a
+      <strong>As of September 2026, GitHub CLI supports attachments.</strong>
+      <code>gh</code> 2.99 adds
+      <code>--attach</code> to the issue and pull request commands for images and video (<a
         href="https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/"
         >GitHub's changelog</a
-      > and <a
-        href="https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli"
-        >docs</a
-      >.
-    </p>
-    <p>
-      Uploads does the parts <code>gh</code> doesn't: capture the screenshot, stage it before a PR exists,
-      keep one attachments comment current across revisions, tag files with metadata and find them later,
-      browse every capture across projects, host any file type, and give you a public URL that works outside
-      GitHub. <a href="/changelog#github-cli-attach">Where Uploads still fits</a>.
+      >). If you have a PR open and a screenshot to drop on it, use it. This page covers the
+      workflow around that: capturing, staging before a PR exists, and keeping one comment current
+      as the branch changes.
     </p>
   </aside>
 
@@ -128,8 +118,7 @@ const FAQ_JSON_LD = JSON.stringify({
       hosts it at <code>github.com/user-attachments/…</code>. That only works in a signed-in
       browser. <del>There is no <code>gh</code> command and no API for it.</del>&#32;
       <strong>Update, September 2026:</strong>
-      <code>gh</code> 2.99 adds <code>--attach</code> for images and video on an existing PR or issue.
-      There is still no API, and the hosted file stays private to GitHub.
+      <code>gh</code> now has <code>--attach</code> for images and video.
     </p>
     <p>
       So an agent that just changed your UI has nowhere to put the proof until a PR exists, and even
@@ -257,24 +246,18 @@ const FAQ_JSON_LD = JSON.stringify({
       or README? <code>--no-comment</code> prints the URL and Markdown without posting.
     </p>
     <p class="pointer">
-      One image, one open PR, <code>gh</code> 2.99 and push access? <code
-        >gh pr comment --attach</code
-      >
-      is enough. Uploads earns its keep when the shot needs to exist before the PR does, update in place,
-      carry metadata, or live at a public URL.
+      One image on an open PR? <code>gh pr comment --attach</code> does that now too.
     </p>
   </section>
 
   <section id="video">
     <h2>
-      Video and everything else <a class="anchor" href="#video" aria-label="Link to this section"
-        >#</a
-      >
+      Video and GIFs <a class="anchor" href="#video" aria-label="Link to this section">#</a>
     </h2>
     <p>
       A short screen recording is often the best proof that a change works. The same <code>put</code
-      >&#32; handles it — MP4, WebM, GIFs, zips, and logs all upload as-is and stage on the branch.
-      One caveat: GitHub only plays videos it hosts itself, so outside video shows up as a&#32;
+      >&#32; handles it — MP4, WebM, and GIFs upload as-is and stage on the branch. One caveat:
+      GitHub only plays videos it hosts itself, so outside video shows up as a&#32;
       <strong>link, not a player</strong>. GIFs embed like images.
     </p>
     <p>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -12,7 +12,7 @@ import { OG_DEFAULT_IMAGE, OG_SITE_NAME } from "../lib/og";
 
 const pageTitle = "uploads.sh — the missing upload command for coding agents";
 const pageDescription =
-  "GitHub has no API for file uploads, so agents can't include screenshots in pull requests and issues. Uploads gives agents a way to host files and show their work. When the pull request opens, all screenshots appear in one tidy comment that updates automatically on each revision.";
+  "Agents take screenshots long before a pull request exists, and GitHub's own attachments only work inside GitHub. Uploads hosts each file at a stable public URL the moment it's captured. When the pull request opens, all screenshots appear in one tidy comment that updates automatically on each revision.";
 
 const authOrigin = SAME_ORIGIN_AUTH_BASE;
 
@@ -604,10 +604,10 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       <h1>The missing upload command for <span class="nb">coding agents.</span></h1>
       <p class="byline">Now Claude Code and Codex can add screenshots to pull requests</p>
       <p class="lede">
-        GitHub has no API for file uploads, so agents can't include screenshots in pull requests and
-        issues. Uploads gives agents a way to host files and show their work. When the pull request
-        opens, all screenshots appear in one tidy comment that updates automatically on each
-        revision.
+        Agents take screenshots long before a pull request exists, and GitHub's own attachments only
+        work inside GitHub. Uploads hosts each file at a stable public URL the moment it's captured.
+        When the pull request opens, all screenshots appear in one tidy comment that updates
+        automatically on each revision.
       </p>
 
       <div class="cmdrow hero-install">

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -363,6 +363,18 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         color: var(--fg);
         margin: 0 0 4px;
       }
+      .feature h3 .soon {
+        display: inline-block;
+        vertical-align: middle;
+        margin-left: 6px;
+        padding: 1px 6px;
+        border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+        border-radius: 999px;
+        color: var(--accent);
+        font: var(--weight-medium) var(--text-micro) / 1.4 var(--sans);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
       .feature p {
         font: var(--text-meta)/1.6 var(--sans);
         color: var(--body);
@@ -767,6 +779,13 @@ Source (and where to look if something breaks): https://github.com/buildinternet
             <p>
               Group uploads into a gallery that can live across multiple PRs — one link for the
               whole set that shows linked issues and pull requests.
+            </p>
+          </div>
+          <div class="feature">
+            <h3>More file types <span class="soon">Soon</span></h3>
+            <p>
+              PDFs, logs, JSON, and zips alongside images and video, so test reports and build
+              output get the same stable URLs. Today: PNG, JPEG, GIF, WebP, AVIF, MP4, and WebM.
             </p>
           </div>
           <div class="feature">

--- a/skills/docs-page-style/SKILL.md
+++ b/skills/docs-page-style/SKILL.md
@@ -118,8 +118,8 @@ wants to act, not read more).
 
 The thing to cut is _throat-clearing_ ("In this guide…", "uploads.sh is a service
 that…"), not substance. A concrete _why_ — a real constraint the tool exists to
-solve, like "GitHub has no API for file uploads, so agents can't include
-screenshots in pull requests" — earns its two or three sentences, because it
+solve, like "Agents take screenshots long before a pull request exists, and
+GitHub's own attachments only work inside GitHub" — earns its two or three sentences, because it
 tells the reader what problem they're actually solving. Lead with that when the
 page has one; keep it tight and get to the capability list.
 

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -42,6 +42,8 @@ of these hold:
 - `gh --version` is 2.99 or newer and you have push access to the repo.
 - The PR or issue already exists, or you are creating it in the same command.
 - The file is an image or video under 10 MB (video up to 100 MB on paid plans).
+  uploads.sh takes PNG, JPEG, GIF, WebP, AVIF, MP4, and WebM only; `gh` also
+  takes SVG and MOV.
 - Nobody needs the link outside GitHub. `user-attachments` URLs do not render
   in Slack, docs, or other tools, and other agents cannot fetch them.
 
@@ -53,7 +55,7 @@ Use uploads.sh when any of these are true instead:
   updates in place instead of piling up.
 - The capture needs metadata (`--meta`), later retrieval (`uploads find`), or
   the Screenshots view across projects.
-- The URL must work outside GitHub, or the file is not an image or video.
+- The URL must work outside GitHub.
 - You are on the hosted MCP with no shell, lack push access, or the repo is on
   GitHub Enterprise Server.
 

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -14,8 +14,9 @@ description: >-
   captured or changed something visual that a shot would make clearer — even
   mid-task, before a PR exists. Also applies when an agent has no local
   filesystem and is uploading via the hosted MCP (agents.uploads.sh). Reach
-  for this instead of drag-and-drop or github.com/user-attachments (agents
-  can't upload there) and instead of hand-rolling cloud-storage uploads.
+  for this instead of drag-and-drop or hand-rolling cloud-storage uploads.
+  GitHub CLI 2.99+ can attach a single image to an existing PR or issue with
+  `gh … --attach`; this skill says when that is enough and when it is not.
   Capture the visual with whatever browser or screenshot tooling you have;
   this skill covers hosting and embedding it.
 ---
@@ -24,12 +25,41 @@ description: >-
 
 ## Why this exists
 
-GitHub's native image hosting (`github.com/user-attachments/…`) only works
-from an authenticated browser session — there is no `gh` CLI or REST endpoint
-for it. Any image URL in a PR/issue body written with `gh … --body-file` must
-already point at something publicly hosted. The **`uploads` CLI** and the
+GitHub's native image hosting (`github.com/user-attachments/…`) is reachable
+from a browser and, since GitHub CLI 2.99 (September 2026), from
+`gh issue|pr create|edit|comment --attach <file>`. There is still no REST
+endpoint, the upload needs push access, and the hosted file is private to
+GitHub. Any other image URL in a PR/issue body written with `gh … --body-file`
+must already point at something publicly hosted. The **`uploads` CLI** and the
 hosted MCP at `https://agents.uploads.sh/mcp` both host the file on uploads.sh
 and return a stable public URL plus ready-to-paste markdown.
+
+## When `gh --attach` is enough
+
+Use plain `gh pr comment --attach ./shot.png` (or `create`/`edit`) when ALL
+of these hold:
+
+- `gh --version` is 2.99 or newer and you have push access to the repo.
+- The PR or issue already exists, or you are creating it in the same command.
+- The file is an image or video under 10 MB (video up to 100 MB on paid plans).
+- Nobody needs the link outside GitHub. `user-attachments` URLs do not render
+  in Slack, docs, or other tools, and other agents cannot fetch them.
+
+Use uploads.sh when any of these are true instead:
+
+- The PR does not exist yet. Stage on the branch with `uploads put`; the
+  attachments comment appears when the PR opens.
+- The shot will be re-taken. Same filename, same URL, and the managed comment
+  updates in place instead of piling up.
+- The capture needs metadata (`--meta`), later retrieval (`uploads find`), or
+  the Screenshots view across projects.
+- The URL must work outside GitHub, or the file is not an image or video.
+- You are on the hosted MCP with no shell, lack push access, or the repo is on
+  GitHub Enterprise Server.
+
+Do not mix the two on one PR: pick one so the comment history stays readable.
+To pull an existing `user-attachments` image out to a public URL, use
+`uploads ingest`.
 
 ## Which surface
 

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -60,8 +60,9 @@ Use uploads.sh when any of these are true instead:
   GitHub Enterprise Server.
 
 Do not mix the two on one PR: pick one so the comment history stays readable.
-To pull an existing `user-attachments` image out to a public URL, use
-`uploads ingest`.
+Media attached with `gh` is still indexed: the GitHub App imports attachments
+from PR and issue text into the workspace. To pull an existing
+`user-attachments` image out to a public URL by hand, use `uploads ingest`.
 
 ## Which surface
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -20,10 +20,13 @@ description: >-
 
 ## What this does and why
 
-GitHub's native image hosting (`github.com/user-attachments/…`) is only reachable
-through an authenticated **browser session** — there is no `gh` CLI or REST endpoint
-for it. So any image URL you put in a PR/issue body written with `gh … --body-file`
-must already point at something publicly hosted.
+GitHub's native image hosting (`github.com/user-attachments/…`) is reachable from
+a **browser session** and, since GitHub CLI 2.99 (September 2026), from
+`gh … --attach` on an existing PR or issue with push access. There is still no
+REST endpoint, and the hosted file is private to GitHub. Any other image URL you
+put in a PR/issue body written with `gh … --body-file` must already point at
+something publicly hosted. The github-screenshots skill says when `gh --attach`
+alone is enough.
 
 This skill covers both transports: the **`uploads` CLI** (local files, git,
 localhost) and the hosted MCP at `https://agents.uploads.sh/mcp` (bytes you


### PR DESCRIPTION
GitHub CLI 2.99 shipped `--attach` today (2026-09-01): images and video on `gh issue|pr create|edit|comment`. Several of our surfaces said GitHub had no `gh` command or API for uploads. This PR replaces those claims and says plainly when `gh --attach` alone is enough.

Interim messaging only. The homepage H1 and the broader positioning are left for a separate pass.

## Changes

- **/github-screenshots**: one-sentence "As of September 2026" callout under the heading, struck-through claim with an inline update, rewritten FAQ #1 (and its JSON-LD), new meta description, and a pointer in the "PR already open" section that `gh pr comment --attach` covers the one-image case.
- **Homepage lede, docs hub, llms-full.txt, VISION.md, README, footer**: reframe around staging before the PR exists and public URLs instead of "GitHub has no API". Footer reads "Screenshot and file host for coding agents."
- **Skills**: correct "Why this exists" in `github-screenshots` and `uploads-cli`, and add a "When `gh --attach` is enough" decision block so agents route to `gh` for the simple case. Skills install from GitHub, so this propagates on merge.
- **Changelog**: short platform entry. It and the guide callout note that `gh`-attached media is still imported by the GitHub App into the Screenshots view (the ingest path matches any `user-attachments` URL in body text).
- **Homepage**: a "More file types" feature card with a Soon pill, signalling the non-media lane while #925 settles the specifics. The limits page says the same in one clause.
- **DocsLayout**: muted `del` style for the struck claim.

## Also corrected: "any file type" was false

Verifying the copy turned up a second inaccuracy. The API allowlists PNG, JPEG, GIF, WebP, AVIF, MP4, and WebM. A `.log`, `.pdf`, `.html`, and `.zip` each 415 on prod. The limits page, the guide's video section ("zips, and logs"), the docs hub, the attach page, and llms.txt all said "any file". They now state the formats. Widening the allowlist is #925.

## Screenshots

/github-screenshots:

![github-screenshots page](https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/claude-github-cli-uploads-messaging-0d0700/localhost-github-screenshots.webp)

Changelog entry:

![changelog entry](https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/claude-github-cli-uploads-messaging-0d0700/localhost-changelog.webp)

Homepage feature grid:

![homepage features](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/924/localhost.webp)

## Verification

`pnpm run check` and `astro check` clean. Pages verified in the local web preview.
