### PR TITLE
fix: admin limits panel shows plan defaults; per-file caps follow the plan

### DIFF
--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -4,6 +4,7 @@ import {
   UnsupportedMediaTypeError,
   type AppError,
 } from "@uploads/errors";
+import { resolveEffectiveLimits } from "@uploads/billing";
 import type { MiddlewareHandler } from "hono";
 import type { WorkspaceVars } from "./workspace";
 
@@ -119,6 +120,14 @@ export interface UploadPolicyOverrides {
    * default later.
    */
   allowedContentTypes?: string[];
+  /**
+   * Subscription plan (issue #613). Set → `maxUploadBytes`/`maxVideoUploadBytes`
+   * fall back to that plan's `defaultLimits` (via `resolveEffectiveLimits`)
+   * instead of `DEFAULT_MAX_UPLOAD_BYTES` when the record carries no explicit
+   * override. Unset (legacy/operator-provisioned workspaces) reproduces
+   * pre-billing behavior byte-for-byte: no plan defaults apply.
+   */
+  plan?: string;
 }
 
 function positiveBytes(value: unknown): number | undefined {
@@ -126,8 +135,19 @@ function positiveBytes(value: unknown): number | undefined {
 }
 
 export function resolveUploadPolicy(record: UploadPolicyOverrides): UploadPolicy {
-  const maxBytes = positiveBytes(record.maxUploadBytes) ?? DEFAULT_MAX_UPLOAD_BYTES;
-  const maxVideoBytes = positiveBytes(record.maxVideoUploadBytes) ?? maxBytes;
+  // Sanitize before handing off to the shared resolution seam, same pattern
+  // as `budget.ts`'s `resolveBudgetLimits`: a zero/negative/non-finite
+  // override collapses to "unset" here, *before* `resolveEffectiveLimits`
+  // decides whether that counts as an explicit override or falls back to
+  // the plan default.
+  const resolved = resolveEffectiveLimits({
+    plan: record.plan,
+    maxUploadBytes: positiveBytes(record.maxUploadBytes),
+    maxVideoUploadBytes: positiveBytes(record.maxVideoUploadBytes),
+  });
+  // No plan stamped: reproduce the legacy fallback exactly.
+  const maxBytes = positiveBytes(resolved.maxUploadBytes) ?? DEFAULT_MAX_UPLOAD_BYTES;
+  const maxVideoBytes = positiveBytes(resolved.maxVideoUploadBytes) ?? maxBytes;
   const allowed =
     record.allowedContentTypes && record.allowedContentTypes.length > 0
       ? new Set(record.allowedContentTypes)

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -699,12 +699,13 @@ describe("workspace limits editing", () => {
     retentionDays: 90,
   };
 
-  it("GET returns current limits and usage", async () => {
+  it("GET returns current limits and usage — plan undefined (legacy), planApplied: false", async () => {
     const { env } = limitsEnv(ADMIN_USER, REC, { bytes: 128, uploadsInPeriod: 5 });
     const res = await app().request("/admin-ui/workspaces/acme/limits", {}, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       workspace: "acme",
+      planApplied: false,
       limits: {
         maxStorageBytes: 250_000_000,
         maxUploadsPerPeriod: 3000,
@@ -712,8 +713,51 @@ describe("workspace limits editing", () => {
         maxVideoUploadBytes: null,
         maxMembers: null,
       },
+      overrides: ["maxStorageBytes", "maxUploadsPerPeriod"],
       usage: { bytes: 128, uploads: 5 },
     });
+  });
+
+  it("GET resolves free-plan defaults for a self-serve workspace with no overrides — issue #613", async () => {
+    const { env } = limitsEnv(ADMIN_USER, {
+      provider: "r2",
+      bucket: "uploads-default",
+      prefix: "acme/",
+      plan: "free",
+    });
+    const res = await app().request("/admin-ui/workspaces/acme/limits", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      planApplied: boolean;
+      overrides: string[];
+      limits: Record<string, number | null>;
+    };
+    expect(body.planApplied).toBe(true);
+    expect(body.overrides).toEqual([]);
+    // Free plan defaults — not "Unlimited"/null (the pre-fix bug).
+    expect(body.limits.maxStorageBytes).toBe(250_000_000);
+    expect(body.limits.maxUploadsPerPeriod).toBe(3000);
+    expect(body.limits.maxUploadBytes).toBe(25_000_000);
+    expect(body.limits.maxVideoUploadBytes).toBe(25_000_000);
+    expect(body.limits.maxMembers).toBe(3);
+  });
+
+  it("GET lets an explicit override win over the plan default", async () => {
+    const { env } = limitsEnv(ADMIN_USER, {
+      provider: "r2",
+      bucket: "uploads-default",
+      prefix: "acme/",
+      plan: "free",
+      maxStorageBytes: 999,
+    });
+    const res = await app().request("/admin-ui/workspaces/acme/limits", {}, env);
+    const body = (await res.json()) as {
+      overrides: string[];
+      limits: Record<string, number | null>;
+    };
+    expect(body.overrides).toEqual(["maxStorageBytes"]);
+    expect(body.limits.maxStorageBytes).toBe(999);
+    expect(body.limits.maxUploadsPerPeriod).toBe(3000); // still the plan default
   });
 
   it("PATCH sets numeric limits on the record", async () => {

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -71,6 +71,7 @@ import {
 import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { LIMIT_FIELDS, validateLimitsPatch } from "../workspace-limits";
 import { planResponse, planSourceFor, validatePlanPatch } from "../workspace-plan";
+import { resolveEffectiveLimits, type WorkspacePlanLimits } from "@uploads/billing";
 import { storageStatusResponse } from "./workspace-storage";
 import { dbFor } from "../db-session";
 
@@ -441,15 +442,30 @@ function repoLinkResponse(link: RepoLink) {
   };
 }
 
-/** Response body shared by GET and PATCH: current budget limits + usage. */
+/**
+ * Response body shared by GET and PATCH /admin-ui/workspaces/:name/limits.
+ *
+ * `limits` used to echo the record's raw override fields (`?? null`),
+ * which reads as "unlimited" for any self-serve workspace — those carry
+ * `plan: "free"` with no explicit overrides, so every field was `null`
+ * even though the free plan's defaults are enforced (issue #613 display
+ * bug; enforcement via `resolveEffectiveLimits`/budget.ts was always
+ * correct — only this projection lied). Mirrors `planResponse`'s shape
+ * (`workspace-plan.ts`) so the two admin panels agree: `limits` is the
+ * resolved effective value per field (null only when truly unlimited —
+ * i.e. `plan` is undefined/legacy, or an explicit override clears it),
+ * `overrides` lists which fields carry an explicit per-workspace override,
+ * and `planApplied` says whether plan defaults were consulted at all.
+ */
 async function limitsResponse(env: Env, name: string, record: WorkspaceRecord) {
-  const limits = {
-    maxStorageBytes: record.maxStorageBytes ?? null,
-    maxUploadsPerPeriod: record.maxUploadsPerPeriod ?? null,
-    maxUploadBytes: record.maxUploadBytes ?? null,
-    maxVideoUploadBytes: record.maxVideoUploadBytes ?? null,
-    maxMembers: record.maxMembers ?? null,
-  };
+  const planApplied = record.plan !== undefined;
+  const resolved = resolveEffectiveLimits(record);
+  const overrides = LIMIT_FIELDS.filter(
+    (field) => record[field as keyof WorkspacePlanLimits] !== undefined,
+  );
+  const limits = Object.fromEntries(
+    LIMIT_FIELDS.map((field) => [field, resolved[field as keyof WorkspacePlanLimits] ?? null]),
+  ) as Record<(typeof LIMIT_FIELDS)[number], number | null>;
   let usage: { bytes: number; uploads: number } | null = null;
   try {
     const u = await getWorkspaceUsage(dbFor(env), name);
@@ -457,7 +473,7 @@ async function limitsResponse(env: Env, name: string, record: WorkspaceRecord) {
   } catch {
     usage = null;
   }
-  return { workspace: name, limits, usage };
+  return { workspace: name, planApplied, limits, overrides, usage };
 }
 
 /**

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -82,7 +82,11 @@ export interface WorkspaceRecord {
   region?: string;
   /** Path-style addressing (`https://endpoint/bucket/key`) instead of virtual-hosted style. `provider: "s3"` only. */
   forcePathStyle?: boolean;
-  /** Max bytes for a single image upload. Falls back to DEFAULT_MAX_UPLOAD_BYTES. */
+  /**
+   * Max bytes for a single image upload. Omit to take the plan default
+   * (`resolveUploadPolicy`, guards.ts, via `resolveEffectiveLimits`); with
+   * no `plan` stamped, falls back to the legacy DEFAULT_MAX_UPLOAD_BYTES.
+   */
   maxUploadBytes?: number;
   /**
    * Max bytes for video/mp4 and video/webm. When unset, videos use maxUploadBytes.

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -156,6 +156,44 @@ describe("resolveUploadPolicy", () => {
     expect(allowed.has("text/html")).toBe(false);
     expect(allowed.has("image/svg+xml")).toBe(false);
   });
+
+  it("resolves pro-plan defaults for both image and video caps when unset", () => {
+    const policy = resolveUploadPolicy({ plan: "pro" });
+    expect(policy.maxBytes).toBe(100_000_000);
+    expect(policy.maxVideoBytes).toBe(100_000_000);
+  });
+
+  it("resolves free-plan defaults for both image and video caps when unset", () => {
+    const policy = resolveUploadPolicy({ plan: "free" });
+    expect(policy.maxBytes).toBe(25_000_000);
+    expect(policy.maxVideoBytes).toBe(25_000_000);
+  });
+
+  it("an explicit override beats the plan default", () => {
+    const policy = resolveUploadPolicy({ plan: "pro", maxUploadBytes: 1000 });
+    expect(policy.maxBytes).toBe(1000);
+    // video has no override of its own, so it resolves independently to the
+    // plan's video default (not to the overridden maxBytes).
+    expect(policy.maxVideoBytes).toBe(100_000_000);
+  });
+
+  it("an explicit video override beats the plan default independently of maxBytes", () => {
+    const policy = resolveUploadPolicy({ plan: "pro", maxVideoUploadBytes: 5000 });
+    expect(policy.maxBytes).toBe(100_000_000);
+    expect(policy.maxVideoBytes).toBe(5000);
+  });
+
+  it("falls back to the legacy DEFAULT_MAX_UPLOAD_BYTES when no plan is stamped", () => {
+    const policy = resolveUploadPolicy({});
+    expect(policy.maxBytes).toBe(DEFAULT_MAX_UPLOAD_BYTES);
+    expect(policy.maxVideoBytes).toBe(DEFAULT_MAX_UPLOAD_BYTES);
+  });
+
+  it("video falls back to maxBytes when only the video field is unresolved", () => {
+    const policy = resolveUploadPolicy({ plan: "pro", maxVideoUploadBytes: 0 });
+    expect(policy.maxBytes).toBe(100_000_000);
+    expect(policy.maxVideoBytes).toBe(100_000_000);
+  });
 });
 
 describe("looksLikeText", () => {

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -230,9 +230,21 @@ export const prerender = false;
         workspace: string,
         data: AdminLimitsResponse,
       ): void {
+        // A field with no explicit override, on a plan-applied record, is
+        // pre-filled with the plan default rather than read as unlimited
+        // (issue #613) — the "plan default" hint marks that it's inherited,
+        // not an operator-set cap.
         const rows = LIMIT_FIELDS.map((f) => {
           const raw = data.limits[f.key];
           const unlimited = raw === null;
+          const isDefault = data.planApplied && !data.overrides.includes(f.key);
+          const defaultHint = isDefault
+            ? `<span class="limit-default-hint text-(length:--text-micro) text-muted-foreground whitespace-nowrap">plan default</span>`
+            : "";
+          // `data-default` carries the inherited value so `buildLimitsBody`
+          // can skip an untouched row instead of stamping an override equal
+          // to the plan default (which would pin the cap across a plan change).
+          const defaultAttr = isDefault && raw !== null ? ` data-default="${raw}"` : "";
           if (f.byte) {
             const split = raw === null ? { value: "", unit: "MB" } : splitBytes(raw);
             const options = LIMIT_UNITS.map(
@@ -240,20 +252,21 @@ export const prerender = false;
                 `<option value="${u.label}"${u.label === split.unit ? " selected" : ""}>${u.label}</option>`,
             ).join("");
             return `
-            <div class="limit-row grid grid-cols-[130px_1fr_70px_auto] max-[560px]:grid-cols-1 items-center gap-2 max-[560px]:gap-1" data-field="${f.key}" data-byte="1">
+            <div class="limit-row grid grid-cols-[130px_1fr_70px_auto_auto] max-[560px]:grid-cols-1 items-center gap-2 max-[560px]:gap-1" data-field="${f.key}" data-byte="1"${defaultAttr}>
               <label class="text-(length:--text-meta) text-body">${f.label}</label>
               <input type="number" min="1" step="1" class="limit-value bg-background border border-border rounded-sm text-foreground px-1.5 py-1 font-mono text-(length:--text-micro) disabled:opacity-50" value="${split.value}" ${unlimited ? "disabled" : ""} />
               <select class="limit-unit ul-select ul-select--sm" style="width:auto" ${unlimited ? "disabled" : ""}>${options}</select>
               <label class="limit-unlimited inline-flex items-center gap-1 text-(length:--text-micro) whitespace-nowrap text-muted-foreground"><input type="checkbox" class="limit-unlim" ${unlimited ? "checked" : ""} /> Unlimited</label>
+              ${defaultHint}
             </div>`;
           }
           return (
             `
-          <div class="limit-row grid grid-cols-[130px_1fr_auto_auto] max-[560px]:grid-cols-1 items-center gap-2 max-[560px]:gap-1" data-field="${f.key}">
+          <div class="limit-row grid grid-cols-[130px_1fr_auto_auto_auto] max-[560px]:grid-cols-1 items-center gap-2 max-[560px]:gap-1" data-field="${f.key}"${defaultAttr}>
             <label class="text-(length:--text-meta) text-body">${f.label}</label>
             <input type="number" min="1" step="1" class="limit-value bg-background border border-border rounded-sm text-foreground px-1.5 py-1 font-mono text-(length:--text-micro) disabled:opacity-50" value="${raw === null ? "" : raw}" ${unlimited ? "disabled" : ""} />
-            <label class="limit-unlimited inline-flex items-center gap-1 text-(length:--text-micro) whitespace-nowrap text-muted-foreground"><input type="checkbox" class="limit-unlim" ${unlimited ? "checked" : ""} /> Unlimited</label>` +
-            `</div>`
+            <label class="limit-unlimited inline-flex items-center gap-1 text-(length:--text-micro) whitespace-nowrap text-muted-foreground"><input type="checkbox" class="limit-unlim" ${unlimited ? "checked" : ""} /> Unlimited</label>
+            ${defaultHint}` + `</div>`
           );
         }).join("");
 
@@ -361,6 +374,7 @@ export const prerender = false;
           if (!valueInput?.value || !Number.isInteger(num) || num < 1) {
             throw new Error(`Enter a whole number ≥ 1 for "${field}", or check Unlimited.`);
           }
+          let value: number;
           if (row.dataset.byte) {
             // Not querySelector<HTMLSelectElement>: same worker-configuration.d.ts
             // `Element.remove()` drift noted above. Fetch as HTMLElement and cast.
@@ -369,10 +383,14 @@ export const prerender = false;
             ) as unknown as HTMLSelectElement | null;
             const unit = unitEl?.value ?? "MB";
             const mult = LIMIT_UNITS.find((u) => u.label === unit)?.mult ?? 1_000_000;
-            body[field] = Math.floor(num * mult);
+            value = Math.floor(num * mult);
           } else {
-            body[field] = num;
+            value = num;
           }
+          // An untouched plan-default row is not an override — leave the
+          // field absent so the plan keeps driving it.
+          if (row.dataset.default !== undefined && Number(row.dataset.default) === value) return;
+          body[field] = value;
         });
         return body;
       }


### PR DESCRIPTION
## What

Two fixes surfaced while investigating a report that new sign-ups appeared to have unlimited limits.

**Display bug (the report).** `GET /admin-ui/workspaces/:name/limits` echoed the record's raw override fields, and the admin page rendered `null` as "Unlimited". Since #412, self-serve records carry `plan: "free"` with no explicit override fields, so every new workspace looked unlimited in the Limits block even though the free plan's caps were enforced (the Plan block above it already showed the real numbers). The response now returns the resolved effective value per field via `resolveEffectiveLimits`, plus `overrides` and `planApplied`, matching `planResponse`'s shape. The form pre-fills inherited values with a "plan default" hint and skips untouched inherited rows on save, so saving no longer stamps overrides equal to the plan default.

**Enforcement gap.** `resolveUploadPolicy` in `guards.ts` read `maxUploadBytes` / `maxVideoUploadBytes` straight off the record with a hardcoded 25 MiB fallback and never consulted the plan. Masked on Free (25 MB ≈ 25 MiB), but a Pro workspace with no explicit override was capped at 25 MiB instead of the marketed 100 MB. It now resolves through the same seam `budget.ts` uses; records with no `plan` keep the legacy fallback byte-for-byte.

## Verified

- `pnpm --filter @uploads/api test`: 175 files, 2566 tests passing (new guards and admin-ui cases included).
- `pnpm --filter @uploads/api typecheck`, `pnpm --filter @uploads/web run typecheck`, `pnpm format:check`: clean.
- Confirmed against a prod self-serve record via `/admin/workspaces/:name` that provisioning writes `plan: "free"` and no overrides, i.e. enforcement was never affected.

Not verified in a browser session: the admin form change is markup plus the save-body filter; it typechecks under astro check.
