### PR TITLE
fix(api): scope the comment-sync private-prefix fan-out to the target (#934)

### DIFF
--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -117,13 +117,57 @@ describe("gatherCommentBody", () => {
       httpMetadata: { contentType: "image/png" },
     });
 
-    const result = await gatherCommentBody(env, ws, workspaceName, target);
+    // No metadata rows for the private object (a raw PUT): the PR head
+    // branch's prefix is what finds it.
+    const result = await gatherCommentBody(env, ws, workspaceName, target, {
+      headBranch: "main",
+    });
     expect(result.body.startsWith(attachmentsMarker(workspaceName))).toBe(true);
     expect(result.body).toContain("hero.png");
     expect(result.body).toContain("private.png");
     // Ordering: the plain-prefix object appears before the private one.
     expect(result.body.indexOf("hero.png")).toBeLessThan(result.body.indexOf("private.png"));
     expect(result.count).toBe(2);
+  });
+
+  it("lists only the private prefixes that hold this target's objects, not every active prefix in the repo (#934)", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    const target = { repo: "acme/web", num: 12, kind: "pull" as const };
+    // The prefix the attachment actually lives under, stamped the way
+    // `put --pr` / attach / promote stamp it.
+    const usedId = await getOrMintPrefixId(env.DB, "acme/web", "feature/shots");
+    const key = `${ghPrivateKeyPrefix(usedId, target)}private.png`;
+    await bucket.put(`acme/${key}`, PNG, { httpMetadata: { contentType: "image/png" } });
+    await replaceFileMetadata(env.DB, workspaceName, key, { "gh.ref": "acme/web#12" });
+    // Many other agent branches minted prefixes in this repo; none hold
+    // anything for PR 12.
+    for (const branch of ["claude/a", "claude/b", "claude/c", "claude/d"]) {
+      await getOrMintPrefixId(env.DB, "acme/web", branch);
+    }
+
+    bucket.listCalls = 0;
+    const result = await gatherCommentBody(env, ws, workspaceName, target);
+    expect(result.body).toContain("private.png");
+    expect(result.count).toBe(1);
+    // Plain prefix + the one private prefix that holds the object.
+    expect(bucket.listCalls).toBe(2);
+  });
+
+  it("finds a metadata-less private object under the repo-level prefix for an issue target (#934)", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    const target = { repo: "acme/web", num: 45, kind: "issues" as const };
+    // Issues resolve to the branch-less sentinel prefix (branch = "").
+    const sentinelId = await getOrMintPrefixId(env.DB, "acme/web", "");
+    await bucket.put(`acme/${ghPrivateKeyPrefix(sentinelId, target)}shot.png`, PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await getOrMintPrefixId(env.DB, "acme/web", "claude/unrelated");
+
+    bucket.listCalls = 0;
+    const result = await gatherCommentBody(env, ws, workspaceName, target);
+    expect(result.body).toContain("shot.png");
+    expect(result.count).toBe(1);
+    expect(bucket.listCalls).toBe(2);
   });
 
   it("links an attachment to its /f/ file page by default (flag absent)", async () => {
@@ -293,9 +337,10 @@ describe("gatherCommentBody attachment metadata (issue #365)", () => {
       { repo: "acme/web", num: 12, kind: "pull" },
     );
 
-    // One query: the unconditional gh.detached filter (issue #709) — the
-    // path/state fetch itself is still skipped, since neither renders here.
-    expect(metadataQueries).toBe(1);
+    // Two queries: the private-prefix discovery scan (issue #934) and the
+    // unconditional gh.detached filter (issue #709) — the path/state fetch
+    // itself is still skipped, since neither renders here.
+    expect(metadataQueries).toBe(2);
     expect(result.body).not.toContain("<code>/settings");
   });
 

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -153,6 +153,26 @@ describe("gatherCommentBody", () => {
     expect(bucket.listCalls).toBe(2);
   });
 
+  it("never lists another repo's private prefix for the same target number (#934 isolation)", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    // One workspace bound to two private repos, both with a PR 12. Private
+    // keys omit the repo, so repo A's prefix must be excluded by ownership,
+    // not by key shape.
+    const targetA = { repo: "acme/web", num: 12, kind: "pull" as const };
+    const targetB = { repo: "acme/api", num: 12, kind: "pull" as const };
+    const idA = await getOrMintPrefixId(env.DB, targetA.repo, "feature/a");
+    const keyA = `${ghPrivateKeyPrefix(idA, targetA)}secret.png`;
+    await bucket.put(`acme/${keyA}`, PNG, { httpMetadata: { contentType: "image/png" } });
+    await replaceFileMetadata(env.DB, workspaceName, keyA, { "gh.ref": "acme/web#12" });
+
+    bucket.listCalls = 0;
+    const result = await gatherCommentBody(env, ws, workspaceName, targetB);
+    expect(result.body).not.toContain("secret.png");
+    expect(result.count).toBe(0);
+    // Plain prefix only: repo A's id is not a candidate for repo B.
+    expect(bucket.listCalls).toBe(1);
+  });
+
   it("finds a metadata-less private object under the repo-level prefix for an issue target (#934)", async () => {
     const { env, ws, workspaceName, bucket } = makeTestEnv();
     const target = { repo: "acme/web", num: 45, kind: "issues" as const };

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -15,7 +15,7 @@ import { galleryUrl, hydrateOwnerGallery } from "./gallery-service";
 import { parseExternalReference } from "./external-references";
 import { createLaneResolver, objectPublicUrls } from "./storage";
 import { posterKeyFor } from "./poster";
-import { listActivePrefixIds } from "./github-private-prefixes";
+import { listPrefixIdsForTarget } from "./github-private-prefixes";
 import type { WorkspaceRecord } from "./workspace";
 import { githubFetch, githubHeaders, installationToken, type GithubAppConfig } from "./github-app";
 import { resolveRepoCommentOptions } from "./repo-comment-config";
@@ -41,12 +41,16 @@ import {
  * @param workspaceName The calling workspace's slug — galleries are looked up
  *   scoped to this name only (D1 rows are tenant-scoped by this string, not
  *   by anything derived from `ws`).
+ * @param opts.headBranch The PR's head branch when the caller knows it (the
+ *   webhook payload does). Lets a metadata-less private attachment under
+ *   that branch's prefix be found; see `listPrefixIdsForTarget`.
  */
 export async function gatherCommentBody(
   env: Env,
   ws: WorkspaceRecord,
   workspaceName: string,
   target: GhTarget,
+  opts: { headBranch?: string } = {},
 ): Promise<{ body: string; count: number }> {
   // Resolve repo `.uploads.yml` (if any) against the workspace's own comment
   // defaults (issue #307). Never throws — a fetch/App degradation collapses
@@ -56,7 +60,7 @@ export async function gatherCommentBody(
   // Attachments (R2 list) and galleries (D1) are independent reads — overlap
   // them so the request only waits the longer of the two, not their sum.
   const [items, galleries] = await Promise.all([
-    gatherAttachments(env, ws, workspaceName, target, options),
+    gatherAttachments(env, ws, workspaceName, target, options, opts),
     gatherGalleries(env, ws, workspaceName, target),
   ]);
 
@@ -108,6 +112,7 @@ async function gatherAttachments(
   workspaceName: string,
   target: GhTarget,
   options: ResolvedCommentOptions,
+  gatherOpts: { headBranch?: string },
 ): Promise<AttachmentItem[]> {
   // Per-workspace/repo choice (issues #304, #307): default (auto/true) links
   // the managed comment's attachments to their `/f/` file page (issue #301's
@@ -118,11 +123,18 @@ async function gatherAttachments(
   // neither meta field would render anything.
   const showMetadata = options.metaPath || options.metaState;
 
-  // Every active private prefix id for this repo (across branches, #631) is
-  // also listed — a private-repo attachment can land under any of them, not
-  // just the plain `ghKeyPrefix`. Plain prefix listed first so ordering
-  // stays stable regardless of listActivePrefixIds' order.
-  const activePrefixIds = await listActivePrefixIds(dbFor(env), target.repo);
+  // A private-repo attachment (#631) can land under a randomized prefix, not
+  // just the plain `ghKeyPrefix`. Only the prefixes that can hold THIS
+  // target's objects are listed (issue #934) — never every active prefix in
+  // the repo, which grew one list per branch that ever ran `put --pr`. Plain
+  // prefix listed first so ordering stays stable regardless of id order.
+  const activePrefixIds = await listPrefixIdsForTarget(
+    dbFor(env),
+    workspaceName,
+    target.repo,
+    target,
+    gatherOpts,
+  );
   const prefixes = [
     ghKeyPrefix(target),
     ...activePrefixIds.map((id) => ghPrivateKeyPrefix(id, target)),

--- a/apps/api/src/github-private-prefixes.ts
+++ b/apps/api/src/github-private-prefixes.ts
@@ -94,7 +94,67 @@ export async function getOrMintPrefixId(
   return active;
 }
 
-/** All active (non-retired) prefix ids for `repo`, across every branch. */
+/** `gh/private/` is 11 chars; the 32-hex id occupies 12..43; the target segment starts at 44. */
+const GH_PRIVATE_ROOT_LEN = "gh/private/".length;
+const GH_PRIVATE_TARGET_OFFSET = GH_PRIVATE_ROOT_LEN + 32 + 1;
+
+/**
+ * The private prefix ids worth listing for one PR/issue target — the
+ * O(1)-per-target replacement for `listActivePrefixIds` on the comment-sync
+ * hot path (issue #934: that fan-out issued one R2 list per branch that ever
+ * ran `put --pr`, and grew without bound).
+ *
+ * Union of three cheap D1 lookups, none of which is a trust decision — every
+ * id returned here is still *listed* under the target's own key path, which
+ * remains the boundary that decides what renders:
+ *
+ * 1. Ids parsed from this workspace's `file_metadata` keys shaped
+ *    `gh/private/<id>/<kind>/<num>/…`. Every server and CLI writer of a
+ *    private attachment stamps at least one metadata row, so this finds the
+ *    prefix an attachment actually landed under, whichever branch minted it.
+ * 2. The repo-level sentinel prefix (`branch = ""`), where issue attachments
+ *    and branch-less uploads resolve. Covers a metadata-less raw PUT there.
+ * 3. The PR head branch's prefix when the caller knows it (the webhook
+ *    payload carries `head.ref`). Covers a metadata-less raw PUT on a PR.
+ */
+export async function listPrefixIdsForTarget(
+  db: D1Queryable,
+  workspace: string,
+  repo: string,
+  target: { kind: "pull" | "issues"; num: number },
+  opts: { headBranch?: string } = {},
+): Promise<string[]> {
+  const segment = `/${target.kind}/${target.num}/`;
+  const { results } = await db
+    .prepare(
+      // Key-range on the PK (workspace, object_key) rather than LIKE/GLOB: D1
+      // caps pattern length (see file-metadata.ts PREFIX_FILTER_SQL), and a
+      // range scan is cheaper than a pattern over the workspace's rows.
+      `SELECT DISTINCT substr(object_key, ?, 32) AS prefix_id FROM file_metadata
+       WHERE workspace = ?
+         AND object_key >= 'gh/private/' AND object_key < 'gh/private0'
+         AND substr(object_key, ?, ?) = ?`,
+    )
+    .bind(GH_PRIVATE_ROOT_LEN + 1, workspace, GH_PRIVATE_TARGET_OFFSET, segment.length, segment)
+    .all<PrefixRow>();
+  const ids = new Set(
+    (results ?? []).map((row) => row.prefix_id).filter((id) => PRIVATE_PREFIX_ID_RE.test(id)),
+  );
+
+  const sentinel = await getActivePrefixId(db, repo, "");
+  if (sentinel) ids.add(sentinel);
+  if (opts.headBranch !== undefined && opts.headBranch !== "") {
+    const head = await getActivePrefixId(db, repo, opts.headBranch);
+    if (head) ids.add(head);
+  }
+  return [...ids].sort();
+}
+
+/**
+ * All active (non-retired) prefix ids for `repo`, across every branch.
+ * Grows with every branch that ever ran `put --pr`; not for per-target hot
+ * paths — use `listPrefixIdsForTarget` there (#934).
+ */
 export async function listActivePrefixIds(db: D1Queryable, repo: string): Promise<string[]> {
   const { results } = await db
     .prepare(

--- a/apps/api/src/github-private-prefixes.ts
+++ b/apps/api/src/github-private-prefixes.ts
@@ -137,9 +137,26 @@ export async function listPrefixIdsForTarget(
     )
     .bind(GH_PRIVATE_ROOT_LEN + 1, workspace, GH_PRIVATE_TARGET_OFFSET, segment.length, segment)
     .all<PrefixRow>();
-  const ids = new Set(
-    (results ?? []).map((row) => row.prefix_id).filter((id) => PRIVATE_PREFIX_ID_RE.test(id)),
-  );
+  const discovered = (results ?? [])
+    .map((row) => row.prefix_id)
+    .filter((id) => PRIVATE_PREFIX_ID_RE.test(id));
+
+  // Private keys omit the repo, so a workspace bound to two private repos
+  // with the same PR/issue number would otherwise surface repo A's prefix
+  // for repo B's comment. Keep only ids this repo minted (rotated or not:
+  // ownership is what matters, and rotation re-keys objects anyway).
+  const ids = new Set<string>();
+  if (discovered.length > 0) {
+    const placeholders = discovered.map(() => "?").join(", ");
+    const owned = await db
+      .prepare(
+        `SELECT prefix_id FROM github_private_prefixes
+         WHERE repo_full_name = ? AND prefix_id IN (${placeholders})`,
+      )
+      .bind(normalizeRepo(repo), ...discovered)
+      .all<PrefixRow>();
+    for (const row of owned.results ?? []) ids.add(row.prefix_id);
+  }
 
   const sentinel = await getActivePrefixId(db, repo, "");
   if (sentinel) ids.add(sentinel);

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -167,7 +167,12 @@ interface PullRequestPayload {
  * gate: a missing/tombstoned linked workspace cleans up the stale link and
  * no-ops, never creates a new one. Caller is responsible for catching.
  */
-async function gatherAndUpsert(env: Env, link: RepoLink, target: GhTarget): Promise<void> {
+async function gatherAndUpsert(
+  env: Env,
+  link: RepoLink,
+  target: GhTarget,
+  opts: { headBranch?: string } = {},
+): Promise<void> {
   const ws = await loadWorkspaceRecord(env, link.workspaceName);
   if (!ws) {
     // The bound workspace is gone or tombstoned — the link is stale;
@@ -177,7 +182,7 @@ async function gatherAndUpsert(env: Env, link: RepoLink, target: GhTarget): Prom
     return;
   }
 
-  const gathered = await gatherCommentBody(env, ws, link.workspaceName, target);
+  const gathered = await gatherCommentBody(env, ws, link.workspaceName, target, opts);
 
   const cfg = githubAppConfig(env);
   if (!cfg) return;
@@ -260,7 +265,9 @@ async function autoPromoteAndComment(
   // under the PR's attachment prefix, so this single gather call already
   // reflects them — no separate "promoted > 0" branch needed.
   const target: GhTarget = { repo, kind: "pull", num };
-  await gatherAndUpsert(env, link, target);
+  // The head branch is what a metadata-less private attachment resolves
+  // under (#934) — pass it so the gather can list that prefix.
+  await gatherAndUpsert(env, link, target, { headBranch: branch });
 }
 
 /**

--- a/apps/api/src/routes/github-private-prefix.ts
+++ b/apps/api/src/routes/github-private-prefix.ts
@@ -20,7 +20,7 @@ import {
   rotatePrivatePrefix,
   type ResolveGhKeyRequest,
 } from "../github-private-prefix-service";
-import { listActivePrefixIds } from "../github-private-prefixes";
+import { listActivePrefixIds, listPrefixIdsForTarget } from "../github-private-prefixes";
 import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { jsonBody } from "./json-body";
@@ -85,7 +85,15 @@ export async function githubPrivatePrefixHandler(c: Context<WorkspaceVars>) {
   // `resolveGhKeyContext` itself) — degrade to an empty list instead.
   let activePrefixIds: string[] = [];
   try {
-    activePrefixIds = await listActivePrefixIds(dbFor(c.env), req.repo);
+    // With a target, only the prefixes that can hold that target's objects
+    // (issue #934) — the CLI's fallback gather lists each id it gets back,
+    // so a repo-wide list here fanned out one R2 list per branch. Without a
+    // target there is nothing to scope by; keep the repo-wide list.
+    activePrefixIds = req.target
+      ? await listPrefixIdsForTarget(dbFor(c.env), c.get("workspaceName"), req.repo, req.target, {
+          headBranch: req.branch,
+        })
+      : await listActivePrefixIds(dbFor(c.env), req.repo);
   } catch (err) {
     console.error(
       JSON.stringify({

--- a/apps/api/test/helpers/fake-file-metadata-table.ts
+++ b/apps/api/test/helpers/fake-file-metadata-table.ts
@@ -226,6 +226,30 @@ export class FileMetadataTable {
         .slice(0, limit);
       return { success: true, results: results as T[], meta: {} };
     }
+    // listPrefixIdsForTarget (issue #934): distinct private prefix ids whose
+    // keys carry this target's `/<kind>/<num>/` segment. Args: (id offset,
+    // workspace, segment offset, segment length, segment); offsets are
+    // 1-based per SQLite substr.
+    if (normalizedSql.startsWith("SELECT DISTINCT substr(object_key, ?, 32) AS prefix_id")) {
+      const [idOffset, workspace, segOffset, segLen, segment] = args as [
+        number,
+        string,
+        number,
+        number,
+        string,
+      ];
+      const scopePrefix = `${workspace} `;
+      const ids = new Set<string>();
+      for (const scopedKey of this.metadata.keys()) {
+        if (!scopedKey.startsWith(scopePrefix)) continue;
+        const objectKey = scopedKey.slice(scopePrefix.length);
+        if (!objectKey.startsWith("gh/private/")) continue;
+        if (objectKey.substr(segOffset - 1, segLen) !== segment) continue;
+        ids.add(objectKey.substr(idOffset - 1, 32));
+      }
+      const results = [...ids].map((prefix_id) => ({ prefix_id }));
+      return { success: true, results: results as T[], meta: {} };
+    }
     // facetValues: distinct values for one meta key (issue #528).
     if (normalizedSql.startsWith("SELECT meta_value, COUNT(*) AS count FROM file_metadata")) {
       const [workspace, key, limit] = args as [string, string, number];

--- a/apps/api/test/helpers/fake-file-metadata-table.ts
+++ b/apps/api/test/helpers/fake-file-metadata-table.ts
@@ -240,8 +240,10 @@ export class FileMetadataTable {
       ];
       const scopePrefix = `${workspace} `;
       const ids = new Set<string>();
-      for (const scopedKey of this.metadata.keys()) {
+      for (const [scopedKey, map] of this.metadata) {
         if (!scopedKey.startsWith(scopePrefix)) continue;
+        // A delete can leave an empty map behind; production has no row then.
+        if (map.size === 0) continue;
         const objectKey = scopedKey.slice(scopePrefix.length);
         if (!objectKey.startsWith("gh/private/")) continue;
         if (objectKey.substr(segOffset - 1, segLen) !== segment) continue;

--- a/apps/api/test/helpers/fake-private-prefixes-table.ts
+++ b/apps/api/test/helpers/fake-private-prefixes-table.ts
@@ -96,6 +96,19 @@ export class PrivatePrefixesTable {
 
   // listActivePrefixIds: every active row for a repo, across branches.
   tryAll<T>(normalizedSql: string, args: unknown[]): FakeAllResult<T> | undefined {
+    // listPrefixIdsForTarget ownership filter (#934): which of the given ids
+    // this repo minted, rotated or not. Args: (repo, ...ids).
+    if (
+      normalizedSql.includes("FROM github_private_prefixes") &&
+      normalizedSql.includes("prefix_id IN (")
+    ) {
+      const [repo, ...ids] = args as [string, ...string[]];
+      const wanted = new Set(ids);
+      const results = [...this.rows.values()]
+        .filter((row) => row.repo_full_name === repo && wanted.has(row.prefix_id))
+        .map((row) => ({ prefix_id: row.prefix_id }));
+      return { success: true, results: results as T[], meta: {} };
+    }
     if (
       normalizedSql.includes("FROM github_private_prefixes") &&
       normalizedSql.includes("rotated_at IS NULL") &&

--- a/apps/api/test/routes-github-private-prefix.test.ts
+++ b/apps/api/test/routes-github-private-prefix.test.ts
@@ -10,6 +10,7 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { app } from "../src/index";
 import { recordRepoLink } from "../src/github-repo-links";
+import { getOrMintPrefixId } from "../src/github-private-prefixes";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
 import { FakeKv } from "./fake-kv";
 import { GITHUB_APP_CFG_ENV } from "./github-app-env";
@@ -122,6 +123,31 @@ describe("POST /v1/:workspace/github/private-prefix", () => {
     };
     expect(body.mode).toBe("private");
     expect(body.prefixId).toMatch(/^[0-9a-f]{32}$/);
+    expect(body.activePrefixIds).toEqual([body.prefixId]);
+  });
+
+  it("with a target: activePrefixIds is scoped to prefixes that can hold that target, not every branch in the repo (#934)", async () => {
+    const { env, db, githubCache } = await makeEnv();
+    githubCache.store.set(`ghinst:${REPO}`, { value: "42" });
+    githubCache.store.set(`ghpriv:${REPO}`, { value: "1" });
+    await recordRepoLink(db as unknown as D1Database, REPO, WS, "test");
+    // Other agent branches minted prefixes in this repo earlier.
+    for (const branch of ["claude/a", "claude/b", "claude/c"]) {
+      await getOrMintPrefixId(db as unknown as D1Database, REPO, branch);
+    }
+
+    const res = await post(
+      "/v1/acme/github/private-prefix",
+      { repo: REPO, branch: "feat-x", target: { kind: "pull", num: 12 } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      mode: string;
+      prefixId: string;
+      activePrefixIds: string[];
+    };
+    expect(body.mode).toBe("private");
     expect(body.activePrefixIds).toEqual([body.prefixId]);
   });
 


### PR DESCRIPTION
Quick fix for #934. Long-term direction (D1 attachment index) is scoped in the issue and not part of this PR.

## What changed

`gatherCommentBody` used `listActivePrefixIds(repo)` and issued one R2 `ListObjects` per active private prefix in the whole repo, on every PR webhook, every `put --pr`, and every link-adoption pass. The set of prefixes grows with every branch that ever ran `put --pr`, so the per-sync cost grew without bound and was heading for the Worker's 1,000-subrequest limit.

New `listPrefixIdsForTarget` (`apps/api/src/github-private-prefixes.ts`) returns only the prefix ids that can hold one PR/issue target's objects:

1. Ids parsed from this workspace's `file_metadata` keys shaped `gh/private/<id>/<kind>/<num>/…`. Every server and CLI writer of a private attachment (CLI/MCP `put --pr`, attach, promote, adopt) stamps at least one metadata row, so this finds the prefix an attachment actually landed under, whichever branch minted it. Key-range on the PK plus `substr`, not LIKE/GLOB, per the D1 pattern cap.
2. The repo-level sentinel prefix (`branch = ""`), where issue attachments resolve. Covers a metadata-less raw PUT there.
3. The PR head branch's prefix when the caller knows it. The webhook passes `head.ref`; other callers omit it.

This is a lookup of *which prefixes to list*, not a trust decision: every id is still listed under the target's own key path, which remains the boundary that decides what renders. A client-stamped `gh.*` row can at most cause one extra (empty) list of its own prefix.

`gatherCommentBody` gains an optional `{ headBranch }` parameter; the webhook's auto-promote path passes it. `listActivePrefixIds` stays for rotation and for the resolve route when no target is supplied.

The private-prefix resolve route returns the same scoped list when the CLI supplies a target, so the local-`gh` fallback gather stops fanning out too.

## Per-sync cost

Before: `1 + (active prefixes in repo)` R2 lists. After: `1 + (prefixes holding this target's objects)`, typically 1 or 2, plus one indexed D1 query.

## Not in this PR

- Retiring `github_private_prefixes` rows on PR close. With the hot path no longer reading "all active prefixes", row growth is no longer a performance problem; left for the index work in #934 if wanted for URL hygiene.
- The D1 attachment index itself (#934 plan).

## Tests

- `gatherCommentBody`: only the prefixes holding the target's objects are listed (asserts `listCalls`), issue targets find the sentinel prefix without metadata, and the existing #631 case now passes `headBranch` for a metadata-less raw PUT.
- Resolve route: `activePrefixIds` is scoped when a target is supplied; the fail-open test is unchanged.
- The hand-rolled D1 fake learned the new query so the webhook/adopt/ingest suites keep running against it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Private attachments now resolve correctly for pull requests, including metadata-less objects.
  - Private-prefix results are scoped to the requested issue or pull request, preventing unrelated prefixes from appearing.
  - Pull request branch information is now used when locating private attachments.

- **Performance**
  - Target-specific prefix discovery reduces unnecessary repository-wide lookups during comment and attachment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->