### PR TITLE
docs: non-media file types are live

### DIFF
--- a/.changeset/non-media-put-help.md
+++ b/.changeset/non-media-put-help.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`put --help` now says uploads are public and to scrub secrets out of logs, JSON, and other text before uploading.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,8 +206,10 @@ records; any future global secrets go through `wrangler secret put` (prod) or
   normalizes dot segments before handlers run.
 - Upload guardrails live in `apps/api/src/guards.ts`: a byte cap (default 25 MiB)
   enforced on `Content-Length` and post-buffer, and a content-type allowlist
-  (images + mp4/webm, no SVG) verified by magic-byte sniffing — the stored
-  content type comes from the bytes, never the client header. Defaults are
+  (images, video incl. MOV, PDF, zip, gzip, and text — no SVG or HTML) verified
+  by magic-byte sniffing, or a declared-type plausibility check for text (no
+  magic bytes) — the stored content type comes from the bytes (or the checked
+  declared type), never the raw client header. Defaults are
   overridable per workspace via `maxUploadBytes` / `allowedContentTypes` on the
   record. Mutating routes carry the `writeRateLimit` middleware, keyed by
   workspace against the `WRITE_LIMITER` Rate Limiting binding (`unsafe.bindings`

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -27,7 +27,7 @@ How to call it:
 - [Full agent guide (llms-full.txt)](https://uploads.sh/llms-full.txt): install, auth, stage/attach loops, hosted MCP contracts, cautions
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
 - [Changelog](https://uploads.sh/changelog): platform updates and CLI releases, newest first (Atom feed at https://uploads.sh/changelog.xml)
-- [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, pair a before/after with --state, get a URL for an image or video (local path or `put --url`), capture a screenshot, annotate with callouts/redactions
+- [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, pair a before/after with --state, get a URL for any accepted file (local path or `put --url`), capture a screenshot, annotate with callouts/redactions
 - [Docs: annotate a screenshot](https://uploads.sh/docs/attach-pull-request-images#annotate): bake boxes, arrows, labels, freeform strokes, and solid redactions into a capture (`uploads screenshot --annotate` or `uploads annotate`)
 - [Docs: galleries](https://uploads.sh/docs/galleries): create an ordered set of media behind one public link at /g/<id>, add files with uploads put --gallery, and link the gallery to a PR or issue
 - [Docs: GitHub App](https://uploads.sh/docs/github-app): recommended install for bot-posted attachment comments, private-repo PR/issue titles, and zero-CLI promotion of branch-staged screenshots when a PR opens

--- a/apps/web/src/content/changelog/non-media-file-types.md
+++ b/apps/web/src/content/changelog/non-media-file-types.md
@@ -1,0 +1,17 @@
+---
+title: "Uploads take PDFs, logs, JSON, and zips"
+date: 2026-09-02T18:00:00Z
+tags: [platform, cli]
+---
+
+The upload allowlist now covers PDF, zip, gzip, MOV, and text files (plain,
+markdown, CSV, JSON, logs) alongside images and video. Test reports, Lighthouse
+output, build logs, and bundles get the same stable URLs and appear in the PR's
+attachments comment as links. MOV uploads and plays on its file page. Size caps
+are the plan's file cap; MOV uses the video cap.
+
+Uploads are public. The text families — logs, CI JSON, env dumps — are the ones
+that tend to carry secrets in practice, so scrub those before uploading.
+
+SVG and HTML stay out: served inline, either can run script on our storage
+origin. SVG support is planned behind a sandboxing header.

--- a/apps/web/src/content/docs/attach-pull-request-images.mdx
+++ b/apps/web/src/content/docs/attach-pull-request-images.mdx
@@ -1,6 +1,6 @@
 ---
 title: Attach & share
-description: Attach screenshots and video to GitHub PRs and issues, get a public URL for an image or video, capture a screenshot, and bake callouts or redactions onto it with the uploads CLI.
+description: Attach screenshots and video to GitHub PRs and issues, get a public URL for any accepted file, capture a screenshot, and bake callouts or redactions onto it with the uploads CLI.
 heading: Attach & share
 tagline: Stage as you work with put. Attach when a PR is already open. Capture, annotate, and share a URL.
 navLabel: Attach & share

--- a/apps/web/src/content/docs/limits.mdx
+++ b/apps/web/src/content/docs/limits.mdx
@@ -76,8 +76,10 @@ attachment caps never apply.
 - **Videos:** <PlanValue of="freeMaxVideo" /> on <PlanValue of="freeName" /> vs GitHub's 10&nbsp;MB on
   free GitHub plans, and <PlanValue of="proMaxVideo" /> on <PlanValue of="proName" /> even when the
   repository is on a free GitHub plan.
-- **Formats:** PNG, JPEG, GIF, WebP, AVIF, MP4, and WebM. SVG is not accepted because inline SVG
-  can carry script. Support for more file types (PDFs, logs, JSON, zips) is coming.
+- **Formats:** images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and
+  text (plain, markdown, CSV, JSON, logs). SVG and HTML are not accepted — served inline, either
+  can run script; SVG support is planned behind a sandboxing header. Uploads are public: scrub
+  secrets out of logs, JSON, and other text files before uploading.
 
 <div class="note">
   One difference to know: GitHub renders inline video players only for its own uploads. Videos

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -95,7 +95,7 @@ const REPO = "https://github.com/buildinternet/uploads";
       <a class="card" href="/docs/attach-pull-request-images">
         <h3>Attach &amp; share <span class="go">→</span></h3>
         <p>
-          Post files to a PR or issue, get a URL for an image or video, capture a screenshot, and
+          Post files to a PR or issue, get a URL for any accepted file, capture a screenshot, and
           annotate it.
         </p>
       </a>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -782,10 +782,10 @@ Source (and where to look if something breaks): https://github.com/buildinternet
             </p>
           </div>
           <div class="feature">
-            <h3>More file types <span class="soon">Soon</span></h3>
+            <h3>More file types</h3>
             <p>
               PDFs, logs, JSON, and zips alongside images and video, so test reports and build
-              output get the same stable URLs. Today: PNG, JPEG, GIF, WebP, AVIF, MP4, and WebM.
+              output get the same stable URLs.
             </p>
           </div>
           <div class="feature">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,7 @@
 # CLI guide
 
 The `@buildinternet/uploads` package wraps the API for scripting and GitHub
-image embeds. Examples use the global `uploads` binary; install it with
+file embeds. Examples use the global `uploads` binary; install it with
 `npm install -g @buildinternet/uploads`. Inside this monorepo, `pnpm uploads …`
 builds the package first, so you pick up local source.
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -205,7 +205,9 @@ high quality; EXIF stripped) so GitHub embeds stay lean. Original bytes are kept
 when they are already smaller, animated, or not an image. Use --no-optimize to
 upload as-is, or --keep-exif when image metadata matters for the discussion.
 Non-media files (PDF, zip, gzip, logs, JSON, CSV, markdown) upload as-is and
-show up in the managed comment as links. HTML and SVG are rejected.
+show up in the managed comment as links. HTML and SVG are rejected. Uploads are
+public, so scrub secrets and tokens out of logs, JSON, and other text before
+uploading.
 
 Optional --frame wraps the image in a device/browser chrome before optimize
 (default off). See: uploads put --help frames

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -42,13 +42,15 @@ of these hold:
 - `gh --version` is 2.99 or newer and you have push access to the repo.
 - The PR or issue already exists, or you are creating it in the same command.
 - The file is an image or video under 10 MB (video up to 100 MB on paid plans).
-  uploads.sh takes PNG, JPEG, GIF, WebP, AVIF, MP4, and WebM only; `gh` also
-  takes SVG and MOV.
+  `gh --attach` takes media only.
 - Nobody needs the link outside GitHub. `user-attachments` URLs do not render
   in Slack, docs, or other tools, and other agents cannot fetch them.
 
 Use uploads.sh when any of these are true instead:
 
+- The artifact is not media: a Lighthouse or test report, a log, JSON, a PDF, or
+  a zip. `gh --attach` does not take those; `uploads put` does, and the managed
+  comment links them.
 - The PR does not exist yet. Stage on the branch with `uploads put`; the
   attachments comment appears when the PR opens.
 - The shot will be re-taken. Same filename, same URL, and the managed comment


### PR DESCRIPTION
Closes #925. Follows #928, which widened the upload allowlist to PDF, zip, gzip, MOV, and text (plain, markdown, CSV, JSON, logs). This PR catches up the copy that still described the old images/video-only allowlist.

## Surfaces touched

- `apps/web/src/content/docs/limits.mdx` — Formats bullet lists the new families, keeps the SVG note, adds HTML, notes SVG is planned (not dated), and tells readers to scrub secrets from text uploads
- `apps/web/src/pages/index.astro` — homepage feature card: dropped the "Soon" pill and the "Today: PNG/JPEG/…" sentence
- `apps/web/src/pages/docs.astro` and `apps/web/src/content/docs/attach-pull-request-images.mdx` — "get a URL for an image or video" → "get a URL for any accepted file"
- `apps/web/public/llms.txt` — same wording fix in the attach & share entry
- `skills/github-screenshots/SKILL.md` — "When gh --attach is enough" now says `gh --attach` takes media only (no longer lists uploads.sh's own allowlist); added a "Use uploads.sh when" bullet for non-media artifacts
- `AGENTS.md` (~line 209) — allowlist description updated to the current families and the text plausibility check
- `docs/cli.md` — "GitHub image embeds" → "GitHub file embeds"
- `packages/uploads/src/commands.ts` — `put --help` gains one sentence: uploads are public, scrub secrets/tokens out of logs, JSON, and other text before uploading
- `apps/web/src/content/changelog/non-media-file-types.md` (new) — changelog entry, dated 2026-09-02, tags `[platform, cli]`

`README.md`, `skills/uploads-cli/SKILL.md`, and `apps/web/public/llms-full.txt` were checked against the brief's grep and already read correctly (generic wording or accurate descriptions of `gh --attach`'s own scope) — no changes needed there.

## Verification

- `pnpm --filter @uploads/web exec astro check` — 0 errors
- `pnpm run check` — clean (lint + format)

## Screenshots

`/docs/limits` Formats bullet:

![limits](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/931/localhost-docs-limits-after.webp)

Homepage feature card:

![homepage](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/931/homepage-more-file-types-after.webp)
