### PR TITLE
docs: credit the hosted MCP as the upload path for agents without a shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ exists, and the files stay private to GitHub. uploads.sh gives agents a stable
 public URL from the same terminal where they build and test the change, while
 the branch is still in progress. The hosted MCP server does the same for agents
 that cannot run a command at all, taking files as bytes or a URL. GitHub has no
-API for that.
+public API (yet) for that.
 
 Keys are hash-free, so re-uploading the same filename overwrites in place and
 the URL never changes — every embed of it updates at once. Workspaces keep

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ GitHub's own attachments work from a browser and, since GitHub CLI 2.99
 (September 2026), from `gh … --attach`, but only once a pull request or issue
 exists, and the files stay private to GitHub. uploads.sh gives agents a stable
 public URL from the same terminal where they build and test the change, while
-the branch is still in progress.
+the branch is still in progress. The hosted MCP server does the same for agents
+that cannot run a command at all, taking files as bytes or a URL. GitHub has no
+API for that.
 
 Keys are hash-free, so re-uploading the same filename overwrites in place and
 the URL never changes — every embed of it updates at once. Workspaces keep

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -20,7 +20,7 @@ the visual. Do not wait until GitHub's attachment path fails.
 
 GitHub's native image hosting works from a browser and, since GitHub CLI 2.99
 (September 2026), from `gh … --attach` for images and video on an existing PR
-or issue with push access. It has no API, and the file stays private to GitHub.
+or issue with push access. It has no public API (yet), and the file stays private to GitHub.
 uploads.sh hosts a local file, a public HTTPS URL
 (`uploads put --url`, or hosted MCP `contentUrl`), or base64 on the hosted
 MCP. It returns durable `url` / `embedUrl` markdown.

--- a/apps/web/src/content/changelog/github-cli-attach.md
+++ b/apps/web/src/content/changelog/github-cli-attach.md
@@ -25,7 +25,7 @@ What it doesn't change:
 - **Public URLs.** GitHub's attachments only render inside GitHub. Uploads URLs
   work in Slack, docs, changelogs, and for any other agent that needs to fetch
   them.
-- **Uploads without a shell.** GitHub has no API for attachments, and
+- **Uploads without a shell.** GitHub has no public API (yet) for attachments, and
   `--attach` needs `gh` on a machine that has the file. The hosted MCP server
   at `agents.uploads.sh` takes files as base64 or a URL and posts them to the
   PR, so ChatGPT, Claude.ai, and cloud agents can attach too.

--- a/apps/web/src/content/changelog/github-cli-attach.md
+++ b/apps/web/src/content/changelog/github-cli-attach.md
@@ -25,6 +25,10 @@ What it doesn't change:
 - **Public URLs.** GitHub's attachments only render inside GitHub. Uploads URLs
   work in Slack, docs, changelogs, and for any other agent that needs to fetch
   them.
+- **Uploads without a shell.** GitHub has no API for attachments, and
+  `--attach` needs `gh` on a machine that has the file. The hosted MCP server
+  at `agents.uploads.sh` takes files as base64 or a URL and posts them to the
+  PR, so ChatGPT, Claude.ai, and cloud agents can attach too.
 - **Capture and context.** `uploads screenshot` takes the shot, `--annotate`
   marks it up, before/after pairs render side by side, and every capture
   carries metadata you can search with `uploads find` or browse on the

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -48,6 +48,10 @@ const FAQ = [
     a: "Since September 2026, yes, for images and video on an existing issue or pull request. Uploads is for the rest of the loop: capturing the shot, staging it before the PR opens, one comment that updates on every revision, and a public URL you can paste anywhere.",
   },
   {
+    q: "What if my agent has no shell or gh?",
+    a: "Use the hosted MCP server at agents.uploads.sh. Its put tool takes files as base64 or a public URL and posts them to a PR or issue, with no filesystem or gh required. GitHub has no API for attachments, so this is the path for agents that cannot run a command.",
+  },
+  {
     q: "Do the image URLs change when I re-upload a screenshot?",
     a: "No. PR and issue attachments get stable keys like gh/owner/repo/pull/123/shot.webp. Upload the same filename again and every embed shows the new image within about a minute.",
   },

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -49,7 +49,7 @@ const FAQ = [
   },
   {
     q: "What if my agent has no shell or gh?",
-    a: "Use the hosted MCP server at agents.uploads.sh. Its put tool takes files as base64 or a public URL and posts them to a PR or issue, with no filesystem or gh required. GitHub has no API for attachments, so this is the path for agents that cannot run a command.",
+    a: "Use the hosted MCP server at agents.uploads.sh. Its put tool takes files as base64 or a public URL and posts them to a PR or issue, with no filesystem or gh required. GitHub has no public API (yet) for attachments, so this is the path for agents that cannot run a command.",
   },
   {
     q: "Do the image URLs change when I re-upload a screenshot?",

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -754,8 +754,8 @@ Source (and where to look if something breaks): https://github.com/buildinternet
           <div class="feature">
             <h3>Capture and host</h3>
             <p>
-              <code>uploads screenshot &lt;url&gt;</code> captures and hosts in one step, with both local
-              and remote browser support.
+              <code>uploads screenshot &lt;url&gt;</code> captures and hosts in one step, with local and
+              remote browser support and optional device chrome via <code>--frame</code>.
             </p>
           </div>
           <div class="feature">
@@ -767,11 +767,11 @@ Source (and where to look if something breaks): https://github.com/buildinternet
             </p>
           </div>
           <div class="feature">
-            <h3>Device frames</h3>
+            <h3>Upload over MCP</h3>
             <p>
-              Wrap a raw screenshot in device chrome — phone, browser, or a specific iPhone — with <code
-                >--frame</code
-              >.
+              The hosted MCP server at <code>agents.uploads.sh</code> takes files as bytes or a URL and
+              posts them to the PR, so agents with no shell, no <code>gh</code>, and no filesystem
+              can still attach. GitHub has no API for that.
             </p>
           </div>
           <div class="feature">

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -771,7 +771,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
             <p>
               The hosted MCP server at <code>agents.uploads.sh</code> takes files as bytes or a URL and
               posts them to the PR, so agents with no shell, no <code>gh</code>, and no filesystem
-              can still attach. GitHub has no API for that.
+              can still attach. GitHub has no public API (yet) for that.
             </p>
           </div>
           <div class="feature">

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -27,8 +27,8 @@ description: >-
 
 GitHub's native image hosting (`github.com/user-attachments/…`) is reachable
 from a browser and, since GitHub CLI 2.99 (September 2026), from
-`gh issue|pr create|edit|comment --attach <file>`. There is still no REST
-endpoint, the upload needs push access, and the hosted file is private to
+`gh issue|pr create|edit|comment --attach <file>`. There is still no public REST
+endpoint (the CLI uses an undocumented upload host), the upload needs push access, and the hosted file is private to
 GitHub. Any other image URL in a PR/issue body written with `gh … --body-file`
 must already point at something publicly hosted. The **`uploads` CLI** and the
 hosted MCP at `https://agents.uploads.sh/mcp` both host the file on uploads.sh

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -22,7 +22,7 @@ description: >-
 
 GitHub's native image hosting (`github.com/user-attachments/…`) is reachable from
 a **browser session** and, since GitHub CLI 2.99 (September 2026), from
-`gh … --attach` on an existing PR or issue with push access. There is still no
+`gh … --attach` on an existing PR or issue with push access. There is still no public
 REST endpoint, and the hosted file is private to GitHub. Any other image URL you
 put in a PR/issue body written with `gh … --body-file` must already point at
 something publicly hosted. The github-screenshots skill says when `gh --attach`


### PR DESCRIPTION
Small copy follow-up to #924. GitHub CLI's `--attach` needs `gh` on a machine that has the file, and GitHub still has no REST or GraphQL API for attachments. The hosted MCP server at `agents.uploads.sh` takes files as base64 or a URL and posts them to the PR, which is the upload path for ChatGPT, Claude.ai, and cloud agents with no shell. We weren't saying so anywhere a reader would compare.

## Changes

- **Homepage**: new "Upload over MCP" feature card. To keep the grid at six cards, "Device frames" folds into "Capture and host" as a `--frame` mention.
- **/github-screenshots FAQ**: "What if my agent has no shell or gh?" pointing at the hosted MCP.
- **Changelog entry** (GitHub CLI can attach media now): "Uploads without a shell" bullet.
- **README**: one sentence after the `gh --attach` paragraph.

Follow-up for extended file types stays tracked in #925.

## Verification

`astro check` and format check clean. Homepage verified in the local preview. Screenshot arrives via the attachments comment.
