### PR TITLE
feat: accept non-media uploads (PDF, zip, gzip, MOV, text)

### DIFF
--- a/.changeset/non-media-file-types.md
+++ b/.changeset/non-media-file-types.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`put` and `attach` accept non-media files: PDF, zip, gzip, MOV, and text (plain, markdown, CSV, JSON, logs). They upload as-is, skip image optimization, and appear in the managed comment as links. Requires the matching platform release.

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -6,7 +6,7 @@
  * `message` in the tool error.
  */
 import { ConflictError, NotFoundError, ValidationError } from "@uploads/errors";
-import { createStorage, type Files } from "@uploads/storage";
+import { createStorage, type Files, type StoredFile } from "@uploads/storage";
 import { recordAdoptionSafe, type UploadSurface } from "./adoption";
 import {
   budgetDenialError,
@@ -390,6 +390,27 @@ export function publicObjectDateFields(meta: {
     return { uploaded: uploadedIso };
   }
   return { uploaded: uploadedIso, modified: modifiedIso };
+}
+
+/**
+ * Put options that carry a stored object's own attributes through a
+ * server-side copy (attach, promote, rotate): its provenance bag, the
+ * visibility that bag encodes, and its stored content type as the declared
+ * claim, so a text object under an extension-less key is admitted by
+ * `inspectUpload` at the destination the same way it was at the source.
+ * Every copy still runs the full `putObject` write path — nothing here
+ * bypasses inspection.
+ */
+export function putOptsFromStoredObject(source: Pick<StoredFile, "metadata" | "type">): {
+  provenance: Record<string, string> | undefined;
+  visibility: Visibility | undefined;
+  declaredContentType: string;
+} {
+  return {
+    provenance: source.metadata,
+    visibility: objectVisibility(source.metadata),
+    declaredContentType: source.type,
+  };
 }
 
 /**

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -36,6 +36,7 @@ import {
   DEFAULT_MAX_UPLOAD_BYTES,
   detectImageDimensions,
   inspectUpload,
+  resolveDeclaredContentType,
   resolveUploadPolicy,
 } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
@@ -442,6 +443,13 @@ export async function putObject(
      * over a potentially multi-MB body. Omit to hash internally as usual.
      */
     contentSha256?: string;
+    /**
+     * The client's claimed Content-Type (already normalized to type/subtype)
+     * or undefined. Only text types are ever trusted, and only when sniffing
+     * finds nothing — see `inspectUpload`. When omitted, the key's extension
+     * is the claim, which is what the hosted MCP and older CLIs rely on.
+     */
+    declaredContentType?: string;
   },
 ): Promise<{
   key: string;
@@ -473,7 +481,8 @@ export async function putObject(
   // cap breach rejects the whole upload instead of landing bytes first.
   if (opts?.metadata) validateMetadataEntries(opts.metadata);
 
-  const inspection = inspectUpload(bytes, resolveUploadPolicy(ws));
+  const declared = resolveDeclaredContentType(opts?.declaredContentType, finalKey);
+  const inspection = inspectUpload(bytes, resolveUploadPolicy(ws), declared);
   if (!inspection.ok) throw inspection.error;
 
   const store = await storage(env, ws);

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -38,6 +38,7 @@ import {
   inspectUpload,
   resolveDeclaredContentType,
   resolveUploadPolicy,
+  uploadKind,
 } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
 import {
@@ -224,7 +225,7 @@ async function storeImageDimensions(
 ): Promise<void> {
   try {
     await deleteServerFileMetadataKeys(dbFor(env), workspaceName, key, IMAGE_META_KEYS);
-    if (!contentType.startsWith("image/")) return;
+    if (uploadKind(contentType) !== "image") return;
     const dims = detectImageDimensions(bytes, contentType);
     if (!dims) return;
     await setServerFileMetadata(dbFor(env), workspaceName, key, {

--- a/apps/api/src/github-attach.ts
+++ b/apps/api/src/github-attach.ts
@@ -205,6 +205,7 @@ export async function attachExistingObject(
     provenance: source.metadata,
     visibility,
     surface: "attach",
+    declaredContentType: source.type,
   });
 
   // Additive merge (PR #157 preserve mode): the source's existing metadata

--- a/apps/api/src/github-attach.ts
+++ b/apps/api/src/github-attach.ts
@@ -27,11 +27,17 @@ import { NotFoundError, ValidationError } from "@uploads/errors";
 import { resolveEmbedBaseUrl, type Files, type StorageConfig } from "@uploads/storage";
 import type { GhTargetKind } from "@uploads/comment-render";
 import { ghKeyPrefix, ghPrivateAttachmentKey, sanitizeKeySegment } from "@uploads/comment-render";
-import { badKey, deleteObject, filePageUrl, putObject, sanitizeKeyBasename } from "./files-core";
+import {
+  badKey,
+  deleteObject,
+  filePageUrl,
+  putObject,
+  putOptsFromStoredObject,
+  sanitizeKeyBasename,
+} from "./files-core";
 import { getFileMetadata, setFileMetadata } from "./file-metadata";
 import { resolveGhKeyContextSafe } from "./github-private-prefix-service";
 import { storage, storageConfig } from "./storage";
-import { objectVisibility } from "./visibility";
 import { webOrigin } from "./web-url";
 import type { WorkspaceRecord } from "./workspace";
 import { dbFor } from "./db-session";
@@ -197,15 +203,12 @@ export async function attachExistingObject(
 
   const sourceMeta = await getFileMetadata(dbFor(env), workspaceName, sourceKey);
   const bytes = new Uint8Array(await source.arrayBuffer());
-  const visibility = objectVisibility(source.metadata);
   const ref = `${owner}/${name}#${req.target.num}`.toLowerCase();
   const nowIso = new Date().toISOString();
 
   const put = await putObject(env, ws, destKey, bytes, workspaceName, {
-    provenance: source.metadata,
-    visibility,
+    ...putOptsFromStoredObject(source),
     surface: "attach",
-    declaredContentType: source.type,
   });
 
   // Additive merge (PR #157 preserve mode): the source's existing metadata

--- a/apps/api/src/github-ingest.test.ts
+++ b/apps/api/src/github-ingest.test.ts
@@ -282,6 +282,7 @@ describe("reconcileIngestSource", () => {
 
     expect(calls).toHaveLength(0);
     expect(summary.skipped).toEqual([{ url: ASSET_URL, reason: "unsupported_media_type" }]);
+    expect(await ledgerRow(env.DB, REPO, ASSET_ID)).toBeNull();
   });
 
   it("an ingested MOV is named with the .mov extension override", async () => {

--- a/apps/api/src/github-ingest.test.ts
+++ b/apps/api/src/github-ingest.test.ts
@@ -265,6 +265,48 @@ describe("reconcileIngestSource", () => {
     expect(await ledgerRow(env.DB, REPO, ASSET_ID)).toBeNull();
   });
 
+  it("media gate is image/video only: a PDF is a permanent skip even though the upload allowlist accepts it", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a]);
+    const fetchImpl = fakeFetch({
+      [ASSET_ID]: () =>
+        new Response(PDF, { status: 200, headers: { "content-type": "application/pdf" } }),
+    });
+    const { putImpl, calls } = spyPut();
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, {
+      fetchImpl,
+      putImpl,
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(summary.skipped).toEqual([{ url: ASSET_URL, reason: "unsupported_media_type" }]);
+  });
+
+  it("an ingested MOV is named with the .mov extension override", async () => {
+    const { env } = baseEnv();
+    const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+    // ftyp box (offset 4) with major brand "qt  " — the exact bytes
+    // guards.ts's detectContentType sniffs as video/quicktime.
+    const MOV = new Uint8Array([
+      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x71, 0x74, 0x20, 0x20,
+    ]);
+    const fetchImpl = fakeFetch({
+      [ASSET_ID]: () =>
+        new Response(MOV, { status: 200, headers: { "content-type": "video/quicktime" } }),
+    });
+    const { putImpl, calls } = spyPut();
+
+    const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, {
+      fetchImpl,
+      putImpl,
+    });
+
+    expect(calls[0]!.key).toBe(`gh/acme-app/pull-7/${attachmentKeyBasename(ASSET_ID)}.mov`);
+    expect(summary.skipped).toEqual([]);
+  });
+
   it("media gate derives from the shared upload allowlist: AVIF (in guards.ts's allowlist) is accepted", async () => {
     const { env } = baseEnv();
     const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };

--- a/apps/api/src/github-ingest.test.ts
+++ b/apps/api/src/github-ingest.test.ts
@@ -28,6 +28,7 @@ import { FakeKv } from "../test/fake-kv";
 import { GITHUB_APP_CFG_ENV } from "../test/github-app-env";
 import { fakeFetch, pngRoute, withGlobalFetch } from "../test/helpers/github-fetch-fakes";
 import { gifOf } from "../test/helpers/image-fixtures";
+import { AVIF, MOV, PDF } from "../test/helpers/media-fixtures";
 import { UsageFakeD1 } from "../test/usage-fake-d1";
 
 const REPO = "acme/app";
@@ -268,7 +269,6 @@ describe("reconcileIngestSource", () => {
   it("media gate is image/video only: a PDF is a permanent skip even though the upload allowlist accepts it", async () => {
     const { env } = baseEnv();
     const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
-    const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a]);
     const fetchImpl = fakeFetch({
       [ASSET_ID]: () =>
         new Response(PDF, { status: 200, headers: { "content-type": "application/pdf" } }),
@@ -287,11 +287,6 @@ describe("reconcileIngestSource", () => {
   it("an ingested MOV is named with the .mov extension override", async () => {
     const { env } = baseEnv();
     const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
-    // ftyp box (offset 4) with major brand "qt  " — the exact bytes
-    // guards.ts's detectContentType sniffs as video/quicktime.
-    const MOV = new Uint8Array([
-      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x71, 0x74, 0x20, 0x20,
-    ]);
     const fetchImpl = fakeFetch({
       [ASSET_ID]: () =>
         new Response(MOV, { status: 200, headers: { "content-type": "video/quicktime" } }),
@@ -310,11 +305,6 @@ describe("reconcileIngestSource", () => {
   it("media gate derives from the shared upload allowlist: AVIF (in guards.ts's allowlist) is accepted", async () => {
     const { env } = baseEnv();
     const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
-    // ftyp box (offset 4) with major brand "avif" — the exact bytes
-    // guards.ts's detectContentType sniffs as image/avif.
-    const AVIF = new Uint8Array([
-      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66,
-    ]);
     const fetchImpl = fakeFetch({
       [ASSET_ID]: () =>
         new Response(AVIF, { status: 200, headers: { "content-type": "image/avif" } }),

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -48,6 +48,7 @@ import {
   detectImageDimensions,
   maxBytesForContentType,
   resolveUploadPolicy,
+  uploadKind,
 } from "./guards";
 import { putObject } from "./files-core";
 import { findRepoLinkStrict } from "./github-repo-links";
@@ -132,6 +133,7 @@ function mergeSummary(into: IngestSummary, from: IngestSummary): void {
  */
 const EXT_OVERRIDES: Record<string, string> = {
   "image/jpeg": "jpg",
+  "video/quicktime": "mov",
 };
 
 function extensionForContentType(contentType: string): string {
@@ -241,15 +243,15 @@ async function fetchAndStore(
   }
   const bytes = new Uint8Array(await res.arrayBuffer());
 
-  // Media gate: membership in the workspace's own upload allowlist
-  // (`resolveUploadPolicy(ws).allowed`, guards.ts) rather than a shadow
-  // table duplicating it — a type this workspace's direct uploads accept
-  // (e.g. `image/avif`) is accepted here too, with no separate list to keep
-  // in sync. Non-sniffable bytes or a type outside the allowlist is the same
-  // permanent `unsupported_media_type` skip either way.
+  // Media gate: the Screenshots view mirrors images and video only. A type
+  // must be in the workspace's own upload allowlist (`resolveUploadPolicy(ws)
+  // .allowed`, guards.ts — no shadow table) AND be an image/video family;
+  // PDFs and archives pasted into a PR are left on GitHub. Non-sniffable
+  // bytes or a type outside the gate is the same permanent
+  // `unsupported_media_type` skip either way.
   const policy = resolveUploadPolicy(ws);
   const sniffed = detectContentType(bytes);
-  if (!sniffed || !policy.allowed.has(sniffed)) {
+  if (!sniffed || !policy.allowed.has(sniffed) || uploadKind(sniffed) === "file") {
     return { kind: "skip", reason: "unsupported_media_type" };
   }
 

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -46,6 +46,7 @@ import { updateFileMetadataValue } from "./file-metadata";
 import {
   detectContentType,
   detectImageDimensions,
+  extensionForContentType as guardsExtensionForContentType,
   maxBytesForContentType,
   resolveUploadPolicy,
   uploadKind,
@@ -125,19 +126,14 @@ function mergeSummary(into: IngestSummary, from: IngestSummary): void {
 }
 
 /**
- * Extensions that don't match their subtype verbatim. Every other content
- * type accepted by the workspace's upload policy derives its extension from
- * the subtype (`image/webp` → `webp`, `image/avif` → `avif`, `video/webm` →
- * `webm`), so this stays a short override list rather than a shadow table of
- * every allowed type — see the media-gate comment in `fetchAndStore`.
+ * Extension for an ingested asset's key. Accepted types get their canonical
+ * extension from the shared upload table in guards.ts (`image/jpeg` → `jpg`,
+ * `video/quicktime` → `mov`), so there is no shadow list to keep in sync —
+ * see the media-gate comment in `fetchAndStore`. The subtype fallback only
+ * covers a type outside that table, which the gate already refuses.
  */
-const EXT_OVERRIDES: Record<string, string> = {
-  "image/jpeg": "jpg",
-  "video/quicktime": "mov",
-};
-
-function extensionForContentType(contentType: string): string {
-  return EXT_OVERRIDES[contentType] ?? contentType.split("/")[1] ?? "bin";
+function extensionForKey(contentType: string): string {
+  return guardsExtensionForContentType(contentType) ?? contentType.split("/")[1] ?? "bin";
 }
 
 /**
@@ -268,7 +264,7 @@ async function fetchAndStore(
   }
 
   const mode: GhKeyMode = deps.mode ?? { mode: "plain" };
-  const key = ingestKeyForMode(mode, ref, attachment.id, extensionForContentType(sniffed));
+  const key = ingestKeyForMode(mode, ref, attachment.id, extensionForKey(sniffed));
   try {
     await putImpl(env, ws, key, bytes, workspaceName, {
       metadata: ingestMetadata(ref, author),

--- a/apps/api/src/github-private-prefix-rotate.test.ts
+++ b/apps/api/src/github-private-prefix-rotate.test.ts
@@ -181,6 +181,31 @@ describe("rotatePrivatePrefix", () => {
     expect(usage.bytes).toBe(PNG.byteLength * 2);
   });
 
+  it("a stored text/plain object under an extension-less key keeps its content type across rotation", async () => {
+    const { env, db, bucket, ws } = await seededEnv();
+    const oldId = await getOrMintPrefixId(db, REPO, BRANCH);
+    const notesKey = ghPrivateBranchAttachmentKey(oldId, "notes");
+    const notes = new TextEncoder().encode("build log\nno errors\n");
+
+    await putObject(env, ws, notesKey, notes, WS, {
+      metadata: { "gh.repo": REPO, "gh.kind": "branch" },
+      declaredContentType: "text/plain",
+    });
+
+    const result = await withFetch(commentFlowFetch({ bodies: [] }), () =>
+      rotatePrivatePrefix(env, ws, WS, "user-1", REPO, BRANCH),
+    );
+
+    expect(result.rotated).toBe(true);
+    if (!result.rotated) throw new Error("expected rotated: true");
+
+    const newKey = ghPrivateBranchAttachmentKey(result.prefixId, "notes");
+    const stored = bucket.store.get(`${PREFIX}${newKey}`);
+    expect(stored).toBeDefined();
+    expect(stored?.contentType).toBe("text/plain");
+    expect([...(stored?.data ?? [])]).toEqual([...notes]);
+  });
+
   it("review fix 1 (Critical): rotating an object carrying inheritable metadata (repo/path/url) doesn't throw a UNIQUE constraint violation — the new key ends up with exactly the old rows, once", async () => {
     const { env, db, ws } = await seededEnv();
     const oldId = await getOrMintPrefixId(db, REPO, BRANCH);

--- a/apps/api/src/github-private-prefix-service.ts
+++ b/apps/api/src/github-private-prefix-service.ts
@@ -260,6 +260,7 @@ export async function rotatePrivatePrefix(
             provenance: source.metadata,
             visibility,
             surface: "rotate",
+            declaredContentType: source.type,
           });
 
           // Wipe whatever's already at `newKey` before renaming onto it —

--- a/apps/api/src/github-private-prefix-service.ts
+++ b/apps/api/src/github-private-prefix-service.ts
@@ -17,7 +17,7 @@ import { ForbiddenError } from "@uploads/errors";
 import { githubAppConfig, installationForRepo, prHeadBranch, repoIsPrivate } from "./github-app";
 import { checkRepoAuthorization, postManagedComment } from "./github-comment-service";
 import { GH_PRIVATE_ROOT, type GhTargetKind, parseGhPrivateKey } from "./github-comment-render";
-import { deleteObject, putObject } from "./files-core";
+import { deleteObject, putObject, putOptsFromStoredObject } from "./files-core";
 import { deleteFileMetadata } from "./file-metadata";
 import {
   getActivePrefixId,
@@ -26,7 +26,6 @@ import {
   retirePrefixId,
 } from "./github-private-prefixes";
 import { storage } from "./storage";
-import { objectVisibility } from "./visibility";
 import type { WorkspaceRecord } from "./workspace";
 import { dbFor } from "./db-session";
 
@@ -242,7 +241,6 @@ export async function rotatePrivatePrefix(
 
           const source = await store.download(item.key);
           const bytes = new Uint8Array(await source.arrayBuffer());
-          const visibility = objectVisibility(source.metadata);
           // Not a byte-for-byte metadata copy: `putObject` runs its normal
           // write path on `provenance: source.metadata` — `sanitizeProvenance`
           // strips it to the client-safe subset, `content-sha256` is
@@ -257,10 +255,8 @@ export async function rotatePrivatePrefix(
           // rows (`repo`, `path`, `url`, …) onto `newKey` before this
           // function's own rename below runs.
           await putObject(env, ws, newKey, bytes, workspaceName, {
-            provenance: source.metadata,
-            visibility,
+            ...putOptsFromStoredObject(source),
             surface: "rotate",
-            declaredContentType: source.type,
           });
 
           // Wipe whatever's already at `newKey` before renaming onto it —

--- a/apps/api/src/github-promote.test.ts
+++ b/apps/api/src/github-promote.test.ts
@@ -146,6 +146,32 @@ describe("promoteBranchAttachments — private prefixes (issue #631)", () => {
     expect(copyMeta["gh.number"]).toBe(String(NUM));
   });
 
+  it("public repo: a stored text/plain object under an extension-less key keeps its content type on promote", async () => {
+    const seeded = await seededEnv({ isPrivate: false });
+    const notes = new TextEncoder().encode("build log\nno errors\n");
+    await seeded.bucket.put(`${PREFIX}${stagedKey("notes")}`, notes, {
+      httpMetadata: { contentType: "text/plain" },
+    });
+    await replaceFileMetadata(seeded.env.DB, WS, stagedKey("notes"), {
+      "gh.repo": REPO,
+      "gh.kind": "branch",
+      "gh.branch": BRANCH,
+      "gh.staged-at": new Date().toISOString(),
+    });
+
+    const result = await promoteBranchAttachments(seeded.env, seeded.ws, WS, {
+      repo: REPO,
+      num: NUM,
+      branch: BRANCH,
+    });
+
+    expect(result.promoted).toEqual([destKey("notes")]);
+    expect(result.skipped).toEqual([]);
+    const stored = seeded.bucket.store.get(`${PREFIX}${destKey("notes")}`);
+    expect(stored?.contentType).toBe("text/plain");
+    expect([...(stored?.data ?? [])]).toEqual([...notes]);
+  });
+
   it("private repo: a file staged under the private branch prefix promotes to the private pull prefix with a metadata flip", async () => {
     const seeded = await seededEnv({ isPrivate: true });
     const prefixId = await getOrMintPrefixId(seeded.db as unknown as D1Database, REPO, BRANCH);

--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -411,6 +411,7 @@ export async function promoteBranchAttachments(
           "gh.promoted-at": nowIso,
         },
         surface: "promote",
+        declaredContentType: source.type,
       });
     } catch (err) {
       // Never leak internal error detail (D1/R2 messages, key policy

--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -18,13 +18,12 @@
  */
 
 import { getMetadataForKeys, setFileMetadata } from "./file-metadata";
-import { putObject } from "./files-core";
+import { putObject, putOptsFromStoredObject } from "./files-core";
 import { resolveBranchLineageSafe } from "./github-branch-renames";
 import { ghPrivateAttachmentKey, ghPrivateBranchKeyPrefix } from "./github-comment-render";
 import { getActivePrefixId } from "./github-private-prefixes";
 import { resolveGhKeyContextSafe } from "./github-private-prefix-service";
 import { storage } from "./storage";
-import { objectVisibility } from "./visibility";
 import type { WorkspaceRecord } from "./workspace";
 import { dbFor } from "./db-session";
 
@@ -388,13 +387,11 @@ export async function promoteBranchAttachments(
     try {
       const source = await store.download(key);
       const bytes = new Uint8Array(await source.arrayBuffer());
-      const visibility = objectVisibility(source.metadata);
 
       // A full replace (opts.metadata): the copy gets a fresh, self-contained
       // gh.* tag set rather than inheriting the staged original's tags.
       await putObject(env, ws, destKey, bytes, workspaceName, {
-        provenance: source.metadata,
-        visibility,
+        ...putOptsFromStoredObject(source),
         metadata: {
           // Uploader attribution (issue #340) survives promotion: the copy is
           // written by the server, so the staged original's tags are the only
@@ -411,7 +408,6 @@ export async function promoteBranchAttachments(
           "gh.promoted-at": nowIso,
         },
         surface: "promote",
-        declaredContentType: source.type,
       });
     } catch (err) {
       // Never leak internal error detail (D1/R2 messages, key policy

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -45,7 +45,7 @@ export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = [
   "application/json",
 ];
 
-const DEFAULT_ALLOWED_SET = new Set(DEFAULT_ALLOWED_CONTENT_TYPES);
+const DEFAULT_ALLOWED_SET: ReadonlySet<string> = new Set(DEFAULT_ALLOWED_CONTENT_TYPES);
 
 /** Video content types the upload path (and poster generation) accepts. */
 export const VIDEO_TYPES = new Set(["video/mp4", "video/webm", "video/quicktime"]);
@@ -66,14 +66,19 @@ export interface UploadPolicy {
   maxBytes: number;
   /** Max for video/* when set; otherwise maxBytes. */
   maxVideoBytes: number;
-  allowed: Set<string>;
+  allowed: ReadonlySet<string>;
 }
 
 /** Fields a workspace record may carry to override the default upload policy. */
 export interface UploadPolicyOverrides {
   maxUploadBytes?: number;
-  /** Cap for video/mp4 and video/webm. When unset, videos use maxUploadBytes. */
+  /** Cap for every type in VIDEO_TYPES (mp4, webm, quicktime). When unset, videos use maxUploadBytes. */
   maxVideoUploadBytes?: number;
+  /**
+   * A full replacement for the default allowlist, not an extension of it —
+   * a workspace with an override does not pick up types added to the
+   * default later.
+   */
   allowedContentTypes?: string[];
 }
 

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -152,6 +152,94 @@ export function detectContentType(bytes: Uint8Array): string | null {
   return null;
 }
 
+/** Bytes inspected by `looksLikeText`. Enough to catch binaries; cheap on a 25 MB log. */
+const TEXT_SAMPLE_BYTES = 8 * 1024;
+
+/**
+ * Plausibility check for declared text uploads (text has no magic bytes):
+ * the first 8 KiB must contain no NUL and decode as UTF-8. A multibyte
+ * sequence cut by the sample boundary is tolerated via streaming decode.
+ */
+export function looksLikeText(bytes: Uint8Array): boolean {
+  if (bytes.byteLength === 0) return false;
+  const sample = bytes.subarray(0, Math.min(bytes.byteLength, TEXT_SAMPLE_BYTES));
+  for (let i = 0; i < sample.length; i++) {
+    if (sample[i] === 0) return false;
+  }
+  try {
+    new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(sample, {
+      stream: sample.length < bytes.byteLength,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extension → content type for the key-extension fallback in
+ * `resolveDeclaredContentType`. Mirrors `inferContentType` in
+ * packages/uploads/src/embed.ts; keep the two in step. html/svg are absent on
+ * purpose — they must never become a declared type.
+ */
+const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  pdf: "application/pdf",
+  zip: "application/zip",
+  gz: "application/gzip",
+  tgz: "application/gzip",
+  txt: "text/plain",
+  text: "text/plain",
+  log: "text/plain",
+  jsonl: "text/plain",
+  ndjson: "text/plain",
+  yaml: "text/plain",
+  yml: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  json: "application/json",
+};
+
+/** Content type implied by a key's extension, or undefined when unknown. */
+export function contentTypeFromKey(key: string): string | undefined {
+  const base = key.slice(key.lastIndexOf("/") + 1);
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0 || dot === base.length - 1) return undefined;
+  return CONTENT_TYPE_BY_EXTENSION[base.slice(dot + 1).toLowerCase()];
+}
+
+/** Normalize a client Content-Type for allowlist compare (type/subtype only, lowercased). */
+export function normalizeDeclaredContentType(raw: string): string {
+  const beforeParams = raw.split(";", 1)[0] ?? raw;
+  return beforeParams.trim().toLowerCase();
+}
+
+/**
+ * The type a client *claims* for an upload: its Content-Type header when
+ * specific, else the key's extension. Only consulted by `inspectUpload` for
+ * text types (everything else is sniffed). `application/octet-stream` and an
+ * empty header count as unspecified so older CLIs (which send octet-stream
+ * for `.log`) and the hosted MCP (which sends no type) still resolve via the
+ * key.
+ */
+export function resolveDeclaredContentType(
+  header: string | undefined,
+  key: string,
+): string | undefined {
+  const normalized = header ? normalizeDeclaredContentType(header) : "";
+  if (normalized && normalized !== "application/octet-stream") return normalized;
+  return contentTypeFromKey(key);
+}
+
 export interface ImageDimensions {
   width: number;
   height: number;

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -18,9 +18,14 @@ import type { WorkspaceVars } from "./workspace";
 export const DEFAULT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // 25 MiB
 
 /**
- * Intended payloads: static images plus the short gif/video clips embedded in
- * GitHub repos. Deliberately excludes `image/svg+xml` — an SVG served inline
- * from storage.uploads.sh can carry script (stored XSS on our own origin).
+ * Intended payloads: static images, the short gif/video clips embedded in
+ * GitHub repos, and the non-media artifacts agents produce (reports, logs,
+ * JSON, archives). Deliberately excludes `image/svg+xml` and `text/html` —
+ * storage.uploads.sh is a bare R2 custom domain with no Worker in front of
+ * it, so the stored content type is the only control, and either of those
+ * served inline can carry script (stored XSS on our own origin). Everything
+ * below renders as inert text, opens in a sandboxed viewer (PDF), or has no
+ * inline handler at all (zip/gzip).
  */
 export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = [
   "image/png",
@@ -30,12 +35,31 @@ export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = [
   "image/avif",
   "video/mp4",
   "video/webm",
+  "video/quicktime",
+  "application/pdf",
+  "application/zip",
+  "application/gzip",
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/json",
 ];
 
 const DEFAULT_ALLOWED_SET = new Set(DEFAULT_ALLOWED_CONTENT_TYPES);
 
 /** Video content types the upload path (and poster generation) accepts. */
-export const VIDEO_TYPES = new Set(["video/mp4", "video/webm"]);
+export const VIDEO_TYPES = new Set(["video/mp4", "video/webm", "video/quicktime"]);
+
+/**
+ * Types with no magic bytes. Accepted only when the client declares one of
+ * them and the body passes `looksLikeText` — see `inspectUpload`.
+ */
+export const TEXT_CONTENT_TYPES: ReadonlySet<string> = new Set([
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/json",
+]);
 
 export interface UploadPolicy {
   /** Max for images (and as fallback when maxVideoBytes is unset). */
@@ -110,8 +134,21 @@ export function detectContentType(bytes: Uint8Array): string | null {
   if (matches(bytes, [0x66, 0x74, 0x79, 0x70], 4)) {
     const brand = asciiAt(bytes, 8, 4);
     if (brand === "avif" || brand === "avis") return "image/avif";
+    if (brand === "qt  ") return "video/quicktime";
     return "video/mp4";
   }
+  // %PDF-
+  if (matches(bytes, [0x25, 0x50, 0x44, 0x46, 0x2d])) return "application/pdf";
+  // PK\x03\x04 (local file header), PK\x05\x06 (empty archive), PK\x07\x08 (spanned)
+  if (
+    matches(bytes, [0x50, 0x4b, 0x03, 0x04]) ||
+    matches(bytes, [0x50, 0x4b, 0x05, 0x06]) ||
+    matches(bytes, [0x50, 0x4b, 0x07, 0x08])
+  ) {
+    return "application/zip";
+  }
+  // gzip member header
+  if (matches(bytes, [0x1f, 0x8b])) return "application/gzip";
   return null;
 }
 

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -323,10 +323,19 @@ export type UploadRejection = {
 };
 export type UploadInspection = { ok: true; contentType: string } | UploadRejection;
 
+/** Coarse family for 413 payloads and the optimizer/poster branches. */
+export type UploadKind = "image" | "video" | "file";
+
+export function uploadKind(contentType: string): UploadKind {
+  if (VIDEO_TYPES.has(contentType)) return "video";
+  if (contentType.startsWith("image/")) return "image";
+  return "file";
+}
+
 /** The shared 413 rejection for both the pre-buffer and post-buffer size checks. */
 function tooLarge(
   maxBytes: number,
-  extra?: { contentType?: string; kind?: "image" | "video" },
+  extra?: { contentType?: string; kind?: UploadKind },
 ): UploadRejection {
   return {
     ok: false,
@@ -354,26 +363,46 @@ export function checkDeclaredLength(
 }
 
 /**
- * Validate a fully-buffered upload body against the policy: sniffed type
- * against the allowlist, then the type-specific size cap.
+ * Validate a fully-buffered upload body against the policy. Sniffed bytes
+ * decide the stored type whenever they can; `declaredType` (from the request
+ * header or the key's extension — see `resolveDeclaredContentType`) is
+ * consulted only when sniffing finds nothing and the claim is one of the
+ * text types, which have no magic. Then the type-specific size cap.
  */
-export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadInspection {
+export function inspectUpload(
+  bytes: Uint8Array,
+  policy: UploadPolicy,
+  declaredType?: string,
+): UploadInspection {
   const detected = detectContentType(bytes);
-  if (detected === null || !policy.allowed.has(detected)) {
+  let contentType: string | null = null;
+  if (detected !== null) {
+    if (policy.allowed.has(detected)) contentType = detected;
+  } else if (
+    declaredType !== undefined &&
+    TEXT_CONTENT_TYPES.has(declaredType) &&
+    policy.allowed.has(declaredType) &&
+    looksLikeText(bytes)
+  ) {
+    contentType = declaredType;
+  }
+  if (contentType === null) {
     return {
       ok: false,
       status: 415,
       error: new UnsupportedMediaTypeError("unsupported media type", {
-        details: { allowed: [...policy.allowed] },
+        details: {
+          allowed: [...policy.allowed],
+          ...(declaredType !== undefined ? { declared: declaredType } : {}),
+        },
       }),
     };
   }
-  const maxBytes = maxBytesForContentType(policy, detected);
-  const kind = VIDEO_TYPES.has(detected) ? ("video" as const) : ("image" as const);
+  const maxBytes = maxBytesForContentType(policy, contentType);
   if (bytes.byteLength > maxBytes) {
-    return tooLarge(maxBytes, { contentType: detected, kind });
+    return tooLarge(maxBytes, { contentType, kind: uploadKind(contentType) });
   }
-  return { ok: true, contentType: detected };
+  return { ok: true, contentType };
 }
 
 /**

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -177,10 +177,11 @@ export function looksLikeText(bytes: Uint8Array): boolean {
 }
 
 /**
- * Extension → content type for the key-extension fallback in
- * `resolveDeclaredContentType`. Mirrors `inferContentType` in
- * packages/uploads/src/embed.ts; keep the two in step. html/svg are absent on
- * purpose — they must never become a declared type.
+ * Server-side counterpart of `inferContentType` in
+ * packages/uploads/src/embed.ts (the CLI's client-side guess). The two lists
+ * share every accepted type but are deliberately not identical: embed.ts
+ * keeps `svg` so the optimizer can pass it through, and this map must never
+ * map svg or html — anything here can become a declared type.
  */
 const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
   png: "image/png",
@@ -214,7 +215,8 @@ export function contentTypeFromKey(key: string): string | undefined {
   const base = key.slice(key.lastIndexOf("/") + 1);
   const dot = base.lastIndexOf(".");
   if (dot <= 0 || dot === base.length - 1) return undefined;
-  return CONTENT_TYPE_BY_EXTENSION[base.slice(dot + 1).toLowerCase()];
+  const ext = base.slice(dot + 1).toLowerCase();
+  return Object.hasOwn(CONTENT_TYPE_BY_EXTENSION, ext) ? CONTENT_TYPE_BY_EXTENSION[ext] : undefined;
 }
 
 /** Normalize a client Content-Type for allowlist compare (type/subtype only, lowercased). */

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -17,7 +17,27 @@ import type { WorkspaceVars } from "./workspace";
 /** Default ceiling on a single upload. Covers screenshots and short clips. */
 export const DEFAULT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // 25 MiB
 
+/** Coarse family for 413 payloads and the optimizer/poster branches. */
+export type UploadKind = "image" | "video" | "file";
+
+type UploadTypeRow = {
+  readonly type: string;
+  readonly kind: UploadKind;
+  /**
+   * `sniff` — recognized by `detectContentType` from its magic bytes.
+   * `declared` — no magic bytes at all; accepted only when the client
+   * declares the type and the body passes `looksLikeText`.
+   */
+  readonly verify: "sniff" | "declared";
+  /** First entry is canonical: the extension derived when naming a key from a type. */
+  readonly extensions: readonly string[];
+};
+
 /**
+ * The single table behind every upload-type decision: the default allowlist,
+ * the video family, which types have no magic bytes, and the extension
+ * mapping in both directions.
+ *
  * Intended payloads: static images, the short gif/video clips embedded in
  * GitHub repos, and the non-media artifacts agents produce (reports, logs,
  * JSON, archives). Deliberately excludes `image/svg+xml` and `text/html` —
@@ -27,39 +47,58 @@ export const DEFAULT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // 25 MiB
  * below renders as inert text, opens in a sandboxed viewer (PDF), or has no
  * inline handler at all (zip/gzip).
  */
-export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = [
-  "image/png",
-  "image/jpeg",
-  "image/gif",
-  "image/webp",
-  "image/avif",
-  "video/mp4",
-  "video/webm",
-  "video/quicktime",
-  "application/pdf",
-  "application/zip",
-  "application/gzip",
-  "text/plain",
-  "text/markdown",
-  "text/csv",
-  "application/json",
+const UPLOAD_TYPES: readonly UploadTypeRow[] = [
+  { type: "image/png", kind: "image", verify: "sniff", extensions: ["png"] },
+  { type: "image/jpeg", kind: "image", verify: "sniff", extensions: ["jpg", "jpeg"] },
+  { type: "image/gif", kind: "image", verify: "sniff", extensions: ["gif"] },
+  { type: "image/webp", kind: "image", verify: "sniff", extensions: ["webp"] },
+  { type: "image/avif", kind: "image", verify: "sniff", extensions: ["avif"] },
+  { type: "video/mp4", kind: "video", verify: "sniff", extensions: ["mp4"] },
+  { type: "video/webm", kind: "video", verify: "sniff", extensions: ["webm"] },
+  { type: "video/quicktime", kind: "video", verify: "sniff", extensions: ["mov"] },
+  { type: "application/pdf", kind: "file", verify: "sniff", extensions: ["pdf"] },
+  { type: "application/zip", kind: "file", verify: "sniff", extensions: ["zip"] },
+  { type: "application/gzip", kind: "file", verify: "sniff", extensions: ["gz", "tgz"] },
+  {
+    type: "text/plain",
+    kind: "file",
+    verify: "declared",
+    extensions: ["txt", "text", "log", "jsonl", "ndjson", "yaml", "yml"],
+  },
+  { type: "text/markdown", kind: "file", verify: "declared", extensions: ["md", "markdown"] },
+  { type: "text/csv", kind: "file", verify: "declared", extensions: ["csv"] },
+  { type: "application/json", kind: "file", verify: "declared", extensions: ["json"] },
 ];
+
+const ROW_BY_TYPE: ReadonlyMap<string, UploadTypeRow> = new Map(
+  UPLOAD_TYPES.map((row) => [row.type, row]),
+);
+
+export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = UPLOAD_TYPES.map((row) => row.type);
 
 const DEFAULT_ALLOWED_SET: ReadonlySet<string> = new Set(DEFAULT_ALLOWED_CONTENT_TYPES);
 
 /** Video content types the upload path (and poster generation) accepts. */
-export const VIDEO_TYPES = new Set(["video/mp4", "video/webm", "video/quicktime"]);
+export const VIDEO_TYPES = new Set(
+  UPLOAD_TYPES.filter((row) => row.kind === "video").map((row) => row.type),
+);
 
 /**
  * Types with no magic bytes. Accepted only when the client declares one of
  * them and the body passes `looksLikeText` — see `inspectUpload`.
  */
-export const TEXT_CONTENT_TYPES: ReadonlySet<string> = new Set([
-  "text/plain",
-  "text/markdown",
-  "text/csv",
-  "application/json",
-]);
+export const TEXT_CONTENT_TYPES: ReadonlySet<string> = new Set(
+  UPLOAD_TYPES.filter((row) => row.verify === "declared").map((row) => row.type),
+);
+
+export function uploadKind(contentType: string): UploadKind {
+  const row = ROW_BY_TYPE.get(contentType);
+  if (row) return row.kind;
+  // Only reachable for a type a workspace added via `allowedContentTypes`;
+  // classify it by family prefix.
+  if (contentType.startsWith("image/")) return "image";
+  return "file";
+}
 
 export interface UploadPolicy {
   /** Max for images (and as fallback when maxVideoBytes is unset). */
@@ -182,38 +221,23 @@ export function looksLikeText(bytes: Uint8Array): boolean {
 }
 
 /**
- * Server-side counterpart of `inferContentType` in
- * packages/uploads/src/embed.ts (the CLI's client-side guess). The two lists
- * share every accepted type but are deliberately not identical: embed.ts
- * keeps `svg` so the optimizer can pass it through, and this map must never
- * map svg or html — anything here can become a declared type.
+ * Extension → content type, built from `UPLOAD_TYPES`. Only the
+ * `verify: "declared"` rows can change an admission outcome (an extension is
+ * one of the two ways a client declares a text type — see
+ * `resolveDeclaredContentType`); the sniffed media rows are here so
+ * `details.declared` on a 415 is informative, so a key's extension still
+ * names a type, and so the CLI-side `inferContentType`
+ * (packages/uploads/src/embed.ts) stays a readable mirror of this list.
+ * Neither svg nor html appears in the table at all.
  */
-const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-  avif: "image/avif",
-  mp4: "video/mp4",
-  webm: "video/webm",
-  mov: "video/quicktime",
-  pdf: "application/pdf",
-  zip: "application/zip",
-  gz: "application/gzip",
-  tgz: "application/gzip",
-  txt: "text/plain",
-  text: "text/plain",
-  log: "text/plain",
-  jsonl: "text/plain",
-  ndjson: "text/plain",
-  yaml: "text/plain",
-  yml: "text/plain",
-  md: "text/markdown",
-  markdown: "text/markdown",
-  csv: "text/csv",
-  json: "application/json",
-};
+const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = Object.fromEntries(
+  UPLOAD_TYPES.flatMap((row) => row.extensions.map((ext) => [ext, row.type] as const)),
+);
+
+/** Canonical extension for an accepted content type, or undefined when it is not one. */
+export function extensionForContentType(type: string): string | undefined {
+  return ROW_BY_TYPE.get(type)?.extensions[0];
+}
 
 /** Content type implied by a key's extension, or undefined when unknown. */
 export function contentTypeFromKey(key: string): string | undefined {
@@ -330,15 +354,6 @@ export type UploadRejection = {
 };
 export type UploadInspection = { ok: true; contentType: string } | UploadRejection;
 
-/** Coarse family for 413 payloads and the optimizer/poster branches. */
-export type UploadKind = "image" | "video" | "file";
-
-export function uploadKind(contentType: string): UploadKind {
-  if (VIDEO_TYPES.has(contentType)) return "video";
-  if (contentType.startsWith("image/")) return "image";
-  return "file";
-}
-
 /** The shared 413 rejection for both the pre-buffer and post-buffer size checks. */
 function tooLarge(
   maxBytes: number,
@@ -387,7 +402,7 @@ export function inspectUpload(
     if (policy.allowed.has(detected)) contentType = detected;
   } else if (
     declaredType !== undefined &&
-    TEXT_CONTENT_TYPES.has(declaredType) &&
+    ROW_BY_TYPE.get(declaredType)?.verify === "declared" &&
     policy.allowed.has(declaredType) &&
     looksLikeText(bytes)
   ) {

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -18,6 +18,7 @@ import {
   checkDeclaredLength,
   maxBytesForContentType,
   normalizeDeclaredContentType,
+  resolveDeclaredContentType,
   resolveUploadPolicy,
 } from "../guards";
 import { contentSha256Hex, splitUploadMetaHeaders } from "../provenance";
@@ -253,6 +254,7 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
         visibility,
         replace: wantReplace,
         metadata,
+        declaredContentType: resolveDeclaredContentType(putOpts.declaredContentType, finalKey),
       },
       run: () => putObject(c.env, ws, key, bytes, workspaceName, idempotentPutOpts),
       reconcile: () =>

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -14,7 +14,12 @@ import {
   reconcileInterruptedUpload,
 } from "../files-core";
 import { getFileMetadata, META_MAX_KEYS, setFileMetadata } from "../file-metadata";
-import { checkDeclaredLength, maxBytesForContentType, resolveUploadPolicy } from "../guards";
+import {
+  checkDeclaredLength,
+  maxBytesForContentType,
+  normalizeDeclaredContentType,
+  resolveUploadPolicy,
+} from "../guards";
 import { contentSha256Hex, splitUploadMetaHeaders } from "../provenance";
 import { createLaneResolver, objectPublicUrls, resolveObjectLane, storage } from "../storage";
 import { hasGithubTags, uploaderTags } from "../uploader-identity";
@@ -25,12 +30,6 @@ import { dbFor, primaryDbFor } from "../db-session";
 
 /** Handler shape shared by the legacy bearer and canonical dual-auth routers. */
 export type SharedFilesHandler = Handler<WorkspaceVars>;
-
-/** Normalize a client Content-Type for allowlist compare (type/subtype only, lowercased). */
-function normalizePresignContentType(raw: string): string {
-  const beforeParams = raw.split(";", 1)[0] ?? raw;
-  return beforeParams.trim().toLowerCase();
-}
 
 export async function signFileHandler(c: Context<WorkspaceVars>) {
   const body = await c.req
@@ -68,7 +67,7 @@ export async function signFileHandler(c: Context<WorkspaceVars>) {
       code: "content_type_required",
     });
   }
-  const contentType = normalizePresignContentType(rawContentType);
+  const contentType = normalizeDeclaredContentType(rawContentType);
   if (!policy.allowed.has(contentType)) {
     throw new UnsupportedMediaTypeError("unsupported media type", {
       code: "unsupported_media_type",
@@ -228,6 +227,7 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
     metadata,
     replace: wantReplace,
     surface: "api" as const,
+    declaredContentType: c.req.header("Content-Type"),
   };
 
   const idempotencyKey = c.req.header("Idempotency-Key");

--- a/apps/api/src/routes/github-attach-route.test.ts
+++ b/apps/api/src/routes/github-attach-route.test.ts
@@ -63,11 +63,11 @@ async function seededEnv(): Promise<Seeded> {
 async function seedSource(
   seeded: Seeded,
   key: string,
-  opts: { bytes?: Uint8Array; meta?: Record<string, string> } = {},
+  opts: { bytes?: Uint8Array; meta?: Record<string, string>; contentType?: string } = {},
 ) {
   const bytes = opts.bytes ?? PNG;
   await seeded.bucket.put(`${PREFIX}${key}`, bytes, {
-    httpMetadata: { contentType: "image/png" },
+    httpMetadata: { contentType: opts.contentType ?? "image/png" },
     customMetadata: {},
   });
   if (opts.meta) {
@@ -212,6 +212,27 @@ describe("POST /v1/workspaces/:workspace/github/attach", () => {
     expect(seeded.bucket.store.get(`${PREFIX}f/abc123/hero.png`)).toBeUndefined();
     // Destination still landed.
     expect(seeded.bucket.store.get(`${PREFIX}${destKey("hero.png")}`)).toBeDefined();
+  });
+
+  it("copies a stored text/plain object under an extension-less key, preserving its content type", async () => {
+    const seeded = await seededEnv();
+    const notes = new TextEncoder().encode("build log\nno errors\n");
+    await seedSource(seeded, "gh/acme/r/branch/feat/notes", {
+      bytes: notes,
+      contentType: "text/plain",
+    });
+
+    const res = await post(seeded.env, {
+      source: "gh/acme/r/branch/feat/notes",
+      repo: REPO,
+      pr: NUM,
+    });
+    expect(res.status).toBe(200);
+
+    const stored = seeded.bucket.store.get(`${PREFIX}${destKey("notes")}`);
+    expect(stored).toBeDefined();
+    expect(stored?.contentType).toBe("text/plain");
+    expect([...(stored?.data ?? [])]).toEqual([...notes]);
   });
 
   it("attaches to an issue with the issues key shape", async () => {

--- a/apps/api/src/upload-idempotency.ts
+++ b/apps/api/src/upload-idempotency.ts
@@ -40,6 +40,8 @@ export interface UploadFingerprintInput {
   visibility: string | undefined;
   replace: boolean;
   metadata: Record<string, string> | undefined;
+  /** The effective declared type (`resolveDeclaredContentType`), since it can change the stored type for the same bytes. */
+  declaredContentType: string | undefined;
 }
 
 export type IdempotentUploadResult<T> = { value: T; replayed: boolean };
@@ -61,6 +63,7 @@ function fingerprintFor(input: UploadFingerprintInput): Promise<string> {
       visibility: input.visibility ?? null,
       replace: input.replace,
       metadata: stableStringify(input.metadata),
+      declaredContentType: input.declaredContentType ?? null,
     }),
   );
 }

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -6,12 +6,15 @@ import {
   DEFAULT_MAX_UPLOAD_BYTES,
   detectContentType,
   detectImageDimensions,
+  extensionForContentType,
   inspectUpload,
   looksLikeText,
   resolveDeclaredContentType,
   resolveUploadPolicy,
+  TEXT_CONTENT_TYPES,
 } from "../src/guards";
 import { gifOf, pngOf } from "./helpers/image-fixtures";
+import { AVIF, ftyp, GZIP, MOV, PDF, ZIP, ZIP_EMPTY } from "./helpers/media-fixtures";
 
 const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
 const JPEG = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0, 0]);
@@ -20,22 +23,6 @@ const WEBP = new Uint8Array([
   0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
 ]);
 const WEBM = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0, 0]);
-const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]); // %PDF-1.7
-const ZIP = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]);
-const ZIP_EMPTY = new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0]);
-const GZIP = new Uint8Array([0x1f, 0x8b, 0x08, 0, 0, 0, 0, 0]);
-const ftyp = (brand: string) =>
-  new Uint8Array([
-    0,
-    0,
-    0,
-    0x18,
-    0x66,
-    0x74,
-    0x79,
-    0x70,
-    ...[...brand].map((ch) => ch.charCodeAt(0)),
-  ]);
 
 describe("detectContentType", () => {
   it("recognizes each intended type from its magic bytes", () => {
@@ -44,7 +31,7 @@ describe("detectContentType", () => {
     expect(detectContentType(GIF)).toBe("image/gif");
     expect(detectContentType(WEBP)).toBe("image/webp");
     expect(detectContentType(WEBM)).toBe("video/webm");
-    expect(detectContentType(ftyp("avif"))).toBe("image/avif");
+    expect(detectContentType(AVIF)).toBe("image/avif");
     expect(detectContentType(ftyp("isom"))).toBe("video/mp4");
     expect(detectContentType(ftyp("mp42"))).toBe("video/mp4");
   });
@@ -60,7 +47,7 @@ describe("detectContentType", () => {
     expect(detectContentType(ZIP)).toBe("application/zip");
     expect(detectContentType(ZIP_EMPTY)).toBe("application/zip");
     expect(detectContentType(GZIP)).toBe("application/gzip");
-    expect(detectContentType(ftyp("qt  "))).toBe("video/quicktime");
+    expect(detectContentType(MOV)).toBe("video/quicktime");
     // MP4 brands still map to mp4, not quicktime.
     expect(detectContentType(ftyp("isom"))).toBe("video/mp4");
   });
@@ -202,6 +189,19 @@ describe("looksLikeText", () => {
   });
 });
 
+describe("the upload-type table", () => {
+  it("is coherent: every allowed type round-trips through its canonical extension, and text types are allowed", () => {
+    for (const type of DEFAULT_ALLOWED_CONTENT_TYPES) {
+      const ext = extensionForContentType(type);
+      expect(ext, type).toBeDefined();
+      expect(contentTypeFromKey(`a/file.${ext}`), type).toBe(type);
+    }
+    for (const type of TEXT_CONTENT_TYPES) {
+      expect(DEFAULT_ALLOWED_CONTENT_TYPES, type).toContain(type);
+    }
+  });
+});
+
 describe("contentTypeFromKey", () => {
   it("maps the accepted non-media extensions", () => {
     expect(contentTypeFromKey("gh/o/r/pull/1/build.log")).toBe("text/plain");
@@ -339,7 +339,7 @@ describe("inspectUpload", () => {
       expect(pdf.status).toBe(413);
       expect(pdf.error.details).toMatchObject({ kind: "file", contentType: "application/pdf" });
     }
-    const mov = inspectUpload(ftyp("qt  "), tight);
+    const mov = inspectUpload(MOV, tight);
     expect(mov).toEqual({ ok: true, contentType: "video/quicktime" });
   });
 });

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -269,4 +269,68 @@ describe("inspectUpload", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.status).toBe(415);
   });
+
+  const text = new TextEncoder().encode("line one\nline two\n");
+
+  it("accepts a declared text type when the body is plausible text", () => {
+    expect(inspectUpload(text, policy, "text/plain")).toEqual({
+      ok: true,
+      contentType: "text/plain",
+    });
+    expect(inspectUpload(new TextEncoder().encode('{"a":1}'), policy, "application/json")).toEqual({
+      ok: true,
+      contentType: "application/json",
+    });
+  });
+
+  it("sniffed bytes win over a declared text type", () => {
+    expect(inspectUpload(PNG, policy, "text/plain")).toEqual({
+      ok: true,
+      contentType: "image/png",
+    });
+  });
+
+  it("rejects declared text with binary bytes, an undeclared body, or a non-text declared type", () => {
+    const binary = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+    for (const [bytes, declared] of [
+      [binary, "text/plain"],
+      [text, undefined],
+      [text, "application/octet-stream"],
+      [text, "text/html"],
+      [text, "image/svg+xml"],
+      [text, "application/xml"],
+    ] as const) {
+      const result = inspectUpload(bytes, policy, declared);
+      expect(result.ok, `${declared}`).toBe(false);
+      if (!result.ok) expect(result.status).toBe(415);
+    }
+  });
+
+  it("honors a workspace allowlist that excludes text", () => {
+    const imagesOnly = resolveUploadPolicy({ allowedContentTypes: ["image/png"] });
+    const result = inspectUpload(text, imagesOnly, "text/plain");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(415);
+  });
+
+  it("reports the declared type in the 415 details", () => {
+    const result = inspectUpload(text, policy, "text/html");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.details).toMatchObject({ declared: "text/html" });
+      expect(result.error.details).toHaveProperty("allowed");
+    }
+  });
+
+  it("caps non-media at maxBytes with kind file, and MOV at maxVideoBytes", () => {
+    const tight = resolveUploadPolicy({ maxUploadBytes: 4, maxVideoUploadBytes: 1000 });
+    const pdf = inspectUpload(PDF, tight);
+    expect(pdf.ok).toBe(false);
+    if (!pdf.ok) {
+      expect(pdf.status).toBe(413);
+      expect(pdf.error.details).toMatchObject({ kind: "file", contentType: "application/pdf" });
+    }
+    const mov = inspectUpload(ftyp("qt  "), tight);
+    expect(mov).toEqual({ ok: true, contentType: "video/quicktime" });
+  });
 });

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -196,6 +196,10 @@ describe("looksLikeText", () => {
     body[8500] = 0;
     expect(looksLikeText(body)).toBe(true);
   });
+
+  it("rejects a multibyte sequence truncated at end of file", () => {
+    expect(looksLikeText(new Uint8Array([0x61, 0xe2]))).toBe(false);
+  });
 });
 
 describe("contentTypeFromKey", () => {
@@ -219,6 +223,11 @@ describe("contentTypeFromKey", () => {
     expect(contentTypeFromKey("a/page.html")).toBeUndefined();
     expect(contentTypeFromKey("a/icon.svg")).toBeUndefined();
     expect(contentTypeFromKey("a/dir.v2/")).toBeUndefined();
+  });
+
+  it("does not resolve through inherited Object.prototype keys", () => {
+    expect(contentTypeFromKey("a/x.constructor")).toBeUndefined();
+    expect(contentTypeFromKey("a/x.toString")).toBeUndefined();
   });
 });
 

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   checkDeclaredLength,
+  contentTypeFromKey,
   DEFAULT_ALLOWED_CONTENT_TYPES,
   DEFAULT_MAX_UPLOAD_BYTES,
   detectContentType,
   detectImageDimensions,
   inspectUpload,
+  looksLikeText,
+  resolveDeclaredContentType,
   resolveUploadPolicy,
 } from "../src/guards";
 import { gifOf, pngOf } from "./helpers/image-fixtures";
@@ -165,6 +168,76 @@ describe("resolveUploadPolicy", () => {
     }
     expect(allowed.has("text/html")).toBe(false);
     expect(allowed.has("image/svg+xml")).toBe(false);
+  });
+});
+
+describe("looksLikeText", () => {
+  const enc = (s: string) => new TextEncoder().encode(s);
+
+  it("accepts ASCII and UTF-8 bodies", () => {
+    expect(looksLikeText(enc("plain log line\n"))).toBe(true);
+    expect(looksLikeText(enc("héllo — ünïcode ✓"))).toBe(true);
+  });
+
+  it("rejects NUL bytes and invalid UTF-8", () => {
+    expect(looksLikeText(new Uint8Array([0x61, 0x00, 0x62]))).toBe(false);
+    expect(looksLikeText(new Uint8Array([0xe9, 0x74, 0xe9]))).toBe(false); // Latin-1 "été"
+    expect(looksLikeText(new Uint8Array(0))).toBe(false);
+  });
+
+  it("does not fail on a multibyte sequence cut by the 8 KiB sample boundary", () => {
+    // 8190 ASCII bytes, then a 3-byte character straddling offset 8192.
+    const body = enc("a".repeat(8190) + "€" + "tail".repeat(50));
+    expect(looksLikeText(body)).toBe(true);
+  });
+
+  it("only samples the head: a NUL after 8 KiB is not inspected", () => {
+    const body = new Uint8Array(9000).fill(0x61);
+    body[8500] = 0;
+    expect(looksLikeText(body)).toBe(true);
+  });
+});
+
+describe("contentTypeFromKey", () => {
+  it("maps the accepted non-media extensions", () => {
+    expect(contentTypeFromKey("gh/o/r/pull/1/build.log")).toBe("text/plain");
+    expect(contentTypeFromKey("a/notes.TXT")).toBe("text/plain");
+    expect(contentTypeFromKey("a/out.jsonl")).toBe("text/plain");
+    expect(contentTypeFromKey("a/config.yaml")).toBe("text/plain");
+    expect(contentTypeFromKey("a/README.md")).toBe("text/markdown");
+    expect(contentTypeFromKey("a/data.csv")).toBe("text/csv");
+    expect(contentTypeFromKey("a/report.json")).toBe("application/json");
+    expect(contentTypeFromKey("a/report.pdf")).toBe("application/pdf");
+    expect(contentTypeFromKey("a/bundle.zip")).toBe("application/zip");
+    expect(contentTypeFromKey("a/bundle.tgz")).toBe("application/gzip");
+    expect(contentTypeFromKey("a/clip.mov")).toBe("video/quicktime");
+    expect(contentTypeFromKey("a/shot.png")).toBe("image/png");
+  });
+
+  it("returns undefined for unknown or missing extensions and never maps html/svg", () => {
+    expect(contentTypeFromKey("a/blob")).toBeUndefined();
+    expect(contentTypeFromKey("a/page.html")).toBeUndefined();
+    expect(contentTypeFromKey("a/icon.svg")).toBeUndefined();
+    expect(contentTypeFromKey("a/dir.v2/")).toBeUndefined();
+  });
+});
+
+describe("resolveDeclaredContentType", () => {
+  it("prefers a specific header, normalized", () => {
+    expect(resolveDeclaredContentType("Text/Plain; charset=utf-8", "a/x.json")).toBe("text/plain");
+  });
+
+  it("falls back to the key extension when the header is absent or octet-stream", () => {
+    expect(resolveDeclaredContentType(undefined, "a/build.log")).toBe("text/plain");
+    expect(resolveDeclaredContentType("application/octet-stream", "a/build.log")).toBe(
+      "text/plain",
+    );
+    expect(resolveDeclaredContentType("", "a/build.log")).toBe("text/plain");
+  });
+
+  it("is undefined when neither source is specific", () => {
+    expect(resolveDeclaredContentType(undefined, "a/blob")).toBeUndefined();
+    expect(resolveDeclaredContentType("application/octet-stream", "a/blob")).toBeUndefined();
   });
 });
 

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -17,6 +17,10 @@ const WEBP = new Uint8Array([
   0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
 ]);
 const WEBM = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0, 0]);
+const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]); // %PDF-1.7
+const ZIP = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]);
+const ZIP_EMPTY = new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0]);
+const GZIP = new Uint8Array([0x1f, 0x8b, 0x08, 0, 0, 0, 0, 0]);
 const ftyp = (brand: string) =>
   new Uint8Array([
     0,
@@ -43,10 +47,24 @@ describe("detectContentType", () => {
   });
 
   it("returns null for unrecognized or truncated payloads", () => {
-    expect(detectContentType(new Uint8Array([0x50, 0x4b, 0x03, 0x04]))).toBeNull(); // zip
     expect(detectContentType(new TextEncoder().encode("<svg></svg>"))).toBeNull();
     expect(detectContentType(new Uint8Array([0x89]))).toBeNull();
     expect(detectContentType(new Uint8Array(0))).toBeNull();
+  });
+
+  it("recognizes the non-media binary types and MOV from their magic bytes", () => {
+    expect(detectContentType(PDF)).toBe("application/pdf");
+    expect(detectContentType(ZIP)).toBe("application/zip");
+    expect(detectContentType(ZIP_EMPTY)).toBe("application/zip");
+    expect(detectContentType(GZIP)).toBe("application/gzip");
+    expect(detectContentType(ftyp("qt  "))).toBe("video/quicktime");
+    // MP4 brands still map to mp4, not quicktime.
+    expect(detectContentType(ftyp("isom"))).toBe("video/mp4");
+  });
+
+  it("does not sniff text: plain ASCII and UTF-8 bodies return null", () => {
+    expect(detectContentType(new TextEncoder().encode("hello world\n"))).toBeNull();
+    expect(detectContentType(new TextEncoder().encode('{"ok":true}'))).toBeNull();
   });
 });
 
@@ -130,6 +148,24 @@ describe("resolveUploadPolicy", () => {
     expect(policy.maxBytes).toBe(DEFAULT_MAX_UPLOAD_BYTES);
     expect(policy.allowed.size).toBe(DEFAULT_ALLOWED_CONTENT_TYPES.length);
   });
+
+  it("default allowlist includes the non-media families and quicktime", () => {
+    const { allowed } = resolveUploadPolicy({});
+    for (const t of [
+      "application/pdf",
+      "application/zip",
+      "application/gzip",
+      "video/quicktime",
+      "text/plain",
+      "text/markdown",
+      "text/csv",
+      "application/json",
+    ]) {
+      expect(allowed.has(t), t).toBe(true);
+    }
+    expect(allowed.has("text/html")).toBe(false);
+    expect(allowed.has("image/svg+xml")).toBe(false);
+  });
 });
 
 describe("inspectUpload", () => {
@@ -148,7 +184,8 @@ describe("inspectUpload", () => {
   });
 
   it("rejects a disallowed sniffed type with 415", () => {
-    const result = inspectUpload(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), policy);
+    const imagesOnly = resolveUploadPolicy({ allowedContentTypes: ["image/png"] });
+    const result = inspectUpload(ZIP, imagesOnly);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.status).toBe(415);
   });

--- a/apps/api/test/helpers/media-fixtures.ts
+++ b/apps/api/test/helpers/media-fixtures.ts
@@ -1,0 +1,30 @@
+/**
+ * Minimal non-image payload headers — just enough leading bytes for
+ * `detectContentType` (guards.ts) to sniff, no real file structure.
+ */
+
+/** %PDF-1.7 header. */
+export const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a]);
+
+/** PK\x03\x04 local file header. */
+export const ZIP = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]);
+
+/** PK\x05\x06 end-of-central-directory (an archive with no entries). */
+export const ZIP_EMPTY = new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0]);
+
+/** gzip member header. */
+export const GZIP = new Uint8Array([0x1f, 0x8b, 0x08, 0, 0, 0, 0, 0]);
+
+/** ISO base media `ftyp` box (offset 4) with the given four-char major brand. */
+export function ftyp(brand: string): Uint8Array {
+  const bytes = new Uint8Array(12);
+  bytes.set([0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70]); // size + "ftyp"
+  for (let i = 0; i < 4; i++) bytes[8 + i] = brand.charCodeAt(i);
+  return bytes;
+}
+
+/** QuickTime: an ftyp box with the "qt  " major brand. */
+export const MOV = ftyp("qt  ");
+
+/** AVIF: an ftyp box with the "avif" major brand. */
+export const AVIF = ftyp("avif");

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -241,6 +241,23 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     expect(bucket.store.get("default/reports/build.log")?.contentType).toBe("text/plain");
   });
 
+  it("stores a text body with no Content-Type header at all as text/plain (hosted-MCP shape)", async () => {
+    const { env, bucket } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/reports/build.log",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN}` },
+        body: new TextEncoder().encode("ok 1\nok 2\n"),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { contentType: string };
+    expect(json.contentType).toBe("text/plain");
+    expect(bucket.store.get("default/reports/build.log")?.contentType).toBe("text/plain");
+  });
+
   it("rejects text declared as html, and text under a key with no known extension", async () => {
     const { env } = await makeEnv();
     const html = new TextEncoder().encode("<!doctype html><script>1</script>");
@@ -739,6 +756,9 @@ describe("POST /v1/:workspace/files/sign content-type policy", () => {
       env,
     );
     expect(res.status).not.toBe(415);
+    const json = (await res.json()) as { error?: { code: string } };
+    expect(json.error?.code).not.toBe("unsupported_media_type");
+    expect(json.error?.code).not.toBe("content_type_required");
   });
 
   it("does not include raw provider detail on presign_unavailable", async () => {

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
+import { PDF, ZIP } from "./helpers/media-fixtures";
 import { DeleteUsageClaimsTable } from "./helpers/fake-delete-usage-claims-table";
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
 import { app } from "../src/index";
@@ -283,15 +284,13 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
 
   it("stores a PDF and a zip by their sniffed types regardless of the header", async () => {
     const { env, bucket } = await makeEnv();
-    const pdf = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a]);
-    const zip = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]);
-    expect((await putShot(env, { key: "reports/r.pdf", body: pdf })).status).toBe(201);
+    expect((await putShot(env, { key: "reports/r.pdf", body: PDF })).status).toBe(201);
     expect(bucket.store.get("default/reports/r.pdf")?.contentType).toBe("application/pdf");
     expect(
       (
         await putShot(env, {
           key: "reports/b.zip",
-          body: zip,
+          body: ZIP,
           headers: { "Content-Type": "text/plain" },
         })
       ).status,

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -211,10 +211,75 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     expect(bucket.store.get("default/screenshots/shot.png")?.contentType).toBe("image/png");
   });
 
-  it("rejects a non-image payload with 415", async () => {
+  it("rejects an unrecognized binary payload with 415", async () => {
     const { env } = await makeEnv();
-    const res = await putShot(env, { body: new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x00]) }); // zip
+    const res = await putShot(env, { body: new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]) });
     expect(res.status).toBe(415);
+  });
+
+  it("stores a declared text/plain body as text/plain", async () => {
+    const { env, bucket } = await makeEnv();
+    const res = await putShot(env, {
+      key: "reports/build.log",
+      body: new TextEncoder().encode("ok 1\nok 2\n"),
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { contentType: string };
+    expect(json.contentType).toBe("text/plain");
+    expect(bucket.store.get("default/reports/build.log")?.contentType).toBe("text/plain");
+  });
+
+  it("resolves the text type from the key extension when the header is octet-stream (old CLIs)", async () => {
+    const { env, bucket } = await makeEnv();
+    const res = await putShot(env, {
+      key: "reports/build.log",
+      body: new TextEncoder().encode("ok\n"),
+      headers: { "Content-Type": "application/octet-stream" },
+    });
+    expect(res.status).toBe(201);
+    expect(bucket.store.get("default/reports/build.log")?.contentType).toBe("text/plain");
+  });
+
+  it("rejects text declared as html, and text under a key with no known extension", async () => {
+    const { env } = await makeEnv();
+    const html = new TextEncoder().encode("<!doctype html><script>1</script>");
+    expect(
+      (
+        await putShot(env, {
+          key: "pages/x.html",
+          body: html,
+          headers: { "Content-Type": "text/html" },
+        })
+      ).status,
+    ).toBe(415);
+    expect(
+      (
+        await putShot(env, {
+          key: "pages/blob",
+          body: new TextEncoder().encode("hello"),
+          headers: { "Content-Type": "application/octet-stream" },
+        })
+      ).status,
+    ).toBe(415);
+  });
+
+  it("stores a PDF and a zip by their sniffed types regardless of the header", async () => {
+    const { env, bucket } = await makeEnv();
+    const pdf = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a]);
+    const zip = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]);
+    expect((await putShot(env, { key: "reports/r.pdf", body: pdf })).status).toBe(201);
+    expect(bucket.store.get("default/reports/r.pdf")?.contentType).toBe("application/pdf");
+    expect(
+      (
+        await putShot(env, {
+          key: "reports/b.zip",
+          body: zip,
+          headers: { "Content-Type": "text/plain" },
+        })
+      ).status,
+    ).toBe(201);
+    expect(bucket.store.get("default/reports/b.zip")?.contentType).toBe("application/zip");
   });
 
   it("rejects an oversized body with 413", async () => {
@@ -660,6 +725,20 @@ describe("POST /v1/:workspace/files/sign content-type policy", () => {
     const json = (await res.json()) as { error?: { code: string } };
     expect(json.error?.code).not.toBe("unsupported_media_type");
     expect(json.error?.code).not.toBe("content_type_required");
+  });
+
+  it("accepts a declared text/plain on presign", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/sign",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ key: "reports/build.log", contentType: "text/plain" }),
+      },
+      env,
+    );
+    expect(res.status).not.toBe(415);
   });
 
   it("does not include raw provider detail on presign_unavailable", async () => {

--- a/apps/api/test/upload-idempotency.test.ts
+++ b/apps/api/test/upload-idempotency.test.ts
@@ -19,6 +19,7 @@ function fingerprint(overrides: Partial<UploadFingerprintInput> = {}): UploadFin
     visibility: undefined,
     replace: false,
     metadata: undefined,
+    declaredContentType: undefined,
     ...overrides,
   };
 }
@@ -109,6 +110,20 @@ describe("upload PUT idempotency", () => {
           run: async () => response("f/abc/other.png"),
           reconcile: async () => null,
           now: new Date("2026-08-24T12:00:30Z"),
+        }),
+      ).rejects.toMatchObject({ code: "idempotency_key_reused" });
+
+      // Same bytes and key, different effective declared type (a `.log` retried
+      // as text/csv): the stored type would differ, so it must conflict too.
+      await expect(
+        putObjectIdempotently(database(sqlite), {
+          workspace: "alpha",
+          principal: "d1-token:one",
+          key: "put-3",
+          fingerprint: fingerprint({ declaredContentType: "text/csv" }),
+          run: async () => response("f/abc/photo.png"),
+          reconcile: async () => null,
+          now: new Date("2026-08-24T12:00:31Z"),
         }),
       ).rejects.toMatchObject({ code: "idempotency_key_reused" });
     } finally {

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -599,7 +599,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       annotations: mcpDestroyPublic,
       securitySchemes: mcpOAuthWrite,
       description:
-        "Upload a file (or files) and get a public URL plus GitHub-ready markdown. Prefer the returned `embedUrl` in GitHub markdown. All uploads are public. Pass `pr`+`repo` to attach to a PR (stable key + managed comment). Pass `branch`+`repo` to stage for a PR that does not exist yet. When the bytes are already at a public HTTPS URL, pass `contentUrl` instead of base64 — the server fetches them.",
+        "Upload a file (or files) and get a public URL plus GitHub-ready markdown. Prefer the returned `embedUrl` in GitHub markdown. All uploads are public. Pass `pr`+`repo` to attach to a PR (stable key + managed comment). Pass `branch`+`repo` to stage for a PR that does not exist yet. When the bytes are already at a public HTTPS URL, pass `contentUrl` instead of base64 — the server fetches them. Accepts images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and text (plain, markdown, CSV, JSON). HTML and SVG are rejected.",
       inputSchema: {
         type: "object",
         properties: {

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1056,11 +1056,13 @@ describe("mcp worker", () => {
 
   it("multi-file put returns partial failures without aborting the batch", async () => {
     const { env, bucket } = await makeEnv();
-    const textB64 = btoa("not an image");
+    // Unrecognized extension + non-sniffable bytes: no declared type resolves
+    // (unlike .txt, which the default allowlist now accepts — see guards.ts).
+    const junkB64 = btoa("not a known type");
     const result = await callTool(env, "put", {
       files: [
         { filename: "good.png", contentBase64: PNG_B64 },
-        { filename: "bad.txt", contentBase64: textB64 },
+        { filename: "bad.bin", contentBase64: junkB64 },
       ],
     });
     expect(result.isError).toBe(false);
@@ -1071,18 +1073,18 @@ describe("mcp worker", () => {
     expect(body.uploads).toHaveLength(1);
     expect(body.uploads[0].file).toBe("good.png");
     expect(body.failures).toHaveLength(1);
-    expect(body.failures[0].file).toBe("bad.txt");
+    expect(body.failures[0].file).toBe("bad.bin");
     expect(body.failures[0].error.message).toBeTruthy();
     expect(bucket.store.size).toBe(1);
   });
 
   it("multi-file total failure is isError with structured failures", async () => {
     const { env, bucket } = await makeEnv();
-    const textB64 = btoa("not an image");
+    const junkB64 = btoa("not a known type");
     const result = await callTool(env, "put", {
       files: [
-        { filename: "a.txt", contentBase64: textB64 },
-        { filename: "b.txt", contentBase64: textB64 },
+        { filename: "a.bin", contentBase64: junkB64 },
+        { filename: "b.bin", contentBase64: junkB64 },
       ],
     });
     expect(result.isError).toBe(true);
@@ -1091,7 +1093,7 @@ describe("mcp worker", () => {
       failures: Array<{ file: string }>;
     };
     expect(body.uploads).toEqual([]);
-    expect(body.failures.map((f) => f.file)).toEqual(["a.txt", "b.txt"]);
+    expect(body.failures.map((f) => f.file)).toEqual(["a.bin", "b.bin"]);
     expect(bucket.store.size).toBe(0);
   });
 

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -241,6 +241,9 @@ describe("fileKind", () => {
     expect(fileKind("video/mp4")).toBe("video");
     expect(fileKind("image/svg+xml")).toBe("unsupported");
     expect(fileKind("application/pdf")).toBe("file");
+    expect(fileKind("video/quicktime")).toBe("video");
+    expect(fileKind("text/plain")).toBe("file");
+    expect(fileKind("application/zip")).toBe("file");
   });
 });
 

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -60,7 +60,7 @@ export type FileFetchResult =
 export type MediaKind = "image" | "video" | "file" | "unsupported";
 
 const imageTypes = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"]);
-const videoTypes = new Set(["video/mp4", "video/webm"]);
+const videoTypes = new Set(["video/mp4", "video/webm", "video/quicktime"]);
 
 /** Classify a content type for rendering; SVG is unsupported per upload policy. */
 export function fileKind(contentType: string): MediaKind {

--- a/docs/superpowers/plans/2026-09-02-non-media-file-types.md
+++ b/docs/superpowers/plans/2026-09-02-non-media-file-types.md
@@ -1,0 +1,1195 @@
+# Non-media file types Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Accept PDF, zip, gzip, MOV, and four text types (plain, markdown, CSV, JSON) on the hosted upload path, with text validated as declared-plus-plausible and everything else still sniffed.
+
+**Architecture:** The security boundary stays in `apps/api/src/guards.ts`: sniffing gains four magic signatures, and `inspectUpload` gains a declared-type argument used only when sniffing returns null and the declared type is text. `putObject` resolves the declared type from the request header or the key's extension so old CLIs and the hosted MCP work unchanged. Ingest gets an explicit media-only gate. The CLI's MIME map (and its copy inside the comment renderer) learns the new extensions, and the optimizer skips sharp for known non-image extensions. Copy ships in a second PR after prod verification.
+
+**Tech Stack:** TypeScript, Hono on Cloudflare Workers, vitest, pnpm workspaces, changesets.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-non-media-file-types-design.md`
+
+## Global Constraints
+
+- Accepted additions, exactly: `application/pdf`, `application/zip`, `application/gzip`, `video/quicktime`, `text/plain`, `text/markdown`, `text/csv`, `application/json`.
+- Never accept `text/html`, `image/svg+xml`, XML, or JavaScript types.
+- No new billing limit field: non-media uses `maxBytes`; `video/quicktime` uses `maxVideoBytes`.
+- Ingest (`github-ingest.ts`) mirrors only `image/*` and `VIDEO_TYPES`.
+- `packages/uploads/src/comment-render.generated.ts` is generated; regenerate with `node packages/uploads/scripts/inline-shared.mjs`, never hand-edit.
+- Changeset header must be exactly `"@buildinternet/uploads": minor`.
+- Commit messages: no attribution lines, no words like "comprehensive".
+- Work from the worktree root `/Users/zachdunn/Code/uploads/.claude/worktrees/serene-newton-d2d0e1` on branch `claude/issue-925-planning-13dccd`.
+- Run `pnpm run check` (lint + format) before each commit of `.ts` files; the pre-commit hook also runs `pnpm types`.
+
+---
+
+## PR 1: platform + client
+
+### Task 1: Sniff PDF, zip, gzip, and MOV; widen the default allowlist
+
+**Files:**
+
+- Modify: `apps/api/src/guards.ts:20-38` (allowlist, `VIDEO_TYPES`), `apps/api/src/guards.ts:94-116` (`detectContentType`)
+- Test: `apps/api/test/guards.test.ts`
+
+**Interfaces:**
+
+- Produces: `DEFAULT_ALLOWED_CONTENT_TYPES` (15 entries), `VIDEO_TYPES` includes `video/quicktime`, new exported `TEXT_CONTENT_TYPES: ReadonlySet<string>`, `detectContentType` returns the four new types.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `detectContentType` describe block in `apps/api/test/guards.test.ts` (fixtures next to the existing `PNG`/`JPEG` constants at the top of the file):
+
+```ts
+const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]); // %PDF-1.7
+const ZIP = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]);
+const ZIP_EMPTY = new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0]);
+const GZIP = new Uint8Array([0x1f, 0x8b, 0x08, 0, 0, 0, 0, 0]);
+```
+
+```ts
+it("recognizes the non-media binary types and MOV from their magic bytes", () => {
+  expect(detectContentType(PDF)).toBe("application/pdf");
+  expect(detectContentType(ZIP)).toBe("application/zip");
+  expect(detectContentType(ZIP_EMPTY)).toBe("application/zip");
+  expect(detectContentType(GZIP)).toBe("application/gzip");
+  expect(detectContentType(ftyp("qt  "))).toBe("video/quicktime");
+  // MP4 brands still map to mp4, not quicktime.
+  expect(detectContentType(ftyp("isom"))).toBe("video/mp4");
+});
+
+it("does not sniff text: plain ASCII and UTF-8 bodies return null", () => {
+  expect(detectContentType(new TextEncoder().encode("hello world\n"))).toBeNull();
+  expect(detectContentType(new TextEncoder().encode('{"ok":true}'))).toBeNull();
+});
+```
+
+Add to the `resolveUploadPolicy` describe block:
+
+```ts
+it("default allowlist includes the non-media families and quicktime", () => {
+  const { allowed } = resolveUploadPolicy({});
+  for (const t of [
+    "application/pdf",
+    "application/zip",
+    "application/gzip",
+    "video/quicktime",
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "application/json",
+  ]) {
+    expect(allowed.has(t), t).toBe(true);
+  }
+  expect(allowed.has("text/html")).toBe(false);
+  expect(allowed.has("image/svg+xml")).toBe(false);
+});
+```
+
+Update the existing test `rejects a disallowed sniffed type with 415` (zip is now allowed by default) to use a restricted policy:
+
+```ts
+it("rejects a disallowed sniffed type with 415", () => {
+  const imagesOnly = resolveUploadPolicy({ allowedContentTypes: ["image/png"] });
+  const result = inspectUpload(ZIP, imagesOnly);
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.status).toBe(415);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @uploads/api test guards`
+Expected: the three new tests FAIL (`detectContentType` returns null for PDF; allowlist lacks `application/pdf`).
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/guards.ts`, replace the allowlist block (lines 20-38) with:
+
+```ts
+/**
+ * Intended payloads: static images, the short gif/video clips embedded in
+ * GitHub repos, and the non-media artifacts agents produce (reports, logs,
+ * JSON, archives). Deliberately excludes `image/svg+xml` and `text/html` —
+ * storage.uploads.sh is a bare R2 custom domain with no Worker in front of
+ * it, so the stored content type is the only control, and either of those
+ * served inline can carry script (stored XSS on our own origin). Everything
+ * below renders as inert text, opens in a sandboxed viewer (PDF), or has no
+ * inline handler at all (zip/gzip).
+ */
+export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+  "application/pdf",
+  "application/zip",
+  "application/gzip",
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/json",
+];
+
+const DEFAULT_ALLOWED_SET = new Set(DEFAULT_ALLOWED_CONTENT_TYPES);
+
+/** Video content types the upload path (and poster generation) accepts. */
+export const VIDEO_TYPES = new Set(["video/mp4", "video/webm", "video/quicktime"]);
+
+/**
+ * Types with no magic bytes. Accepted only when the client declares one of
+ * them and the body passes `looksLikeText` — see `inspectUpload`.
+ */
+export const TEXT_CONTENT_TYPES: ReadonlySet<string> = new Set([
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/json",
+]);
+```
+
+In `detectContentType`, before the `return null;`, add:
+
+```ts
+// %PDF-
+if (matches(bytes, [0x25, 0x50, 0x44, 0x46, 0x2d])) return "application/pdf";
+// PK\x03\x04 (local file header), PK\x05\x06 (empty archive), PK\x07\x08 (spanned)
+if (
+  matches(bytes, [0x50, 0x4b, 0x03, 0x04]) ||
+  matches(bytes, [0x50, 0x4b, 0x05, 0x06]) ||
+  matches(bytes, [0x50, 0x4b, 0x07, 0x08])
+) {
+  return "application/zip";
+}
+// gzip member header
+if (matches(bytes, [0x1f, 0x8b])) return "application/gzip";
+```
+
+And inside the existing `ftyp` branch, before `return "video/mp4";`:
+
+```ts
+if (brand === "qt  ") return "video/quicktime";
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @uploads/api test guards`
+Expected: PASS. Also run `pnpm --filter @uploads/api test` to catch the routes test `rejects a non-image payload with 415` (it sends zip bytes, now allowed). Fix that test in Task 4; for now note it fails.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/guards.ts apps/api/test/guards.test.ts
+git commit -m "feat(api): sniff pdf, zip, gzip, and mov; widen the default allowlist"
+```
+
+### Task 2: `looksLikeText`, `contentTypeFromKey`, and `resolveDeclaredContentType`
+
+**Files:**
+
+- Modify: `apps/api/src/guards.ts` (new exports after `detectContentType`)
+- Test: `apps/api/test/guards.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  - `looksLikeText(bytes: Uint8Array): boolean`
+  - `contentTypeFromKey(key: string): string | undefined` (only the eight new types plus the existing media map; `undefined` for unknown extensions)
+  - `resolveDeclaredContentType(header: string | undefined, key: string): string | undefined` (normalized header when specific, else key extension)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new describe block in `apps/api/test/guards.test.ts` and extend the import list with `looksLikeText, contentTypeFromKey, resolveDeclaredContentType`:
+
+```ts
+describe("looksLikeText", () => {
+  const enc = (s: string) => new TextEncoder().encode(s);
+
+  it("accepts ASCII and UTF-8 bodies", () => {
+    expect(looksLikeText(enc("plain log line\n"))).toBe(true);
+    expect(looksLikeText(enc("héllo — ünïcode ✓"))).toBe(true);
+  });
+
+  it("rejects NUL bytes and invalid UTF-8", () => {
+    expect(looksLikeText(new Uint8Array([0x61, 0x00, 0x62]))).toBe(false);
+    expect(looksLikeText(new Uint8Array([0xe9, 0x74, 0xe9]))).toBe(false); // Latin-1 "été"
+    expect(looksLikeText(new Uint8Array(0))).toBe(false);
+  });
+
+  it("does not fail on a multibyte sequence cut by the 8 KiB sample boundary", () => {
+    // 8190 ASCII bytes, then a 3-byte character straddling offset 8192.
+    const body = enc("a".repeat(8190) + "€" + "tail".repeat(50));
+    expect(looksLikeText(body)).toBe(true);
+  });
+
+  it("only samples the head: a NUL after 8 KiB is not inspected", () => {
+    const body = new Uint8Array(9000).fill(0x61);
+    body[8500] = 0;
+    expect(looksLikeText(body)).toBe(true);
+  });
+});
+
+describe("contentTypeFromKey", () => {
+  it("maps the accepted non-media extensions", () => {
+    expect(contentTypeFromKey("gh/o/r/pull/1/build.log")).toBe("text/plain");
+    expect(contentTypeFromKey("a/notes.TXT")).toBe("text/plain");
+    expect(contentTypeFromKey("a/out.jsonl")).toBe("text/plain");
+    expect(contentTypeFromKey("a/config.yaml")).toBe("text/plain");
+    expect(contentTypeFromKey("a/README.md")).toBe("text/markdown");
+    expect(contentTypeFromKey("a/data.csv")).toBe("text/csv");
+    expect(contentTypeFromKey("a/report.json")).toBe("application/json");
+    expect(contentTypeFromKey("a/report.pdf")).toBe("application/pdf");
+    expect(contentTypeFromKey("a/bundle.zip")).toBe("application/zip");
+    expect(contentTypeFromKey("a/bundle.tgz")).toBe("application/gzip");
+    expect(contentTypeFromKey("a/clip.mov")).toBe("video/quicktime");
+    expect(contentTypeFromKey("a/shot.png")).toBe("image/png");
+  });
+
+  it("returns undefined for unknown or missing extensions and never maps html/svg", () => {
+    expect(contentTypeFromKey("a/blob")).toBeUndefined();
+    expect(contentTypeFromKey("a/page.html")).toBeUndefined();
+    expect(contentTypeFromKey("a/icon.svg")).toBeUndefined();
+    expect(contentTypeFromKey("a/dir.v2/")).toBeUndefined();
+  });
+});
+
+describe("resolveDeclaredContentType", () => {
+  it("prefers a specific header, normalized", () => {
+    expect(resolveDeclaredContentType("Text/Plain; charset=utf-8", "a/x.json")).toBe("text/plain");
+  });
+
+  it("falls back to the key extension when the header is absent or octet-stream", () => {
+    expect(resolveDeclaredContentType(undefined, "a/build.log")).toBe("text/plain");
+    expect(resolveDeclaredContentType("application/octet-stream", "a/build.log")).toBe(
+      "text/plain",
+    );
+    expect(resolveDeclaredContentType("", "a/build.log")).toBe("text/plain");
+  });
+
+  it("is undefined when neither source is specific", () => {
+    expect(resolveDeclaredContentType(undefined, "a/blob")).toBeUndefined();
+    expect(resolveDeclaredContentType("application/octet-stream", "a/blob")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @uploads/api test guards`
+Expected: FAIL with "does not provide an export named looksLikeText" (or similar).
+
+- [ ] **Step 3: Implement**
+
+Add to `apps/api/src/guards.ts` directly after `detectContentType`:
+
+```ts
+/** Bytes inspected by `looksLikeText`. Enough to catch binaries; cheap on a 25 MB log. */
+const TEXT_SAMPLE_BYTES = 8 * 1024;
+
+/**
+ * Plausibility check for declared text uploads (text has no magic bytes):
+ * the first 8 KiB must contain no NUL and decode as UTF-8. A multibyte
+ * sequence cut by the sample boundary is tolerated via streaming decode.
+ */
+export function looksLikeText(bytes: Uint8Array): boolean {
+  if (bytes.byteLength === 0) return false;
+  const sample = bytes.subarray(0, Math.min(bytes.byteLength, TEXT_SAMPLE_BYTES));
+  for (let i = 0; i < sample.length; i++) {
+    if (sample[i] === 0) return false;
+  }
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(sample, {
+      stream: sample.length < bytes.byteLength,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extension → content type for the key-extension fallback in
+ * `resolveDeclaredContentType`. Mirrors `inferContentType` in
+ * packages/uploads/src/embed.ts; keep the two in step. html/svg are absent on
+ * purpose — they must never become a declared type.
+ */
+const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  pdf: "application/pdf",
+  zip: "application/zip",
+  gz: "application/gzip",
+  tgz: "application/gzip",
+  txt: "text/plain",
+  text: "text/plain",
+  log: "text/plain",
+  jsonl: "text/plain",
+  ndjson: "text/plain",
+  yaml: "text/plain",
+  yml: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  json: "application/json",
+};
+
+/** Content type implied by a key's extension, or undefined when unknown. */
+export function contentTypeFromKey(key: string): string | undefined {
+  const base = key.slice(key.lastIndexOf("/") + 1);
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0 || dot === base.length - 1) return undefined;
+  return CONTENT_TYPE_BY_EXTENSION[base.slice(dot + 1).toLowerCase()];
+}
+
+/** Normalize a client Content-Type for allowlist compare (type/subtype only, lowercased). */
+export function normalizeDeclaredContentType(raw: string): string {
+  const beforeParams = raw.split(";", 1)[0] ?? raw;
+  return beforeParams.trim().toLowerCase();
+}
+
+/**
+ * The type a client *claims* for an upload: its Content-Type header when
+ * specific, else the key's extension. Only consulted by `inspectUpload` for
+ * text types (everything else is sniffed). `application/octet-stream` and an
+ * empty header count as unspecified so older CLIs (which send octet-stream
+ * for `.log`) and the hosted MCP (which sends no type) still resolve via the
+ * key.
+ */
+export function resolveDeclaredContentType(
+  header: string | undefined,
+  key: string,
+): string | undefined {
+  const normalized = header ? normalizeDeclaredContentType(header) : "";
+  if (normalized && normalized !== "application/octet-stream") return normalized;
+  return contentTypeFromKey(key);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @uploads/api test guards`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/guards.ts apps/api/test/guards.test.ts
+git commit -m "feat(api): text plausibility check and key-extension content-type fallback"
+```
+
+### Task 3: `inspectUpload` accepts declared text types
+
+**Files:**
+
+- Modify: `apps/api/src/guards.ts:194-252` (`UploadInspection`, `tooLarge`, `inspectUpload`)
+- Test: `apps/api/test/guards.test.ts`, `apps/api/test/guards-video.test.ts`
+
+**Interfaces:**
+
+- Consumes: `TEXT_CONTENT_TYPES`, `looksLikeText`, `VIDEO_TYPES` from Tasks 1-2.
+- Produces: `inspectUpload(bytes: Uint8Array, policy: UploadPolicy, declaredType?: string): UploadInspection`. The 413 `kind` is now `"image" | "video" | "file"`. The 415 error `details` is `{ allowed: string[]; declared?: string }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `inspectUpload` describe block in `apps/api/test/guards.test.ts`:
+
+```ts
+const text = new TextEncoder().encode("line one\nline two\n");
+
+it("accepts a declared text type when the body is plausible text", () => {
+  expect(inspectUpload(text, policy, "text/plain")).toEqual({
+    ok: true,
+    contentType: "text/plain",
+  });
+  expect(inspectUpload(new TextEncoder().encode('{"a":1}'), policy, "application/json")).toEqual({
+    ok: true,
+    contentType: "application/json",
+  });
+});
+
+it("sniffed bytes win over a declared text type", () => {
+  expect(inspectUpload(PNG, policy, "text/plain")).toEqual({ ok: true, contentType: "image/png" });
+});
+
+it("rejects declared text with binary bytes, an undeclared body, or a non-text declared type", () => {
+  const binary = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+  for (const [bytes, declared] of [
+    [binary, "text/plain"],
+    [text, undefined],
+    [text, "application/octet-stream"],
+    [text, "text/html"],
+    [text, "image/svg+xml"],
+    [text, "application/xml"],
+  ] as const) {
+    const result = inspectUpload(bytes, policy, declared);
+    expect(result.ok, `${declared}`).toBe(false);
+    if (!result.ok) expect(result.status).toBe(415);
+  }
+});
+
+it("honors a workspace allowlist that excludes text", () => {
+  const imagesOnly = resolveUploadPolicy({ allowedContentTypes: ["image/png"] });
+  const result = inspectUpload(text, imagesOnly, "text/plain");
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.status).toBe(415);
+});
+
+it("reports the declared type in the 415 details", () => {
+  const result = inspectUpload(text, policy, "text/html");
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.error.details).toMatchObject({ declared: "text/html" });
+    expect(result.error.details).toHaveProperty("allowed");
+  }
+});
+
+it("caps non-media at maxBytes with kind file, and MOV at maxVideoBytes", () => {
+  const tight = resolveUploadPolicy({ maxUploadBytes: 4, maxVideoUploadBytes: 1000 });
+  const pdf = inspectUpload(PDF, tight);
+  expect(pdf.ok).toBe(false);
+  if (!pdf.ok) {
+    expect(pdf.status).toBe(413);
+    expect(pdf.error.details).toMatchObject({ kind: "file", contentType: "application/pdf" });
+  }
+  const mov = inspectUpload(ftyp("qt  "), tight);
+  expect(mov).toEqual({ ok: true, contentType: "video/quicktime" });
+});
+```
+
+Check `apps/api/test/guards-video.test.ts` still passes unchanged (it only uses mp4/webm).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @uploads/api test guards`
+Expected: the declared-text tests FAIL (current `inspectUpload` ignores the third argument and returns 415 for text).
+
+- [ ] **Step 3: Implement**
+
+Replace `tooLarge`'s `kind` union and `inspectUpload` in `apps/api/src/guards.ts`:
+
+```ts
+/** Coarse family for 413 payloads and the optimizer/poster branches. */
+export type UploadKind = "image" | "video" | "file";
+
+export function uploadKind(contentType: string): UploadKind {
+  if (VIDEO_TYPES.has(contentType)) return "video";
+  if (contentType.startsWith("image/")) return "image";
+  return "file";
+}
+
+/** The shared 413 rejection for both the pre-buffer and post-buffer size checks. */
+function tooLarge(
+  maxBytes: number,
+  extra?: { contentType?: string; kind?: UploadKind },
+): UploadRejection {
+  return {
+    ok: false,
+    status: 413,
+    error: new PayloadTooLargeError("payload too large", {
+      code: "upload_too_large",
+      details: { maxBytes, ...extra },
+    }),
+  };
+}
+```
+
+```ts
+/**
+ * Validate a fully-buffered upload body against the policy. Sniffed bytes
+ * decide the stored type whenever they can; `declaredType` (from the request
+ * header or the key's extension — see `resolveDeclaredContentType`) is
+ * consulted only when sniffing finds nothing and the claim is one of the
+ * text types, which have no magic. Then the type-specific size cap.
+ */
+export function inspectUpload(
+  bytes: Uint8Array,
+  policy: UploadPolicy,
+  declaredType?: string,
+): UploadInspection {
+  const detected = detectContentType(bytes);
+  let contentType: string | null = null;
+  if (detected !== null) {
+    if (policy.allowed.has(detected)) contentType = detected;
+  } else if (
+    declaredType !== undefined &&
+    TEXT_CONTENT_TYPES.has(declaredType) &&
+    policy.allowed.has(declaredType) &&
+    looksLikeText(bytes)
+  ) {
+    contentType = declaredType;
+  }
+  if (contentType === null) {
+    return {
+      ok: false,
+      status: 415,
+      error: new UnsupportedMediaTypeError("unsupported media type", {
+        details: {
+          allowed: [...policy.allowed],
+          ...(declaredType !== undefined ? { declared: declaredType } : {}),
+        },
+      }),
+    };
+  }
+  const maxBytes = maxBytesForContentType(policy, contentType);
+  if (bytes.byteLength > maxBytes) {
+    return tooLarge(maxBytes, { contentType, kind: uploadKind(contentType) });
+  }
+  return { ok: true, contentType };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @uploads/api test guards`
+Expected: PASS (both `guards.test.ts` and `guards-video.test.ts`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/guards.ts apps/api/test/guards.test.ts
+git commit -m "feat(api): accept declared text types in inspectUpload"
+```
+
+### Task 4: Thread the declared type through `putObject` and the PUT route
+
+**Files:**
+
+- Modify: `apps/api/src/files-core.ts:401-478` (`putObject` opts + inspection call)
+- Modify: `apps/api/src/routes/files-shared-handlers.ts:30-33` (delete local normalizer), `:65-77` (presign uses the shared one), `:225-232` (PUT `putOpts`)
+- Test: `apps/api/test/routes-files.test.ts`
+
+**Interfaces:**
+
+- Consumes: `resolveDeclaredContentType`, `normalizeDeclaredContentType` from Task 2; `inspectUpload(bytes, policy, declared)` from Task 3.
+- Produces: `putObject(..., opts: { declaredContentType?: string })`. When omitted, `putObject` still resolves via the key extension.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `apps/api/test/routes-files.test.ts`, inside `describe("PUT /v1/:workspace/files upload guardrails")`, replace the zip-bytes 415 test and add the new cases:
+
+```ts
+it("rejects an unrecognized binary payload with 415", async () => {
+  const { env } = await makeEnv();
+  const res = await putShot(env, { body: new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]) });
+  expect(res.status).toBe(415);
+});
+
+it("stores a declared text/plain body as text/plain", async () => {
+  const { env, bucket } = await makeEnv();
+  const res = await putShot(env, {
+    key: "reports/build.log",
+    body: new TextEncoder().encode("ok 1\nok 2\n"),
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+  expect(res.status).toBe(201);
+  expect((await res.json()).contentType).toBe("text/plain");
+  expect(bucket.store.get("default/reports/build.log")?.contentType).toBe("text/plain");
+});
+
+it("resolves the text type from the key extension when the header is octet-stream (old CLIs)", async () => {
+  const { env, bucket } = await makeEnv();
+  const res = await putShot(env, {
+    key: "reports/build.log",
+    body: new TextEncoder().encode("ok\n"),
+    headers: { "Content-Type": "application/octet-stream" },
+  });
+  expect(res.status).toBe(201);
+  expect(bucket.store.get("default/reports/build.log")?.contentType).toBe("text/plain");
+});
+
+it("rejects text declared as html, and text under a key with no known extension", async () => {
+  const { env } = await makeEnv();
+  const html = new TextEncoder().encode("<!doctype html><script>1</script>");
+  expect(
+    (
+      await putShot(env, {
+        key: "pages/x.html",
+        body: html,
+        headers: { "Content-Type": "text/html" },
+      })
+    ).status,
+  ).toBe(415);
+  expect(
+    (
+      await putShot(env, {
+        key: "pages/blob",
+        body: new TextEncoder().encode("hello"),
+        headers: { "Content-Type": "application/octet-stream" },
+      })
+    ).status,
+  ).toBe(415);
+});
+
+it("stores a PDF and a zip by their sniffed types regardless of the header", async () => {
+  const { env, bucket } = await makeEnv();
+  const pdf = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a]);
+  const zip = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]);
+  expect((await putShot(env, { key: "reports/r.pdf", body: pdf })).status).toBe(201);
+  expect(bucket.store.get("default/reports/r.pdf")?.contentType).toBe("application/pdf");
+  expect(
+    (
+      await putShot(env, {
+        key: "reports/b.zip",
+        body: zip,
+        headers: { "Content-Type": "text/plain" },
+      })
+    ).status,
+  ).toBe(201);
+  expect(bucket.store.get("default/reports/b.zip")?.contentType).toBe("application/zip");
+});
+```
+
+In `describe("POST /v1/:workspace/files/sign content-type policy")` add:
+
+```ts
+it("accepts a declared text/plain on presign", async () => {
+  const { env } = await makeEnv();
+  const res = await app.request(
+    "/v1/default/files/sign",
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "reports/build.log", contentType: "text/plain" }),
+    },
+    env,
+  );
+  expect(res.status).not.toBe(415);
+});
+```
+
+(Match the request shape used by the neighboring presign tests in that describe block; copy their body fields exactly.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @uploads/api test routes-files`
+Expected: the text/plain PUT returns 415 today; FAIL.
+
+- [ ] **Step 3: Implement**
+
+`apps/api/src/files-core.ts`: add to `putObject`'s `opts` type, after `contentSha256`:
+
+```ts
+    /**
+     * The client's claimed Content-Type (already normalized to type/subtype)
+     * or undefined. Only text types are ever trusted, and only when sniffing
+     * finds nothing — see `inspectUpload`. When omitted, the key's extension
+     * is the claim, which is what the hosted MCP and older CLIs rely on.
+     */
+    declaredContentType?: string;
+```
+
+Replace the inspection line:
+
+```ts
+const declared = resolveDeclaredContentType(opts?.declaredContentType, finalKey);
+const inspection = inspectUpload(bytes, resolveUploadPolicy(ws), declared);
+if (!inspection.ok) throw inspection.error;
+```
+
+and add `resolveDeclaredContentType` to the `./guards` import in that file.
+
+`apps/api/src/routes/files-shared-handlers.ts`: delete the local `normalizePresignContentType` (lines 30-33), import `normalizeDeclaredContentType` from `../guards`, and use it in `signFileHandler` where the local one was called. In `putFileHandler`, change `putOpts`:
+
+```ts
+const putOpts = {
+  provenance,
+  visibility,
+  metadata,
+  replace: wantReplace,
+  surface: "api" as const,
+  declaredContentType: c.req.header("Content-Type"),
+};
+```
+
+(`resolveDeclaredContentType` normalizes, so passing the raw header is correct.) The idempotent path spreads `putOpts`, so it inherits the field.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @uploads/api test`
+Expected: PASS across the api project. If `files-core.test.ts` or the MCP tests construct `putObject` opts with exact object equality, add `declaredContentType` there.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/files-core.ts apps/api/src/routes/files-shared-handlers.ts apps/api/test/routes-files.test.ts
+git commit -m "feat(api): resolve the declared upload type from the header or key extension"
+```
+
+### Task 5: Ingest stays media-only
+
+**Files:**
+
+- Modify: `apps/api/src/github-ingest.ts:244-254`
+- Test: `apps/api/src/github-ingest.test.ts`
+
+**Interfaces:**
+
+- Consumes: `uploadKind` from Task 3.
+
+- [ ] **Step 1: Write the failing test**
+
+Add next to the AVIF test in `apps/api/src/github-ingest.test.ts`:
+
+```ts
+it("media gate is image/video only: a PDF is a permanent skip even though the upload allowlist accepts it", async () => {
+  const { env } = baseEnv();
+  const ref: IngestSourceRef = { repo: REPO, kind: "pull", num: 7, source: "body" };
+  const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a]);
+  const fetchImpl = fakeFetch({
+    [ASSET_ID]: () =>
+      new Response(PDF, { status: 200, headers: { "content-type": "application/pdf" } }),
+  });
+  const { putImpl, calls } = spyPut();
+
+  const summary = await reconcileIngestSource(env, ws, WS, ref, `see ${ASSET_URL}`, null, {
+    fetchImpl,
+    putImpl,
+  });
+
+  expect(calls).toHaveLength(0);
+  expect(summary.skipped).toEqual([{ url: ASSET_URL, reason: "unsupported_media_type" }]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @uploads/api test github-ingest`
+Expected: FAIL — the PDF is now in the default allowlist, so `calls` has length 1.
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/github-ingest.ts`, update the comment and gate:
+
+```ts
+// Media gate: the Screenshots view mirrors images and video only. A type
+// must be in the workspace's own upload allowlist (`resolveUploadPolicy(ws)
+// .allowed`, guards.ts — no shadow table) AND be an image/video family;
+// PDFs and archives pasted into a PR are left on GitHub. Non-sniffable
+// bytes or a type outside the gate is the same permanent
+// `unsupported_media_type` skip either way.
+const policy = resolveUploadPolicy(ws);
+const sniffed = detectContentType(bytes);
+if (!sniffed || !policy.allowed.has(sniffed) || uploadKind(sniffed) === "file") {
+  return { kind: "skip", reason: "unsupported_media_type" };
+}
+```
+
+Add `uploadKind` to the `./guards` import.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @uploads/api test github-ingest`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/github-ingest.ts apps/api/src/github-ingest.test.ts
+git commit -m "fix(ingest): keep GitHub attachment mirroring to images and video"
+```
+
+### Task 6: Web recognizes `video/quicktime`
+
+**Files:**
+
+- Modify: `apps/web/src/lib/public-file.ts:62`
+- Test: `apps/web/src/lib/public-file.test.ts:238-245`
+
+- [ ] **Step 1: Write the failing test**
+
+Extend the `fileKind` test:
+
+```ts
+expect(fileKind("video/quicktime")).toBe("video");
+expect(fileKind("text/plain")).toBe("file");
+expect(fileKind("application/zip")).toBe("file");
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @uploads/web test public-file`
+Expected: FAIL on quicktime.
+
+- [ ] **Step 3: Implement**
+
+```ts
+const videoTypes = new Set(["video/mp4", "video/webm", "video/quicktime"]);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @uploads/web test public-file`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/public-file.ts apps/web/src/lib/public-file.test.ts
+git commit -m "feat(web): treat video/quicktime as video on the file page"
+```
+
+### Task 7: CLI MIME map, comment renderer copy, and optimizer skip
+
+**Files:**
+
+- Modify: `packages/uploads/src/embed.ts:3-24`
+- Modify: `packages/comment-render/src/index.ts:95-116` (the copied `inferContentType`)
+- Regenerate: `packages/uploads/src/comment-render.generated.ts` via `node packages/uploads/scripts/inline-shared.mjs`
+- Modify: `packages/uploads/src/optimize.ts:110-145, 210-228` (import `inferContentType`, delete `guessContentType`, early passthrough)
+- Create: `packages/uploads/test/embed.test.ts`
+- Test: `packages/uploads/test/optimize.test.ts`, `packages/uploads/test/github.test.ts`
+- Create: `.changeset/non-media-file-types.md`
+
+**Interfaces:**
+
+- Produces: `inferContentType(filename)` returns the eight new types plus `video/webm`; `optimizeImageForUpload` returns `skippedReason: "not_image"` without touching sharp for a known non-image extension.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/uploads/test/embed.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { inferContentType } from "../src/embed.js";
+
+describe("inferContentType", () => {
+  it("maps media and the accepted non-media extensions", () => {
+    expect(inferContentType("shot.png")).toBe("image/png");
+    expect(inferContentType("clip.webm")).toBe("video/webm");
+    expect(inferContentType("clip.MOV")).toBe("video/quicktime");
+    expect(inferContentType("report.pdf")).toBe("application/pdf");
+    expect(inferContentType("bundle.zip")).toBe("application/zip");
+    expect(inferContentType("bundle.tar.gz")).toBe("application/gzip");
+    expect(inferContentType("bundle.tgz")).toBe("application/gzip");
+    expect(inferContentType("build.log")).toBe("text/plain");
+    expect(inferContentType("notes.txt")).toBe("text/plain");
+    expect(inferContentType("events.jsonl")).toBe("text/plain");
+    expect(inferContentType("config.yml")).toBe("text/plain");
+    expect(inferContentType("README.md")).toBe("text/markdown");
+    expect(inferContentType("data.csv")).toBe("text/csv");
+    expect(inferContentType("lighthouse.json")).toBe("application/json");
+  });
+
+  it("falls back to octet-stream for unknown extensions", () => {
+    expect(inferContentType("blob")).toBe("application/octet-stream");
+    expect(inferContentType("page.html")).toBe("application/octet-stream");
+  });
+});
+```
+
+Add to `packages/uploads/test/optimize.test.ts`:
+
+```ts
+it("passes a known non-image extension through without probing", async () => {
+  const bytes = new TextEncoder().encode("not an image");
+  const result = await optimizeImageForUpload(bytes, "build.log");
+  expect(result.optimized).toBe(false);
+  expect(result.skippedReason).toBe("not_image");
+  expect(result.contentType).toBe("text/plain");
+  expect(result.filename).toBe("build.log");
+  expect(result.bytes).toBe(bytes);
+});
+```
+
+Add to the `attachmentsCommentBody` describe in `packages/uploads/test/github.test.ts`:
+
+```ts
+it("renders pdf, json, and zip items as link bullets, never as embeds", () => {
+  const body = attachmentsCommentBody([
+    { key: "gh/o/r/pull/1/lighthouse.json", url: "https://x.test/lighthouse.json" },
+    {
+      key: "gh/o/r/pull/1/report.pdf",
+      url: "https://x.test/report.pdf",
+      pageUrl: "https://uploads.sh/f/w/report.pdf",
+    },
+    { key: "gh/o/r/pull/1/dist.zip", url: "https://x.test/dist.zip" },
+  ]);
+  expect(body).toContain("- [lighthouse.json](https://x.test/lighthouse.json)");
+  expect(body).toContain("- [report.pdf](https://uploads.sh/f/w/report.pdf)");
+  expect(body).toContain("- [dist.zip](https://x.test/dist.zip)");
+  expect(body).not.toContain("<img");
+});
+```
+
+(If the renderer prefers `url` over `pageUrl` for bullets, assert whichever the existing `notes.txt` test shows; the point is the bullet form and no `<img>`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @buildinternet/uploads test embed optimize github`
+Expected: `embed.test.ts` FAILS on `.log`/`.pdf`; the optimize test FAILS on `contentType` (currently octet-stream).
+
+- [ ] **Step 3: Implement**
+
+`packages/uploads/src/embed.ts` — replace the `switch`:
+
+```ts
+const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  pdf: "application/pdf",
+  zip: "application/zip",
+  gz: "application/gzip",
+  tgz: "application/gzip",
+  txt: "text/plain",
+  text: "text/plain",
+  log: "text/plain",
+  jsonl: "text/plain",
+  ndjson: "text/plain",
+  yaml: "text/plain",
+  yml: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  json: "application/json",
+};
+
+/**
+ * Content type from a filename's extension. Mirrors `CONTENT_TYPE_BY_EXTENSION`
+ * in apps/api/src/guards.ts (the server's key-extension fallback); keep the
+ * two in step. `svg` stays here only so the optimizer can pass it through —
+ * the server rejects it.
+ */
+export function inferContentType(filename: string): string {
+  const ext = filename.includes(".")
+    ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase()
+    : "";
+  return CONTENT_TYPE_BY_EXTENSION[ext] ?? "application/octet-stream";
+}
+```
+
+`packages/comment-render/src/index.ts` — replace the copied `inferContentType` body with the same table and function (keep the "Copied from packages/uploads/src/embed.ts" comment). Then run:
+
+```bash
+node packages/uploads/scripts/inline-shared.mjs
+```
+
+`packages/uploads/src/optimize.ts`:
+
+- `import { inferContentType } from "./embed.js";`
+- delete `guessContentType` (lines ~210-228) and replace every `guessContentType(filename)` call with `inferContentType(filename)`.
+- after the `looksLikeSvg` passthrough, add:
+
+```ts
+// A known non-image extension (log, pdf, zip, video…) never needs sharp.
+// Unknown extensions still get probed so an extension-less screenshot is
+// optimized as before.
+const guessed = inferContentType(filename);
+if (guessed !== "application/octet-stream" && !guessed.startsWith("image/")) {
+  return passthrough(bytes, filename, guessed, "not_image");
+}
+```
+
+Create `.changeset/non-media-file-types.md`:
+
+```md
+---
+"@buildinternet/uploads": minor
+---
+
+`put` and `attach` accept non-media files: PDF, zip, gzip, MOV, and text (plain, markdown, CSV, JSON, logs). They upload as-is, skip image optimization, and appear in the managed comment as links. Requires the matching platform release.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @buildinternet/uploads test` and `node packages/uploads/scripts/inline-shared.mjs --check`
+Expected: PASS; check exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/uploads/src/embed.ts packages/uploads/src/optimize.ts packages/comment-render/src/index.ts packages/uploads/src/comment-render.generated.ts packages/uploads/test/embed.test.ts packages/uploads/test/optimize.test.ts packages/uploads/test/github.test.ts .changeset/non-media-file-types.md
+git commit -m "feat(cli): know the non-media extensions and skip the optimizer for them"
+```
+
+### Task 8: Hosted MCP `put` description and CLI help mention the families
+
+**Files:**
+
+- Modify: `apps/mcp/src/tools.ts:602` (description string)
+- Modify: `packages/uploads/src/commands.ts:203-206` (put help paragraph)
+- Test: `packages/uploads/test/cli-help.test.ts` (only if it snapshots the paragraph; update the snapshot)
+
+- [ ] **Step 1: Edit the strings**
+
+MCP description: append one sentence to the existing `put` description:
+
+```
+Accepts images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and text (plain, markdown, CSV, JSON). HTML and SVG are rejected.
+```
+
+CLI help paragraph (replace the "Still images…" paragraph):
+
+```
+Still images (PNG/JPEG/…) are optimized to WebP by default (long edge capped,
+high quality; EXIF stripped) so GitHub embeds stay lean. Original bytes are kept
+when they are already smaller, animated, or not an image. Use --no-optimize to
+upload as-is, or --keep-exif when image metadata matters for the discussion.
+Non-media files (PDF, zip, gzip, logs, JSON, CSV, markdown) upload as-is and
+show up in the managed comment as links. HTML and SVG are rejected.
+```
+
+- [ ] **Step 2: Run the help and MCP tests**
+
+Run: `pnpm --filter @buildinternet/uploads test cli-help` and `pnpm --filter @uploads/mcp test`
+Expected: PASS (update any snapshot that pins the old paragraph).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/mcp/src/tools.ts packages/uploads/src/commands.ts packages/uploads/test/cli-help.test.ts
+git commit -m "docs: mention the accepted non-media families in put help and the MCP tool"
+```
+
+### Task 9: Full verification and PR
+
+- [ ] **Step 1: Run everything**
+
+```bash
+pnpm run check && pnpm types && pnpm test
+```
+
+Expected: clean. Fix anything that fails before opening the PR.
+
+- [ ] **Step 2: Local end-to-end**
+
+Using the local stack recipe in `AGENTS.md` (dev server via `preview_start`, or `pnpm --filter @uploads/api dev`), PUT a `.log`, `.json`, `.pdf` (any real PDF), `.zip`, and a `.html` and confirm 201/201/201/201/415. Open one `/f/` page for the PDF and confirm the "Open" fallback renders.
+
+- [ ] **Step 3: Open the PR**
+
+Title: `feat: accept non-media uploads (PDF, zip, gzip, MOV, text)`. Body: link `#925`, summarize the decisions from the spec (declared-plus-plausible text, no new cap, ingest media-only, HTML/SVG still out), and list the prod verification steps from PR 2 Task 10 as a checklist. Do not request a CodeRabbit review unless asked; this is a security-relevant guard change, so say in the body that one is warranted and let Zach decide.
+
+## PR 2: copy (after PR 1 is on prod)
+
+### Task 10: Prod verification
+
+- [ ] **Step 1: Confirm the API deploy**
+
+```bash
+gh run list --repo buildinternet/uploads --branch main --limit 3
+```
+
+- [ ] **Step 2: Upload each family with the released or local CLI**
+
+From the worktree, with a workspace token in the environment:
+
+```bash
+printf 'line 1\nline 2\n' > /tmp/verify.log
+printf '{"ok":true}' > /tmp/verify.json
+pnpm --filter @buildinternet/uploads exec node dist/cli.js put /tmp/verify.log /tmp/verify.json --format json
+```
+
+Then one real PDF, one zip, one MOV, and one `.html` (expect `unsupported_media_type`). Open each `/f/` page. Attach the log and PDF to a scratch PR with `--pr` and confirm the managed comment shows link bullets. Note whether the MOV got a poster.
+
+- [ ] **Step 3: Record results in the PR 1 thread**
+
+Comment on PR 1 with the URLs and the MOV poster outcome.
+
+### Task 11: Copy, skills, changelog
+
+**Files:**
+
+- Modify: `apps/web/src/content/docs/limits.mdx:79-80`
+- Modify: `apps/web/src/pages/index.astro:785-790`
+- Modify: `skills/github-screenshots/SKILL.md:44-46` and the "Use uploads.sh when" list
+- Modify: `skills/uploads-cli/SKILL.md`, `docs/cli.md`, `AGENTS.md:209`, `README.md`, `apps/web/public/llms.txt`, `apps/web/public/llms-full.txt`, the docs hub page, `/docs/attach` (grep targets below)
+- Create: `apps/web/src/content/changelog/non-media-file-types.md`
+
+- [ ] **Step 1: Find every claim**
+
+```bash
+grep -rn "PNG, JPEG\|images and video\|image or video\|any file\|is coming\|More file types\|no SVG" apps/web/src apps/web/public skills docs README.md AGENTS.md VISION.md CONTRIBUTING.md --include='*.md' --include='*.mdx' --include='*.astro' --include='*.txt' --include='*.ts'
+```
+
+- [ ] **Step 2: Rewrite each**
+
+`limits.mdx` Formats bullet:
+
+```md
+- **Formats:** images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and
+  text (plain, markdown, CSV, JSON, logs). SVG and HTML are not accepted because either can carry
+  script when served inline.
+```
+
+`index.astro` feature card:
+
+```html
+<div class="feature">
+  <h3>More than screenshots</h3>
+  <p>
+    PDFs, logs, JSON, and zips alongside images and video, so test reports and build output get the
+    same stable URLs and land in the PR comment as links.
+  </p>
+</div>
+```
+
+`skills/github-screenshots/SKILL.md` "When gh --attach is enough" bullet:
+
+```md
+- The file is an image or video under 10 MB (video up to 100 MB on paid plans).
+  `gh --attach` takes media only.
+```
+
+and add to "Use uploads.sh when":
+
+```md
+- The artifact is not media: a Lighthouse or test report, a log, JSON, a PDF, or
+  a zip. `gh --attach` does not take those; `uploads put` does, and the managed
+  comment links them.
+```
+
+Changelog `apps/web/src/content/changelog/non-media-file-types.md`:
+
+```md
+---
+title: "Uploads take PDFs, logs, JSON, and zips"
+date: 2026-09-0XT00:00:00Z
+tags: [platform, cli]
+---
+
+The upload allowlist now covers PDF, zip, gzip, MOV, and text files (plain,
+markdown, CSV, JSON, logs) alongside images and video. Test reports, Lighthouse
+output, build logs, and bundles get the same stable URLs and appear in the PR's
+attachments comment as links. Size caps are the plan's file cap; MOV uses the
+video cap.
+
+SVG and HTML stay out: served inline they can run script on our storage origin.
+```
+
+(Set the date to the merge day.) Follow `skills/docs-page-style` for the `.mdx` edit.
+
+- [ ] **Step 3: Verify the site builds and the pages read right**
+
+```bash
+pnpm --filter @uploads/web exec astro check && pnpm run check
+```
+
+Open `/docs/limits`, `/`, and `/changelog` in the local preview and screenshot the limits bullet and the feature card for the PR body (use `/github-screenshots`).
+
+- [ ] **Step 4: Commit and open PR 2**
+
+```bash
+git add -A apps/web/src skills docs README.md AGENTS.md apps/web/public
+git commit -m "docs: say which non-media file types uploads.sh accepts"
+```
+
+Title: `docs: non-media file types are live`. Link `#925` and PR 1; close #925 from this PR.

--- a/docs/superpowers/specs/2026-09-02-non-media-file-types-design.md
+++ b/docs/superpowers/specs/2026-09-02-non-media-file-types-design.md
@@ -93,8 +93,7 @@ test keeps its meaning; a new case asserts a PDF is a permanent `unsupported_med
   missing `webm`. The copy in `packages/comment-render/src/index.ts` and the generated
   `packages/uploads/src/comment-render.generated.ts` follow (regenerate, do not hand-edit the
   generated file; check how it is produced first).
-- `optimizeImageForUpload` already passes non-images through as `not_image`. `optimizeImageForUpload`
-  returns early for a known non-image extension before any sharp call, and the EXIF-facts probe is
+- `optimizeImageForUpload` returns early for a known non-image extension before any sharp call, and the EXIF-facts probe is
   gated the same way, so a 20 MB zip never touches sharp. Keys keep their original extension on
   passthrough (verify, do not assume).
 - The managed comment already renders anything that is not an image or a poster-backed video as
@@ -161,5 +160,6 @@ Shipped in a second PR after the API change is live, so the site never claims wh
 - Inline text/JSON viewer on `/f/` (follow-up issue).
 - A separate non-media size cap or plan field.
 - Presign byte verification (#410).
-- `Content-Disposition: attachment` on the storage origin (needs a `files-sdk` option).
+- `Content-Disposition: attachment` on the storage hosts. Reachable as a zone Transform Rule (ops
+  config, not this repo); optional hardening, not required for the accepted set.
 - Ingesting non-media attachments from GitHub.

--- a/docs/superpowers/specs/2026-09-02-non-media-file-types-design.md
+++ b/docs/superpowers/specs/2026-09-02-non-media-file-types-design.md
@@ -27,13 +27,16 @@ The default allowlist grows to:
 
 Stays out: `text/html`, `image/svg+xml`, `application/xml`/`text/xml`, `application/javascript`,
 `application/octet-stream`, and anything else. The reason is the same as the existing SVG
-exclusion: `storage.uploads.sh` is a bare R2 custom domain with no Worker in front of it, so we
-cannot add a CSP or a `Content-Disposition` there, and the stored content type is the only
-control. HTML and SVG execute script in that origin. The types above do not: browsers render
-`text/*` and `application/json` as inert text, PDF opens in a sandboxed viewer (PDFium / PDF.js
-resource origin / PDFKit) that never runs in the page origin, and zip/gzip have no inline handler
-and always download. `files-sdk`'s `upload()` has no `contentDisposition` option, so forcing
-downloads is not available without an upstream change; it is also not needed for this set.
+exclusion: `storage.uploads.sh` is a bare R2 custom domain, and no Worker sits in front of it, so
+nothing in this repo sets headers on that path — headers there are zone-level Cloudflare Transform
+Rules (ops config, the same mechanism the nosniff follow-up below proposes), not something this
+code controls. The stored content type is the control this code does own. HTML and SVG execute
+script in that origin. The types above do not: browsers render `text/*` and `application/json` as
+inert text, PDF opens in a sandboxed viewer (PDFium / PDF.js resource origin / PDFKit) that never
+runs in the page origin, and zip/gzip have no inline handler and always download. `files-sdk`'s
+`upload()` has no `contentDisposition` option, so forcing downloads from application code is not
+available without an upstream change; a `Content-Disposition: attachment` Transform Rule scoped to
+`text/*` and `application/json` is an optional hardening on the ops side, not needed for this set.
 
 Ops follow-up (not code): add `X-Content-Type-Options: nosniff` on the storage hosts via the same
 Cloudflare Transform Rule mechanism that sets `Cache-Control`. Modern browsers already refuse to
@@ -90,9 +93,10 @@ test keeps its meaning; a new case asserts a PDF is a permanent `unsupported_med
   missing `webm`. The copy in `packages/comment-render/src/index.ts` and the generated
   `packages/uploads/src/comment-render.generated.ts` follow (regenerate, do not hand-edit the
   generated file; check how it is produced first).
-- `optimizeImageForUpload` already passes non-images through as `not_image`. The CLI skips
-  loading the optimizer entirely when the inferred type is not `image/*`, so a 20 MB zip never
-  touches sharp. Keys keep their original extension on passthrough (verify, do not assume).
+- `optimizeImageForUpload` already passes non-images through as `not_image`. `optimizeImageForUpload`
+  returns early for a known non-image extension before any sharp call, and the EXIF-facts probe is
+  gated the same way, so a 20 MB zip never touches sharp. Keys keep their original extension on
+  passthrough (verify, do not assume).
 - The managed comment already renders anything that is not an image or a poster-backed video as
   a `- [name](link)` bullet. No renderer change beyond the MIME map. MOV with a poster renders
   like MP4.
@@ -114,6 +118,8 @@ test keeps its meaning; a new case asserts a PDF is a permanent `unsupported_med
 
 Shipped in a second PR after the API change is live, so the site never claims what prod rejects:
 
+- The text families are the ones that carry secrets in practice (logs, CI JSON, env dumps): the
+  limits page and `put` help must say uploads are public and to scrub before uploading.
 - `apps/web/src/content/docs/limits.mdx` Formats bullet: list the families, keep the SVG sentence,
   add "HTML is not accepted for the same reason", drop "is coming".
 - `apps/web/src/pages/index.astro` "More file types" card: remove the Soon pill and the "Today:"
@@ -145,7 +151,10 @@ Shipped in a second PR after the API change is live, so the site never claims wh
 - `packages/comment-render` test: a `.pdf` item renders as a link bullet.
 - `apps/web` test for `fileKind("video/quicktime") === "video"`.
 - Prod verification after merge: `uploads put` a `.log`, `.pdf`, `.json`, `.zip`, `.mov`, and a
-  `.html` (expect 415); open each `/f/` page; confirm a PR comment renders the bullets.
+  `.html` (expect 415); open each `/f/` page; confirm a PR comment renders the bullets; confirm
+  `text/markdown` and `text/csv` are echoed verbatim by the storage hosts; confirm a `.tgz`
+  round-trips byte-for-byte (no transparent decompression, no `Content-Encoding: gzip` added at the
+  edge); confirm one MOV plays in Chrome on `/f/`.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-09-02-non-media-file-types-design.md
+++ b/docs/superpowers/specs/2026-09-02-non-media-file-types-design.md
@@ -1,0 +1,156 @@
+# Non-media file types (issue #925)
+
+## Problem
+
+The default allowlist in `apps/api/src/guards.ts` accepts PNG, JPEG, GIF, WebP, AVIF, MP4, and
+WebM. A `.log`, `.pdf`, `.json`, or `.zip` 415s. With `gh --attach` (CLI 2.99) covering images
+and video on GitHub itself, non-media artifacts (Lighthouse and Storybook output, test reports,
+PDFs, JSON, logs, zips) are the lane nobody serves for agents. PR #924 corrected the copy to
+match today's behavior and left a "More file types — Soon" card on the homepage.
+
+## Decisions
+
+### Accepted types
+
+The default allowlist grows to:
+
+| Type               | Extensions                               | Sniff                 | Size cap        |
+| ------------------ | ---------------------------------------- | --------------------- | --------------- |
+| `application/pdf`  | pdf                                      | `%PDF-`               | `maxBytes`      |
+| `application/zip`  | zip                                      | `PK\x03\x04`          | `maxBytes`      |
+| `application/gzip` | gz, tgz                                  | `\x1f\x8b`            | `maxBytes`      |
+| `video/quicktime`  | mov                                      | `ftyp` brand `qt`     | `maxVideoBytes` |
+| `text/plain`       | txt, log, text, jsonl, ndjson, yaml, yml | declared + text check | `maxBytes`      |
+| `text/markdown`    | md, markdown                             | declared + text check | `maxBytes`      |
+| `text/csv`         | csv                                      | declared + text check | `maxBytes`      |
+| `application/json` | json                                     | declared + text check | `maxBytes`      |
+
+Stays out: `text/html`, `image/svg+xml`, `application/xml`/`text/xml`, `application/javascript`,
+`application/octet-stream`, and anything else. The reason is the same as the existing SVG
+exclusion: `storage.uploads.sh` is a bare R2 custom domain with no Worker in front of it, so we
+cannot add a CSP or a `Content-Disposition` there, and the stored content type is the only
+control. HTML and SVG execute script in that origin. The types above do not: browsers render
+`text/*` and `application/json` as inert text, PDF opens in a sandboxed viewer (PDFium / PDF.js
+resource origin / PDFKit) that never runs in the page origin, and zip/gzip have no inline handler
+and always download. `files-sdk`'s `upload()` has no `contentDisposition` option, so forcing
+downloads is not available without an upstream change; it is also not needed for this set.
+
+Ops follow-up (not code): add `X-Content-Type-Options: nosniff` on the storage hosts via the same
+Cloudflare Transform Rule mechanism that sets `Cache-Control`. Modern browsers already refuse to
+sniff `text/plain` into HTML, so this is belt-and-braces.
+
+### Text types are declared-only, with a plausibility check
+
+Text has no magic bytes. `inspectUpload` gains a `declaredType` argument and this order:
+
+1. `detectContentType(bytes)` as today. A magic hit wins and must be in the allowlist. The
+   declared header is ignored for sniffable bytes, exactly as now (a zip renamed to `.png` is
+   still stored as zip, and rejected if zip is not allowed).
+2. If sniffing returns `null` and `declaredType` is one of the four text types, is in the
+   allowlist, and `looksLikeText(bytes)` passes, accept with the declared type.
+3. Otherwise 415, with `details.declared` added alongside `details.allowed` so the error explains
+   itself (`text/html` declared → "unsupported media type", allowed list shows it is out).
+
+`looksLikeText` samples the first 8 KiB: no NUL byte, and valid UTF-8 (`TextDecoder` with
+`fatal: true`; the sample is trimmed back to a code-point boundary before decoding so a cut
+multibyte sequence is not a false negative). Empty bodies are already rejected earlier. No
+HTML-shaped heuristics: the served type is what matters, and `text/plain` is inert.
+
+The declared type is resolved server-side as: the request `Content-Type` (normalized like presign
+does, params stripped, lowercased) when it is specific, else the final key's extension via a new
+`contentTypeFromKey(key)` in `guards.ts` (same table as the CLI map). `application/octet-stream`
+counts as unspecified. `putObject` takes `opts.declaredContentType` and applies the key-extension
+fallback itself, so the hosted MCP (which passes a filename and never a type) works with no MCP
+change, and CLIs older than this release (which send `application/octet-stream` for `.log`) work
+too.
+
+Presign already validates the declared type against the allowlist and cannot sniff; text types
+join that path unchanged. The presign integrity gap for binary types is issue #410 and is not
+widened here (a declared `application/pdf` carrying HTML bytes is served as PDF, which does not
+execute).
+
+### Size caps: no new plan field
+
+Non-media types use `maxUploadBytes` (25 MB free, 100 MB Pro). `video/quicktime` joins
+`VIDEO_TYPES` and uses `maxVideoUploadBytes`. No new `LIMIT_FIELDS` entry, no billing, admin, or
+backfill work. The limits table row is already labeled "Max file size". `UploadInspection.kind`
+gains `"file"` so 413 payloads and analytics stay honest.
+
+### Ingest stays media-only
+
+`github-ingest.ts` currently gates on "sniffed type is in the workspace allowlist". After this
+change that would start mirroring every PDF and zip pasted into a PR into the Screenshots view.
+The gate becomes allowlist membership **and** `image/*` or `VIDEO_TYPES`. Text types are
+unreachable there anyway (ingest only sniffs). The existing "derives from the shared allowlist"
+test keeps its meaning; a new case asserts a PDF is a permanent `unsupported_media_type` skip.
+
+### Client pipeline
+
+- `packages/uploads/src/embed.ts` `inferContentType` gains the extension rows above plus the
+  missing `webm`. The copy in `packages/comment-render/src/index.ts` and the generated
+  `packages/uploads/src/comment-render.generated.ts` follow (regenerate, do not hand-edit the
+  generated file; check how it is produced first).
+- `optimizeImageForUpload` already passes non-images through as `not_image`. The CLI skips
+  loading the optimizer entirely when the inferred type is not `image/*`, so a 20 MB zip never
+  touches sharp. Keys keep their original extension on passthrough (verify, do not assume).
+- The managed comment already renders anything that is not an image or a poster-backed video as
+  a `- [name](link)` bullet. No renderer change beyond the MIME map. MOV with a poster renders
+  like MP4.
+- Hosted MCP: no code change. Its `put` description gains one clause listing the accepted
+  families.
+
+### Web
+
+- `apps/web/src/lib/public-file.ts` `videoTypes` gains `video/quicktime`. The `file` branch of
+  `MediaStage` ("Preview unavailable / Open <name>") already covers PDF, text, and zip. Inline
+  text/JSON preview on `/f/` is a follow-up issue, not this change.
+- `workspace-screenshots.ts` already has `mov` in `VIDEO_EXT` and an `other` tile.
+- `/admin/metrics` already buckets `other`. No change.
+- Poster generation: `POSTER_SOURCE_CONTENT_TYPES = VIDEO_TYPES` picks up MOV automatically.
+  Whether Media Transformations decodes a given MOV is best-effort and already fail-soft; verify
+  one MOV on prod after deploy and note the result in the PR.
+
+### Copy
+
+Shipped in a second PR after the API change is live, so the site never claims what prod rejects:
+
+- `apps/web/src/content/docs/limits.mdx` Formats bullet: list the families, keep the SVG sentence,
+  add "HTML is not accepted for the same reason", drop "is coming".
+- `apps/web/src/pages/index.astro` "More file types" card: remove the Soon pill and the "Today:"
+  sentence.
+- `skills/github-screenshots/SKILL.md` "When gh --attach is enough": the file-type bullet becomes
+  "The file is an image or video under 10 MB" and a new "Use uploads.sh when" bullet covers
+  non-media artifacts (`gh --attach` takes images and video only).
+- `skills/uploads-cli/SKILL.md`, `docs/cli.md`, CLI `put` help text, `AGENTS.md` line ~209,
+  docs hub capability list, `/docs/attach` page, `llms.txt`/`llms-full.txt`: grep for
+  "PNG, JPEG", "images and video", "image or video", and "any file" and correct each.
+- Changelog entry under `apps/web/src/content/changelog/` (platform + CLI).
+- Changeset: `"@buildinternet/uploads": minor` for the MIME map and optimizer skip.
+
+## Testing
+
+- `apps/api/test/guards.test.ts`: `detectContentType` for PDF, zip, gzip, MOV (`ftyp` + `qt  `)
+  and MP4 unchanged; `contentTypeFromKey`; `looksLikeText` (ASCII, UTF-8 with a cut multibyte tail
+  at 8 KiB, NUL → false, Latin-1 bytes → false); `inspectUpload` matrix: declared `text/plain` +
+  text → ok; declared `text/plain` + PNG bytes → stored as PNG; declared `text/html` → 415;
+  declared `application/octet-stream` + text → 415; no declared + key `.log` → ok via fallback;
+  declared `text/plain` + binary → 415; PDF over `maxBytes` → 413 with `kind: "file"`; MOV uses
+  `maxVideoBytes`.
+- `apps/api/test/routes-files.test.ts`: PUT `.log` with `Content-Type: text/plain` → 200 with
+  `contentType: text/plain`; PUT `.html` → 415; PUT PDF bytes → 200; presign `text/plain` accepted,
+  `text/html` still rejected.
+- `apps/api/src/github-ingest.test.ts`: PDF asset → permanent skip even though the allowlist
+  accepts it.
+- `packages/uploads` tests: `inferContentType` new rows; optimizer skipped for `.pdf`.
+- `packages/comment-render` test: a `.pdf` item renders as a link bullet.
+- `apps/web` test for `fileKind("video/quicktime") === "video"`.
+- Prod verification after merge: `uploads put` a `.log`, `.pdf`, `.json`, `.zip`, `.mov`, and a
+  `.html` (expect 415); open each `/f/` page; confirm a PR comment renders the bullets.
+
+## Out of scope
+
+- Inline text/JSON viewer on `/f/` (follow-up issue).
+- A separate non-media size cap or plan field.
+- Presign byte verification (#410).
+- `Content-Disposition: attachment` on the storage origin (needs a `files-sdk` option).
+- Ingesting non-media attachments from GitHub.

--- a/packages/comment-render/src/index.ts
+++ b/packages/comment-render/src/index.ts
@@ -92,27 +92,39 @@ export function parseGhPrivateKey(
 }
 
 /** GitHub-embed helper (content type). Copied from packages/uploads/src/embed.ts. */
+const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  pdf: "application/pdf",
+  zip: "application/zip",
+  gz: "application/gzip",
+  tgz: "application/gzip",
+  txt: "text/plain",
+  text: "text/plain",
+  log: "text/plain",
+  jsonl: "text/plain",
+  ndjson: "text/plain",
+  yaml: "text/plain",
+  yml: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  json: "application/json",
+};
+
 function inferContentType(filename: string): string {
   const ext = filename.includes(".")
     ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase()
     : "";
-  switch (ext) {
-    case "png":
-      return "image/png";
-    case "jpg":
-    case "jpeg":
-      return "image/jpeg";
-    case "gif":
-      return "image/gif";
-    case "webp":
-      return "image/webp";
-    case "svg":
-      return "image/svg+xml";
-    case "mp4":
-      return "video/mp4";
-    default:
-      return "application/octet-stream";
-  }
+  return CONTENT_TYPE_BY_EXTENSION[ext] ?? "application/octet-stream";
 }
 
 /** Hidden marker identifying the one comment this CLI manages. Never change it — existing comments are found by exact match. */

--- a/packages/comment-render/src/index.ts
+++ b/packages/comment-render/src/index.ts
@@ -120,11 +120,25 @@ const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
   json: "application/json",
 };
 
-function inferContentType(filename: string): string {
+export function inferContentType(filename: string): string {
   const ext = filename.includes(".")
     ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase()
     : "";
   return CONTENT_TYPE_BY_EXTENSION[ext] ?? "application/octet-stream";
+}
+
+/**
+ * Coarse family a filename belongs to, for the callers that only branch on
+ * "is this an image / a video / something else" — `unknown` when the
+ * extension maps to nothing (an extension-less screenshot, say), which those
+ * callers treat as "might be an image, probe it".
+ */
+export function fileKindFromName(filename: string): "image" | "video" | "file" | "unknown" {
+  const type = inferContentType(filename);
+  if (type === "application/octet-stream") return "unknown";
+  if (type.startsWith("image/")) return "image";
+  if (type.startsWith("video/")) return "video";
+  return "file";
 }
 
 /** Hidden marker identifying the one comment this CLI manages. Never change it — existing comments are found by exact match. */

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,4 +1,4 @@
-import { Files } from "files-sdk";
+import { Files, type StoredFile } from "files-sdk";
 export { createFilesRouter } from "files-sdk/api";
 import { r2, s3FetchAdapter } from "files-sdk/r2";
 
@@ -267,4 +267,4 @@ export async function signedDownloadUrl(
   });
 }
 
-export type { Files };
+export type { Files, StoredFile };

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -29,7 +29,7 @@ import {
   workspaceFromToken,
   type ResolvedConfig,
 } from "./config.js";
-import { buildUploadMarkdown } from "./embed.js";
+import { buildUploadMarkdown, inferContentType } from "./embed.js";
 import { readLocalRepoCommentConfig, resolveCommentOptions } from "./comment-config.js";
 import { urlForGithubEmbed } from "./public-urls.js";
 import { UploadsError } from "./errors.js";
@@ -600,6 +600,18 @@ async function mergeImageFacts(
   return mergeDerivedMeta(metadata ?? {}, facts);
 }
 
+/**
+ * Gate for `mergeImageFacts`: only a filename whose inferred type is
+ * image/* (or unresolved — an extension-less screenshot) is worth an
+ * `imageFactsFromBytes` probe (`sharp(bytes).metadata()` under the hood). A
+ * known non-image extension (a 25 MB zip, a `.log`, a PDF…) skips the probe
+ * entirely rather than paying a sharp call that can only come back empty.
+ */
+function shouldProbeImageFacts(filename: string): boolean {
+  const guessed = inferContentType(filename);
+  return guessed === "application/octet-stream" || guessed.startsWith("image/");
+}
+
 export interface UploadPreparedImageOptions {
   frame: {
     frameId?: string;
@@ -684,9 +696,10 @@ export async function uploadPreparedImage(
   opts: UploadPreparedImageOptions,
 ): Promise<UploadPreparedImageResult> {
   // Read EXIF from the original bytes before the optimizer strips it.
-  const metadata = opts.deriveImageFacts
-    ? await mergeImageFacts(bytes, opts.metadata)
-    : opts.metadata;
+  const metadata =
+    opts.deriveImageFacts && shouldProbeImageFacts(sourceName)
+      ? await mergeImageFacts(bytes, opts.metadata)
+      : opts.metadata;
   const prepared = await prepareImageForUpload(bytes, sourceName, {
     frameId: opts.frame.frameId,
     frameUrl: opts.frame.frameUrl,
@@ -1319,9 +1332,10 @@ async function uploadAttachmentBatch(
         const baseMetadata = mergeSidecarMeta(file, bytes, opts.metadata);
         // Same EXIF promotion uploadPreparedImage does; attach keeps its own
         // per-file tail (it builds keys differently), so it opts in here too.
-        const metadata = opts.deriveImageFacts
-          ? await mergeImageFacts(bytes, baseMetadata)
-          : baseMetadata;
+        const metadata =
+          opts.deriveImageFacts && shouldProbeImageFacts(sourceName)
+            ? await mergeImageFacts(bytes, baseMetadata)
+            : baseMetadata;
         const prepared = await prepareImageForUpload(bytes, sourceName, {
           ...opts.frame,
           optimize: opts.optimize,

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -204,6 +204,8 @@ Still images (PNG/JPEG/…) are optimized to WebP by default (long edge capped,
 high quality; EXIF stripped) so GitHub embeds stay lean. Original bytes are kept
 when they are already smaller, animated, or not an image. Use --no-optimize to
 upload as-is, or --keep-exif when image metadata matters for the discussion.
+Non-media files (PDF, zip, gzip, logs, JSON, CSV, markdown) upload as-is and
+show up in the managed comment as links. HTML and SVG are rejected.
 
 Optional --frame wraps the image in a device/browser chrome before optimize
 (default off). See: uploads put --help frames

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -29,7 +29,7 @@ import {
   workspaceFromToken,
   type ResolvedConfig,
 } from "./config.js";
-import { buildUploadMarkdown, inferContentType } from "./embed.js";
+import { buildUploadMarkdown, fileKindFromName } from "./embed.js";
 import { readLocalRepoCommentConfig, resolveCommentOptions } from "./comment-config.js";
 import { urlForGithubEmbed } from "./public-urls.js";
 import { UploadsError } from "./errors.js";
@@ -585,31 +585,30 @@ export async function prepareImageForUpload(
 }
 
 /**
- * Merge an image's own EXIF-derived facts under any explicit metadata.
+ * Merge an image's own EXIF-derived facts under any explicit metadata, when
+ * the caller asked for them and the filename could plausibly be an image —
+ * only an `image/*` extension, or none at all (an extension-less
+ * screenshot), is worth an `imageFactsFromBytes` probe
+ * (`sharp(bytes).metadata()` under the hood); a known non-image extension (a
+ * 25 MB zip, a `.log`, a PDF…) skips it rather than paying a sharp call that
+ * can only come back empty.
+ *
  * Best-effort by contract: `imageFactsFromBytes` never rejects, and a full key
  * budget drops the derived pairs rather than failing the upload. Returns the
  * input untouched (including `undefined`) when there is nothing to add, so a
  * metadata-free upload stays metadata-free.
  */
-async function mergeImageFacts(
+async function maybeDeriveImageFacts(
+  enabled: boolean | undefined,
+  sourceName: string,
   bytes: Uint8Array,
   metadata: Record<string, string> | undefined,
 ): Promise<Record<string, string> | undefined> {
+  const kind = fileKindFromName(sourceName);
+  if (!enabled || (kind !== "image" && kind !== "unknown")) return metadata;
   const facts = await imageFactsFromBytes(bytes);
   if (Object.keys(facts).length === 0) return metadata;
   return mergeDerivedMeta(metadata ?? {}, facts);
-}
-
-/**
- * Gate for `mergeImageFacts`: only a filename whose inferred type is
- * image/* (or unresolved — an extension-less screenshot) is worth an
- * `imageFactsFromBytes` probe (`sharp(bytes).metadata()` under the hood). A
- * known non-image extension (a 25 MB zip, a `.log`, a PDF…) skips the probe
- * entirely rather than paying a sharp call that can only come back empty.
- */
-function shouldProbeImageFacts(filename: string): boolean {
-  const guessed = inferContentType(filename);
-  return guessed === "application/octet-stream" || guessed.startsWith("image/");
 }
 
 export interface UploadPreparedImageOptions {
@@ -696,10 +695,12 @@ export async function uploadPreparedImage(
   opts: UploadPreparedImageOptions,
 ): Promise<UploadPreparedImageResult> {
   // Read EXIF from the original bytes before the optimizer strips it.
-  const metadata =
-    opts.deriveImageFacts && shouldProbeImageFacts(sourceName)
-      ? await mergeImageFacts(bytes, opts.metadata)
-      : opts.metadata;
+  const metadata = await maybeDeriveImageFacts(
+    opts.deriveImageFacts,
+    sourceName,
+    bytes,
+    opts.metadata,
+  );
   const prepared = await prepareImageForUpload(bytes, sourceName, {
     frameId: opts.frame.frameId,
     frameUrl: opts.frame.frameUrl,
@@ -1332,10 +1333,12 @@ async function uploadAttachmentBatch(
         const baseMetadata = mergeSidecarMeta(file, bytes, opts.metadata);
         // Same EXIF promotion uploadPreparedImage does; attach keeps its own
         // per-file tail (it builds keys differently), so it opts in here too.
-        const metadata =
-          opts.deriveImageFacts && shouldProbeImageFacts(sourceName)
-            ? await mergeImageFacts(bytes, baseMetadata)
-            : baseMetadata;
+        const metadata = await maybeDeriveImageFacts(
+          opts.deriveImageFacts,
+          sourceName,
+          bytes,
+          baseMetadata,
+        );
         const prepared = await prepareImageForUpload(bytes, sourceName, {
           ...opts.frame,
           optimize: opts.optimize,

--- a/packages/uploads/src/comment-render.generated.ts
+++ b/packages/uploads/src/comment-render.generated.ts
@@ -122,11 +122,25 @@ const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
   json: "application/json",
 };
 
-function inferContentType(filename: string): string {
+export function inferContentType(filename: string): string {
   const ext = filename.includes(".")
     ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase()
     : "";
   return CONTENT_TYPE_BY_EXTENSION[ext] ?? "application/octet-stream";
+}
+
+/**
+ * Coarse family a filename belongs to, for the callers that only branch on
+ * "is this an image / a video / something else" — `unknown` when the
+ * extension maps to nothing (an extension-less screenshot, say), which those
+ * callers treat as "might be an image, probe it".
+ */
+export function fileKindFromName(filename: string): "image" | "video" | "file" | "unknown" {
+  const type = inferContentType(filename);
+  if (type === "application/octet-stream") return "unknown";
+  if (type.startsWith("image/")) return "image";
+  if (type.startsWith("video/")) return "video";
+  return "file";
 }
 
 /** Hidden marker identifying the one comment this CLI manages. Never change it — existing comments are found by exact match. */

--- a/packages/uploads/src/comment-render.generated.ts
+++ b/packages/uploads/src/comment-render.generated.ts
@@ -94,27 +94,39 @@ export function parseGhPrivateKey(
 }
 
 /** GitHub-embed helper (content type). Copied from packages/uploads/src/embed.ts. */
+const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  pdf: "application/pdf",
+  zip: "application/zip",
+  gz: "application/gzip",
+  tgz: "application/gzip",
+  txt: "text/plain",
+  text: "text/plain",
+  log: "text/plain",
+  jsonl: "text/plain",
+  ndjson: "text/plain",
+  yaml: "text/plain",
+  yml: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  json: "application/json",
+};
+
 function inferContentType(filename: string): string {
   const ext = filename.includes(".")
     ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase()
     : "";
-  switch (ext) {
-    case "png":
-      return "image/png";
-    case "jpg":
-    case "jpeg":
-      return "image/jpeg";
-    case "gif":
-      return "image/gif";
-    case "webp":
-      return "image/webp";
-    case "svg":
-      return "image/svg+xml";
-    case "mp4":
-      return "video/mp4";
-    default:
-      return "application/octet-stream";
-  }
+  return CONTENT_TYPE_BY_EXTENSION[ext] ?? "application/octet-stream";
 }
 
 /** Hidden marker identifying the one comment this CLI manages. Never change it — existing comments are found by exact match. */

--- a/packages/uploads/src/embed.ts
+++ b/packages/uploads/src/embed.ts
@@ -1,45 +1,16 @@
 /** GitHub-embed helpers (content type + markdown). */
 
-const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-  avif: "image/avif",
-  svg: "image/svg+xml",
-  mp4: "video/mp4",
-  webm: "video/webm",
-  mov: "video/quicktime",
-  pdf: "application/pdf",
-  zip: "application/zip",
-  gz: "application/gzip",
-  tgz: "application/gzip",
-  txt: "text/plain",
-  text: "text/plain",
-  log: "text/plain",
-  jsonl: "text/plain",
-  ndjson: "text/plain",
-  yaml: "text/plain",
-  yml: "text/plain",
-  md: "text/markdown",
-  markdown: "text/markdown",
-  csv: "text/csv",
-  json: "application/json",
-};
-
 /**
- * Content type from a filename's extension. Mirrors `CONTENT_TYPE_BY_EXTENSION`
- * in apps/api/src/guards.ts (the server's key-extension fallback); keep the
- * two in step. `svg` stays here only so the optimizer can pass it through —
+ * The filename→type map and its two readers live in
+ * packages/comment-render/src/index.ts (inlined here as
+ * `comment-render.generated.ts`), so the CLI and the managed-comment renderer
+ * cannot drift apart. Re-exported from this module because every existing
+ * caller imports them from `./embed.js`. That map mirrors the upload table in
+ * apps/api/src/guards.ts; keep the two in step. `svg` is the one deliberate
+ * difference — it stays here only so the optimizer can pass it through, and
  * the server rejects it.
  */
-export function inferContentType(filename: string): string {
-  const ext = filename.includes(".")
-    ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase()
-    : "";
-  return CONTENT_TYPE_BY_EXTENSION[ext] ?? "application/octet-stream";
-}
+export { fileKindFromName, inferContentType } from "./comment-render.generated.js";
 
 export function buildMarkdown(url: string, opts: { alt: string; width?: number }): string {
   if (opts.width) {

--- a/packages/uploads/src/embed.ts
+++ b/packages/uploads/src/embed.ts
@@ -1,26 +1,44 @@
 /** GitHub-embed helpers (content type + markdown). */
 
+const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  pdf: "application/pdf",
+  zip: "application/zip",
+  gz: "application/gzip",
+  tgz: "application/gzip",
+  txt: "text/plain",
+  text: "text/plain",
+  log: "text/plain",
+  jsonl: "text/plain",
+  ndjson: "text/plain",
+  yaml: "text/plain",
+  yml: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  json: "application/json",
+};
+
+/**
+ * Content type from a filename's extension. Mirrors `CONTENT_TYPE_BY_EXTENSION`
+ * in apps/api/src/guards.ts (the server's key-extension fallback); keep the
+ * two in step. `svg` stays here only so the optimizer can pass it through —
+ * the server rejects it.
+ */
 export function inferContentType(filename: string): string {
   const ext = filename.includes(".")
     ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase()
     : "";
-  switch (ext) {
-    case "png":
-      return "image/png";
-    case "jpg":
-    case "jpeg":
-      return "image/jpeg";
-    case "gif":
-      return "image/gif";
-    case "webp":
-      return "image/webp";
-    case "svg":
-      return "image/svg+xml";
-    case "mp4":
-      return "video/mp4";
-    default:
-      return "application/octet-stream";
-  }
+  return CONTENT_TYPE_BY_EXTENSION[ext] ?? "application/octet-stream";
 }
 
 export function buildMarkdown(url: string, opts: { alt: string; width?: number }): string {

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -403,7 +403,7 @@ export function createUploadsMcpTools(opts: {
       annotations: mcpDestroyPublic,
       securitySchemes: mcpOAuthWrite,
       description:
-        "Upload one or more files and get a public URL plus GitHub-ready markdown. Prefer `embedUrl` in GitHub markdown. Pass `contentUrl` for a public HTTPS file, or http://localhost on this machine, instead of a local path. With `pr`/`issue`, keys are stable and the managed comment is synced. All uploads are public.",
+        "Upload one or more files and get a public URL plus GitHub-ready markdown. Prefer `embedUrl` in GitHub markdown. Pass `contentUrl` for a public HTTPS file, or http://localhost on this machine, instead of a local path. With `pr`/`issue`, keys are stable and the managed comment is synced. All uploads are public. Accepts images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and text (plain, markdown, CSV, JSON). HTML and SVG are rejected.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/uploads/src/optimize.ts
+++ b/packages/uploads/src/optimize.ts
@@ -6,7 +6,7 @@
  * SVG, video, and non-images are left unchanged.
  */
 import sharp from "sharp";
-import { inferContentType } from "./embed.js";
+import { fileKindFromName, inferContentType } from "./embed.js";
 
 /** Longest edge in pixels (screenshots beyond this rarely help PR review). */
 export const DEFAULT_OPTIMIZE_MAX_EDGE = 2400;
@@ -114,22 +114,24 @@ export async function optimizeImageForUpload(
   opts: OptimizeImageOptions = {},
 ): Promise<OptimizeImageResult> {
   const originalBytes = bytes.byteLength;
+  // The filename's own claim, used by every passthrough exit below.
+  const guessed = inferContentType(filename);
   if (opts.enabled === false) {
-    return passthrough(bytes, filename, inferContentType(filename), "disabled");
+    return passthrough(bytes, filename, guessed, "disabled");
   }
   if (originalBytes === 0) {
-    return passthrough(bytes, filename, inferContentType(filename), "empty");
+    return passthrough(bytes, filename, guessed, "empty");
   }
   // A known non-image extension (log, pdf, zip, video…) never needs sharp —
   // and must be checked before `looksLikeSvg` below, since that check sniffs
   // the leading bytes for an XML/SVG prologue with no regard for the actual
   // extension: a `.log` or `.json` file that happens to start with `<?xml`
   // (a JUnit report, say) would otherwise misreport as `skippedReason: "svg"`
-  // / `image/svg+xml`. Unknown extensions still fall through to the SVG sniff
-  // and the sharp probe below, so an extension-less screenshot is optimized
-  // as before.
-  const guessed = inferContentType(filename);
-  if (guessed !== "application/octet-stream" && !guessed.startsWith("image/")) {
+  // / `image/svg+xml`. An unknown extension is still "might be an image": it
+  // falls through to the SVG sniff and the sharp probe below, so an
+  // extension-less screenshot is optimized as before.
+  const kind = fileKindFromName(filename);
+  if (kind === "file" || kind === "video") {
     return passthrough(bytes, filename, guessed, "not_image");
   }
 
@@ -152,21 +154,16 @@ export async function optimizeImageForUpload(
   try {
     meta = await image.metadata();
   } catch {
-    return passthrough(bytes, filename, inferContentType(filename), "not_image");
+    return passthrough(bytes, filename, guessed, "not_image");
   }
 
   if (!meta.format) {
-    return passthrough(bytes, filename, inferContentType(filename), "not_image");
+    return passthrough(bytes, filename, guessed, "not_image");
   }
 
   // Animated GIF/WebP: keep as-is (re-encoding often breaks or balloons size).
   if ((meta.pages ?? 1) > 1) {
-    return passthrough(
-      bytes,
-      filename,
-      meta.format === "gif" ? "image/gif" : inferContentType(filename),
-      "animated",
-    );
+    return passthrough(bytes, filename, meta.format === "gif" ? "image/gif" : guessed, "animated");
   }
 
   if (meta.format === "gif") {
@@ -203,11 +200,11 @@ export async function optimizeImageForUpload(
       encoded = await image.webp({ quality, effort: 4 }).toBuffer();
     }
   } catch {
-    return passthrough(bytes, filename, inferContentType(filename), "encode_failed");
+    return passthrough(bytes, filename, guessed, "encode_failed");
   }
 
   if (encoded.byteLength >= originalBytes) {
-    return passthrough(bytes, filename, inferContentType(filename), "not_smaller");
+    return passthrough(bytes, filename, guessed, "not_smaller");
   }
 
   const outFilename = withImageExtension(filename, format === "jpeg" ? "jpg" : "webp");

--- a/packages/uploads/src/optimize.ts
+++ b/packages/uploads/src/optimize.ts
@@ -120,16 +120,21 @@ export async function optimizeImageForUpload(
   if (originalBytes === 0) {
     return passthrough(bytes, filename, inferContentType(filename), "empty");
   }
-  if (looksLikeSvg(bytes, filename)) {
-    return passthrough(bytes, filename, "image/svg+xml", "svg");
-  }
-
-  // A known non-image extension (log, pdf, zip, video…) never needs sharp.
-  // Unknown extensions still get probed so an extension-less screenshot is
-  // optimized as before.
+  // A known non-image extension (log, pdf, zip, video…) never needs sharp —
+  // and must be checked before `looksLikeSvg` below, since that check sniffs
+  // the leading bytes for an XML/SVG prologue with no regard for the actual
+  // extension: a `.log` or `.json` file that happens to start with `<?xml`
+  // (a JUnit report, say) would otherwise misreport as `skippedReason: "svg"`
+  // / `image/svg+xml`. Unknown extensions still fall through to the SVG sniff
+  // and the sharp probe below, so an extension-less screenshot is optimized
+  // as before.
   const guessed = inferContentType(filename);
   if (guessed !== "application/octet-stream" && !guessed.startsWith("image/")) {
     return passthrough(bytes, filename, guessed, "not_image");
+  }
+
+  if (looksLikeSvg(bytes, filename)) {
+    return passthrough(bytes, filename, "image/svg+xml", "svg");
   }
 
   const format: OptimizeOutputFormat = opts.format ?? "webp";

--- a/packages/uploads/src/optimize.ts
+++ b/packages/uploads/src/optimize.ts
@@ -6,6 +6,7 @@
  * SVG, video, and non-images are left unchanged.
  */
 import sharp from "sharp";
+import { inferContentType } from "./embed.js";
 
 /** Longest edge in pixels (screenshots beyond this rarely help PR review). */
 export const DEFAULT_OPTIMIZE_MAX_EDGE = 2400;
@@ -114,13 +115,21 @@ export async function optimizeImageForUpload(
 ): Promise<OptimizeImageResult> {
   const originalBytes = bytes.byteLength;
   if (opts.enabled === false) {
-    return passthrough(bytes, filename, guessContentType(filename), "disabled");
+    return passthrough(bytes, filename, inferContentType(filename), "disabled");
   }
   if (originalBytes === 0) {
-    return passthrough(bytes, filename, guessContentType(filename), "empty");
+    return passthrough(bytes, filename, inferContentType(filename), "empty");
   }
   if (looksLikeSvg(bytes, filename)) {
     return passthrough(bytes, filename, "image/svg+xml", "svg");
+  }
+
+  // A known non-image extension (log, pdf, zip, video…) never needs sharp.
+  // Unknown extensions still get probed so an extension-less screenshot is
+  // optimized as before.
+  const guessed = inferContentType(filename);
+  if (guessed !== "application/octet-stream" && !guessed.startsWith("image/")) {
+    return passthrough(bytes, filename, guessed, "not_image");
   }
 
   const format: OptimizeOutputFormat = opts.format ?? "webp";
@@ -138,11 +147,11 @@ export async function optimizeImageForUpload(
   try {
     meta = await image.metadata();
   } catch {
-    return passthrough(bytes, filename, guessContentType(filename), "not_image");
+    return passthrough(bytes, filename, inferContentType(filename), "not_image");
   }
 
   if (!meta.format) {
-    return passthrough(bytes, filename, guessContentType(filename), "not_image");
+    return passthrough(bytes, filename, inferContentType(filename), "not_image");
   }
 
   // Animated GIF/WebP: keep as-is (re-encoding often breaks or balloons size).
@@ -150,7 +159,7 @@ export async function optimizeImageForUpload(
     return passthrough(
       bytes,
       filename,
-      meta.format === "gif" ? "image/gif" : guessContentType(filename),
+      meta.format === "gif" ? "image/gif" : inferContentType(filename),
       "animated",
     );
   }
@@ -189,11 +198,11 @@ export async function optimizeImageForUpload(
       encoded = await image.webp({ quality, effort: 4 }).toBuffer();
     }
   } catch {
-    return passthrough(bytes, filename, guessContentType(filename), "encode_failed");
+    return passthrough(bytes, filename, inferContentType(filename), "encode_failed");
   }
 
   if (encoded.byteLength >= originalBytes) {
-    return passthrough(bytes, filename, guessContentType(filename), "not_smaller");
+    return passthrough(bytes, filename, inferContentType(filename), "not_smaller");
   }
 
   const outFilename = withImageExtension(filename, format === "jpeg" ? "jpg" : "webp");
@@ -205,26 +214,6 @@ export async function optimizeImageForUpload(
     originalBytes,
     outputBytes: encoded.byteLength,
   };
-}
-
-function guessContentType(filename: string): string {
-  switch (extensionOf(filename)) {
-    case "png":
-      return "image/png";
-    case "jpg":
-    case "jpeg":
-      return "image/jpeg";
-    case "gif":
-      return "image/gif";
-    case "webp":
-      return "image/webp";
-    case "avif":
-      return "image/avif";
-    case "svg":
-      return "image/svg+xml";
-    default:
-      return "application/octet-stream";
-  }
 }
 
 /** Rewrite an object key's trailing image extension to match optimized output. */

--- a/packages/uploads/test/embed.test.ts
+++ b/packages/uploads/test/embed.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, it } from "vitest";
-import { buildMarkdown, buildUploadMarkdown } from "../src/embed.js";
+import { buildMarkdown, buildUploadMarkdown, inferContentType } from "../src/embed.js";
+
+describe("inferContentType", () => {
+  it("maps media and the accepted non-media extensions", () => {
+    expect(inferContentType("shot.png")).toBe("image/png");
+    expect(inferContentType("clip.webm")).toBe("video/webm");
+    expect(inferContentType("clip.MOV")).toBe("video/quicktime");
+    expect(inferContentType("report.pdf")).toBe("application/pdf");
+    expect(inferContentType("bundle.zip")).toBe("application/zip");
+    expect(inferContentType("bundle.tar.gz")).toBe("application/gzip");
+    expect(inferContentType("bundle.tgz")).toBe("application/gzip");
+    expect(inferContentType("build.log")).toBe("text/plain");
+    expect(inferContentType("notes.txt")).toBe("text/plain");
+    expect(inferContentType("events.jsonl")).toBe("text/plain");
+    expect(inferContentType("config.yml")).toBe("text/plain");
+    expect(inferContentType("README.md")).toBe("text/markdown");
+    expect(inferContentType("data.csv")).toBe("text/csv");
+    expect(inferContentType("lighthouse.json")).toBe("application/json");
+  });
+
+  it("falls back to octet-stream for unknown extensions", () => {
+    expect(inferContentType("blob")).toBe("application/octet-stream");
+    expect(inferContentType("page.html")).toBe("application/octet-stream");
+  });
+});
 
 describe("buildMarkdown", () => {
   it("emits image markdown without width", () => {

--- a/packages/uploads/test/embed.test.ts
+++ b/packages/uploads/test/embed.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildMarkdown, buildUploadMarkdown, inferContentType } from "../src/embed.js";
+import {
+  buildMarkdown,
+  buildUploadMarkdown,
+  fileKindFromName,
+  inferContentType,
+} from "../src/embed.js";
 
 describe("inferContentType", () => {
   it("maps media and the accepted non-media extensions", () => {
@@ -22,6 +27,20 @@ describe("inferContentType", () => {
   it("falls back to octet-stream for unknown extensions", () => {
     expect(inferContentType("blob")).toBe("application/octet-stream");
     expect(inferContentType("page.html")).toBe("application/octet-stream");
+  });
+});
+
+describe("fileKindFromName", () => {
+  it("classifies by the inferred type, with unknown for unmapped extensions", () => {
+    expect(fileKindFromName("shot.png")).toBe("image");
+    expect(fileKindFromName("icon.svg")).toBe("image");
+    expect(fileKindFromName("clip.MOV")).toBe("video");
+    expect(fileKindFromName("clip.webm")).toBe("video");
+    expect(fileKindFromName("report.pdf")).toBe("file");
+    expect(fileKindFromName("build.log")).toBe("file");
+    expect(fileKindFromName("data.csv")).toBe("file");
+    expect(fileKindFromName("screenshot")).toBe("unknown");
+    expect(fileKindFromName("page.html")).toBe("unknown");
   });
 });
 

--- a/packages/uploads/test/github.test.ts
+++ b/packages/uploads/test/github.test.ts
@@ -254,6 +254,22 @@ describe("attachmentsCommentBody", () => {
     expect(body).toContain('<a href="https://uploads.sh">uploads.sh</a>');
   });
 
+  it("renders pdf, json, and zip items as link bullets, never as embeds", () => {
+    const body = attachmentsCommentBody([
+      { key: "gh/o/r/pull/1/lighthouse.json", url: "https://x.test/lighthouse.json" },
+      {
+        key: "gh/o/r/pull/1/report.pdf",
+        url: "https://x.test/report.pdf",
+        pageUrl: "https://uploads.sh/f/w/report.pdf",
+      },
+      { key: "gh/o/r/pull/1/dist.zip", url: "https://x.test/dist.zip" },
+    ]);
+    expect(body).toContain("- [lighthouse.json](https://x.test/lighthouse.json)");
+    expect(body).toContain("- [report.pdf](https://uploads.sh/f/w/report.pdf)");
+    expect(body).toContain("- [dist.zip](https://x.test/dist.zip)");
+    expect(body).not.toContain("<img");
+  });
+
   it("uses a narrower width for phone-like filenames", () => {
     const body = attachmentsCommentBody([
       {

--- a/packages/uploads/test/optimize.test.ts
+++ b/packages/uploads/test/optimize.test.ts
@@ -75,6 +75,16 @@ describe("optimizeImageForUpload", () => {
     expect(result.skippedReason).toBe("svg");
   });
 
+  it("passes a known non-image extension through without probing", async () => {
+    const bytes = new TextEncoder().encode("not an image");
+    const result = await optimizeImageForUpload(bytes, "build.log");
+    expect(result.optimized).toBe(false);
+    expect(result.skippedReason).toBe("not_image");
+    expect(result.contentType).toBe("text/plain");
+    expect(result.filename).toBe("build.log");
+    expect(result.bytes).toBe(bytes);
+  });
+
   it("caps the long edge when larger than maxEdge", async () => {
     const png = await solidPng(4000, 2000);
     const result = await optimizeImageForUpload(png, "wide.png", {

--- a/packages/uploads/test/optimize.test.ts
+++ b/packages/uploads/test/optimize.test.ts
@@ -85,6 +85,16 @@ describe("optimizeImageForUpload", () => {
     expect(result.bytes).toBe(bytes);
   });
 
+  it("passes a known non-image extension through even when its bytes start with an XML/SVG prologue", async () => {
+    const bytes = new TextEncoder().encode('<?xml version="1.0"?><testsuite/>');
+    const result = await optimizeImageForUpload(bytes, "junit.log");
+    expect(result.optimized).toBe(false);
+    expect(result.skippedReason).toBe("not_image");
+    expect(result.contentType).toBe("text/plain");
+    expect(result.filename).toBe("junit.log");
+    expect(result.bytes).toBe(bytes);
+  });
+
   it("caps the long edge when larger than maxEdge", async () => {
     const png = await solidPng(4000, 2000);
     const result = await optimizeImageForUpload(png, "wide.png", {


### PR DESCRIPTION
Widens the hosted upload allowlist beyond images and video. Part of #925 (the copy PR that follows closes it).

Design: [spec](docs/superpowers/specs/2026-09-02-non-media-file-types-design.md) · [plan](docs/superpowers/plans/2026-09-02-non-media-file-types.md).

## What changes

- **New default types:** `application/pdf`, `application/zip`, `application/gzip`, `video/quicktime`, `text/plain`, `text/markdown`, `text/csv`, `application/json`. HTML, SVG, XML, and JavaScript stay out for the reason the SVG comment in `guards.ts` already gives: `storage.uploads.sh` is a bare R2 custom domain with no Worker in front, so the stored content type is the control this repo owns.
- **Sniffing:** PDF, zip (all three PK signatures), gzip, and MOV (`ftyp` brand `qt`) are magic-byte sniffed like everything else. Magic bytes always win over the header.
- **Text is declared-plus-plausible.** Text has no magic. When sniffing returns null, the declared type is accepted only if it is one of the four text types, is in the workspace allowlist, and the first 8 KiB has no NUL and decodes as UTF-8. The declared type is the `Content-Type` header when specific, else the key's extension, so older CLIs (which send `application/octet-stream` for `.log`) and the hosted MCP (which sends no type) work with no client change.
- **Size caps:** no new plan field. Non-media uses `maxUploadBytes`; MOV joins `VIDEO_TYPES` and uses the video cap. 413 payloads gain `kind: "file"`.
- **Ingest stays media-only.** `github-ingest.ts` now gates on image/video explicitly, so PDFs and zips pasted into a PR are not mirrored into the Screenshots view. Ingested MOVs get a `.mov` key.
- **Copies carry the stored type.** `attach`, promote, and private-prefix rotation pass the source object's content type through, so an extension-less stored text object survives a copy.
- **CLI:** the MIME map (and its generated copy in the comment renderer) learns the new extensions plus `webm`; the optimizer and the EXIF-facts probe return early for known non-image extensions, so a 20 MB zip never touches sharp. Non-media items render in the managed comment as link bullets, as before. Changeset: minor.
- **Web:** `fileKind("video/quicktime")` is `video`. The `/f/` page's existing `file` fallback covers PDF, text, and zip.
- **Presign:** the shared normalizer replaces the route-local one; text types join the existing declared-only path. The #410 integrity gap is unchanged, not widened.

## Not in this PR

- Site copy, skill text, and changelog. Those ship separately after prod verification so the docs never claim what prod rejects.
- `declaredContentType` in the idempotency fingerprint (follow-up; cannot escalate past the allowlist).
- Inline text/JSON preview on `/f/`.

## Verification

`pnpm run check`, `pnpm types`, and `pnpm test` (5712 passed) on the final tree. Route tests cover: `.log` with `text/plain` → 201 stored as text; `.log` with `application/octet-stream` and with no header → 201; `text/html` → 415; text under an extension-less key → 415; PDF/zip stored by sniffed type regardless of header; presign `text/plain` accepted, `text/html` still rejected; ingest skips a PDF and keys a MOV as `.mov`.

Prod checklist before the copy PR:

- [ ] `uploads put` a `.log`, `.json`, `.pdf`, `.zip`, `.tgz`, `.mov`, and a `.html` (expect 415); open each `/f/` page
- [ ] storage hosts echo `text/markdown` and `text/csv` verbatim
- [ ] a `.tgz` round-trips byte-for-byte (no edge `Content-Encoding: gzip` / transparent decompression)
- [ ] one MOV gets a poster and plays in Chrome on `/f/`
- [ ] attach a log and a PDF to a scratch PR; the managed comment shows link bullets
- [ ] add `X-Content-Type-Options: nosniff` on the storage hosts via a Transform Rule (ops)

This touches the upload guard, so a CodeRabbit review is warranted; not requested automatically per repo policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upload PDFs, ZIP/GZIP archives, MOV videos, and supported text formats including plain text, Markdown, CSV, JSON, and logs.
  - Non-media files are uploaded unchanged, bypass image optimization, and appear as links in managed comments.
  - Content types and file extensions are detected more reliably, including extension-less text files.
  - MOV files are recognized and displayed as videos.

- **Bug Fixes**
  - GitHub attachment ingestion continues to accept only images and videos; unsupported non-media attachments are skipped safely.
  - File copies and promotions preserve content type and original file data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->