### PR TITLE
feat(billing): raise the Free video cap to 25 MB to match the file cap

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -96,12 +96,12 @@ storage / billing, `/admin` (users, oauth, email, metrics), and the auth flows
 
 **Plans (both live).**
 
-|           | Free         | Pro                                       |
-| --------- | ------------ | ----------------------------------------- |
-| Storage   | 250 MB       | 10 GB                                     |
-| Max file  | 25 MB        | 100 MB                                    |
-| Max video | 8 MB         | 100 MB (same as file cap)                 |
-| Members   | 3 (marketed) | seatless; 25 is an unmarketed abuse guard |
+|           | Free                     | Pro                                       |
+| --------- | ------------------------ | ----------------------------------------- |
+| Storage   | 250 MB                   | 10 GB                                     |
+| Max file  | 25 MB                    | 100 MB                                    |
+| Max video | 25 MB (same as file cap) | 100 MB (same as file cap)                 |
+| Members   | 3 (marketed)             | seatless; 25 is an unmarketed abuse guard |
 
 Free is available in perpetuity; Pro is purchased through Stripe Checkout. Seats
 and roles are deliberately not sold — they are reserved for a future Team tier.

--- a/apps/api/scripts/workspace-limit-defaults.json
+++ b/apps/api/scripts/workspace-limit-defaults.json
@@ -2,7 +2,7 @@
   "maxStorageBytes": 25000000000,
   "maxUploadsPerPeriod": 10000,
   "maxUploadBytes": 25000000,
-  "maxVideoUploadBytes": 8000000,
+  "maxVideoUploadBytes": 25000000,
   "allowedKeyPrefixes": ["f", "screenshots", "gh"],
   "maxKeyDepth": 8
 }

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -939,7 +939,7 @@ describe("workspace plan editing", () => {
         maxStorageBytes: 250_000_000,
         maxUploadsPerPeriod: 3000,
         maxUploadBytes: 25_000_000,
-        maxVideoUploadBytes: 8_000_000,
+        maxVideoUploadBytes: 25_000_000,
         maxMembers: 3,
       },
       overrides: [],

--- a/apps/api/src/routes/internal-billing.test.ts
+++ b/apps/api/src/routes/internal-billing.test.ts
@@ -177,7 +177,7 @@ describe("POST /internal/billing/plan", () => {
         maxStorageBytes: 250_000_000,
         maxUploadsPerPeriod: 3000,
         maxUploadBytes: 25_000_000,
-        maxVideoUploadBytes: 8_000_000,
+        maxVideoUploadBytes: 25_000_000,
       },
     });
     const res = await post(

--- a/apps/api/test/self-serve-plan-backfill.test.ts
+++ b/apps/api/test/self-serve-plan-backfill.test.ts
@@ -20,7 +20,7 @@ describe("backfillSelfServePlans", () => {
         maxStorageBytes: 250_000_000,
         maxUploadsPerPeriod: 3000,
         maxUploadBytes: 25_000_000,
-        maxVideoUploadBytes: 8_000_000,
+        maxVideoUploadBytes: 25_000_000,
       } satisfies WorkspaceRecord,
     });
 

--- a/apps/api/test/workspace-limit-defaults.test.ts
+++ b/apps/api/test/workspace-limit-defaults.test.ts
@@ -11,7 +11,7 @@ describe("workspace-limit-defaults.json", () => {
       maxStorageBytes: 25_000_000_000,
       maxUploadsPerPeriod: 10_000,
       maxUploadBytes: 25_000_000,
-      maxVideoUploadBytes: 8_000_000,
+      maxVideoUploadBytes: 25_000_000,
       allowedKeyPrefixes: ["f", "screenshots", "gh"],
       maxKeyDepth: 8,
     });

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -96,7 +96,7 @@ Never put `ADMIN_TOKEN` in agent configs. It is break-glass operator access.
 
 ## Pricing
 
-Hosted Free is self-serve: 250 MB storage, 25 MB per file, 8 MB per video,
+Hosted Free is self-serve: 250 MB storage, 25 MB per file (video included),
 and 3 members. At the default WebP optimize, 250 MB holds thousands of
 screenshots. Paid hosted plans start at $10 per month (Pro: 10 GB storage,
 files up to 100 MB). Caps and what happens at a limit:

--- a/apps/web/src/content/docs/limits.mdx
+++ b/apps/web/src/content/docs/limits.mdx
@@ -29,8 +29,9 @@ same caps.
 
 <LimitsTable />
 
-On <PlanValue of="proName" /> there is one file cap: videos get the same <PlanValue of="proMaxUpload" />
-ceiling as everything else. Only <PlanValue of="freeName" /> carves videos out with a smaller cap.
+Each plan has one file cap: videos get the same ceiling as everything else,
+<PlanValue of="freeMaxUpload" /> on <PlanValue of="freeName" /> and <PlanValue of="proMaxUpload" /> on
+<PlanValue of="proName" />.
 
 <div class="note">
   Both plans also carry internal rate guards against automated abuse. Normal use — even heavy
@@ -72,8 +73,9 @@ attachment caps never apply.
 - **Images:** up to <PlanValue of="freeMaxUpload" /> on free
   (<PlanValue of="proMaxUpload" /> on <PlanValue of="proName" />), vs GitHub's 10&nbsp;MB on every
   GitHub plan.
-- **Videos:** <PlanValue of="proMaxVideo" /> on <PlanValue of="proName" />, even when the repository
-  is on a free GitHub plan where direct attachments stop at 10&nbsp;MB.
+- **Videos:** <PlanValue of="freeMaxVideo" /> on <PlanValue of="freeName" /> vs GitHub's 10&nbsp;MB on
+  free GitHub plans, and <PlanValue of="proMaxVideo" /> on <PlanValue of="proName" /> even when the
+  repository is on a free GitHub plan.
 - **Formats:** PNG, JPEG, GIF, WebP, AVIF, MP4, and WebM. SVG is not accepted because inline SVG
   can carry script. Support for more file types (PDFs, logs, JSON, zips) is coming.
 

--- a/apps/web/src/lib/billing-ui.test.ts
+++ b/apps/web/src/lib/billing-ui.test.ts
@@ -23,7 +23,7 @@ function makeBilling(overrides: Partial<WorkspaceBilling> = {}): WorkspaceBillin
       maxStorageBytes: 250_000_000,
       maxUploadsPerPeriod: 3000,
       maxUploadBytes: 25_000_000,
-      maxVideoUploadBytes: 8_000_000,
+      maxVideoUploadBytes: 25_000_000,
     },
     usage: null,
     planSource: "none",
@@ -225,7 +225,7 @@ describe("renderPlanCardBodyHtml", () => {
     const html = renderPlanCardBodyHtml(makeBilling(), null);
     expect(html).toContain('<strong id="ws-plan-name">Free plan</strong>');
     expect(html).toContain("This plan is active on your workspace.");
-    expect(html).toContain("Max upload size: files up to 25 MB, videos up to 8 MB.");
+    expect(html).toContain("Max upload size: files up to 25 MB.");
     expect(html).toContain('id="ws-subscription-status" hidden');
   });
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -10,7 +10,7 @@ pnpm workspace:limits <name> \
   --max-storage 25GB \
   --max-uploads-per-month 10000 \
   --max-upload-bytes 25MB \
-  --max-video-bytes 8MB \
+  --max-video-bytes 25MB \
   --retention-days 90 \
   --allowed-prefixes default \
   --max-key-depth 8

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -172,7 +172,7 @@ and only an admin can raise them (`pnpm workspace:limits`, see above):
 | `maxStorageBytes`     | 1 GB                     |
 | `maxUploadsPerPeriod` | 3000 / UTC month         |
 | `maxUploadBytes`      | 25 MB                    |
-| `maxVideoUploadBytes` | 8 MB                     |
+| `maxVideoUploadBytes` | 25 MB                    |
 | `allowedKeyPrefixes`  | `f`, `screenshots`, `gh` |
 | `maxKeyDepth`         | 8                        |
 

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -66,7 +66,9 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
       maxStorageBytes: 250_000_000,
       maxUploadsPerPeriod: 3000,
       maxUploadBytes: 25_000_000,
-      maxVideoUploadBytes: 8_000_000,
+      // Raised from 8 MB on 2026-09-01 so video shares the file cap on every
+      // plan. GitHub's own attachments stop at 10 MB for video on free plans.
+      maxVideoUploadBytes: 25_000_000,
       // Owner + 2 collaborators, pending invites included (issue #450).
       maxMembers: 3,
     },
@@ -80,7 +82,7 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     byoBucket: true,
     // Decided 2026-07-22 (first-paid-plan memo): two marketed meters —
     // storage and one unified file cap (video ceiling = upload ceiling on
-    // pro; only free carves video out). maxUploadsPerPeriod is an internal
+    // every plan since 2026-09-01). maxUploadsPerPeriod is an internal
     // abuse guard, not a marketed limit.
     defaultLimits: {
       maxStorageBytes: 10_000_000_000,

--- a/packages/billing/test/plans.test.ts
+++ b/packages/billing/test/plans.test.ts
@@ -8,7 +8,7 @@ describe("PLANS catalog", () => {
       maxStorageBytes: 250_000_000,
       maxUploadsPerPeriod: 3000,
       maxUploadBytes: 25_000_000,
-      maxVideoUploadBytes: 8_000_000,
+      maxVideoUploadBytes: 25_000_000,
       maxMembers: 3,
     });
   });


### PR DESCRIPTION
Free video cap goes from 8 MB to 25 MB, matching the Free file cap. Every plan now has one file limit.

## Why

GitHub CLI 2.99 shipped `--attach` today with a 10 MB video cap on free plans. Our Free video cap was 8 MB, so we were below GitHub on the one number people will compare.

| | uploads.sh Free | uploads.sh Pro | GitHub free | GitHub paid |
|---|---|---|---|---|
| Images | 25 MB | 100 MB | 10 MB | 10 MB |
| Video | 8 MB → **25 MB** | 100 MB | 10 MB | 100 MB |

## Changes

- `packages/billing/src/plans.ts`: `maxVideoUploadBytes` 25_000_000 on Free, comment updated. Tests follow.
- `apps/web/src/lib/billing-ui.test.ts`: fixture matches the catalog; the plan card now renders a single "files up to 25 MB" line on Free because the video ceiling equals the file ceiling.
- `/docs/limits`: "only Free carves videos out" sentence replaced; the GitHub comparison now states Free video vs GitHub's 10 MB. The table reads from the catalog and updates on its own.
- `PRODUCT.md`, `docs/workspaces.md`, `docs/ops.md` example, `llms-full.txt`: number updated.

## Rollout

Self-serve free records carry `plan: "free"` with no explicit limit numbers and resolve from the catalog, so the new cap applies on deploy. A legacy record with an explicit `maxVideoUploadBytes: 8000000` override would keep 8 MB; the July backfill cleared overrides equal to the then-defaults, so none are expected. `POST /admin/self-serve/backfill-plan?dryRun=1` after deploy confirms.

No changeset: platform packages only.

## Verification

Billing, web billing-ui, and backfill tests pass (85 tests). `astro check` and format check clean. `/docs/limits` verified in the local preview.
