### PR TITLE
feat: accept SVG and XML on lanes verified to serve them sandboxed

### DIFF
--- a/.changeset/svg-xml-active-content.md
+++ b/.changeset/svg-xml-active-content.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`put` and `attach` accept SVG and XML (`image/svg+xml`, `application/xml`, `text/xml`) on a storage lane once its public host is verified to serve them behind a sandboxing Content-Security-Policy. An unverified lane keeps 415ing these types. The managed comment embeds SVG as `<img>`. Requires the matching platform release.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "./file-metadata": "./src/file-metadata.ts",
     "./file-search": "./src/file-search.ts",
     "./guards": "./src/guards.ts",
+    "./active-content": "./src/active-content.ts",
     "./budget": "./src/budget.ts",
     "./usage": "./src/usage.ts",
     "./reconcile": "./src/reconcile.ts",

--- a/apps/api/src/active-content-hosts.test.ts
+++ b/apps/api/src/active-content-hosts.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  HOSTED_ACTIVE_CONTENT_HOSTS,
+  hostActiveContentKey,
+  probeHostActiveContent,
+  readHostActiveContent,
+  runActiveContentHostSweep,
+} from "./active-content-hosts";
+import { FakeR2Bucket } from "../test/fake-r2";
+
+/**
+ * `vi.fn`'s inferred call signature never structurally matches the
+ * overloaded `typeof fetch`, so every fake is built with an explicit,
+ * fetch-compatible signature and handed to the functions under test through
+ * this cast rather than fighting TS overload assignability at each call
+ * site — the fake's own `.mock.calls` stay precisely typed for assertions.
+ */
+function asFetch(
+  fn: ReturnType<typeof vi.fn<(url: string, init?: RequestInit) => Promise<Response>>>,
+): typeof fetch {
+  return fn as unknown as typeof fetch;
+}
+
+/** In-memory REGISTRY KV stand-in — get/put/delete over a Map. */
+function fakeRegistry(records: Record<string, unknown> = {}) {
+  const store = new Map(Object.entries(records));
+  return {
+    store,
+    get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+    put: vi.fn(async (key: string, value: string) => {
+      store.set(key, JSON.parse(value));
+    }) as unknown as KVNamespace["put"],
+    delete: (async (key: string) => {
+      store.delete(key);
+    }) as unknown as KVNamespace["delete"],
+  };
+}
+
+const goodHeaders = {
+  "content-type": "image/svg+xml",
+  "content-security-policy": "default-src 'none'; sandbox",
+  "x-content-type-options": "nosniff",
+};
+
+function env(over: Record<string, unknown> = {}) {
+  return {
+    UPLOADS_DEFAULT: new FakeR2Bucket(),
+    REGISTRY: fakeRegistry(),
+    ...over,
+  } as unknown as Env;
+}
+
+describe("hostActiveContentKey", () => {
+  it("namespaces the KV key by host", () => {
+    expect(hostActiveContentKey("storage.uploads.sh")).toBe(
+      "host-active-content:storage.uploads.sh",
+    );
+  });
+});
+
+describe("HOSTED_ACTIVE_CONTENT_HOSTS", () => {
+  it("is the deduped hosted host set", () => {
+    expect([...new Set(HOSTED_ACTIVE_CONTENT_HOSTS)]).toEqual([...HOSTED_ACTIVE_CONTENT_HOSTS]);
+    expect(HOSTED_ACTIVE_CONTENT_HOSTS).toEqual(
+      expect.arrayContaining(["storage.uploads.sh", "store.uploads.sh", "embed.uploads.sh"]),
+    );
+    expect(HOSTED_ACTIVE_CONTENT_HOSTS.length).toBe(3);
+  });
+});
+
+describe("probeHostActiveContent", () => {
+  it("writes the probe object, deletes it, and records ok:true on a passing host", async () => {
+    const bucket = new FakeR2Bucket();
+    const registry = fakeRegistry();
+    const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response("<svg/>", { status: 200, headers: goodHeaders }),
+    );
+
+    const record = await probeHostActiveContent(e, "storage.uploads.sh", asFetch(fetchImpl));
+
+    expect(record.ok).toBe(true);
+    expect(typeof record.verifiedAt).toBe("string");
+    expect(Number.isFinite(Date.parse(record.verifiedAt))).toBe(true);
+
+    // Object written under the CSP-verify prefix as an SVG with the right
+    // content type, then deleted (finally) once the probe resolved.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const fetchedUrl = fetchImpl.mock.calls[0]?.[0];
+    expect(fetchedUrl).toMatch(
+      /^https:\/\/storage\.uploads\.sh\/_internal\/uploads-csp-verify\/[0-9a-f-]+\.svg$/,
+    );
+    expect(bucket.store.size).toBe(0);
+
+    // KV host record persisted under the namespaced key.
+    expect(registry.put).toHaveBeenCalledTimes(1);
+    expect(registry.store.get("host-active-content:storage.uploads.sh")).toEqual(record);
+  });
+
+  it("still writes an object and deletes it, and records ok:false with a detail, on a failing probe", async () => {
+    const bucket = new FakeR2Bucket();
+    const registry = fakeRegistry();
+    const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response("<svg/>", { status: 200, headers: { "content-type": "text/plain" } }),
+    );
+
+    const record = await probeHostActiveContent(e, "store.uploads.sh", asFetch(fetchImpl));
+
+    expect(record.ok).toBe(false);
+    expect(record.detail).toBeTruthy();
+    expect(bucket.store.size).toBe(0);
+    expect(registry.store.get("host-active-content:store.uploads.sh")).toEqual(record);
+  });
+
+  it("records ok:false when the fetch throws (inconclusive)", async () => {
+    const bucket = new FakeR2Bucket();
+    const registry = fakeRegistry();
+    const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async () => {
+      throw new Error("network unreachable");
+    });
+
+    const record = await probeHostActiveContent(e, "embed.uploads.sh", asFetch(fetchImpl));
+
+    expect(record.ok).toBe(false);
+    expect(bucket.store.size).toBe(0);
+    expect(registry.store.get("host-active-content:embed.uploads.sh")).toEqual(record);
+  });
+
+  it("records a failure without ever reaching the fetch when the R2 put itself throws", async () => {
+    const bucket = new FakeR2Bucket();
+    bucket.put = vi.fn(async () => {
+      throw new Error("r2 unavailable");
+    }) as unknown as FakeR2Bucket["put"];
+    const registry = fakeRegistry();
+    const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response("<svg/>", { status: 200, headers: goodHeaders }),
+    );
+
+    const record = await probeHostActiveContent(e, "storage.uploads.sh", asFetch(fetchImpl));
+
+    expect(record.ok).toBe(false);
+    expect(record.detail).toContain("r2 unavailable");
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(registry.store.get("host-active-content:storage.uploads.sh")).toEqual(record);
+  });
+});
+
+describe("runActiveContentHostSweep", () => {
+  it("probes every hosted host and returns a record for each", async () => {
+    const bucket = new FakeR2Bucket();
+    const registry = fakeRegistry();
+    const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response("<svg/>", { status: 200, headers: goodHeaders }),
+    );
+
+    const results = await runActiveContentHostSweep(e, asFetch(fetchImpl));
+
+    expect(Object.keys(results).sort()).toEqual([...HOSTED_ACTIVE_CONTENT_HOSTS].sort());
+    for (const host of HOSTED_ACTIVE_CONTENT_HOSTS) {
+      expect(results[host]?.ok).toBe(true);
+      expect(registry.store.get(hostActiveContentKey(host))).toEqual(results[host]);
+    }
+  });
+
+  it("never throws when one host's probe blows up, and still covers the rest", async () => {
+    const bucket = new FakeR2Bucket();
+    const registry = fakeRegistry();
+    const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async (url) => {
+      if (url.includes("store.uploads.sh")) throw new Error("boom");
+      return new Response("<svg/>", { status: 200, headers: goodHeaders });
+    });
+
+    const results = await runActiveContentHostSweep(e, asFetch(fetchImpl));
+
+    expect(Object.keys(results).sort()).toEqual([...HOSTED_ACTIVE_CONTENT_HOSTS].sort());
+    expect(results["store.uploads.sh"]?.ok).toBe(false);
+    expect(results["storage.uploads.sh"]?.ok).toBe(true);
+    expect(results["embed.uploads.sh"]?.ok).toBe(true);
+  });
+
+  it("never throws even when REGISTRY.put itself rejects for a host", async () => {
+    const bucket = new FakeR2Bucket();
+    const registry = fakeRegistry();
+    const originalPut = registry.put;
+    registry.put = vi.fn(async (key: string, value: string) => {
+      if (key.includes("store.uploads.sh")) throw new Error("kv unavailable");
+      return (originalPut as unknown as (k: string, v: string) => Promise<void>)(key, value);
+    }) as unknown as KVNamespace["put"];
+    const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response("<svg/>", { status: 200, headers: goodHeaders }),
+    );
+
+    const results = await runActiveContentHostSweep(e, asFetch(fetchImpl));
+
+    expect(Object.keys(results).sort()).toEqual([...HOSTED_ACTIVE_CONTENT_HOSTS].sort());
+    expect(results["store.uploads.sh"]?.ok).toBe(false);
+    expect(results["storage.uploads.sh"]?.ok).toBe(true);
+  });
+});
+
+describe("readHostActiveContent", () => {
+  it("returns null when no record exists", async () => {
+    const e = env({ REGISTRY: fakeRegistry() });
+    expect(await readHostActiveContent(e, "storage.uploads.sh")).toBeNull();
+  });
+
+  it("returns the stored record", async () => {
+    const record = { ok: true, verifiedAt: new Date().toISOString() };
+    const e = env({
+      REGISTRY: fakeRegistry({ "host-active-content:storage.uploads.sh": record }),
+    });
+    expect(await readHostActiveContent(e, "storage.uploads.sh")).toEqual(record);
+  });
+});

--- a/apps/api/src/active-content-hosts.test.ts
+++ b/apps/api/src/active-content-hosts.test.ts
@@ -36,11 +36,21 @@ function fakeRegistry(records: Record<string, unknown> = {}) {
   };
 }
 
-const goodHeaders = {
-  "content-type": "image/svg+xml",
-  "content-security-policy": "default-src 'none'; sandbox",
-  "x-content-type-options": "nosniff",
-};
+/**
+ * A passing response for whichever probe object the URL names — the probe
+ * writes an SVG *and* an XML object (issue #929 adversarial review M-1) and
+ * requires the served content type to match each.
+ */
+function okProbeResponse(url: string): Response {
+  return new Response("<probe/>", {
+    status: 200,
+    headers: {
+      "content-type": url.endsWith(".xml") ? "application/xml" : "image/svg+xml",
+      "content-security-policy": "default-src 'none'; sandbox",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
 
 function env(over: Record<string, unknown> = {}) {
   return {
@@ -73,8 +83,8 @@ describe("probeHostActiveContent", () => {
     const bucket = new FakeR2Bucket();
     const registry = fakeRegistry();
     const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
-    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
-      async () => new Response("<svg/>", { status: 200, headers: goodHeaders }),
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async (url) =>
+      okProbeResponse(url),
     );
 
     const record = await probeHostActiveContent(e, "storage.uploads.sh", asFetch(fetchImpl));
@@ -83,13 +93,18 @@ describe("probeHostActiveContent", () => {
     expect(typeof record.verifiedAt).toBe("string");
     expect(Number.isFinite(Date.parse(record.verifiedAt))).toBe(true);
 
-    // Object written under the shared verify-probe prefix as an SVG with the
-    // right content type, then deleted (finally) once the probe resolved.
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-    const fetchedUrl = fetchImpl.mock.calls[0]?.[0];
-    expect(fetchedUrl).toMatch(
+    // Two objects written under the shared verify-probe prefix — one SVG,
+    // one XML, sharing a stem — each fetched back, then both deleted
+    // (finally) once the probe resolved.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const fetchedUrls = fetchImpl.mock.calls.map((call) => call[0]);
+    expect(fetchedUrls[0]).toMatch(
       /^https:\/\/storage\.uploads\.sh\/_internal\/uploads-verify\/[0-9a-f-]+\.svg$/,
     );
+    expect(fetchedUrls[1]).toMatch(
+      /^https:\/\/storage\.uploads\.sh\/_internal\/uploads-verify\/[0-9a-f-]+\.xml$/,
+    );
+    expect(fetchedUrls[0]?.replace(/\.svg$/, "")).toBe(fetchedUrls[1]?.replace(/\.xml$/, ""));
     expect(bucket.store.size).toBe(0);
 
     // KV host record persisted under the namespaced key.
@@ -114,6 +129,29 @@ describe("probeHostActiveContent", () => {
     expect(registry.store.get("host-active-content:store.uploads.sh")).toEqual(record);
   });
 
+  it("records ok:false when the host sandboxes SVG but not XML (issue #929 M-1)", async () => {
+    const bucket = new FakeR2Bucket();
+    const registry = fakeRegistry();
+    const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
+    // An extension-scoped Transform Rule (`ends_with ".svg"`) looks exactly
+    // like this from outside: the SVG probe passes, the XML one comes back
+    // bare. One passing probe must not open all three gated types.
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async (url) =>
+      url.endsWith(".xml")
+        ? new Response("<probe/>", {
+            status: 200,
+            headers: { "content-type": "application/xml" },
+          })
+        : okProbeResponse(url),
+    );
+
+    const record = await probeHostActiveContent(e, "storage.uploads.sh", asFetch(fetchImpl));
+
+    expect(record.ok).toBe(false);
+    expect(record.detail).toContain("application/xml probe");
+    expect(bucket.store.size).toBe(0);
+  });
+
   it("records ok:false when the fetch throws (inconclusive)", async () => {
     const bucket = new FakeR2Bucket();
     const registry = fakeRegistry();
@@ -136,8 +174,8 @@ describe("probeHostActiveContent", () => {
     }) as unknown as FakeR2Bucket["put"];
     const registry = fakeRegistry();
     const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
-    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
-      async () => new Response("<svg/>", { status: 200, headers: goodHeaders }),
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async (url) =>
+      okProbeResponse(url),
     );
 
     const record = await probeHostActiveContent(e, "storage.uploads.sh", asFetch(fetchImpl));
@@ -147,7 +185,7 @@ describe("probeHostActiveContent", () => {
     // rather than echoing the storage client's raw error (house style: every
     // verify hint is curated remediation text, never a provider message).
     expect(record.detail).toBe(
-      "could not write the SVG probe to this bucket — check the storage credentials, then check again",
+      "could not write the image/svg+xml probe to this bucket — check the storage credentials, then check again",
     );
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(registry.store.get("host-active-content:storage.uploads.sh")).toEqual(record);
@@ -159,8 +197,8 @@ describe("runActiveContentHostSweep", () => {
     const bucket = new FakeR2Bucket();
     const registry = fakeRegistry();
     const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
-    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
-      async () => new Response("<svg/>", { status: 200, headers: goodHeaders }),
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async (url) =>
+      okProbeResponse(url),
     );
 
     const results = await runActiveContentHostSweep(e, asFetch(fetchImpl));
@@ -178,7 +216,7 @@ describe("runActiveContentHostSweep", () => {
     const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
     const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async (url) => {
       if (url.includes("store.uploads.sh")) throw new Error("boom");
-      return new Response("<svg/>", { status: 200, headers: goodHeaders });
+      return okProbeResponse(url);
     });
 
     const results = await runActiveContentHostSweep(e, asFetch(fetchImpl));
@@ -198,8 +236,8 @@ describe("runActiveContentHostSweep", () => {
       return (originalPut as unknown as (k: string, v: string) => Promise<void>)(key, value);
     }) as unknown as KVNamespace["put"];
     const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
-    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
-      async () => new Response("<svg/>", { status: 200, headers: goodHeaders }),
+    const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async (url) =>
+      okProbeResponse(url),
     );
 
     const results = await runActiveContentHostSweep(e, asFetch(fetchImpl));

--- a/apps/api/src/active-content-hosts.test.ts
+++ b/apps/api/src/active-content-hosts.test.ts
@@ -83,12 +83,12 @@ describe("probeHostActiveContent", () => {
     expect(typeof record.verifiedAt).toBe("string");
     expect(Number.isFinite(Date.parse(record.verifiedAt))).toBe(true);
 
-    // Object written under the CSP-verify prefix as an SVG with the right
-    // content type, then deleted (finally) once the probe resolved.
+    // Object written under the shared verify-probe prefix as an SVG with the
+    // right content type, then deleted (finally) once the probe resolved.
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     const fetchedUrl = fetchImpl.mock.calls[0]?.[0];
     expect(fetchedUrl).toMatch(
-      /^https:\/\/storage\.uploads\.sh\/_internal\/uploads-csp-verify\/[0-9a-f-]+\.svg$/,
+      /^https:\/\/storage\.uploads\.sh\/_internal\/uploads-verify\/[0-9a-f-]+\.svg$/,
     );
     expect(bucket.store.size).toBe(0);
 
@@ -143,7 +143,12 @@ describe("probeHostActiveContent", () => {
     const record = await probeHostActiveContent(e, "storage.uploads.sh", asFetch(fetchImpl));
 
     expect(record.ok).toBe(false);
-    expect(record.detail).toContain("r2 unavailable");
+    // The shared probe reports a failed write as its own inconclusive check
+    // rather than echoing the storage client's raw error (house style: every
+    // verify hint is curated remediation text, never a provider message).
+    expect(record.detail).toBe(
+      "could not write the SVG probe to this bucket — check the storage credentials, then check again",
+    );
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(registry.store.get("host-active-content:storage.uploads.sh")).toEqual(record);
   });

--- a/apps/api/src/active-content-hosts.ts
+++ b/apps/api/src/active-content-hosts.ts
@@ -29,7 +29,15 @@ export function hostActiveContentKey(host: string): string {
   return `host-active-content:${host}`;
 }
 
-function hostOf(url: string): string | null {
+/**
+ * Hostname from a URL string, lowercased; `null` for an empty/unparseable
+ * one. Exported (issue #929 final-review) as the one copy of this helper —
+ * `./active-content.ts` and `./routes/workspace-settings.ts` each kept their
+ * own before, drifting only in whether `url` was typed optional, never in
+ * behavior.
+ */
+export function hostOf(url: string | undefined | null): string | null {
+  if (!url) return null;
   try {
     return new URL(url).hostname.toLowerCase();
   } catch {

--- a/apps/api/src/active-content-hosts.ts
+++ b/apps/api/src/active-content-hosts.ts
@@ -7,7 +7,7 @@
  * response headers there itself. What it *can* do is probe: write an inert
  * SVG into the shared bucket, fetch it back through the public host, check
  * the headers, and record the result in KV so every workspace sharing that
- * host inherits the verdict (see `activeContentAllowed` in
+ * host inherits the verdict (see `activeContentStatus` in
  * `./active-content.ts`, which reads what this module writes).
  *
  * Invoked daily from the Worker `scheduled` handler (index.ts) and on demand
@@ -17,7 +17,7 @@ import { DEFAULT_EMBED_PUBLIC_BASE_URL, DEFAULT_EMBEDDABLE_HOSTS, hostOf } from 
 import { SELF_SERVE_PUBLIC_BASE_URL } from "./self-serve-defaults";
 import { probeActiveContent } from "./storage-verify";
 
-/** KV `REGISTRY` record for one hosted host's most recent probe. No TTL — freshness is judged by the reader (`activeContentAllowed`). */
+/** KV `REGISTRY` record for one hosted host's most recent probe. No TTL — freshness is judged by the reader (`activeContentStatus`). */
 export interface HostActiveContentRecord {
   ok: boolean;
   verifiedAt: string;

--- a/apps/api/src/active-content-hosts.ts
+++ b/apps/api/src/active-content-hosts.ts
@@ -13,9 +13,9 @@
  * Invoked daily from the Worker `scheduled` handler (index.ts) and on demand
  * from `POST /admin-ui/active-content/probe`.
  */
-import { DEFAULT_EMBED_PUBLIC_BASE_URL, DEFAULT_EMBEDDABLE_HOSTS } from "@uploads/storage";
+import { DEFAULT_EMBED_PUBLIC_BASE_URL, DEFAULT_EMBEDDABLE_HOSTS, hostOf } from "@uploads/storage";
 import { SELF_SERVE_PUBLIC_BASE_URL } from "./self-serve-defaults";
-import { ACTIVE_CONTENT_PROBE_SVG, checkActiveContentHeaders } from "./storage-verify";
+import { probeActiveContent } from "./storage-verify";
 
 /** KV `REGISTRY` record for one hosted host's most recent probe. No TTL — freshness is judged by the reader (`activeContentAllowed`). */
 export interface HostActiveContentRecord {
@@ -27,22 +27,6 @@ export interface HostActiveContentRecord {
 /** KV key a host's probe result lives under in `REGISTRY`. */
 export function hostActiveContentKey(host: string): string {
   return `host-active-content:${host}`;
-}
-
-/**
- * Hostname from a URL string, lowercased; `null` for an empty/unparseable
- * one. Exported (issue #929 final-review) as the one copy of this helper —
- * `./active-content.ts` and `./routes/workspace-settings.ts` each kept their
- * own before, drifting only in whether `url` was typed optional, never in
- * behavior.
- */
-export function hostOf(url: string | undefined | null): string | null {
-  if (!url) return null;
-  try {
-    return new URL(url).hostname.toLowerCase();
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -78,46 +62,45 @@ function hostsToSweep(env: Env): string[] {
   return [...hosts];
 }
 
-/** Prefix the CSP-verify probe object lives under in the shared bucket. */
-const CSP_PROBE_PREFIX = "_internal/uploads-csp-verify/";
+/**
+ * The two methods `probeActiveContent` needs, over an R2 binding — the
+ * hosted hosts are served straight out of the platform's own bucket, so
+ * there is no HTTP storage client here the way a BYO lane has one.
+ */
+function bucketProbeClient(bucket: R2Bucket) {
+  return {
+    upload: (key: string, body: Uint8Array, opts?: { contentType?: string }) =>
+      bucket.put(key, body, { httpMetadata: { contentType: opts?.contentType } }),
+    delete: async (key: string) => {
+      await bucket.delete(key);
+    },
+  };
+}
 
 /**
- * Probes one hosted host: writes `ACTIVE_CONTENT_PROBE_SVG` into
- * `env.UPLOADS_DEFAULT` under a fresh CSP-verify key, fetches it back
- * through `host`'s public URL, deletes the object (always — `finally`), and
- * persists the result to `REGISTRY`. Never throws: a write failure, a probe
- * failure, or a thrown fetch all resolve to an `ok: false` record with a
- * `detail`, which is exactly what `runActiveContentHostSweep` relies on to
- * keep one host's trouble from stopping the rest.
+ * Probes one hosted host through the shared `probeActiveContent` (write the
+ * inert SVG into `env.UPLOADS_DEFAULT`, fetch it back through `host`'s
+ * public URL, delete it) and persists the verdict to `REGISTRY`. Never
+ * throws: a write failure, a header failure, and a thrown fetch all resolve
+ * to an `ok: false` record with a `detail`, which is what
+ * `runActiveContentHostSweep` relies on to keep one host's trouble from
+ * stopping the rest.
  */
 export async function probeHostActiveContent(
   env: Env,
   host: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<HostActiveContentRecord> {
-  const key = `${CSP_PROBE_PREFIX}${crypto.randomUUID()}.svg`;
-  let record: HostActiveContentRecord;
-  try {
-    await env.UPLOADS_DEFAULT.put(key, ACTIVE_CONTENT_PROBE_SVG, {
-      httpMetadata: { contentType: "image/svg+xml" },
-    });
-    try {
-      const check = await checkActiveContentHeaders(`https://${host}`, key, fetchImpl);
-      record = {
-        ok: check.ok,
-        verifiedAt: new Date().toISOString(),
-        ...(check.hint ? { detail: check.hint } : {}),
-      };
-    } finally {
-      await env.UPLOADS_DEFAULT.delete(key).catch(() => {});
-    }
-  } catch (err) {
-    record = {
-      ok: false,
-      verifiedAt: new Date().toISOString(),
-      detail: err instanceof Error ? err.message : String(err),
-    };
-  }
+  const check = await probeActiveContent(
+    bucketProbeClient(env.UPLOADS_DEFAULT),
+    `https://${host}`,
+    fetchImpl,
+  );
+  const record: HostActiveContentRecord = {
+    ok: check.ok,
+    verifiedAt: new Date().toISOString(),
+    ...(check.hint ? { detail: check.hint } : {}),
+  };
   await env.REGISTRY.put(hostActiveContentKey(host), JSON.stringify(record));
   return record;
 }
@@ -133,19 +116,23 @@ export async function runActiveContentHostSweep(
   env: Env,
   fetchImpl: typeof fetch = fetch,
 ): Promise<Record<string, HostActiveContentRecord>> {
-  const results: Record<string, HostActiveContentRecord> = {};
-  for (const host of hostsToSweep(env)) {
-    try {
-      results[host] = await probeHostActiveContent(env, host, fetchImpl);
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      results[host] = { ok: false, verifiedAt: new Date().toISOString(), detail };
-      console.error(
-        JSON.stringify({ message: "active_content_host_probe_failed", host, error: detail }),
-      );
-    }
-  }
-  return results;
+  // In parallel: each probe already catches its own failures, the set is a
+  // handful of hosts, and a slow or hanging host shouldn't hold up the rest
+  // of a cron run.
+  const entries = await Promise.all(
+    hostsToSweep(env).map(async (host): Promise<[string, HostActiveContentRecord]> => {
+      try {
+        return [host, await probeHostActiveContent(env, host, fetchImpl)];
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.error(
+          JSON.stringify({ message: "active_content_host_probe_failed", host, error: detail }),
+        );
+        return [host, { ok: false, verifiedAt: new Date().toISOString(), detail }];
+      }
+    }),
+  );
+  return Object.fromEntries(entries);
 }
 
 /** Reads a hosted host's most recent probe record, or `null` if it has never been probed. */

--- a/apps/api/src/active-content-hosts.ts
+++ b/apps/api/src/active-content-hosts.ts
@@ -1,0 +1,151 @@
+/**
+ * Daily probe of the hosted storage hosts for the SVG/XML sandboxing CSP
+ * (issue #929, design doc "Lane state" / "Hosted lanes"). Ops sets the
+ * `Content-Security-Policy: sandbox` + `X-Content-Type-Options: nosniff`
+ * headers on each hosted custom domain via a Cloudflare zone Transform Rule
+ * — this repo has no Worker in front of those domains and cannot set
+ * response headers there itself. What it *can* do is probe: write an inert
+ * SVG into the shared bucket, fetch it back through the public host, check
+ * the headers, and record the result in KV so every workspace sharing that
+ * host inherits the verdict (see `activeContentAllowed` in
+ * `./active-content.ts`, which reads what this module writes).
+ *
+ * Invoked daily from the Worker `scheduled` handler (index.ts) and on demand
+ * from `POST /admin-ui/active-content/probe`.
+ */
+import { DEFAULT_EMBED_PUBLIC_BASE_URL, DEFAULT_EMBEDDABLE_HOSTS } from "@uploads/storage";
+import { SELF_SERVE_PUBLIC_BASE_URL } from "./self-serve-defaults";
+import { ACTIVE_CONTENT_PROBE_SVG, checkActiveContentHeaders } from "./storage-verify";
+
+/** KV `REGISTRY` record for one hosted host's most recent probe. No TTL — freshness is judged by the reader (`activeContentAllowed`). */
+export interface HostActiveContentRecord {
+  ok: boolean;
+  verifiedAt: string;
+  detail?: string;
+}
+
+/** KV key a host's probe result lives under in `REGISTRY`. */
+export function hostActiveContentKey(host: string): string {
+  return `host-active-content:${host}`;
+}
+
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Every hosted host the daily sweep covers, deduped: the shared bucket's
+ * public host + its store twin (`DEFAULT_EMBEDDABLE_HOSTS`), the embed CDN
+ * twin (`DEFAULT_EMBED_PUBLIC_BASE_URL`), and the host self-serve workspaces
+ * are provisioned onto (`SELF_SERVE_PUBLIC_BASE_URL`) — on this deployment
+ * that's the same host as the shared bucket's, but a self-hoster who
+ * repoints either constant gets it swept automatically rather than needing
+ * to edit this list too.
+ */
+export const HOSTED_ACTIVE_CONTENT_HOSTS: readonly string[] = (() => {
+  const hosts = new Set<string>(DEFAULT_EMBEDDABLE_HOSTS);
+  const embedHost = hostOf(DEFAULT_EMBED_PUBLIC_BASE_URL);
+  if (embedHost) hosts.add(embedHost);
+  const selfServeHost = hostOf(SELF_SERVE_PUBLIC_BASE_URL);
+  if (selfServeHost) hosts.add(selfServeHost);
+  return [...hosts];
+})();
+
+/**
+ * The hosts to sweep for a given `env`: the static default set, plus an
+ * `EMBED_PUBLIC_BASE_URL` override for a self-host that points the embed
+ * twin somewhere else (`storage.ts` reads the same binding for the same
+ * reason). Deduped.
+ */
+function hostsToSweep(env: Env): string[] {
+  const hosts = new Set<string>(HOSTED_ACTIVE_CONTENT_HOSTS);
+  if (env.EMBED_PUBLIC_BASE_URL) {
+    const overrideHost = hostOf(env.EMBED_PUBLIC_BASE_URL);
+    if (overrideHost) hosts.add(overrideHost);
+  }
+  return [...hosts];
+}
+
+/** Prefix the CSP-verify probe object lives under in the shared bucket. */
+const CSP_PROBE_PREFIX = "_internal/uploads-csp-verify/";
+
+/**
+ * Probes one hosted host: writes `ACTIVE_CONTENT_PROBE_SVG` into
+ * `env.UPLOADS_DEFAULT` under a fresh CSP-verify key, fetches it back
+ * through `host`'s public URL, deletes the object (always — `finally`), and
+ * persists the result to `REGISTRY`. Never throws: a write failure, a probe
+ * failure, or a thrown fetch all resolve to an `ok: false` record with a
+ * `detail`, which is exactly what `runActiveContentHostSweep` relies on to
+ * keep one host's trouble from stopping the rest.
+ */
+export async function probeHostActiveContent(
+  env: Env,
+  host: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<HostActiveContentRecord> {
+  const key = `${CSP_PROBE_PREFIX}${crypto.randomUUID()}.svg`;
+  let record: HostActiveContentRecord;
+  try {
+    await env.UPLOADS_DEFAULT.put(key, ACTIVE_CONTENT_PROBE_SVG, {
+      httpMetadata: { contentType: "image/svg+xml" },
+    });
+    try {
+      const check = await checkActiveContentHeaders(`https://${host}`, key, fetchImpl);
+      record = {
+        ok: check.ok,
+        verifiedAt: new Date().toISOString(),
+        ...(check.hint ? { detail: check.hint } : {}),
+      };
+    } finally {
+      await env.UPLOADS_DEFAULT.delete(key).catch(() => {});
+    }
+  } catch (err) {
+    record = {
+      ok: false,
+      verifiedAt: new Date().toISOString(),
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+  await env.REGISTRY.put(hostActiveContentKey(host), JSON.stringify(record));
+  return record;
+}
+
+/**
+ * Probes every hosted host and writes each result to `REGISTRY`. One host's
+ * probe blowing up (a thrown error `probeHostActiveContent` itself didn't
+ * catch, e.g. the KV write) never stops the sweep from covering the rest —
+ * that host just gets a synthesized `ok: false` record in the returned map
+ * (best-effort; not re-persisted to KV if the KV write is what failed).
+ */
+export async function runActiveContentHostSweep(
+  env: Env,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Record<string, HostActiveContentRecord>> {
+  const results: Record<string, HostActiveContentRecord> = {};
+  for (const host of hostsToSweep(env)) {
+    try {
+      results[host] = await probeHostActiveContent(env, host, fetchImpl);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      results[host] = { ok: false, verifiedAt: new Date().toISOString(), detail };
+      console.error(
+        JSON.stringify({ message: "active_content_host_probe_failed", host, error: detail }),
+      );
+    }
+  }
+  return results;
+}
+
+/** Reads a hosted host's most recent probe record, or `null` if it has never been probed. */
+export async function readHostActiveContent(
+  env: Env,
+  host: string,
+): Promise<HostActiveContentRecord | null> {
+  return (
+    (await env.REGISTRY.get<HostActiveContentRecord>(hostActiveContentKey(host), "json")) ?? null
+  );
+}

--- a/apps/api/src/active-content.test.ts
+++ b/apps/api/src/active-content.test.ts
@@ -116,17 +116,32 @@ describe("activeContentAllowed — cheap local gates", () => {
   });
 });
 
+// `SHARED_WS.publicBaseUrl` is `https://storage.uploads.sh`, one of
+// `DEFAULT_EMBEDDABLE_HOSTS` (packages/storage), so it always has an embed
+// twin: `resolveEmbedBaseUrl` resolves it to the default `embed.uploads.sh`.
+// That means the gate must see a fresh `ok` record for *both* hosts before
+// it opens (issue #929 final-review item 1) — the object is reachable
+// through either URL, so either one serving it un-sandboxed is a bypass.
 describe("activeContentAllowed — shared lane", () => {
-  it("allows when the host's KV record is ok and fresh", async () => {
+  it("allows when both the stable host's and the embed twin's KV records are ok and fresh", async () => {
     const registry = fakeRegistry({
       "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
+      "host-active-content:embed.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
     });
     expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(true);
   });
 
-  it("denies when the host's KV record is stale (older than HOST_RECORD_MAX_AGE_MS)", async () => {
+  it("denies when the stable host is ok but the embed twin has never been probed", async () => {
     const registry = fakeRegistry({
-      "host-active-content:storage.uploads.sh": {
+      "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
+    });
+    expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(false);
+  });
+
+  it("denies when the embed twin's record is stale even though the stable host's is fresh", async () => {
+    const registry = fakeRegistry({
+      "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
+      "host-active-content:embed.uploads.sh": {
         ok: true,
         verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS + 1),
       },
@@ -134,9 +149,24 @@ describe("activeContentAllowed — shared lane", () => {
     expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(false);
   });
 
-  it("allows exactly at the HOST_RECORD_MAX_AGE_MS boundary", async () => {
+  it("denies when the stable host's KV record is stale (older than HOST_RECORD_MAX_AGE_MS), even with a fresh embed record", async () => {
     const registry = fakeRegistry({
       "host-active-content:storage.uploads.sh": {
+        ok: true,
+        verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS + 1),
+      },
+      "host-active-content:embed.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
+    });
+    expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(false);
+  });
+
+  it("allows exactly at the HOST_RECORD_MAX_AGE_MS boundary on both hosts", async () => {
+    const registry = fakeRegistry({
+      "host-active-content:storage.uploads.sh": {
+        ok: true,
+        verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS),
+      },
+      "host-active-content:embed.uploads.sh": {
         ok: true,
         verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS),
       },
@@ -150,11 +180,20 @@ describe("activeContentAllowed — shared lane", () => {
     );
   });
 
-  it("denies when the host record exists but failed its probe (ok: false)", async () => {
+  it("denies when the stable host record exists but failed its probe (ok: false), even with a fresh embed record", async () => {
     const registry = fakeRegistry({
       "host-active-content:storage.uploads.sh": { ok: false, verifiedAt: isoAgo(0) },
+      "host-active-content:embed.uploads.sh": { ok: true, verifiedAt: isoAgo(0) },
     });
     expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(false);
+  });
+
+  it("allows off a single host record when the workspace's public host has no embed twin", async () => {
+    const registry = fakeRegistry({
+      "host-active-content:cdn.example": { ok: true, verifiedAt: isoAgo(0) },
+    });
+    const ws: WorkspaceRecord = { ...SHARED_WS, publicBaseUrl: "https://cdn.example" };
+    expect(await activeContentAllowed(env({ REGISTRY: registry }), ws, NOW)).toBe(true);
   });
 
   it("denies when the shared workspace has no publicBaseUrl to derive a host from", async () => {

--- a/apps/api/src/active-content.test.ts
+++ b/apps/api/src/active-content.test.ts
@@ -4,6 +4,7 @@ import {
   HOST_RECORD_MAX_AGE_MS,
   LANE_STAMP_MAX_AGE_MS,
   activeContentAllowed,
+  activeContentStatus,
 } from "./active-content";
 import type { WorkspaceRecord } from "./workspace";
 
@@ -254,5 +255,68 @@ describe("activeContentAllowed — BYO lane", () => {
         NOW,
       ),
     ).toBe(true);
+  });
+});
+
+/**
+ * The status behind the gate (issue #929 simplify): `activeContentAllowed` is
+ * `.allowed`, and the settings page reads the rest — so every closed gate has
+ * to name the check that closed it, and an open one has to hand over the
+ * timestamp it actually trusted.
+ */
+describe("activeContentStatus — the reason behind the verdict", () => {
+  const freshHosts = {
+    "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
+    "host-active-content:embed.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
+  };
+
+  it("names the check that closed the gate", async () => {
+    const cases: Array<[string, Env, WorkspaceRecord]> = [
+      ["opted_out", env(), { ...SHARED_WS, activeContentUploads: false }],
+      ["flag_off", env({ FLAGS: undefined }), SHARED_WS],
+      ["flag_off", env({ FLAGS: flagsOff }), SHARED_WS],
+      ["flag_off", env({ FLAGS: flagsThrows }), SHARED_WS],
+      [
+        "unhealthy",
+        env({ REGISTRY: fakeRegistry(freshHosts) }),
+        { ...SHARED_WS, storageUnhealthyAt: isoAgo(0) },
+      ],
+      ["host_missing", env(), SHARED_WS],
+      [
+        "host_stale",
+        env({
+          REGISTRY: fakeRegistry({
+            ...freshHosts,
+            "host-active-content:storage.uploads.sh": {
+              ok: true,
+              verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS + 1),
+            },
+          }),
+        }),
+        SHARED_WS,
+      ],
+      ["lane_missing", env(), BYO_WS],
+      [
+        "lane_stale",
+        env(),
+        { ...BYO_WS, storageActiveContentVerifiedAt: isoAgo(LANE_STAMP_MAX_AGE_MS + 1) },
+      ],
+    ];
+    for (const [reason, e, ws] of cases) {
+      expect(await activeContentStatus(e, ws, NOW), reason).toEqual({ allowed: false, reason });
+    }
+  });
+
+  it("reports the timestamp it trusted — the host record's for a shared lane, the lane's own for BYO", async () => {
+    expect(
+      await activeContentStatus(env({ REGISTRY: fakeRegistry(freshHosts) }), SHARED_WS, NOW),
+    ).toEqual({ allowed: true, verifiedAt: isoAgo(1000) });
+    expect(
+      await activeContentStatus(
+        env(),
+        { ...BYO_WS, storageActiveContentVerifiedAt: isoAgo(5000) },
+        NOW,
+      ),
+    ).toEqual({ allowed: true, verifiedAt: isoAgo(5000) });
   });
 });

--- a/apps/api/src/active-content.test.ts
+++ b/apps/api/src/active-content.test.ts
@@ -283,6 +283,16 @@ describe("activeContentStatus — the reason behind the verdict", () => {
       ],
       ["host_missing", env(), SHARED_WS],
       [
+        "host_not_ok",
+        env({
+          REGISTRY: fakeRegistry({
+            ...freshHosts,
+            "host-active-content:storage.uploads.sh": { ok: false, verifiedAt: isoAgo(1000) },
+          }),
+        }),
+        SHARED_WS,
+      ],
+      [
         "host_stale",
         env({
           REGISTRY: fakeRegistry({

--- a/apps/api/src/active-content.test.ts
+++ b/apps/api/src/active-content.test.ts
@@ -161,6 +161,10 @@ describe("activeContentAllowed — shared lane", () => {
     const { publicBaseUrl: _unused, ...noUrl } = SHARED_WS;
     expect(await activeContentAllowed(env(), noUrl, NOW)).toBe(false);
   });
+
+  it("denies (fails closed) rather than throwing when the REGISTRY binding is absent", async () => {
+    expect(await activeContentAllowed(env({ REGISTRY: undefined }), SHARED_WS, NOW)).toBe(false);
+  });
 });
 
 describe("activeContentAllowed — BYO lane", () => {

--- a/apps/api/src/active-content.test.ts
+++ b/apps/api/src/active-content.test.ts
@@ -6,6 +6,7 @@ import {
   activeContentAllowed,
   activeContentStatus,
 } from "./active-content";
+import { HOSTED_ACTIVE_CONTENT_HOSTS } from "./active-content-hosts";
 import type { WorkspaceRecord } from "./workspace";
 
 const NOW = new Date("2026-09-02T12:00:00.000Z");
@@ -54,6 +55,21 @@ function isoAgo(ms: number): string {
   return new Date(NOW.getTime() - ms).toISOString();
 }
 
+/**
+ * A fresh `ok` record for every hosted host the daily sweep covers, plus any
+ * extras. The shared-lane gate requires all of them (issue #929 adversarial
+ * review H-1) — `storage.uploads.sh` and `store.uploads.sh` are two custom
+ * domains of the *same* bucket, so a rule missing from either serves the same
+ * bytes un-sandboxed.
+ */
+function hostRecords(over: Record<string, unknown> = {}, ageMs = 1000) {
+  const records: Record<string, unknown> = {};
+  for (const host of HOSTED_ACTIVE_CONTENT_HOSTS) {
+    records[`host-active-content:${host}`] = { ok: true, verifiedAt: isoAgo(ageMs) };
+  }
+  return { ...records, ...over };
+}
+
 describe("activeContentAllowed — cheap local gates", () => {
   it("denies when the workspace opted out, before touching FLAGS or REGISTRY", async () => {
     expect(
@@ -85,17 +101,13 @@ describe("activeContentAllowed — cheap local gates", () => {
         return true;
       },
     };
-    const registry = fakeRegistry({
-      "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(0) },
-    });
+    const registry = fakeRegistry(hostRecords({}, 0));
     await activeContentAllowed(env({ FLAGS: capturing, REGISTRY: registry }), SHARED_WS, NOW);
     expect(seen).toEqual([ACTIVE_CONTENT_FLAG, false]);
   });
 
   it("denies when the active lane is flagged unhealthy, regardless of lane state", async () => {
-    const registry = fakeRegistry({
-      "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(0) },
-    });
+    const registry = fakeRegistry(hostRecords({}, 0));
     expect(
       await activeContentAllowed(
         env({ REGISTRY: registry }),
@@ -118,60 +130,90 @@ describe("activeContentAllowed — cheap local gates", () => {
 });
 
 // `SHARED_WS.publicBaseUrl` is `https://storage.uploads.sh`, one of
-// `DEFAULT_EMBEDDABLE_HOSTS` (packages/storage), so it always has an embed
-// twin: `resolveEmbedBaseUrl` resolves it to the default `embed.uploads.sh`.
-// That means the gate must see a fresh `ok` record for *both* hosts before
-// it opens (issue #929 final-review item 1) — the object is reachable
-// through either URL, so either one serving it un-sandboxed is a bypass.
+// `DEFAULT_EMBEDDABLE_HOSTS` (packages/storage) — but the same bytes are
+// also served by `store.uploads.sh` (the same bucket's second custom domain)
+// and by the `embed.uploads.sh` twin `resolveEmbedBaseUrl` derives. Any one
+// of them serving the object un-sandboxed is a bypass, so the gate requires
+// a fresh `ok` record for every hosted host the sweep covers, plus this
+// workspace's own host and its twin (issue #929 adversarial review H-1).
 describe("activeContentAllowed — shared lane", () => {
-  it("allows when both the stable host's and the embed twin's KV records are ok and fresh", async () => {
-    const registry = fakeRegistry({
-      "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
-      "host-active-content:embed.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
-    });
+  it("allows when every hosted host's KV record is ok and fresh", async () => {
+    const registry = fakeRegistry(hostRecords());
     expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(true);
   });
 
-  it("denies when the stable host is ok but the embed twin has never been probed", async () => {
-    const registry = fakeRegistry({
-      "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
+  it("denies when the store twin — same bucket, same keys — has never been probed", async () => {
+    const records = hostRecords();
+    delete records["host-active-content:store.uploads.sh"];
+    expect(
+      await activeContentAllowed(env({ REGISTRY: fakeRegistry(records) }), SHARED_WS, NOW),
+    ).toBe(false);
+  });
+
+  it("denies when the store twin's record failed its probe, however fresh the others are", async () => {
+    const registry = fakeRegistry(
+      hostRecords({
+        "host-active-content:store.uploads.sh": { ok: false, verifiedAt: isoAgo(0) },
+      }),
+    );
+    const status = await activeContentStatus(env({ REGISTRY: registry }), SHARED_WS, NOW);
+    expect(status).toEqual({
+      allowed: false,
+      reason: "host_not_ok",
+      host: "store.uploads.sh",
     });
-    expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(false);
+  });
+
+  it("denies when the store twin's record is stale, and names it", async () => {
+    const registry = fakeRegistry(
+      hostRecords({
+        "host-active-content:store.uploads.sh": {
+          ok: true,
+          verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS + 1),
+        },
+      }),
+    );
+    expect(await activeContentStatus(env({ REGISTRY: registry }), SHARED_WS, NOW)).toEqual({
+      allowed: false,
+      reason: "host_stale",
+      host: "store.uploads.sh",
+    });
+  });
+
+  it("denies when the stable host is ok but the embed twin has never been probed", async () => {
+    const records = hostRecords();
+    delete records["host-active-content:embed.uploads.sh"];
+    expect(
+      await activeContentAllowed(env({ REGISTRY: fakeRegistry(records) }), SHARED_WS, NOW),
+    ).toBe(false);
   });
 
   it("denies when the embed twin's record is stale even though the stable host's is fresh", async () => {
-    const registry = fakeRegistry({
-      "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
-      "host-active-content:embed.uploads.sh": {
-        ok: true,
-        verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS + 1),
-      },
-    });
+    const registry = fakeRegistry(
+      hostRecords({
+        "host-active-content:embed.uploads.sh": {
+          ok: true,
+          verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS + 1),
+        },
+      }),
+    );
     expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(false);
   });
 
-  it("denies when the stable host's KV record is stale (older than HOST_RECORD_MAX_AGE_MS), even with a fresh embed record", async () => {
-    const registry = fakeRegistry({
-      "host-active-content:storage.uploads.sh": {
-        ok: true,
-        verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS + 1),
-      },
-      "host-active-content:embed.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
-    });
+  it("denies when the stable host's KV record is stale (older than HOST_RECORD_MAX_AGE_MS), even with fresh twins", async () => {
+    const registry = fakeRegistry(
+      hostRecords({
+        "host-active-content:storage.uploads.sh": {
+          ok: true,
+          verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS + 1),
+        },
+      }),
+    );
     expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(false);
   });
 
-  it("allows exactly at the HOST_RECORD_MAX_AGE_MS boundary on both hosts", async () => {
-    const registry = fakeRegistry({
-      "host-active-content:storage.uploads.sh": {
-        ok: true,
-        verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS),
-      },
-      "host-active-content:embed.uploads.sh": {
-        ok: true,
-        verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS),
-      },
-    });
+  it("allows exactly at the HOST_RECORD_MAX_AGE_MS boundary on every host", async () => {
+    const registry = fakeRegistry(hostRecords({}, HOST_RECORD_MAX_AGE_MS));
     expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(true);
   });
 
@@ -181,20 +223,48 @@ describe("activeContentAllowed — shared lane", () => {
     );
   });
 
-  it("denies when the stable host record exists but failed its probe (ok: false), even with a fresh embed record", async () => {
-    const registry = fakeRegistry({
-      "host-active-content:storage.uploads.sh": { ok: false, verifiedAt: isoAgo(0) },
-      "host-active-content:embed.uploads.sh": { ok: true, verifiedAt: isoAgo(0) },
-    });
+  it("denies when the stable host record exists but failed its probe (ok: false), even with fresh twins", async () => {
+    const registry = fakeRegistry(
+      hostRecords({
+        "host-active-content:storage.uploads.sh": { ok: false, verifiedAt: isoAgo(0) },
+      }),
+    );
     expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(false);
   });
 
-  it("allows off a single host record when the workspace's public host has no embed twin", async () => {
-    const registry = fakeRegistry({
-      "host-active-content:cdn.example": { ok: true, verifiedAt: isoAgo(0) },
-    });
+  it("still requires the hosted host set for an off-list shared host with no embed twin", async () => {
     const ws: WorkspaceRecord = { ...SHARED_WS, publicBaseUrl: "https://cdn.example" };
-    expect(await activeContentAllowed(env({ REGISTRY: registry }), ws, NOW)).toBe(true);
+    // Its own host alone is not enough — the platform hosts serve the same
+    // shared bucket whatever URL this workspace happens to be pointed at.
+    expect(
+      await activeContentAllowed(
+        env({
+          REGISTRY: fakeRegistry({
+            "host-active-content:cdn.example": { ok: true, verifiedAt: isoAgo(0) },
+          }),
+        }),
+        ws,
+        NOW,
+      ),
+    ).toBe(false);
+    expect(
+      await activeContentAllowed(
+        env({
+          REGISTRY: fakeRegistry(
+            hostRecords({ "host-active-content:cdn.example": { ok: true, verifiedAt: isoAgo(0) } }),
+          ),
+        }),
+        ws,
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("denies when the workspace's own off-list host is missing, and names it", async () => {
+    const ws: WorkspaceRecord = { ...SHARED_WS, publicBaseUrl: "https://cdn.example" };
+    expect(
+      await activeContentStatus(env({ REGISTRY: fakeRegistry(hostRecords()) }), ws, NOW),
+    ).toEqual({ allowed: false, reason: "host_missing", host: "cdn.example" });
   });
 
   it("denies when the shared workspace has no publicBaseUrl to derive a host from", async () => {
@@ -265,13 +335,10 @@ describe("activeContentAllowed — BYO lane", () => {
  * timestamp it actually trusted.
  */
 describe("activeContentStatus — the reason behind the verdict", () => {
-  const freshHosts = {
-    "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
-    "host-active-content:embed.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
-  };
+  const freshHosts = hostRecords();
 
   it("names the check that closed the gate", async () => {
-    const cases: Array<[string, Env, WorkspaceRecord]> = [
+    const cases: Array<[string, Env, WorkspaceRecord, string?]> = [
       ["opted_out", env(), { ...SHARED_WS, activeContentUploads: false }],
       ["flag_off", env({ FLAGS: undefined }), SHARED_WS],
       ["flag_off", env({ FLAGS: flagsOff }), SHARED_WS],
@@ -281,7 +348,7 @@ describe("activeContentStatus — the reason behind the verdict", () => {
         env({ REGISTRY: fakeRegistry(freshHosts) }),
         { ...SHARED_WS, storageUnhealthyAt: isoAgo(0) },
       ],
-      ["host_missing", env(), SHARED_WS],
+      ["host_missing", env(), SHARED_WS, "storage.uploads.sh"],
       [
         "host_not_ok",
         env({
@@ -291,6 +358,7 @@ describe("activeContentStatus — the reason behind the verdict", () => {
           }),
         }),
         SHARED_WS,
+        "storage.uploads.sh",
       ],
       [
         "host_stale",
@@ -304,6 +372,7 @@ describe("activeContentStatus — the reason behind the verdict", () => {
           }),
         }),
         SHARED_WS,
+        "storage.uploads.sh",
       ],
       ["lane_missing", env(), BYO_WS],
       [
@@ -312,8 +381,12 @@ describe("activeContentStatus — the reason behind the verdict", () => {
         { ...BYO_WS, storageActiveContentVerifiedAt: isoAgo(LANE_STAMP_MAX_AGE_MS + 1) },
       ],
     ];
-    for (const [reason, e, ws] of cases) {
-      expect(await activeContentStatus(e, ws, NOW), reason).toEqual({ allowed: false, reason });
+    for (const [reason, e, ws, host] of cases) {
+      expect(await activeContentStatus(e, ws, NOW), reason).toEqual({
+        allowed: false,
+        reason,
+        ...(host ? { host } : {}),
+      });
     }
   });
 

--- a/apps/api/src/active-content.test.ts
+++ b/apps/api/src/active-content.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVE_CONTENT_FLAG,
+  HOST_RECORD_MAX_AGE_MS,
+  LANE_STAMP_MAX_AGE_MS,
+  activeContentAllowed,
+} from "./active-content";
+import type { WorkspaceRecord } from "./workspace";
+
+const NOW = new Date("2026-09-02T12:00:00.000Z");
+
+const flagsOn = { getBooleanValue: async () => true };
+const flagsOff = { getBooleanValue: async (_k: string, def: boolean) => def };
+const flagsThrows = {
+  getBooleanValue: async () => {
+    throw new Error("flagship unreachable");
+  },
+};
+
+/** In-memory REGISTRY KV stand-in — `get` over a Map, seeded with host records. */
+function fakeRegistry(records: Record<string, unknown> = {}) {
+  const store = new Map(Object.entries(records));
+  return {
+    get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+  };
+}
+
+function env(over: Record<string, unknown> = {}) {
+  return {
+    FLAGS: flagsOn,
+    REGISTRY: fakeRegistry(),
+    ...over,
+  } as unknown as Env;
+}
+
+const SHARED_WS: WorkspaceRecord = {
+  provider: "r2",
+  bucket: "shared",
+  binding: "UPLOADS_DEFAULT",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+const BYO_WS: WorkspaceRecord = {
+  provider: "r2",
+  bucket: "acme-bucket",
+  publicBaseUrl: "https://cdn.acme.example",
+  accountId: "acct",
+  accessKeyId: "enc:v1:x",
+  secretAccessKey: "enc:v1:y",
+};
+
+function isoAgo(ms: number): string {
+  return new Date(NOW.getTime() - ms).toISOString();
+}
+
+describe("activeContentAllowed — cheap local gates", () => {
+  it("denies when the workspace opted out, before touching FLAGS or REGISTRY", async () => {
+    expect(
+      await activeContentAllowed(
+        env({ FLAGS: undefined, REGISTRY: undefined }),
+        { ...SHARED_WS, activeContentUploads: false },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("denies when the FLAGS binding is absent entirely", async () => {
+    expect(await activeContentAllowed(env({ FLAGS: undefined }), SHARED_WS, NOW)).toBe(false);
+  });
+
+  it("fails closed when Flagship evaluation falls back to the default", async () => {
+    expect(await activeContentAllowed(env({ FLAGS: flagsOff }), SHARED_WS, NOW)).toBe(false);
+  });
+
+  it("fails closed when Flagship evaluation throws", async () => {
+    expect(await activeContentAllowed(env({ FLAGS: flagsThrows }), SHARED_WS, NOW)).toBe(false);
+  });
+
+  it("checks the flag with the documented flag key and a false default", async () => {
+    let seen: [string, boolean] | null = null;
+    const capturing = {
+      getBooleanValue: async (key: string, def: boolean) => {
+        seen = [key, def];
+        return true;
+      },
+    };
+    const registry = fakeRegistry({
+      "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(0) },
+    });
+    await activeContentAllowed(env({ FLAGS: capturing, REGISTRY: registry }), SHARED_WS, NOW);
+    expect(seen).toEqual([ACTIVE_CONTENT_FLAG, false]);
+  });
+
+  it("denies when the active lane is flagged unhealthy, regardless of lane state", async () => {
+    const registry = fakeRegistry({
+      "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(0) },
+    });
+    expect(
+      await activeContentAllowed(
+        env({ REGISTRY: registry }),
+        { ...SHARED_WS, storageUnhealthyAt: isoAgo(1000) },
+        NOW,
+      ),
+    ).toBe(false);
+    expect(
+      await activeContentAllowed(
+        env(),
+        {
+          ...BYO_WS,
+          storageActiveContentVerifiedAt: isoAgo(0),
+          storageUnhealthyAt: isoAgo(1000),
+        },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("activeContentAllowed — shared lane", () => {
+  it("allows when the host's KV record is ok and fresh", async () => {
+    const registry = fakeRegistry({
+      "host-active-content:storage.uploads.sh": { ok: true, verifiedAt: isoAgo(1000) },
+    });
+    expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(true);
+  });
+
+  it("denies when the host's KV record is stale (older than HOST_RECORD_MAX_AGE_MS)", async () => {
+    const registry = fakeRegistry({
+      "host-active-content:storage.uploads.sh": {
+        ok: true,
+        verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS + 1),
+      },
+    });
+    expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(false);
+  });
+
+  it("allows exactly at the HOST_RECORD_MAX_AGE_MS boundary", async () => {
+    const registry = fakeRegistry({
+      "host-active-content:storage.uploads.sh": {
+        ok: true,
+        verifiedAt: isoAgo(HOST_RECORD_MAX_AGE_MS),
+      },
+    });
+    expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(true);
+  });
+
+  it("denies when no host record has ever been written", async () => {
+    expect(await activeContentAllowed(env({ REGISTRY: fakeRegistry() }), SHARED_WS, NOW)).toBe(
+      false,
+    );
+  });
+
+  it("denies when the host record exists but failed its probe (ok: false)", async () => {
+    const registry = fakeRegistry({
+      "host-active-content:storage.uploads.sh": { ok: false, verifiedAt: isoAgo(0) },
+    });
+    expect(await activeContentAllowed(env({ REGISTRY: registry }), SHARED_WS, NOW)).toBe(false);
+  });
+
+  it("denies when the shared workspace has no publicBaseUrl to derive a host from", async () => {
+    const { publicBaseUrl: _unused, ...noUrl } = SHARED_WS;
+    expect(await activeContentAllowed(env(), noUrl, NOW)).toBe(false);
+  });
+});
+
+describe("activeContentAllowed — BYO lane", () => {
+  it("allows when storageActiveContentVerifiedAt is fresh", async () => {
+    expect(
+      await activeContentAllowed(
+        env(),
+        { ...BYO_WS, storageActiveContentVerifiedAt: isoAgo(1000) },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("denies when storageActiveContentVerifiedAt is stale (older than LANE_STAMP_MAX_AGE_MS)", async () => {
+    expect(
+      await activeContentAllowed(
+        env(),
+        { ...BYO_WS, storageActiveContentVerifiedAt: isoAgo(LANE_STAMP_MAX_AGE_MS + 1) },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("allows exactly at the LANE_STAMP_MAX_AGE_MS boundary", async () => {
+    expect(
+      await activeContentAllowed(
+        env(),
+        { ...BYO_WS, storageActiveContentVerifiedAt: isoAgo(LANE_STAMP_MAX_AGE_MS) },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("denies when the lane has never been verified", async () => {
+    expect(await activeContentAllowed(env(), BYO_WS, NOW)).toBe(false);
+  });
+
+  it("never touches REGISTRY for a BYO lane", async () => {
+    const registry = {
+      get: async () => {
+        throw new Error("REGISTRY should not be read for a BYO lane");
+      },
+    } as unknown as KVNamespace;
+    expect(
+      await activeContentAllowed(
+        env({ REGISTRY: registry }),
+        { ...BYO_WS, storageActiveContentVerifiedAt: isoAgo(0) },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/active-content.ts
+++ b/apps/api/src/active-content.ts
@@ -16,18 +16,19 @@
  * that host shares one Transform Rule), while a BYO workspace carries its
  * own stamp because only its owner controls that host's headers.
  *
- * A shared-lane workspace's object is actually reachable through *two*
- * hosts — the stable `ws.publicBaseUrl` host and, when it's one of the
- * default embeddable hosts, the `embed.uploads.sh` twin `objectPublicUrls`
- * (`./storage.ts`) also hands out for it (`resolveEmbedBaseUrl`, same
- * `@uploads/storage` helper). Gating on the stable host's record alone would
- * let SVG/XML through on a URL an unverified host still serves un-sandboxed,
- * so the shared-lane branch below requires a fresh `ok` record for *every*
- * host that can serve the object.
+ * A shared-lane workspace's object is reachable through *several* hosts, not
+ * one: the shared bucket carries more than one custom domain (`storage.` and
+ * `store.uploads.sh` are the same bucket, same keys, same bytes), and
+ * `objectPublicUrls` (`./storage.ts`) also hands out the `embed.uploads.sh`
+ * twin (`resolveEmbedBaseUrl`, same `@uploads/storage` helper). Any one of
+ * them serving the object un-sandboxed defeats the gate, so the shared-lane
+ * branch below requires a fresh `ok` record for *every* hosted host the
+ * daily sweep covers (`HOSTED_ACTIVE_CONTENT_HOSTS`), plus this workspace's
+ * own host and its embed twin — not just the two the workspace's URLs name.
  */
 import { hostOf, resolveEmbedBaseUrl } from "@uploads/storage";
 import { isSharedLane } from "./storage";
-import { readHostActiveContent } from "./active-content-hosts";
+import { HOSTED_ACTIVE_CONTENT_HOSTS, readHostActiveContent } from "./active-content-hosts";
 import type { WorkspaceRecord } from "./workspace";
 
 /** Flagship kill switch, fail-closed like `POSTER_FLAG`. */
@@ -85,6 +86,8 @@ export interface ActiveContentStatus {
   /** Only ever set when the lane check passed — a fresh, passing stamp. */
   verifiedAt?: string;
   reason?: ActiveContentReason;
+  /** For a `host_*` reason, the hosted host whose record closed the gate — the sweep covers several, and "which one" is the first thing an operator asks. */
+  host?: string;
 }
 
 /** One hosted host's KV record as a status: fresh and `ok` allows; anything else says why not. */
@@ -104,13 +107,15 @@ async function hostStatus(env: Env, host: string, now: Date): Promise<ActiveCont
  * struggling BYO lane never gets active-content treated as a new problem to
  * diagnose), then the lane-specific freshness check.
  *
- * Shared lane: reads `REGISTRY`'s `host-active-content:<host>` record (see
+ * Shared lane: reads `REGISTRY`'s `host-active-content:<host>` records (see
  * `./active-content-hosts.ts`, written by the daily cron/admin probe) for
- * the hostname of `ws.publicBaseUrl` — allowed only when that record exists,
- * passed, and is within `HOST_RECORD_MAX_AGE_MS` *and* the same is true of
- * the embed twin's host when `resolveEmbedBaseUrl` resolves to a different
- * one (the object is reachable through both; either serving it un-sandboxed
- * defeats the gate). BYO lane: allowed when `ws.storageActiveContentVerifiedAt`
+ * every host that can serve a shared-bucket object — the sweep's own set
+ * (`HOSTED_ACTIVE_CONTENT_HOSTS`: the shared bucket's custom domains, the
+ * embed twin, the self-serve host), plus this workspace's `publicBaseUrl`
+ * host and the twin `resolveEmbedBaseUrl` derives for it, deduped and read
+ * in parallel. Allowed only when *every* one of those records exists,
+ * passed, and is within `HOST_RECORD_MAX_AGE_MS`; the first that isn't names
+ * itself in `host`. BYO lane: allowed when `ws.storageActiveContentVerifiedAt`
  * is within `LANE_STAMP_MAX_AGE_MS` (the unhealthy check above already
  * covers the "lane broke" case, so this branch is freshness only; a BYO
  * lane has no separate embed twin to check).
@@ -142,23 +147,73 @@ export async function activeContentStatus(
     if (!env.REGISTRY) return { allowed: false, reason: "host_missing" };
     const host = hostOf(ws.publicBaseUrl);
     if (!host) return { allowed: false, reason: "host_missing" };
-    const stable = await hostStatus(env, host, now);
-    if (!stable.allowed) return stable;
-    // Same derivation `objectPublicUrls` (./storage.ts) uses for the embed
-    // URL it hands every shared-lane caller — when it names a different
-    // host than the stable one just checked, that host must be fresh and
-    // `ok` too, or the object is still reachable un-sandboxed through it.
+    // The sweep's own host set first (so a `store.uploads.sh` whose rule was
+    // never applied — or was pulled later — closes the gate for every
+    // workspace on the shared bucket, not just the ones whose URLs name it),
+    // then this workspace's own host, then the embed twin
+    // `objectPublicUrls` (./storage.ts) hands every shared-lane caller.
+    // Deduped: on this deployment most of these collapse to two hosts.
+    const hosts = new Set<string>(HOSTED_ACTIVE_CONTENT_HOSTS);
+    hosts.add(host);
     const embedHost = hostOf(resolveEmbedBaseUrl(ws.publicBaseUrl, env.EMBED_PUBLIC_BASE_URL));
-    if (embedHost && embedHost !== host) {
-      const twin = await hostStatus(env, embedHost, now);
-      if (!twin.allowed) return twin;
-    }
-    return stable;
+    if (embedHost) hosts.add(embedHost);
+    // In parallel — a handful of independent KV reads, and a shared-lane put
+    // waits on all of them.
+    const checked = await Promise.all(
+      [...hosts].map(async (h) => [h, await hostStatus(env, h, now)] as const),
+    );
+    const failed = checked.find(([, status]) => !status.allowed);
+    if (failed) return { ...failed[1], host: failed[0] };
+    // Every host passed; report the workspace's own host's timestamp, the
+    // one a settings page means by "verified".
+    return checked.find(([h]) => h === host)![1];
   }
   if (!ws.storageActiveContentVerifiedAt) return { allowed: false, reason: "lane_missing" };
   return fresh(ws.storageActiveContentVerifiedAt, LANE_STAMP_MAX_AGE_MS, now)
     ? { allowed: true, verifiedAt: ws.storageActiveContentVerifiedAt }
     : { allowed: false, reason: "lane_stale" };
+}
+
+/**
+ * The reasons a *server-side copy* of bytes already stored in this workspace
+ * tolerates (issue #929 adversarial review M-2). All five are freshness
+ * reasons: a host record that has gone stale, failed, or was never written,
+ * or a BYO lane stamp that lapsed. None of them says the object shouldn't
+ * exist — the bytes are already sitting on this same lane, served by this
+ * same host — so refusing the copy would make a stored SVG uncopyable the
+ * moment verification lapsed and would wedge private-prefix rotation
+ * outright, without removing anything from the internet.
+ *
+ * The three that are NOT here are policy, not freshness: `opted_out`,
+ * `flag_off` and `unhealthy` are somebody deciding this workspace (or the
+ * whole platform) should stop taking gated types. A kill switch that new
+ * copies can walk straight past is not a kill switch, so those deny — and
+ * the batch copy paths (`github-promote.ts`,
+ * `github-private-prefix-service.ts`) skip the individual object rather than
+ * failing the whole batch.
+ */
+const COPY_TOLERATED_REASONS: ReadonlySet<ActiveContentReason> = new Set([
+  "host_missing",
+  "host_not_ok",
+  "host_stale",
+  "lane_missing",
+  "lane_stale",
+]);
+
+/**
+ * The gate as a server-side copy sees it: `activeContentStatus`'s verdict,
+ * widened by {@link COPY_TOLERATED_REASONS}. Used only by `putObject`'s
+ * `serverCopy` path.
+ */
+export async function activeContentAllowedForCopy(
+  env: Env,
+  ws: WorkspaceRecord,
+  now = new Date(),
+): Promise<boolean> {
+  const status = await activeContentStatus(env, ws, now);
+  return (
+    status.allowed || (status.reason !== undefined && COPY_TOLERATED_REASONS.has(status.reason))
+  );
 }
 
 /** The gate itself — `activeContentStatus`'s verdict, for the callers that only decide admission. */

--- a/apps/api/src/active-content.ts
+++ b/apps/api/src/active-content.ts
@@ -71,6 +71,7 @@ export type ActiveContentReason =
   | "unhealthy"
   | "host_stale"
   | "host_missing"
+  | "host_not_ok"
   | "lane_stale"
   | "lane_missing";
 
@@ -89,7 +90,8 @@ export interface ActiveContentStatus {
 /** One hosted host's KV record as a status: fresh and `ok` allows; anything else says why not. */
 async function hostStatus(env: Env, host: string, now: Date): Promise<ActiveContentStatus> {
   const record = await readHostActiveContent(env, host);
-  if (!record?.ok) return { allowed: false, reason: "host_missing" };
+  if (!record) return { allowed: false, reason: "host_missing" };
+  if (!record.ok) return { allowed: false, reason: "host_not_ok" };
   if (!fresh(record.verifiedAt, HOST_RECORD_MAX_AGE_MS, now)) {
     return { allowed: false, reason: "host_stale" };
   }

--- a/apps/api/src/active-content.ts
+++ b/apps/api/src/active-content.ts
@@ -1,0 +1,95 @@
+/**
+ * Gate for SVG/XML "active content" uploads (issue #929, design doc
+ * "Decision: one mechanism, per lane" / "Gate"). `image/svg+xml`,
+ * `application/xml`, and `text/xml` are declared-only types
+ * (`apps/api/src/guards.ts`) accepted on a lane only while that lane's
+ * public host is verified to serve them behind a sandboxing CSP — this is
+ * the single choke point every caller (`putObject`, presign, ingest, the
+ * MCP ceiling) asks.
+ *
+ * Modeled directly on `posterGenerationAllowed` (`./poster.ts`): cheapest
+ * checks first, Flagship fails closed (a missing binding, a disabled flag,
+ * and a thrown evaluation are all indistinguishable from "off"), and a
+ * workspace-level opt-out short-circuits everything else. What's different
+ * from the poster gate is the lane split — a shared-bucket workspace
+ * inherits the *host's* daily-probed verdict from KV (every workspace on
+ * that host shares one Transform Rule), while a BYO workspace carries its
+ * own stamp because only its owner controls that host's headers.
+ */
+import { isSharedLane } from "./storage";
+import { readHostActiveContent } from "./active-content-hosts";
+import type { WorkspaceRecord } from "./workspace";
+
+/** Flagship kill switch, fail-closed like `POSTER_FLAG`. */
+export const ACTIVE_CONTENT_FLAG = "active-content-uploads";
+
+/**
+ * How long a hosted host's daily-probed KV record stays trusted. Comfortably
+ * wider than the daily cron interval so one missed/slow run doesn't flip
+ * every workspace on that host off; a genuinely broken Transform Rule still
+ * closes the gate within two days.
+ */
+export const HOST_RECORD_MAX_AGE_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * How long a BYO lane's own `storageActiveContentVerifiedAt` stamp stays
+ * trusted — far wider than the hosted host window because nothing re-probes
+ * a BYO lane on a schedule (only save-time verify, "Check now", and the
+ * lane-verify route touch it). A month is long enough that an abandoned
+ * lane's SVG/XML acceptance quietly expires rather than staying trusted
+ * forever.
+ */
+export const LANE_STAMP_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+function hostOf(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/** True when `iso` parses and is within `maxAgeMs` of `now`. Absent/unparseable is never fresh. */
+function fresh(iso: string | undefined, maxAgeMs: number, now: Date): boolean {
+  if (!iso) return false;
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return false;
+  return now.getTime() - t <= maxAgeMs;
+}
+
+/**
+ * Every gate, cheapest first: workspace opt-out, missing/disabled/thrown
+ * Flagship flag, a lane currently flagged unhealthy (issue #826 — a
+ * struggling BYO lane never gets active-content treated as a new problem to
+ * diagnose), then the lane-specific freshness check.
+ *
+ * Shared lane: reads `REGISTRY`'s `host-active-content:<host>` record (see
+ * `./active-content-hosts.ts`, written by the daily cron/admin probe) for
+ * the hostname of `ws.publicBaseUrl` — allowed when it exists, passed, and
+ * is within `HOST_RECORD_MAX_AGE_MS`. BYO lane: allowed when
+ * `ws.storageActiveContentVerifiedAt` is within `LANE_STAMP_MAX_AGE_MS`
+ * (the unhealthy check above already covers the "lane broke" case, so this
+ * branch is freshness only).
+ */
+export async function activeContentAllowed(
+  env: Env,
+  ws: WorkspaceRecord,
+  now = new Date(),
+): Promise<boolean> {
+  if (ws.activeContentUploads === false) return false;
+  if (!env.FLAGS) return false;
+  try {
+    if (!(await env.FLAGS.getBooleanValue(ACTIVE_CONTENT_FLAG, false))) return false;
+  } catch {
+    return false;
+  }
+  if (ws.storageUnhealthyAt) return false;
+  if (isSharedLane(ws)) {
+    const host = hostOf(ws.publicBaseUrl);
+    if (!host) return false;
+    const record = await readHostActiveContent(env, host);
+    return !!record && record.ok && fresh(record.verifiedAt, HOST_RECORD_MAX_AGE_MS, now);
+  }
+  return fresh(ws.storageActiveContentVerifiedAt, LANE_STAMP_MAX_AGE_MS, now);
+}

--- a/apps/api/src/active-content.ts
+++ b/apps/api/src/active-content.ts
@@ -15,9 +15,19 @@
  * inherits the *host's* daily-probed verdict from KV (every workspace on
  * that host shares one Transform Rule), while a BYO workspace carries its
  * own stamp because only its owner controls that host's headers.
+ *
+ * A shared-lane workspace's object is actually reachable through *two*
+ * hosts — the stable `ws.publicBaseUrl` host and, when it's one of the
+ * default embeddable hosts, the `embed.uploads.sh` twin `objectPublicUrls`
+ * (`./storage.ts`) also hands out for it (`resolveEmbedBaseUrl`, same
+ * `@uploads/storage` helper). Gating on the stable host's record alone would
+ * let SVG/XML through on a URL an unverified host still serves un-sandboxed,
+ * so the shared-lane branch below requires a fresh `ok` record for *every*
+ * host that can serve the object.
  */
+import { resolveEmbedBaseUrl } from "@uploads/storage";
 import { isSharedLane } from "./storage";
-import { readHostActiveContent } from "./active-content-hosts";
+import { hostOf, readHostActiveContent } from "./active-content-hosts";
 import type { WorkspaceRecord } from "./workspace";
 
 /** Flagship kill switch, fail-closed like `POSTER_FLAG`. */
@@ -41,21 +51,18 @@ export const HOST_RECORD_MAX_AGE_MS = 48 * 60 * 60 * 1000;
  */
 export const LANE_STAMP_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
-function hostOf(url: string | undefined): string | null {
-  if (!url) return null;
-  try {
-    return new URL(url).hostname.toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
 /** True when `iso` parses and is within `maxAgeMs` of `now`. Absent/unparseable is never fresh. */
 function fresh(iso: string | undefined, maxAgeMs: number, now: Date): boolean {
   if (!iso) return false;
   const t = Date.parse(iso);
   if (!Number.isFinite(t)) return false;
   return now.getTime() - t <= maxAgeMs;
+}
+
+/** One host's KV record exists, passed, and is within `HOST_RECORD_MAX_AGE_MS` of `now`. */
+async function hostRecordFresh(env: Env, host: string, now: Date): Promise<boolean> {
+  const record = await readHostActiveContent(env, host);
+  return !!record && record.ok && fresh(record.verifiedAt, HOST_RECORD_MAX_AGE_MS, now);
 }
 
 /**
@@ -66,11 +73,14 @@ function fresh(iso: string | undefined, maxAgeMs: number, now: Date): boolean {
  *
  * Shared lane: reads `REGISTRY`'s `host-active-content:<host>` record (see
  * `./active-content-hosts.ts`, written by the daily cron/admin probe) for
- * the hostname of `ws.publicBaseUrl` — allowed when it exists, passed, and
- * is within `HOST_RECORD_MAX_AGE_MS`. BYO lane: allowed when
- * `ws.storageActiveContentVerifiedAt` is within `LANE_STAMP_MAX_AGE_MS`
- * (the unhealthy check above already covers the "lane broke" case, so this
- * branch is freshness only).
+ * the hostname of `ws.publicBaseUrl` — allowed only when that record exists,
+ * passed, and is within `HOST_RECORD_MAX_AGE_MS` *and* the same is true of
+ * the embed twin's host when `resolveEmbedBaseUrl` resolves to a different
+ * one (the object is reachable through both; either serving it un-sandboxed
+ * defeats the gate). BYO lane: allowed when `ws.storageActiveContentVerifiedAt`
+ * is within `LANE_STAMP_MAX_AGE_MS` (the unhealthy check above already
+ * covers the "lane broke" case, so this branch is freshness only; a BYO
+ * lane has no separate embed twin to check).
  */
 export async function activeContentAllowed(
   env: Env,
@@ -93,8 +103,16 @@ export async function activeContentAllowed(
     if (!env.REGISTRY) return false;
     const host = hostOf(ws.publicBaseUrl);
     if (!host) return false;
-    const record = await readHostActiveContent(env, host);
-    return !!record && record.ok && fresh(record.verifiedAt, HOST_RECORD_MAX_AGE_MS, now);
+    if (!(await hostRecordFresh(env, host, now))) return false;
+    // Same derivation `objectPublicUrls` (./storage.ts) uses for the embed
+    // URL it hands every shared-lane caller — when it names a different
+    // host than the stable one just checked, that host must be fresh and
+    // `ok` too, or the object is still reachable un-sandboxed through it.
+    const embedHost = hostOf(resolveEmbedBaseUrl(ws.publicBaseUrl, env.EMBED_PUBLIC_BASE_URL));
+    if (embedHost && embedHost !== host && !(await hostRecordFresh(env, embedHost, now))) {
+      return false;
+    }
+    return true;
   }
   return fresh(ws.storageActiveContentVerifiedAt, LANE_STAMP_MAX_AGE_MS, now);
 }

--- a/apps/api/src/active-content.ts
+++ b/apps/api/src/active-content.ts
@@ -25,9 +25,9 @@
  * so the shared-lane branch below requires a fresh `ok` record for *every*
  * host that can serve the object.
  */
-import { resolveEmbedBaseUrl } from "@uploads/storage";
+import { hostOf, resolveEmbedBaseUrl } from "@uploads/storage";
 import { isSharedLane } from "./storage";
-import { hostOf, readHostActiveContent } from "./active-content-hosts";
+import { readHostActiveContent } from "./active-content-hosts";
 import type { WorkspaceRecord } from "./workspace";
 
 /** Flagship kill switch, fail-closed like `POSTER_FLAG`. */
@@ -51,18 +51,49 @@ export const HOST_RECORD_MAX_AGE_MS = 48 * 60 * 60 * 1000;
  */
 export const LANE_STAMP_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
-/** True when `iso` parses and is within `maxAgeMs` of `now`. Absent/unparseable is never fresh. */
-function fresh(iso: string | undefined, maxAgeMs: number, now: Date): boolean {
+/**
+ * True when `iso` parses and is within `maxAgeMs` of `now`. Absent or
+ * unparseable is never fresh. Exported so the settings projection
+ * (`routes/workspace-settings.ts`) judges a lane stamp by exactly the rule
+ * the gate below judges it by, instead of reimplementing the arithmetic.
+ */
+export function fresh(iso: string | undefined, maxAgeMs: number, now: Date): boolean {
   if (!iso) return false;
   const t = Date.parse(iso);
   if (!Number.isFinite(t)) return false;
   return now.getTime() - t <= maxAgeMs;
 }
 
-/** One host's KV record exists, passed, and is within `HOST_RECORD_MAX_AGE_MS` of `now`. */
-async function hostRecordFresh(env: Env, host: string, now: Date): Promise<boolean> {
+/** Why the gate is closed, when it is. Absent on an allowed status. */
+export type ActiveContentReason =
+  | "opted_out"
+  | "flag_off"
+  | "unhealthy"
+  | "host_stale"
+  | "host_missing"
+  | "lane_stale"
+  | "lane_missing";
+
+/**
+ * The gate's verdict plus what a display needs to explain it: the timestamp
+ * it actually trusted (a hosted host's KV record, or a BYO lane's own stamp)
+ * and, when the gate is closed, which check closed it.
+ */
+export interface ActiveContentStatus {
+  allowed: boolean;
+  /** Only ever set when the lane check passed — a fresh, passing stamp. */
+  verifiedAt?: string;
+  reason?: ActiveContentReason;
+}
+
+/** One hosted host's KV record as a status: fresh and `ok` allows; anything else says why not. */
+async function hostStatus(env: Env, host: string, now: Date): Promise<ActiveContentStatus> {
   const record = await readHostActiveContent(env, host);
-  return !!record && record.ok && fresh(record.verifiedAt, HOST_RECORD_MAX_AGE_MS, now);
+  if (!record?.ok) return { allowed: false, reason: "host_missing" };
+  if (!fresh(record.verifiedAt, HOST_RECORD_MAX_AGE_MS, now)) {
+    return { allowed: false, reason: "host_stale" };
+  }
+  return { allowed: true, verifiedAt: record.verifiedAt };
 }
 
 /**
@@ -81,38 +112,58 @@ async function hostRecordFresh(env: Env, host: string, now: Date): Promise<boole
  * is within `LANE_STAMP_MAX_AGE_MS` (the unhealthy check above already
  * covers the "lane broke" case, so this branch is freshness only; a BYO
  * lane has no separate embed twin to check).
+ *
+ * Returns the reason alongside the verdict so the settings page can say
+ * *why* SVG/XML are off without reimplementing any of this — a display that
+ * could disagree with the gate is worse than no display.
  */
-export async function activeContentAllowed(
+export async function activeContentStatus(
   env: Env,
   ws: WorkspaceRecord,
   now = new Date(),
-): Promise<boolean> {
-  if (ws.activeContentUploads === false) return false;
-  if (!env.FLAGS) return false;
+): Promise<ActiveContentStatus> {
+  if (ws.activeContentUploads === false) return { allowed: false, reason: "opted_out" };
+  if (!env.FLAGS) return { allowed: false, reason: "flag_off" };
   try {
-    if (!(await env.FLAGS.getBooleanValue(ACTIVE_CONTENT_FLAG, false))) return false;
+    if (!(await env.FLAGS.getBooleanValue(ACTIVE_CONTENT_FLAG, false))) {
+      return { allowed: false, reason: "flag_off" };
+    }
   } catch {
-    return false;
+    return { allowed: false, reason: "flag_off" };
   }
-  if (ws.storageUnhealthyAt) return false;
+  if (ws.storageUnhealthyAt) return { allowed: false, reason: "unhealthy" };
   if (isSharedLane(ws)) {
     // `REGISTRY` backs every workspace record too, so a real deployment
     // always has it bound — this guard exists so a caller/fixture that
     // wires up `FLAGS` without `REGISTRY` fails closed instead of throwing,
     // same fail-closed posture as the missing-`FLAGS` check above.
-    if (!env.REGISTRY) return false;
+    if (!env.REGISTRY) return { allowed: false, reason: "host_missing" };
     const host = hostOf(ws.publicBaseUrl);
-    if (!host) return false;
-    if (!(await hostRecordFresh(env, host, now))) return false;
+    if (!host) return { allowed: false, reason: "host_missing" };
+    const stable = await hostStatus(env, host, now);
+    if (!stable.allowed) return stable;
     // Same derivation `objectPublicUrls` (./storage.ts) uses for the embed
     // URL it hands every shared-lane caller — when it names a different
     // host than the stable one just checked, that host must be fresh and
     // `ok` too, or the object is still reachable un-sandboxed through it.
     const embedHost = hostOf(resolveEmbedBaseUrl(ws.publicBaseUrl, env.EMBED_PUBLIC_BASE_URL));
-    if (embedHost && embedHost !== host && !(await hostRecordFresh(env, embedHost, now))) {
-      return false;
+    if (embedHost && embedHost !== host) {
+      const twin = await hostStatus(env, embedHost, now);
+      if (!twin.allowed) return twin;
     }
-    return true;
+    return stable;
   }
-  return fresh(ws.storageActiveContentVerifiedAt, LANE_STAMP_MAX_AGE_MS, now);
+  if (!ws.storageActiveContentVerifiedAt) return { allowed: false, reason: "lane_missing" };
+  return fresh(ws.storageActiveContentVerifiedAt, LANE_STAMP_MAX_AGE_MS, now)
+    ? { allowed: true, verifiedAt: ws.storageActiveContentVerifiedAt }
+    : { allowed: false, reason: "lane_stale" };
+}
+
+/** The gate itself — `activeContentStatus`'s verdict, for the callers that only decide admission. */
+export async function activeContentAllowed(
+  env: Env,
+  ws: WorkspaceRecord,
+  now = new Date(),
+): Promise<boolean> {
+  return (await activeContentStatus(env, ws, now)).allowed;
 }

--- a/apps/api/src/active-content.ts
+++ b/apps/api/src/active-content.ts
@@ -86,6 +86,11 @@ export async function activeContentAllowed(
   }
   if (ws.storageUnhealthyAt) return false;
   if (isSharedLane(ws)) {
+    // `REGISTRY` backs every workspace record too, so a real deployment
+    // always has it bound — this guard exists so a caller/fixture that
+    // wires up `FLAGS` without `REGISTRY` fails closed instead of throwing,
+    // same fail-closed posture as the missing-`FLAGS` check above.
+    if (!env.REGISTRY) return false;
     const host = hostOf(ws.publicBaseUrl);
     if (!host) return false;
     const record = await readHostActiveContent(env, host);

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -37,6 +37,7 @@ import {
   DEFAULT_MAX_UPLOAD_BYTES,
   detectImageDimensions,
   inspectUpload,
+  isGatedContentType,
   resolveDeclaredContentType,
   resolveUploadPolicy,
   uploadKind,
@@ -492,6 +493,15 @@ export async function putObject(
      * applies; this only widens the *allowlist*, never the acceptance rules.
      */
     serverCopy?: boolean;
+    /**
+     * A caller that has already resolved `activeContentAllowed(env, ws)` for
+     * this workspace passes it here rather than making every put re-resolve
+     * it — the MCP `put` tool's multi-file batch does, so one tool call
+     * evaluates the flag (and reads KV) at most once for up to 20 files.
+     * Only consulted when the declared type is a gated one, and never
+     * consulted at all for a `serverCopy`.
+     */
+    activeContent?: boolean;
   },
 ): Promise<{
   key: string;
@@ -524,10 +534,16 @@ export async function putObject(
   if (opts?.metadata) validateMetadataEntries(opts.metadata);
 
   const declared = resolveDeclaredContentType(opts?.declaredContentType, finalKey);
-  // A server-side copy of bytes already stored in this workspace doesn't
-  // re-run the active-content gate — see `opts.serverCopy`'s doc comment.
-  // `||` short-circuits before the `await`, so a copy never touches FLAGS/KV.
-  const activeContent = opts?.serverCopy === true || (await activeContentAllowed(env, ws));
+  // The gate only ever decides whether the gated SVG/XML rows are admitted,
+  // and those are declared-only — so a put that claims anything else can
+  // never be changed by it, and doesn't pay for it: no Flagship evaluation,
+  // no KV read (issue #929). A server-side copy of bytes already stored in
+  // this workspace skips it too (see `opts.serverCopy`), and a caller that
+  // has already resolved the answer passes it in (`opts.activeContent`).
+  const activeContent =
+    declared !== undefined && isGatedContentType(declared)
+      ? opts?.serverCopy === true || (opts?.activeContent ?? (await activeContentAllowed(env, ws)))
+      : false;
   const policy = resolveUploadPolicy(ws, { activeContent });
   const inspection = inspectUpload(bytes, policy, declared);
   if (!inspection.ok) throw inspection.error;

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -7,6 +7,7 @@
  */
 import { ConflictError, NotFoundError, ValidationError } from "@uploads/errors";
 import { createStorage, type Files, type StoredFile } from "@uploads/storage";
+import { activeContentAllowed } from "./active-content";
 import { recordAdoptionSafe, type UploadSurface } from "./adoption";
 import {
   budgetDenialError,
@@ -504,7 +505,8 @@ export async function putObject(
   if (opts?.metadata) validateMetadataEntries(opts.metadata);
 
   const declared = resolveDeclaredContentType(opts?.declaredContentType, finalKey);
-  const inspection = inspectUpload(bytes, resolveUploadPolicy(ws), declared);
+  const policy = resolveUploadPolicy(ws, { activeContent: await activeContentAllowed(env, ws) });
+  const inspection = inspectUpload(bytes, policy, declared);
   if (!inspection.ok) throw inspection.error;
 
   const store = await storage(env, ws);

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -401,8 +401,8 @@ export function publicObjectDateFields(meta: {
  * claim, so a text object under an extension-less key is admitted by
  * `inspectUpload` at the destination the same way it was at the source.
  * Every copy still runs the full `putObject` write path — the size cap,
- * sniffing, and (for a declared type) the row's plausibility/reputation
- * check all still apply. What `serverCopy: true` skips is only the
+ * sniffing, and (for a declared type) the row's `admit` check all still
+ * apply. What `serverCopy: true` skips is only the
  * active-content *lane gate* (issue #929 review): a copy of bytes already
  * stored in this same workspace doesn't change exposure — same active lane,
  * same serving host — so re-running `activeContentAllowed` on it would only

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -7,7 +7,7 @@
  */
 import { ConflictError, NotFoundError, ValidationError } from "@uploads/errors";
 import { createStorage, type Files, type StoredFile } from "@uploads/storage";
-import { activeContentAllowed } from "./active-content";
+import { activeContentAllowed, activeContentAllowedForCopy } from "./active-content";
 import { recordAdoptionSafe, type UploadSurface } from "./adoption";
 import {
   budgetDenialError,
@@ -402,13 +402,15 @@ export function publicObjectDateFields(meta: {
  * `inspectUpload` at the destination the same way it was at the source.
  * Every copy still runs the full `putObject` write path — the size cap,
  * sniffing, and (for a declared type) the row's `admit` check all still
- * apply. What `serverCopy: true` skips is only the
- * active-content *lane gate* (issue #929 review): a copy of bytes already
- * stored in this same workspace doesn't change exposure — same active lane,
- * same serving host — so re-running `activeContentAllowed` on it would only
- * make a stored SVG uncopyable the moment its lane's verification stamp
- * lapses, and would wedge prefix rotation outright. See `putObject`'s
- * `opts.serverCopy`.
+ * apply. What `serverCopy: true` changes is only *which* active-content
+ * verdicts admit a gated type (issue #929 review, tightened by the
+ * adversarial review's M-2): a copy of bytes already stored in this same
+ * workspace doesn't change exposure — same active lane, same serving host —
+ * so a lapsed verification stamp or a stale host record must not make a
+ * stored SVG uncopyable (it would wedge prefix rotation outright). A
+ * *policy* close — the workspace opt-out, the Flagship kill switch, an
+ * unhealthy lane — still refuses the copy. See
+ * `activeContentAllowedForCopy` and `putObject`'s `opts.serverCopy`.
  */
 export function putOptsFromStoredObject(source: Pick<StoredFile, "metadata" | "type">): {
   provenance: Record<string, string> | undefined;
@@ -486,11 +488,15 @@ export async function putObject(
     /**
      * Set by `putOptsFromStoredObject` (issue #929 review): `bytes` are
      * already stored in this same workspace (attach/promote/rotate copying
-     * an existing object to a new key), so the active-content lane gate does
-     * not re-run for this put — the destination is the same active lane as
-     * the source, so a copy changes nothing about exposure. Everything else
-     * `inspectUpload` checks (size, sniffing, plausibility/reputation) still
-     * applies; this only widens the *allowlist*, never the acceptance rules.
+     * an existing object to a new key), so the active-content gate is
+     * evaluated through `activeContentAllowedForCopy` rather than the
+     * ordinary `activeContentAllowed` — the destination is the same active
+     * lane as the source, so a *freshness* close (stale/absent host record,
+     * lapsed BYO stamp) changes nothing about exposure and must not make a
+     * stored SVG uncopyable. A policy close (workspace opt-out, kill switch,
+     * unhealthy lane) still 415s the copy. Everything else `inspectUpload`
+     * checks (size, sniffing, plausibility/reputation) still applies; this
+     * only widens the *allowlist*, never the acceptance rules.
      */
     serverCopy?: boolean;
     /**
@@ -499,7 +505,8 @@ export async function putObject(
      * it — the MCP `put` tool's multi-file batch does, so one tool call
      * evaluates the flag (and reads KV) at most once for up to 20 files.
      * Only consulted when the declared type is a gated one, and never
-     * consulted at all for a `serverCopy`.
+     * consulted at all for a `serverCopy` (which asks the copy-specific
+     * question instead — see `serverCopy` above).
      */
     activeContent?: boolean;
   },
@@ -538,12 +545,17 @@ export async function putObject(
   // and those are declared-only — so a put that claims anything else can
   // never be changed by it, and doesn't pay for it: no Flagship evaluation,
   // no KV read (issue #929). A server-side copy of bytes already stored in
-  // this workspace skips it too (see `opts.serverCopy`), and a caller that
-  // has already resolved the answer passes it in (`opts.activeContent`).
-  const activeContent =
-    declared !== undefined && isGatedContentType(declared)
-      ? opts?.serverCopy === true || (opts?.activeContent ?? (await activeContentAllowed(env, ws)))
-      : false;
+  // this workspace asks the copy-specific question (see `opts.serverCopy`)
+  // — still an evaluation, so the kill switch and the workspace opt-out
+  // reach the copy paths too — and a caller that has already resolved the
+  // ordinary answer passes it in (`opts.activeContent`).
+  let activeContent = false;
+  if (declared !== undefined && isGatedContentType(declared)) {
+    activeContent =
+      opts?.serverCopy === true
+        ? await activeContentAllowedForCopy(env, ws)
+        : (opts?.activeContent ?? (await activeContentAllowed(env, ws)));
+  }
   const policy = resolveUploadPolicy(ws, { activeContent });
   const inspection = inspectUpload(bytes, policy, declared);
   if (!inspection.ok) throw inspection.error;
@@ -960,6 +972,16 @@ export async function downloadResponse(
   );
   if (typeof file.size === "number") headers.set("Content-Length", String(file.size));
   headers.set("Cache-Control", "no-store");
+  // `Content-Disposition: attachment` is what keeps this route from
+  // rendering anything on `api.uploads.sh` — a first-party origin, unlike
+  // the bare storage hosts. These two make that a belt-and-braces claim
+  // rather than the only one (issue #929 adversarial review L-2): `nosniff`
+  // stops a browser re-deciding the type it was handed, and `sandbox` puts
+  // the document in an opaque origin with scripting off should it ever be
+  // rendered anyway. Both are inert for the attachment path every other
+  // content type takes.
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("Content-Security-Policy", "sandbox");
   return new Response(file.stream(), { headers });
 }
 

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -399,18 +399,27 @@ export function publicObjectDateFields(meta: {
  * visibility that bag encodes, and its stored content type as the declared
  * claim, so a text object under an extension-less key is admitted by
  * `inspectUpload` at the destination the same way it was at the source.
- * Every copy still runs the full `putObject` write path — nothing here
- * bypasses inspection.
+ * Every copy still runs the full `putObject` write path — the size cap,
+ * sniffing, and (for a declared type) the row's plausibility/reputation
+ * check all still apply. What `serverCopy: true` skips is only the
+ * active-content *lane gate* (issue #929 review): a copy of bytes already
+ * stored in this same workspace doesn't change exposure — same active lane,
+ * same serving host — so re-running `activeContentAllowed` on it would only
+ * make a stored SVG uncopyable the moment its lane's verification stamp
+ * lapses, and would wedge prefix rotation outright. See `putObject`'s
+ * `opts.serverCopy`.
  */
 export function putOptsFromStoredObject(source: Pick<StoredFile, "metadata" | "type">): {
   provenance: Record<string, string> | undefined;
   visibility: Visibility | undefined;
   declaredContentType: string;
+  serverCopy: true;
 } {
   return {
     provenance: source.metadata,
     visibility: objectVisibility(source.metadata),
     declaredContentType: source.type,
+    serverCopy: true as const,
   };
 }
 
@@ -473,6 +482,16 @@ export async function putObject(
      * is the claim, which is what the hosted MCP and older CLIs rely on.
      */
     declaredContentType?: string;
+    /**
+     * Set by `putOptsFromStoredObject` (issue #929 review): `bytes` are
+     * already stored in this same workspace (attach/promote/rotate copying
+     * an existing object to a new key), so the active-content lane gate does
+     * not re-run for this put — the destination is the same active lane as
+     * the source, so a copy changes nothing about exposure. Everything else
+     * `inspectUpload` checks (size, sniffing, plausibility/reputation) still
+     * applies; this only widens the *allowlist*, never the acceptance rules.
+     */
+    serverCopy?: boolean;
   },
 ): Promise<{
   key: string;
@@ -505,7 +524,11 @@ export async function putObject(
   if (opts?.metadata) validateMetadataEntries(opts.metadata);
 
   const declared = resolveDeclaredContentType(opts?.declaredContentType, finalKey);
-  const policy = resolveUploadPolicy(ws, { activeContent: await activeContentAllowed(env, ws) });
+  // A server-side copy of bytes already stored in this workspace doesn't
+  // re-run the active-content gate — see `opts.serverCopy`'s doc comment.
+  // `||` short-circuits before the `await`, so a copy never touches FLAGS/KV.
+  const activeContent = opts?.serverCopy === true || (await activeContentAllowed(env, ws));
+  const policy = resolveUploadPolicy(ws, { activeContent });
   const inspection = inspectUpload(bytes, policy, declared);
   if (!inspection.ok) throw inspection.error;
 

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -244,14 +244,12 @@ async function fetchAndStore(
   // .allowed`, guards.ts — no shadow table) AND be an image/video family;
   // PDFs and archives pasted into a PR are left on GitHub. Non-sniffable
   // bytes or a type outside the gate is the same permanent
-  // `unsupported_media_type` skip either way. `activeContent: false` here,
-  // not the real `activeContentAllowed(env, ws)` result (issue #929
-  // final-review): the gated types (SVG, XML) are declared-only and have no
-  // magic bytes, so `detectContentType` below returns null for them and the
-  // `!sniffed` skip fires before the allowlist is ever consulted — the real
-  // gate can never change this function's outcome. Passing `false` skips the per-asset Flagship
-  // evaluation and KV read that a real gate call would otherwise cost on
-  // every ingested asset.
+  // `unsupported_media_type` skip either way. `activeContent: false` (issue
+  // #929): the gated types are declared-only, so `detectContentType` returns
+  // null for them and the `!sniffed` skip fires before the allowlist is ever
+  // consulted — the real gate can't change this outcome, only cost a
+  // Flagship evaluation and a KV read per asset. The ceiling below is
+  // gate-independent regardless — see `uploadLimits` (guards.ts).
   const policy = resolveUploadPolicy(ws, { activeContent: false });
   const sniffed = detectContentType(bytes);
   if (!sniffed || !policy.allowed.has(sniffed) || uploadKind(sniffed) === "file") {

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -246,11 +246,10 @@ async function fetchAndStore(
   // bytes or a type outside the gate is the same permanent
   // `unsupported_media_type` skip either way. `activeContent: false` here,
   // not the real `activeContentAllowed(env, ws)` result (issue #929
-  // final-review): SVG is declared-only, never sniffed, so `detectContentType`
-  // below can't admit one regardless of what the gate says, and XML sniffs
-  // to `kind: "file"`, which the `uploadKind(sniffed) === "file"` check right
-  // below always skips anyway — so the real gate can never change this
-  // function's outcome. Passing `false` skips the per-asset Flagship
+  // final-review): the gated types (SVG, XML) are declared-only and have no
+  // magic bytes, so `detectContentType` below returns null for them and the
+  // `!sniffed` skip fires before the allowlist is ever consulted — the real
+  // gate can never change this function's outcome. Passing `false` skips the per-asset Flagship
   // evaluation and KV read that a real gate call would otherwise cost on
   // every ingested asset.
   const policy = resolveUploadPolicy(ws, { activeContent: false });

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -24,6 +24,7 @@
  */
 
 import { AppError, isRetryableType, NotFoundError } from "@uploads/errors";
+import { activeContentAllowed } from "./active-content";
 import { attachmentKeyBasename, extractUserAttachments } from "./github-attachment-extract";
 import { GH_PRIVATE_ROOT, sanitizeKeySegment } from "./github-comment-render";
 import {
@@ -244,8 +245,12 @@ async function fetchAndStore(
   // .allowed`, guards.ts — no shadow table) AND be an image/video family;
   // PDFs and archives pasted into a PR are left on GitHub. Non-sniffable
   // bytes or a type outside the gate is the same permanent
-  // `unsupported_media_type` skip either way.
-  const policy = resolveUploadPolicy(ws);
+  // `unsupported_media_type` skip either way. SVG is declared-only (never
+  // sniffed) so `detectContentType` alone never admits one here regardless
+  // of the gate — but the policy still needs the real gate result so its
+  // `allowed` set matches what every other caller would compute for this
+  // workspace (issue #929).
+  const policy = resolveUploadPolicy(ws, { activeContent: await activeContentAllowed(env, ws) });
   const sniffed = detectContentType(bytes);
   if (!sniffed || !policy.allowed.has(sniffed) || uploadKind(sniffed) === "file") {
     return { kind: "skip", reason: "unsupported_media_type" };

--- a/apps/api/src/github-ingest.ts
+++ b/apps/api/src/github-ingest.ts
@@ -24,7 +24,6 @@
  */
 
 import { AppError, isRetryableType, NotFoundError } from "@uploads/errors";
-import { activeContentAllowed } from "./active-content";
 import { attachmentKeyBasename, extractUserAttachments } from "./github-attachment-extract";
 import { GH_PRIVATE_ROOT, sanitizeKeySegment } from "./github-comment-render";
 import {
@@ -245,12 +244,16 @@ async function fetchAndStore(
   // .allowed`, guards.ts — no shadow table) AND be an image/video family;
   // PDFs and archives pasted into a PR are left on GitHub. Non-sniffable
   // bytes or a type outside the gate is the same permanent
-  // `unsupported_media_type` skip either way. SVG is declared-only (never
-  // sniffed) so `detectContentType` alone never admits one here regardless
-  // of the gate — but the policy still needs the real gate result so its
-  // `allowed` set matches what every other caller would compute for this
-  // workspace (issue #929).
-  const policy = resolveUploadPolicy(ws, { activeContent: await activeContentAllowed(env, ws) });
+  // `unsupported_media_type` skip either way. `activeContent: false` here,
+  // not the real `activeContentAllowed(env, ws)` result (issue #929
+  // final-review): SVG is declared-only, never sniffed, so `detectContentType`
+  // below can't admit one regardless of what the gate says, and XML sniffs
+  // to `kind: "file"`, which the `uploadKind(sniffed) === "file"` check right
+  // below always skips anyway — so the real gate can never change this
+  // function's outcome. Passing `false` skips the per-asset Flagship
+  // evaluation and KV read that a real gate call would otherwise cost on
+  // every ingested asset.
+  const policy = resolveUploadPolicy(ws, { activeContent: false });
   const sniffed = detectContentType(bytes);
   if (!sniffed || !policy.allowed.has(sniffed) || uploadKind(sniffed) === "file") {
     return { kind: "skip", reason: "unsupported_media_type" };

--- a/apps/api/src/github-private-prefix-rotate.test.ts
+++ b/apps/api/src/github-private-prefix-rotate.test.ts
@@ -346,6 +346,48 @@ describe("rotatePrivatePrefix", () => {
     expect(seen.bodies).toHaveLength(1);
   });
 
+  // Rotation is a revocation mechanism: an operator rotating a leaked prefix
+  // must never be wedged by one object the active-content gate has since
+  // closed on (issue #929 adversarial review M-2). The refused object keeps
+  // its old key — the next rotation's resumability sweep retries it.
+  it("skips an SVG the active-content gate refuses, moves everything else, and reports it", async () => {
+    const { env, db, bucket, ws } = await seededEnv();
+    const oldId = await getOrMintPrefixId(db, REPO, BRANCH);
+    const pngKey = ghPrivateBranchAttachmentKey(oldId, "shot.png");
+    const svgKey = ghPrivateBranchAttachmentKey(oldId, "diagram.svg");
+    const svg = new TextEncoder().encode(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>',
+    );
+
+    await putObject(env, ws, pngKey, PNG, WS, {
+      metadata: { "gh.repo": REPO, "gh.kind": "branch" },
+    });
+    // Written straight to the bucket: `seededEnv` binds no FLAGS, so a
+    // direct put of a gated type would 415 here too. This stands in for an
+    // SVG stored while the gate was open.
+    await bucket.put(`${PREFIX}${svgKey}`, svg, {
+      httpMetadata: { contentType: "image/svg+xml" },
+    });
+
+    const result = await withFetch(commentFlowFetch({ bodies: [] }), () =>
+      rotatePrivatePrefix(env, ws, WS, "user-1", REPO, BRANCH),
+    );
+
+    expect(result.rotated).toBe(true);
+    if (!result.rotated) throw new Error("expected rotated: true");
+    expect(result.moved).toBe(1);
+    expect(result.skipped).toEqual([svgKey]);
+
+    // The PNG moved; the refused SVG kept its old key and never landed at
+    // the new prefix.
+    const newPngKey = ghPrivateBranchAttachmentKey(result.prefixId, "shot.png");
+    const newSvgKey = ghPrivateBranchAttachmentKey(result.prefixId, "diagram.svg");
+    expect(bucket.store.has(`${PREFIX}${newPngKey}`)).toBe(true);
+    expect(bucket.store.has(`${PREFIX}${pngKey}`)).toBe(false);
+    expect(bucket.store.has(`${PREFIX}${newSvgKey}`)).toBe(false);
+    expect(bucket.store.has(`${PREFIX}${svgKey}`)).toBe(true);
+  });
+
   it("no active id → { rotated: false, reason: 'no_prefix' }", async () => {
     const { env, ws } = await seededEnv();
     const result = await rotatePrivatePrefix(env, ws, WS, "user-1", REPO, "unminted-branch");

--- a/apps/api/src/github-private-prefix-service.ts
+++ b/apps/api/src/github-private-prefix-service.ts
@@ -13,7 +13,7 @@
  * unauthorized caller's response is indistinguishable from a public repo's,
  * and no row is minted along that path.
  */
-import { ForbiddenError } from "@uploads/errors";
+import { ForbiddenError, UnsupportedMediaTypeError } from "@uploads/errors";
 import { githubAppConfig, installationForRepo, prHeadBranch, repoIsPrivate } from "./github-app";
 import { checkRepoAuthorization, postManagedComment } from "./github-comment-service";
 import { GH_PRIVATE_ROOT, type GhTargetKind, parseGhPrivateKey } from "./github-comment-render";
@@ -139,7 +139,20 @@ export async function resolveGhKeyContextSafe(
 
 export type RotatePrivatePrefixResult =
   | { rotated: false; reason: string }
-  | { rotated: true; prefixId: string; moved: number };
+  | {
+      rotated: true;
+      prefixId: string;
+      moved: number;
+      /**
+       * Old keys this rotation could not re-write at the new prefix because
+       * the destination refused the type (a 415 from `putObject`'s
+       * active-content gate — issue #929 adversarial review M-2). They keep
+       * their old key and stay reachable at the retired prefix; the next
+       * rotation's resumability sweep picks them up again once the gate
+       * reopens. Absent when nothing was skipped.
+       */
+      skipped?: string[];
+    };
 
 /**
  * Rotate the active prefix id for `(repo, branch)` (issue #631, Task 8):
@@ -194,6 +207,12 @@ export type RotatePrivatePrefixResult =
  * now-half-migrated attachments. The failed object's OLD copy is left in
  * place (never reached the delete step), so nothing is lost; the next call
  * picks it up via the resumability sweep above.
+ *
+ * The one exception is a 415 (`UnsupportedMediaTypeError`): rotation is a
+ * *revocation* mechanism — an operator rotating a leaked prefix must not be
+ * wedged by one SVG the active-content gate has since closed on (issue #929
+ * adversarial review M-2). Such an object is recorded in `skipped` and left
+ * where it is; everything else still moves, and the next rotation retries it.
  */
 export async function rotatePrivatePrefix(
   env: Env,
@@ -224,6 +243,7 @@ export async function rotatePrivatePrefix(
 
   const targets = new Map<string, { kind: GhTargetKind; num: number }>();
   let moved = 0;
+  const skipped: string[] = [];
 
   try {
     for (const sourceId of sourceIds) {
@@ -254,10 +274,27 @@ export async function rotatePrivatePrefix(
           // content-identical object) and write inheritable `file_metadata`
           // rows (`repo`, `path`, `url`, …) onto `newKey` before this
           // function's own rename below runs.
-          await putObject(env, ws, newKey, bytes, workspaceName, {
-            ...putOptsFromStoredObject(source),
-            surface: "rotate",
-          });
+          try {
+            await putObject(env, ws, newKey, bytes, workspaceName, {
+              ...putOptsFromStoredObject(source),
+              surface: "rotate",
+            });
+          } catch (err) {
+            // Only a 415 is tolerated here (see the partial-failure note
+            // above); every other error still propagates. Nothing below has
+            // run yet, so the old key keeps its bytes and its D1 rows.
+            if (!(err instanceof UnsupportedMediaTypeError)) throw err;
+            console.error(
+              JSON.stringify({
+                message: "rotate copy refused: unsupported media type",
+                key: item.key,
+                newKey,
+                error: err.message,
+              }),
+            );
+            skipped.push(item.key);
+            continue;
+          }
 
           // Wipe whatever's already at `newKey` before renaming onto it —
           // `putObject`'s inheritance above may have just written donor rows
@@ -350,5 +387,5 @@ export async function rotatePrivatePrefix(
     );
   }
 
-  return { rotated: true, prefixId: newId, moved };
+  return { rotated: true, prefixId: newId, moved, ...(skipped.length ? { skipped } : {}) };
 }

--- a/apps/api/src/github-promote.test.ts
+++ b/apps/api/src/github-promote.test.ts
@@ -366,6 +366,44 @@ describe("promoteBranchAttachments — private prefixes (issue #631)", () => {
     expect(result.promoted).toEqual([destKey("hero.png")]);
   });
 
+  // With `serverCopy` now honoring the kill switch and the workspace
+  // opt-out (issue #929 adversarial review M-2), one staged SVG can become
+  // un-copyable while the rest of the batch is fine. The promote must skip
+  // it by name and carry on, not fail the whole call.
+  it("skips a staged SVG the active-content gate refuses and still promotes the rest", async () => {
+    const seeded = await seededEnv({ isPrivate: false });
+    await seedPlainStaged(seeded, "hero.png");
+    const svg = new TextEncoder().encode(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>',
+    );
+    await seeded.bucket.put(`${PREFIX}${stagedKey("diagram.svg")}`, svg, {
+      httpMetadata: { contentType: "image/svg+xml" },
+    });
+    await replaceFileMetadata(seeded.env.DB, WS, stagedKey("diagram.svg"), {
+      "gh.repo": REPO,
+      "gh.kind": "branch",
+      "gh.branch": BRANCH,
+      "gh.staged-at": new Date().toISOString(),
+    });
+
+    // `seededEnv` binds no FLAGS, so the gate closes with `flag_off` — a
+    // policy close, which a server copy no longer walks past.
+    const result = await promoteBranchAttachments(seeded.env, seeded.ws, WS, {
+      repo: REPO,
+      num: NUM,
+      branch: BRANCH,
+    });
+
+    expect(result.promoted).toEqual([destKey("hero.png")]);
+    expect(result.skipped).toEqual([
+      { key: stagedKey("diagram.svg"), reason: "unsupported_media_type" },
+    ]);
+    // The refused object never landed at the destination, and its staged
+    // original is untouched.
+    expect(seeded.bucket.store.has(`${PREFIX}${destKey("diagram.svg")}`)).toBe(false);
+    expect(seeded.bucket.store.has(`${PREFIX}${stagedKey("diagram.svg")}`)).toBe(true);
+  });
+
   it("returns empty arrays when nothing is staged under either prefix", async () => {
     const seeded = await seededEnv({ isPrivate: true });
 

--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -17,6 +17,7 @@
  * same contract as any other overwrite in this API).
  */
 
+import { UnsupportedMediaTypeError } from "@uploads/errors";
 import { getMetadataForKeys, setFileMetadata } from "./file-metadata";
 import { putObject, putOptsFromStoredObject } from "./files-core";
 import { resolveBranchLineageSafe } from "./github-branch-renames";
@@ -410,6 +411,24 @@ export async function promoteBranchAttachments(
         surface: "promote",
       });
     } catch (err) {
+      // A 415 is this one object's problem, not the batch's (issue #929
+      // adversarial review M-2): now that `serverCopy` honors the kill
+      // switch and the workspace opt-out, a staged SVG can become
+      // un-copyable while every other attachment in the same promote is
+      // fine. Skip it by its own name so the caller can see why, and carry
+      // on with the rest.
+      if (err instanceof UnsupportedMediaTypeError) {
+        console.error(
+          JSON.stringify({
+            message: "promote copy refused: unsupported media type",
+            key,
+            destKey,
+            error: err.message,
+          }),
+        );
+        skipped.push({ key, reason: "unsupported_media_type" });
+        continue;
+      }
       // Never leak internal error detail (D1/R2 messages, key policy
       // internals) to API callers — log the detail server-side and report a
       // generic reason.

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -220,11 +220,20 @@ export function uploadKind(contentType: string): UploadKind {
   return "file";
 }
 
-export interface UploadPolicy {
+/** True when `type` is one of the lane-gated SVG/XML rows (issue #929). */
+export function isGatedContentType(type: string): boolean {
+  return GATED_SET.has(type);
+}
+
+/** The byte ceilings half of an upload policy — see `uploadLimits`. */
+export interface UploadLimits {
   /** Max for images (and as fallback when maxVideoBytes is unset). */
   maxBytes: number;
   /** Max for video/* when set; otherwise maxBytes. */
   maxVideoBytes: number;
+}
+
+export interface UploadPolicy extends UploadLimits {
   allowed: ReadonlySet<string>;
 }
 
@@ -254,18 +263,17 @@ function positiveBytes(value: unknown): number | undefined {
 }
 
 /**
- * Builds the effective upload policy for a workspace. `opts.activeContent`
- * (issue #929) is required — never defaulted — so no caller can forget to
- * pass its `activeContentAllowed(env, ws)` result and silently open (or
- * close) the gated SVG/XML rows. When `false`, the gated types are stripped
- * from the resulting `allowed` set even when the workspace's own
- * `allowedContentTypes` override names one explicitly — an override extends
- * or restricts the ungated allowlist, it can't bypass lane verification.
+ * The workspace's byte ceilings, resolved from its own overrides and its
+ * plan's defaults. Deliberately separate from admission (`resolveUploadPolicy`
+ * below): a limit is plan-and-override arithmetic only, so it is the same
+ * number whether or not the active-content gate (issue #929) is open. That is
+ * why every caller that only needs a ceiling — the PUT route's pre-buffer
+ * `Content-Length` check, the MCP `put` pre-decode ceiling, `github-ingest` —
+ * calls this instead of building a whole policy behind a made-up gate value:
+ * the gated SVG/XML rows change which *types* are admitted, never how many
+ * bytes a workspace may send.
  */
-export function resolveUploadPolicy(
-  record: UploadPolicyOverrides,
-  opts: { activeContent: boolean },
-): UploadPolicy {
+export function uploadLimits(record: UploadPolicyOverrides): UploadLimits {
   // Sanitize before handing off to the shared resolution seam, same pattern
   // as `budget.ts`'s `resolveBudgetLimits`: a zero/negative/non-finite
   // override collapses to "unset" here, *before* `resolveEffectiveLimits`
@@ -279,6 +287,24 @@ export function resolveUploadPolicy(
   // No plan stamped: reproduce the legacy fallback exactly.
   const maxBytes = positiveBytes(resolved.maxUploadBytes) ?? DEFAULT_MAX_UPLOAD_BYTES;
   const maxVideoBytes = positiveBytes(resolved.maxVideoUploadBytes) ?? maxBytes;
+  return { maxBytes, maxVideoBytes };
+}
+
+/**
+ * Builds the effective upload policy for a workspace: `uploadLimits` plus the
+ * admitted type set. `opts.activeContent` (issue #929) is required — never
+ * defaulted — so no caller can forget to pass its `activeContentAllowed(env,
+ * ws)` result and silently open (or close) the gated SVG/XML rows. When
+ * `false`, the gated types are stripped from the resulting `allowed` set even
+ * when the workspace's own `allowedContentTypes` override names one
+ * explicitly — an override extends or restricts the ungated allowlist, it
+ * can't bypass lane verification.
+ */
+export function resolveUploadPolicy(
+  record: UploadPolicyOverrides,
+  opts: { activeContent: boolean },
+): UploadPolicy {
+  const limits = uploadLimits(record);
   const base =
     record.allowedContentTypes && record.allowedContentTypes.length > 0
       ? new Set(record.allowedContentTypes)
@@ -286,17 +312,17 @@ export function resolveUploadPolicy(
   const allowed = opts.activeContent
     ? base
     : new Set([...base].filter((type) => !GATED_SET.has(type)));
-  return { maxBytes, maxVideoBytes, allowed };
+  return { ...limits, allowed };
 }
 
 /**
- * The effective byte ceiling for one content type: the policy's own
+ * The effective byte ceiling for one content type: the workspace's own
  * `maxVideoBytes`/`maxBytes`, tightened by the row's own `maxBytes` when it
  * has one (issue #929 review — the gated SVG/XML rows cap at 4 MiB
  * regardless of how high a workspace's general upload ceiling is set).
  */
-export function maxBytesForContentType(policy: UploadPolicy, contentType: string): number {
-  const base = VIDEO_TYPES.has(contentType) ? policy.maxVideoBytes : policy.maxBytes;
+export function maxBytesForContentType(limits: UploadLimits, contentType: string): number {
+  const base = VIDEO_TYPES.has(contentType) ? limits.maxVideoBytes : limits.maxBytes;
   const rowMax = ROW_BY_TYPE.get(contentType)?.maxBytes;
   return rowMax !== undefined ? Math.min(base, rowMax) : base;
 }
@@ -615,16 +641,27 @@ function tooLarge(
 }
 
 /**
- * Pre-buffer size gate: reject on a declared `Content-Length` over the larger
- * of image/video caps before the body is read into isolate memory.
- * `inspectUpload` is the authoritative backstop for type-specific limits.
+ * Pre-buffer size gate: reject on a declared `Content-Length` over the
+ * ceiling before the body is read into isolate memory. `inspectUpload` is
+ * the authoritative backstop for type-specific limits.
+ *
+ * With `declaredType` (the caller knows what the client claims — the PUT
+ * route's `resolveDeclaredContentType`), the ceiling is that type's own
+ * (`maxBytesForContentType`), so a declared 50 MB SVG is refused before it
+ * is buffered rather than after — the gated SVG/XML rows cap at 4 MiB and
+ * their plausibility check decodes the whole body. Without it, the larger of
+ * the image/video caps, which is the loosest any body could be admitted at.
  */
 export function checkDeclaredLength(
   contentLength: string | undefined,
-  policy: UploadPolicy,
+  limits: UploadLimits,
+  declaredType?: string,
 ): UploadRejection | null {
   const declared = Number(contentLength);
-  const ceiling = Math.max(policy.maxBytes, policy.maxVideoBytes);
+  const ceiling =
+    declaredType !== undefined
+      ? maxBytesForContentType(limits, declaredType)
+      : Math.max(limits.maxBytes, limits.maxVideoBytes);
   if (Number.isFinite(declared) && declared > ceiling) return tooLarge(ceiling);
   return null;
 }

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -27,11 +27,26 @@ type UploadTypeRow = {
   /**
    * `sniff` — recognized by `detectContentType` from its magic bytes.
    * `declared` — no magic bytes at all; accepted only when the client
-   * declares the type and the body passes `looksLikeText`.
+   * declares the type and the body passes the row's `plausible` check
+   * (defaults to `looksLikeText` when the row doesn't name its own).
    */
   readonly verify: "sniff" | "declared";
-  /** First entry is canonical: the extension derived when naming a key from a type. */
+  /** First entry is canonical: the extension derived when naming a key from a type. Empty for a declaration-only type with no key convention (`text/xml`). */
   readonly extensions: readonly string[];
+  /**
+   * Present only on a row whose acceptance additionally depends on the
+   * upload lane's active-content verification state (issue #929) —
+   * `resolveUploadPolicy` strips these rows from the allowlist unless its
+   * caller's gate passed.
+   */
+  readonly gate?: "active-content";
+  /**
+   * Declared-row plausibility predicate `inspectUpload` runs instead of the
+   * bare `looksLikeText` call. Every declared row that names one relies on
+   * it entirely (not layered on top of `looksLikeText` by the caller) — the
+   * gated SVG/XML rows below compose `looksLikeText` themselves.
+   */
+  readonly plausible?: (bytes: Uint8Array) => boolean;
 };
 
 /**
@@ -41,14 +56,17 @@ type UploadTypeRow = {
  *
  * Intended payloads: static images, the short gif/video clips embedded in
  * GitHub repos, and the non-media artifacts agents produce (reports, logs,
- * JSON, archives). Deliberately excludes `image/svg+xml` and `text/html` —
- * storage.uploads.sh is a bare R2 custom domain with no Worker in front of
- * it, so the stored content type is the only control, and either of those
- * served inline can carry script (stored XSS on our own origin). Everything
- * below renders as inert text, opens in a sandboxed viewer (PDF), or has no
- * inline handler at all (zip/gzip).
+ * JSON, archives). Deliberately excludes `text/html` outright — served
+ * inline from a bare R2 custom domain with no Worker in front of it (the
+ * stored content type is the only control), it can always carry script.
+ * `image/svg+xml`/`application/xml`/`text/xml` (below, `GATED_UPLOAD_TYPES`)
+ * carry the same risk but are accepted — declared-only, plausibility-
+ * filtered, and only on a lane proven to serve them behind a sandboxing CSP
+ * (issue #929, `./active-content.ts`). Everything else renders as inert
+ * text, opens in a sandboxed viewer (PDF), or has no inline handler at all
+ * (zip/gzip).
  */
-const UPLOAD_TYPES: readonly UploadTypeRow[] = [
+const UNGATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
   { type: "image/png", kind: "image", verify: "sniff", extensions: ["png"] },
   { type: "image/jpeg", kind: "image", verify: "sniff", extensions: ["jpg", "jpeg"] },
   { type: "image/gif", kind: "image", verify: "sniff", extensions: ["gif"] },
@@ -71,13 +89,66 @@ const UPLOAD_TYPES: readonly UploadTypeRow[] = [
   { type: "application/json", kind: "file", verify: "declared", extensions: ["json"] },
 ];
 
+/**
+ * `image/svg+xml`, `application/xml`, `text/xml` — accepted only on a lane
+ * whose public host is verified to serve them behind a sandboxing CSP
+ * (issue #929, spec "Guards"). Declared-only, never sniffed, on purpose: a
+ * `.log` that starts with `<?xml` keeps being `text/plain`, and a `.png`
+ * carrying SVG bytes still 415s (sniffing wins in `inspectUpload` whenever
+ * it recognizes anything at all). Each row's `plausible` is a reputation
+ * pre-filter, not the control — the sandboxing CSP on the serving host is
+ * what actually neutralizes an active payload; this just keeps an obviously
+ * hostile body from ever reaching a verified lane.
+ */
+const GATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
+  {
+    type: "image/svg+xml",
+    kind: "image",
+    verify: "declared",
+    extensions: ["svg"],
+    gate: "active-content",
+    plausible: (bytes) => looksLikeSvg(bytes) && !containsActiveMarkup(decodeFull(bytes)),
+  },
+  {
+    type: "application/xml",
+    kind: "file",
+    verify: "declared",
+    extensions: ["xml"],
+    gate: "active-content",
+    plausible: (bytes) => looksLikeXml(bytes) && !containsActiveMarkup(decodeFull(bytes)),
+  },
+  {
+    // Declaration-only: no extension maps to it, so a key's extension alone
+    // can never claim this type — only an explicit Content-Type header can.
+    type: "text/xml",
+    kind: "file",
+    verify: "declared",
+    extensions: [],
+    gate: "active-content",
+    plausible: (bytes) => looksLikeXml(bytes) && !containsActiveMarkup(decodeFull(bytes)),
+  },
+];
+
+const UPLOAD_TYPES: readonly UploadTypeRow[] = [...UNGATED_UPLOAD_TYPES, ...GATED_UPLOAD_TYPES];
+
 const ROW_BY_TYPE: ReadonlyMap<string, UploadTypeRow> = new Map(
   UPLOAD_TYPES.map((row) => [row.type, row]),
 );
 
-export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = UPLOAD_TYPES.map((row) => row.type);
+/** The ungated default allowlist — unchanged by issue #929; see `GATED_CONTENT_TYPES`. */
+export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = UNGATED_UPLOAD_TYPES.map(
+  (row) => row.type,
+);
+
+/**
+ * `image/svg+xml`, `application/xml`, `text/xml` — never in
+ * `DEFAULT_ALLOWED_CONTENT_TYPES`; `resolveUploadPolicy` adds them only when
+ * its caller's `activeContent` gate passed (issue #929).
+ */
+export const GATED_CONTENT_TYPES: readonly string[] = GATED_UPLOAD_TYPES.map((row) => row.type);
 
 const DEFAULT_ALLOWED_SET: ReadonlySet<string> = new Set(DEFAULT_ALLOWED_CONTENT_TYPES);
+const GATED_SET: ReadonlySet<string> = new Set(GATED_CONTENT_TYPES);
 
 /** Video content types the upload path (and poster generation) accepts. */
 export const VIDEO_TYPES = new Set(
@@ -85,11 +156,14 @@ export const VIDEO_TYPES = new Set(
 );
 
 /**
- * Types with no magic bytes. Accepted only when the client declares one of
- * them and the body passes `looksLikeText` — see `inspectUpload`.
+ * Ungated types with no magic bytes. Accepted only when the client declares
+ * one of them and the body passes `looksLikeText` — see `inspectUpload`.
+ * Excludes the gated SVG/XML rows (also declared-only, but with their own
+ * `plausible` check and a separate acceptance gate) so this set's meaning —
+ * "declared text, no further condition" — doesn't change under issue #929.
  */
 export const TEXT_CONTENT_TYPES: ReadonlySet<string> = new Set(
-  UPLOAD_TYPES.filter((row) => row.verify === "declared").map((row) => row.type),
+  UNGATED_UPLOAD_TYPES.filter((row) => row.verify === "declared").map((row) => row.type),
 );
 
 export function uploadKind(contentType: string): UploadKind {
@@ -134,7 +208,19 @@ function positiveBytes(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
-export function resolveUploadPolicy(record: UploadPolicyOverrides): UploadPolicy {
+/**
+ * Builds the effective upload policy for a workspace. `opts.activeContent`
+ * (issue #929) is required — never defaulted — so no caller can forget to
+ * pass its `activeContentAllowed(env, ws)` result and silently open (or
+ * close) the gated SVG/XML rows. When `false`, the gated types are stripped
+ * from the resulting `allowed` set even when the workspace's own
+ * `allowedContentTypes` override names one explicitly — an override extends
+ * or restricts the ungated allowlist, it can't bypass lane verification.
+ */
+export function resolveUploadPolicy(
+  record: UploadPolicyOverrides,
+  opts: { activeContent: boolean },
+): UploadPolicy {
   // Sanitize before handing off to the shared resolution seam, same pattern
   // as `budget.ts`'s `resolveBudgetLimits`: a zero/negative/non-finite
   // override collapses to "unset" here, *before* `resolveEffectiveLimits`
@@ -148,10 +234,13 @@ export function resolveUploadPolicy(record: UploadPolicyOverrides): UploadPolicy
   // No plan stamped: reproduce the legacy fallback exactly.
   const maxBytes = positiveBytes(resolved.maxUploadBytes) ?? DEFAULT_MAX_UPLOAD_BYTES;
   const maxVideoBytes = positiveBytes(resolved.maxVideoUploadBytes) ?? maxBytes;
-  const allowed =
+  const base =
     record.allowedContentTypes && record.allowedContentTypes.length > 0
       ? new Set(record.allowedContentTypes)
-      : DEFAULT_ALLOWED_SET;
+      : new Set([...DEFAULT_ALLOWED_SET, ...GATED_SET]);
+  const allowed = opts.activeContent
+    ? base
+    : new Set([...base].filter((type) => !GATED_SET.has(type)));
   return { maxBytes, maxVideoBytes, allowed };
 }
 
@@ -240,6 +329,75 @@ export function looksLikeText(bytes: Uint8Array): boolean {
   }
 }
 
+/** Bytes decoded when sniffing an SVG/XML prefix shape — small on purpose; these are declared-only rows, not a general parser. */
+const XML_SNIFF_BYTES = 4 * 1024;
+
+/**
+ * Best-effort UTF-8 decode of `bytes`, never throwing (mirrors
+ * `TextDecoder`'s default non-fatal mode). `ignoreBOM: false` means a
+ * leading BOM is consumed rather than left in the output — the explicit
+ * manual strip in `looksLikeSvg` below is a defensive fallback, not the
+ * primary mechanism.
+ */
+function decodeLossy(bytes: Uint8Array): string {
+  return new TextDecoder("utf-8", { fatal: false, ignoreBOM: false }).decode(bytes);
+}
+
+/** Decodes the whole body — used by the gated rows' `plausible` checks, which scan the full (small) SVG/XML body for active markup, not just the head. */
+function decodeFull(bytes: Uint8Array): string {
+  return decodeLossy(bytes);
+}
+
+/**
+ * Shape check for a declared `image/svg+xml` upload: `looksLikeText`, and
+ * — in the first {@link XML_SNIFF_BYTES} decoded — the text starts with
+ * `<svg` once a leading BOM and any number of `<?xml … ?>` prologs,
+ * `<!-- … -->` comments, and `<!DOCTYPE …>` declarations (in any order) are
+ * stripped. Pure shape; the reputation pre-filter (`containsActiveMarkup`)
+ * is a separate, composed check — see `GATED_UPLOAD_TYPES`.
+ */
+export function looksLikeSvg(bytes: Uint8Array): boolean {
+  if (!looksLikeText(bytes)) return false;
+  let head = decodeLossy(bytes.subarray(0, Math.min(bytes.byteLength, XML_SNIFF_BYTES)));
+  if (head.charCodeAt(0) === 0xfeff) head = head.slice(1);
+  let prev: string;
+  do {
+    prev = head;
+    head = head
+      .replace(/^\s+/, "")
+      .replace(/^<\?xml[\s\S]*?\?>/, "")
+      .replace(/^<!--[\s\S]*?-->/, "")
+      .replace(/^<!DOCTYPE[^>]*>/i, "");
+  } while (head !== prev && head.length > 0);
+  return head.trimStart().startsWith("<svg");
+}
+
+/**
+ * Shape check for a declared `application/xml`/`text/xml` upload:
+ * `looksLikeText`, and the first non-whitespace character (within the first
+ * {@link XML_SNIFF_BYTES} decoded) is `<`. Deliberately looser than
+ * {@link looksLikeSvg} — any well-formed-looking XML document, not just one
+ * rooted at a specific element.
+ */
+export function looksLikeXml(bytes: Uint8Array): boolean {
+  if (!looksLikeText(bytes)) return false;
+  const head = decodeLossy(bytes.subarray(0, Math.min(bytes.byteLength, XML_SNIFF_BYTES)));
+  return /^\s*</.test(head);
+}
+
+/**
+ * Reputation pre-filter for a gated SVG/XML body (issue #929): true when the
+ * text contains a `<script` tag, an `on*=` event-handler attribute, a
+ * `javascript:` URL, `<foreignObject` (SVG can embed arbitrary HTML through
+ * it), or an `<?xml-stylesheet` processing instruction (can point at an XSLT
+ * that runs script). This is defense in depth, not the control — the
+ * sandboxing CSP the serving lane is verified to send (`./active-content.ts`)
+ * is what actually neutralizes anything this filter misses.
+ */
+export function containsActiveMarkup(text: string): boolean {
+  return /<script|\bon[a-z]+\s*=|javascript:|<foreignobject|<\?xml-stylesheet/i.test(text);
+}
+
 /**
  * Extension → content type, built from `UPLOAD_TYPES`. Only the
  * `verify: "declared"` rows can change an admission outcome (an extension is
@@ -248,7 +406,10 @@ export function looksLikeText(bytes: Uint8Array): boolean {
  * `details.declared` on a 415 is informative, so a key's extension still
  * names a type, and so the CLI-side `inferContentType`
  * (packages/uploads/src/embed.ts) stays a readable mirror of this list.
- * Neither svg nor html appears in the table at all.
+ * `svg`/`xml` map to their gated types (declaration-only still applies —
+ * this table only ever feeds `contentTypeFromKey`, which names a claim, not
+ * an acceptance); `text/xml` has no extension, so it can only ever be
+ * claimed by an explicit Content-Type header. `html` never appears.
  */
 const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = Object.fromEntries(
   UPLOAD_TYPES.flatMap((row) => row.extensions.map((ext) => [ext, row.type] as const)),
@@ -420,13 +581,14 @@ export function inspectUpload(
   let contentType: string | null = null;
   if (detected !== null) {
     if (policy.allowed.has(detected)) contentType = detected;
-  } else if (
-    declaredType !== undefined &&
-    ROW_BY_TYPE.get(declaredType)?.verify === "declared" &&
-    policy.allowed.has(declaredType) &&
-    looksLikeText(bytes)
-  ) {
-    contentType = declaredType;
+  } else if (declaredType !== undefined && policy.allowed.has(declaredType)) {
+    const row = ROW_BY_TYPE.get(declaredType);
+    // Each declared row names its own plausibility check (SVG/XML: their own
+    // shape + reputation filter; every other declared row falls back to the
+    // plain `looksLikeText` this always used to call directly).
+    if (row?.verify === "declared" && (row.plausible ?? looksLikeText)(bytes)) {
+      contentType = declaredType;
+    }
   }
   if (contentType === null) {
     return {

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -47,6 +47,25 @@ type UploadTypeRow = {
    * gated SVG/XML rows below compose `looksLikeText` themselves.
    */
   readonly plausible?: (bytes: Uint8Array) => boolean;
+  /**
+   * Per-row byte ceiling, tighter than the policy's own `maxBytes`/
+   * `maxVideoBytes` — set on the gated SVG/XML rows (issue #929 review) so
+   * `inspectUpload` can reject an oversize declared body with 413 *before*
+   * `plausible` ever decodes/regex-scans it (`decodeFull`/`containsActiveMarkup`
+   * are O(body size), and these rows are meant to stay small). Absent means
+   * "no tighter cap than the policy's own" — see `maxBytesForContentType`.
+   */
+  readonly maxBytes?: number;
+  /**
+   * Optional diagnostic companion to `plausible` (issue #929 review):
+   * called only when `plausible` returned false, this returns a
+   * machine-readable `details.reason` for the 415 when the failure is more
+   * specific than "declared type didn't pass its check" — today just
+   * `"active_markup"` on a gated row whose shape passed but
+   * `containsActiveMarkup` didn't. `undefined` (no reason) for every other
+   * failure, including on ungated declared rows, which don't set this at all.
+   */
+  readonly plausibleReason?: (bytes: Uint8Array) => string | undefined;
 };
 
 /**
@@ -96,10 +115,30 @@ const UNGATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
  * `.log` that starts with `<?xml` keeps being `text/plain`, and a `.png`
  * carrying SVG bytes still 415s (sniffing wins in `inspectUpload` whenever
  * it recognizes anything at all). Each row's `plausible` is a reputation
- * pre-filter, not the control — the sandboxing CSP on the serving host is
- * what actually neutralizes an active payload; this just keeps an obviously
- * hostile body from ever reaching a verified lane.
+ * pre-filter over a *buffered* body — PUT, MCP, and server-side copies all
+ * decode it — not the control: the sandboxing CSP on the serving host is
+ * what actually neutralizes an active payload, and a presigned upload
+ * writes straight to the bucket with no server inspection at all, `plausible`
+ * included. `maxBytes` caps every row at 4 MiB, well under the general
+ * upload ceiling, so `inspectUpload` can reject an oversize body with 413
+ * before `plausible` decodes/regex-scans it at all — see `maxBytesForContentType`.
  */
+const GATED_MAX_BYTES = 4 * 1024 * 1024;
+
+/** `plausibleReason` for the gated SVG row: "active_markup" when the shape passed but the reputation filter didn't, else no specific reason. */
+function svgPlausibleReason(bytes: Uint8Array): string | undefined {
+  return looksLikeSvg(bytes) && containsActiveMarkup(decodeFull(bytes))
+    ? "active_markup"
+    : undefined;
+}
+
+/** `plausibleReason` for the gated XML/text-xml rows — same shape as `svgPlausibleReason`, against `looksLikeXml`. */
+function xmlPlausibleReason(bytes: Uint8Array): string | undefined {
+  return looksLikeXml(bytes) && containsActiveMarkup(decodeFull(bytes))
+    ? "active_markup"
+    : undefined;
+}
+
 const GATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
   {
     type: "image/svg+xml",
@@ -107,7 +146,9 @@ const GATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
     verify: "declared",
     extensions: ["svg"],
     gate: "active-content",
+    maxBytes: GATED_MAX_BYTES,
     plausible: (bytes) => looksLikeSvg(bytes) && !containsActiveMarkup(decodeFull(bytes)),
+    plausibleReason: svgPlausibleReason,
   },
   {
     type: "application/xml",
@@ -115,7 +156,9 @@ const GATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
     verify: "declared",
     extensions: ["xml"],
     gate: "active-content",
+    maxBytes: GATED_MAX_BYTES,
     plausible: (bytes) => looksLikeXml(bytes) && !containsActiveMarkup(decodeFull(bytes)),
+    plausibleReason: xmlPlausibleReason,
   },
   {
     // Declaration-only: no extension maps to it, so a key's extension alone
@@ -125,7 +168,9 @@ const GATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
     verify: "declared",
     extensions: [],
     gate: "active-content",
+    maxBytes: GATED_MAX_BYTES,
     plausible: (bytes) => looksLikeXml(bytes) && !containsActiveMarkup(decodeFull(bytes)),
+    plausibleReason: xmlPlausibleReason,
   },
 ];
 
@@ -244,8 +289,16 @@ export function resolveUploadPolicy(
   return { maxBytes, maxVideoBytes, allowed };
 }
 
+/**
+ * The effective byte ceiling for one content type: the policy's own
+ * `maxVideoBytes`/`maxBytes`, tightened by the row's own `maxBytes` when it
+ * has one (issue #929 review — the gated SVG/XML rows cap at 4 MiB
+ * regardless of how high a workspace's general upload ceiling is set).
+ */
 export function maxBytesForContentType(policy: UploadPolicy, contentType: string): number {
-  return VIDEO_TYPES.has(contentType) ? policy.maxVideoBytes : policy.maxBytes;
+  const base = VIDEO_TYPES.has(contentType) ? policy.maxVideoBytes : policy.maxBytes;
+  const rowMax = ROW_BY_TYPE.get(contentType)?.maxBytes;
+  return rowMax !== undefined ? Math.min(base, rowMax) : base;
 }
 
 /** True when `bytes` contains `signature` at `offset` (bounds-checked). */
@@ -390,9 +443,14 @@ export function looksLikeXml(bytes: Uint8Array): boolean {
  * text contains a `<script` tag, an `on*=` event-handler attribute, a
  * `javascript:` URL, `<foreignObject` (SVG can embed arbitrary HTML through
  * it), or an `<?xml-stylesheet` processing instruction (can point at an XSLT
- * that runs script). This is defense in depth, not the control — the
+ * that runs script). This is defense in depth, not the control, and it only
+ * ever runs on a *buffered* body a server handler actually reads — the PUT
+ * route, the MCP `put` tool, and server-side copies (`putOptsFromStoredObject`
+ * bypasses the gate entirely, so this filter never even applies there). A
+ * presigned upload writes straight to the bucket over HTTP with no server in
+ * the loop, so nothing here ever inspects it — which is exactly why the
  * sandboxing CSP the serving lane is verified to send (`./active-content.ts`)
- * is what actually neutralizes anything this filter misses.
+ * is the actual control, not this filter.
  */
 export function containsActiveMarkup(text: string): boolean {
   return /<script|\bon[a-z]+\s*=|javascript:|<foreignobject|<\?xml-stylesheet/i.test(text);
@@ -579,18 +637,46 @@ export function inspectUpload(
 ): UploadInspection {
   const detected = detectContentType(bytes);
   let contentType: string | null = null;
+  let declaredOversize: UploadRejection | null = null;
   if (detected !== null) {
     if (policy.allowed.has(detected)) contentType = detected;
   } else if (declaredType !== undefined && policy.allowed.has(declaredType)) {
     const row = ROW_BY_TYPE.get(declaredType);
-    // Each declared row names its own plausibility check (SVG/XML: their own
-    // shape + reputation filter; every other declared row falls back to the
-    // plain `looksLikeText` this always used to call directly).
-    if (row?.verify === "declared" && (row.plausible ?? looksLikeText)(bytes)) {
-      contentType = declaredType;
+    if (row?.verify === "declared") {
+      // Size gate before plausibility, not after: a declared row's
+      // `plausible` (the gated SVG/XML rows especially) decodes and
+      // regex-scans the *whole* body, so an oversize payload must 413
+      // before that scan ever runs, not after (issue #929 review).
+      const declaredMaxBytes = maxBytesForContentType(policy, declaredType);
+      if (bytes.byteLength > declaredMaxBytes) {
+        declaredOversize = tooLarge(declaredMaxBytes, {
+          contentType: declaredType,
+          kind: uploadKind(declaredType),
+        });
+      } else if ((row.plausible ?? looksLikeText)(bytes)) {
+        // Each declared row names its own plausibility check (SVG/XML:
+        // their own shape + reputation filter; every other declared row
+        // falls back to the plain `looksLikeText` this always used to call
+        // directly).
+        contentType = declaredType;
+      }
     }
   }
+  if (contentType === null && declaredOversize) return declaredOversize;
   if (contentType === null) {
+    // A machine-readable `reason`, in the two cases that have a specific
+    // one (issue #929 review): the type is gated and this workspace's lane
+    // hasn't verified for it (`policy.allowed` never had it to begin with,
+    // regardless of what `plausible` would have said), or the gate is open
+    // but the body's own reputation filter (not its shape) is what failed.
+    // Every other rejection carries no `reason` — the generic 415 stands.
+    let reason: string | undefined;
+    if (declaredType !== undefined) {
+      reason =
+        GATED_SET.has(declaredType) && !policy.allowed.has(declaredType)
+          ? "lane_not_verified"
+          : ROW_BY_TYPE.get(declaredType)?.plausibleReason?.(bytes);
+    }
     return {
       ok: false,
       status: 415,
@@ -598,6 +684,7 @@ export function inspectUpload(
         details: {
           allowed: [...policy.allowed],
           ...(declaredType !== undefined ? { declared: declaredType } : {}),
+          ...(reason !== undefined ? { reason } : {}),
         },
       }),
     };

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -451,6 +451,12 @@ export function looksLikeXml(bytes: Uint8Array): boolean {
  * the loop, so nothing here ever inspects it — which is exactly why the
  * sandboxing CSP the serving lane is verified to send (`./active-content.ts`)
  * is the actual control, not this filter.
+ *
+ * `\bon[a-z]+\s*=` is deliberately broad: it also matches ordinary
+ * non-handler attributes that happen to start with "on", e.g. `online=` or
+ * `once=` on an unrelated element — a false-positive 415, not a security
+ * gap, and reputation defense in depth is allowed to be loose. Revisit if
+ * that starts rejecting real uploads often enough to bite.
  */
 export function containsActiveMarkup(text: string): boolean {
   return /<script|\bon[a-z]+\s*=|javascript:|<foreignobject|<\?xml-stylesheet/i.test(text);

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -624,12 +624,16 @@ function tooLarge(
  * ceiling before the body is read into isolate memory. `inspectUpload` is
  * the authoritative backstop for type-specific limits.
  *
- * With `declaredType` (the caller knows what the client claims — the PUT
- * route's `resolveDeclaredContentType`), the ceiling is that type's own
- * (`maxBytesForContentType`), so a declared 50 MB SVG is refused before it
- * is buffered rather than after — the gated SVG/XML rows cap at 4 MiB and
- * their plausibility check decodes the whole body. Without it, the larger of
- * the image/video caps, which is the loosest any body could be admitted at.
+ * The ceiling starts at the larger of the workspace's image/video caps — the
+ * loosest any body could be admitted at — and is *tightened*, never raised,
+ * when `declaredType` names a row with its own `maxBytes` (the gated
+ * SVG/XML rows cap at 4 MiB and their `admit` check decodes the whole
+ * body), so a declared 50 MB SVG is refused before it is buffered rather
+ * than after. A declared type with no row-level cap of its own (an ordinary
+ * image/video type) never narrows the ceiling below the workspace's general
+ * limit, even when that type's own per-type max (`maxBytesForContentType`)
+ * would be lower — this check only ever tightens for rows that carry their
+ * own cap.
  */
 export function checkDeclaredLength(
   contentLength: string | undefined,
@@ -637,10 +641,8 @@ export function checkDeclaredLength(
   declaredType?: string,
 ): UploadRejection | null {
   const declared = Number(contentLength);
-  const ceiling =
-    declaredType !== undefined
-      ? maxBytesForContentType(limits, declaredType)
-      : Math.max(limits.maxBytes, limits.maxVideoBytes);
+  const rowMax = declaredType === undefined ? undefined : ROW_BY_TYPE.get(declaredType)?.maxBytes;
+  const ceiling = Math.min(Math.max(limits.maxBytes, limits.maxVideoBytes), rowMax ?? Infinity);
   if (Number.isFinite(declared) && declared > ceiling) return tooLarge(ceiling);
   return null;
 }

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -450,10 +450,9 @@ export function looksLikeXml(bytes: Uint8Array): boolean {
  * it), or an `<?xml-stylesheet` processing instruction (can point at an XSLT
  * that runs script). This is defense in depth, not the control, and it only
  * ever runs on a *buffered* body a server handler actually reads — the PUT
- * route, the MCP `put` tool, and server-side copies (`putOptsFromStoredObject`
- * bypasses the gate entirely, so this filter never even applies there). A
- * presigned upload writes straight to the bucket over HTTP with no server in
- * the loop, so nothing here ever inspects it — which is exactly why the
+ * route, the MCP `put` tool, and server-side copies. A presigned upload
+ * writes straight to the bucket over HTTP with no server in the loop, so
+ * nothing here ever inspects it — which is exactly why the
  * sandboxing CSP the serving lane is verified to send (`./active-content.ts`)
  * is the actual control, not this filter.
  *

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -21,51 +21,43 @@ export const DEFAULT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // 25 MiB
 /** Coarse family for 413 payloads and the optimizer/poster branches. */
 export type UploadKind = "image" | "video" | "file";
 
+/**
+ * One declared row's verdict on a body: accepted, or rejected — with a
+ * machine-readable `details.reason` for the 415 when the failure is more
+ * specific than "the declared type didn't pass its check" (today just
+ * `"active_markup"`).
+ */
+type Admission = { ok: true } | { ok: false; reason?: string };
+
 type UploadTypeRow = {
   readonly type: string;
   readonly kind: UploadKind;
   /**
    * `sniff` — recognized by `detectContentType` from its magic bytes.
    * `declared` — no magic bytes at all; accepted only when the client
-   * declares the type and the body passes the row's `plausible` check
-   * (defaults to `looksLikeText` when the row doesn't name its own).
+   * declares the type and the body passes the row's `admit` check
+   * (defaults to `admitText` when the row doesn't name its own).
    */
   readonly verify: "sniff" | "declared";
   /** First entry is canonical: the extension derived when naming a key from a type. Empty for a declaration-only type with no key convention (`text/xml`). */
   readonly extensions: readonly string[];
   /**
-   * Present only on a row whose acceptance additionally depends on the
-   * upload lane's active-content verification state (issue #929) —
-   * `resolveUploadPolicy` strips these rows from the allowlist unless its
-   * caller's gate passed.
-   */
-  readonly gate?: "active-content";
-  /**
-   * Declared-row plausibility predicate `inspectUpload` runs instead of the
-   * bare `looksLikeText` call. Every declared row that names one relies on
-   * it entirely (not layered on top of `looksLikeText` by the caller) — the
+   * Declared-row admission check `inspectDeclared` runs instead of the bare
+   * `admitText` default. Every declared row that names one relies on it
+   * entirely (not layered on top of `looksLikeText` by the caller) — the
    * gated SVG/XML rows below compose `looksLikeText` themselves.
    */
-  readonly plausible?: (bytes: Uint8Array) => boolean;
+  readonly admit?: (bytes: Uint8Array) => Admission;
   /**
-   * Per-row byte ceiling, tighter than the policy's own `maxBytes`/
+   * Per-row byte ceiling, tighter than the workspace's own `maxBytes`/
    * `maxVideoBytes` — set on the gated SVG/XML rows (issue #929 review) so
-   * `inspectUpload` can reject an oversize declared body with 413 *before*
-   * `plausible` ever decodes/regex-scans it (`decodeFull`/`containsActiveMarkup`
-   * are O(body size), and these rows are meant to stay small). Absent means
-   * "no tighter cap than the policy's own" — see `maxBytesForContentType`.
+   * `inspectDeclared` can reject an oversize declared body with 413 *before*
+   * `admit` ever decodes/regex-scans it (the decode and
+   * `containsActiveMarkup` are O(body size), and these rows are meant to
+   * stay small). Absent means "no tighter cap than the workspace's own" —
+   * see `maxBytesForContentType`.
    */
   readonly maxBytes?: number;
-  /**
-   * Optional diagnostic companion to `plausible` (issue #929 review):
-   * called only when `plausible` returned false, this returns a
-   * machine-readable `details.reason` for the 415 when the failure is more
-   * specific than "declared type didn't pass its check" — today just
-   * `"active_markup"` on a gated row whose shape passed but
-   * `containsActiveMarkup` didn't. `undefined` (no reason) for every other
-   * failure, including on ungated declared rows, which don't set this at all.
-   */
-  readonly plausibleReason?: (bytes: Uint8Array) => string | undefined;
 };
 
 /**
@@ -114,30 +106,39 @@ const UNGATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
  * (issue #929, spec "Guards"). Declared-only, never sniffed, on purpose: a
  * `.log` that starts with `<?xml` keeps being `text/plain`, and a `.png`
  * carrying SVG bytes still 415s (sniffing wins in `inspectUpload` whenever
- * it recognizes anything at all). Each row's `plausible` is a reputation
+ * it recognizes anything at all). Each row's `admit` runs a reputation
  * pre-filter over a *buffered* body — PUT, MCP, and server-side copies all
- * decode it — not the control: the sandboxing CSP on the serving host is
- * what actually neutralizes an active payload, and a presigned upload
- * writes straight to the bucket with no server inspection at all, `plausible`
- * included. `maxBytes` caps every row at 4 MiB, well under the general
- * upload ceiling, so `inspectUpload` can reject an oversize body with 413
- * before `plausible` decodes/regex-scans it at all — see `maxBytesForContentType`.
+ * decode it — which is not the control: the sandboxing CSP on the serving
+ * host is what actually neutralizes an active payload, and a presigned
+ * upload writes straight to the bucket with no server inspection at all,
+ * `admit` included. `maxBytes` caps every row at 4 MiB, well under the
+ * general upload ceiling, so `inspectDeclared` can reject an oversize body
+ * with 413 before `admit` decodes/regex-scans it at all — see
+ * `maxBytesForContentType`.
  */
 const GATED_MAX_BYTES = 4 * 1024 * 1024;
 
-/** `plausibleReason` for the gated SVG row: "active_markup" when the shape passed but the reputation filter didn't, else no specific reason. */
-function svgPlausibleReason(bytes: Uint8Array): string | undefined {
-  return looksLikeSvg(bytes) && containsActiveMarkup(decodeFull(bytes))
-    ? "active_markup"
-    : undefined;
+/** The default declared-row admission: text has no magic bytes, so a plausible decode is all there is to check. */
+function admitText(bytes: Uint8Array): Admission {
+  return looksLikeText(bytes) ? { ok: true } : { ok: false };
 }
 
-/** `plausibleReason` for the gated XML/text-xml rows — same shape as `svgPlausibleReason`, against `looksLikeXml`. */
-function xmlPlausibleReason(bytes: Uint8Array): string | undefined {
-  return looksLikeXml(bytes) && containsActiveMarkup(decodeFull(bytes))
-    ? "active_markup"
-    : undefined;
+/**
+ * Admission for a gated SVG/XML row: the row's own shape check first, then —
+ * over a single decode of the whole (small, `maxBytes`-capped) body — the
+ * `containsActiveMarkup` reputation filter, whose failure is specific enough
+ * to name in the 415.
+ */
+function admitMarkup(shape: (bytes: Uint8Array) => boolean): (bytes: Uint8Array) => Admission {
+  return (bytes) => {
+    if (!shape(bytes)) return { ok: false };
+    if (containsActiveMarkup(decodeLossy(bytes))) return { ok: false, reason: "active_markup" };
+    return { ok: true };
+  };
 }
+
+const admitSvg = admitMarkup(looksLikeSvg);
+const admitXml = admitMarkup(looksLikeXml);
 
 const GATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
   {
@@ -145,20 +146,16 @@ const GATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
     kind: "image",
     verify: "declared",
     extensions: ["svg"],
-    gate: "active-content",
     maxBytes: GATED_MAX_BYTES,
-    plausible: (bytes) => looksLikeSvg(bytes) && !containsActiveMarkup(decodeFull(bytes)),
-    plausibleReason: svgPlausibleReason,
+    admit: admitSvg,
   },
   {
     type: "application/xml",
     kind: "file",
     verify: "declared",
     extensions: ["xml"],
-    gate: "active-content",
     maxBytes: GATED_MAX_BYTES,
-    plausible: (bytes) => looksLikeXml(bytes) && !containsActiveMarkup(decodeFull(bytes)),
-    plausibleReason: xmlPlausibleReason,
+    admit: admitXml,
   },
   {
     // Declaration-only: no extension maps to it, so a key's extension alone
@@ -167,10 +164,8 @@ const GATED_UPLOAD_TYPES: readonly UploadTypeRow[] = [
     kind: "file",
     verify: "declared",
     extensions: [],
-    gate: "active-content",
     maxBytes: GATED_MAX_BYTES,
-    plausible: (bytes) => looksLikeXml(bytes) && !containsActiveMarkup(decodeFull(bytes)),
-    plausibleReason: xmlPlausibleReason,
+    admit: admitXml,
   },
 ];
 
@@ -198,17 +193,6 @@ const GATED_SET: ReadonlySet<string> = new Set(GATED_CONTENT_TYPES);
 /** Video content types the upload path (and poster generation) accepts. */
 export const VIDEO_TYPES = new Set(
   UPLOAD_TYPES.filter((row) => row.kind === "video").map((row) => row.type),
-);
-
-/**
- * Ungated types with no magic bytes. Accepted only when the client declares
- * one of them and the body passes `looksLikeText` — see `inspectUpload`.
- * Excludes the gated SVG/XML rows (also declared-only, but with their own
- * `plausible` check and a separate acceptance gate) so this set's meaning —
- * "declared text, no further condition" — doesn't change under issue #929.
- */
-export const TEXT_CONTENT_TYPES: ReadonlySet<string> = new Set(
-  UNGATED_UPLOAD_TYPES.filter((row) => row.verify === "declared").map((row) => row.type),
 );
 
 export function uploadKind(contentType: string): UploadKind {
@@ -420,11 +404,6 @@ const XML_SNIFF_BYTES = 4 * 1024;
  */
 function decodeLossy(bytes: Uint8Array): string {
   return new TextDecoder("utf-8", { fatal: false, ignoreBOM: false }).decode(bytes);
-}
-
-/** Decodes the whole body — used by the gated rows' `plausible` checks, which scan the full (small) SVG/XML body for active markup, not just the head. */
-function decodeFull(bytes: Uint8Array): string {
-  return decodeLossy(bytes);
 }
 
 /**
@@ -667,11 +646,61 @@ export function checkDeclaredLength(
 }
 
 /**
+ * The shared 415. `reason` is a machine-readable narrowing of *why*, present
+ * only in the two cases specific enough to name (issue #929 review): the
+ * declared type is gated and this workspace's lane hasn't verified for it
+ * (`lane_not_verified`), or the gate is open but the body's own reputation
+ * filter, not its shape, is what failed (`active_markup`). Every other
+ * rejection carries none — the generic 415 stands.
+ */
+function unsupported(
+  policy: UploadPolicy,
+  declaredType?: string,
+  reason?: string,
+): UploadRejection {
+  return {
+    ok: false,
+    status: 415,
+    error: new UnsupportedMediaTypeError("unsupported media type", {
+      details: {
+        allowed: [...policy.allowed],
+        ...(declaredType !== undefined ? { declared: declaredType } : {}),
+        ...(reason !== undefined ? { reason } : {}),
+      },
+    }),
+  };
+}
+
+/**
+ * The declared-type branch of `inspectUpload`: bytes no sniffer recognized,
+ * under a claim the policy allows and a row that accepts claims at all.
+ * Size first, admission second — a declared row's `admit` (the gated
+ * SVG/XML rows especially) decodes and regex-scans the *whole* body, so an
+ * oversize payload has to 413 before that scan runs, not after (issue #929
+ * review).
+ */
+function inspectDeclared(
+  bytes: Uint8Array,
+  row: UploadTypeRow,
+  policy: UploadPolicy,
+  declaredType: string,
+): UploadInspection {
+  const maxBytes = maxBytesForContentType(policy, declaredType);
+  if (bytes.byteLength > maxBytes) {
+    return tooLarge(maxBytes, { contentType: declaredType, kind: uploadKind(declaredType) });
+  }
+  const admission = (row.admit ?? admitText)(bytes);
+  return admission.ok
+    ? { ok: true, contentType: declaredType }
+    : unsupported(policy, declaredType, admission.reason);
+}
+
+/**
  * Validate a fully-buffered upload body against the policy. Sniffed bytes
  * decide the stored type whenever they can; `declaredType` (from the request
  * header or the key's extension — see `resolveDeclaredContentType`) is
- * consulted only when sniffing finds nothing and the claim is one of the
- * text types, which have no magic. Then the type-specific size cap.
+ * consulted only when sniffing finds nothing and the claim is a declared
+ * row, which have no magic. Then the type-specific size cap.
  */
 export function inspectUpload(
   bytes: Uint8Array,
@@ -679,64 +708,28 @@ export function inspectUpload(
   declaredType?: string,
 ): UploadInspection {
   const detected = detectContentType(bytes);
-  let contentType: string | null = null;
-  let declaredOversize: UploadRejection | null = null;
   if (detected !== null) {
-    if (policy.allowed.has(detected)) contentType = detected;
-  } else if (declaredType !== undefined && policy.allowed.has(declaredType)) {
+    if (!policy.allowed.has(detected))
+      return unsupported(policy, declaredType, laneReason(policy, declaredType));
+    const maxBytes = maxBytesForContentType(policy, detected);
+    return bytes.byteLength > maxBytes
+      ? tooLarge(maxBytes, { contentType: detected, kind: uploadKind(detected) })
+      : { ok: true, contentType: detected };
+  }
+  if (declaredType !== undefined && policy.allowed.has(declaredType)) {
     const row = ROW_BY_TYPE.get(declaredType);
-    if (row?.verify === "declared") {
-      // Size gate before plausibility, not after: a declared row's
-      // `plausible` (the gated SVG/XML rows especially) decodes and
-      // regex-scans the *whole* body, so an oversize payload must 413
-      // before that scan ever runs, not after (issue #929 review).
-      const declaredMaxBytes = maxBytesForContentType(policy, declaredType);
-      if (bytes.byteLength > declaredMaxBytes) {
-        declaredOversize = tooLarge(declaredMaxBytes, {
-          contentType: declaredType,
-          kind: uploadKind(declaredType),
-        });
-      } else if ((row.plausible ?? looksLikeText)(bytes)) {
-        // Each declared row names its own plausibility check (SVG/XML:
-        // their own shape + reputation filter; every other declared row
-        // falls back to the plain `looksLikeText` this always used to call
-        // directly).
-        contentType = declaredType;
-      }
-    }
+    if (row?.verify === "declared") return inspectDeclared(bytes, row, policy, declaredType);
   }
-  if (contentType === null && declaredOversize) return declaredOversize;
-  if (contentType === null) {
-    // A machine-readable `reason`, in the two cases that have a specific
-    // one (issue #929 review): the type is gated and this workspace's lane
-    // hasn't verified for it (`policy.allowed` never had it to begin with,
-    // regardless of what `plausible` would have said), or the gate is open
-    // but the body's own reputation filter (not its shape) is what failed.
-    // Every other rejection carries no `reason` — the generic 415 stands.
-    let reason: string | undefined;
-    if (declaredType !== undefined) {
-      reason =
-        GATED_SET.has(declaredType) && !policy.allowed.has(declaredType)
-          ? "lane_not_verified"
-          : ROW_BY_TYPE.get(declaredType)?.plausibleReason?.(bytes);
-    }
-    return {
-      ok: false,
-      status: 415,
-      error: new UnsupportedMediaTypeError("unsupported media type", {
-        details: {
-          allowed: [...policy.allowed],
-          ...(declaredType !== undefined ? { declared: declaredType } : {}),
-          ...(reason !== undefined ? { reason } : {}),
-        },
-      }),
-    };
-  }
-  const maxBytes = maxBytesForContentType(policy, contentType);
-  if (bytes.byteLength > maxBytes) {
-    return tooLarge(maxBytes, { contentType, kind: uploadKind(contentType) });
-  }
-  return { ok: true, contentType };
+  return unsupported(policy, declaredType, laneReason(policy, declaredType));
+}
+
+/** `"lane_not_verified"` when the claim is a gated type this lane hasn't verified for; nothing otherwise. */
+function laneReason(policy: UploadPolicy, declaredType?: string): string | undefined {
+  return declaredType !== undefined &&
+    GATED_SET.has(declaredType) &&
+    !policy.allowed.has(declaredType)
+    ? "lane_not_verified"
+    : undefined;
 }
 
 /**

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,6 +20,7 @@ import { workspaceSettings } from "./routes/workspace-settings";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { runUsageAlertSweep } from "./usage-alert-sweep";
+import { runActiveContentHostSweep } from "./active-content-hosts";
 import { runObservabilityRetention } from "./observability-retention";
 import { purgeExpiredIdempotencyRequests } from "./idempotency-core";
 import { galleries } from "./routes/galleries";
@@ -275,6 +276,18 @@ export default {
         console.error(
           JSON.stringify({
             message: "usage_alert_sweep_failed",
+            error: appErr.message,
+            code: appErr.code,
+          }),
+        );
+      }),
+    );
+    ctx.waitUntil(
+      runActiveContentHostSweep(env).catch((err) => {
+        const appErr = AppError.from(err);
+        console.error(
+          JSON.stringify({
+            message: "active_content_sweep_failed",
             error: appErr.message,
             code: appErr.code,
           }),

--- a/apps/api/src/retention-sweep.ts
+++ b/apps/api/src/retention-sweep.ts
@@ -7,6 +7,7 @@
  */
 import { deleteOrg, listOrgs } from "./org-workspaces";
 import { purgeExpiredObjects } from "./retention";
+import { PROBE_PREFIX } from "./storage-verify";
 import { teardownWorkspace } from "./workspace-teardown";
 import { isPurgedTombstone, type PurgedTombstone, type WorkspaceRecord } from "./workspace";
 
@@ -34,6 +35,11 @@ export interface SweepResult {
     deleted: boolean;
     error?: string;
   }>;
+  /** Orphaned storage-verify probe objects reaped from the shared bucket (issue #929 adversarial review L-4). */
+  probesReaped: {
+    deleted: number;
+    error?: string;
+  };
 }
 
 /**
@@ -43,6 +49,65 @@ export interface SweepResult {
  * both the provisioning window and KV propagation.
  */
 const ORPHAN_ORG_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How old a `_internal/uploads-verify/` probe object has to be before this
+ * sweep deletes it. Every probe (`storage-verify.ts` `probeActiveContent`,
+ * the round-trip check) deletes its own object in a `finally`, best-effort —
+ * so anything still here a day later is an orphan from a delete that failed,
+ * not a probe in flight. A day is orders of magnitude past the 5 s fetch
+ * timeout that bounds a live probe.
+ */
+const PROBE_ORPHAN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/** Bound on the probe-prefix listing, matching the paging idiom the object sweeps use. */
+const PROBE_LIST_MAX_PAGES = 20;
+
+/**
+ * Deletes orphaned probe objects from the shared default bucket (issue #929
+ * adversarial review L-4). Probe cleanup is best-effort at the probe site,
+ * and the hosted-host sweep now writes several probe objects a day, so a
+ * persistent delete failure would otherwise accumulate forever: nothing else
+ * reaps this prefix (`verifyStorageConfig`'s not-empty check deliberately
+ * filters it out, and it belongs to no workspace, so no retention policy
+ * covers it).
+ *
+ * Never throws: the caller runs this inside the daily retention sweep, and a
+ * probe-reap failure must not take the retention sweep down with it — the
+ * error is reported on the result and logged, same posture as the orphan-org
+ * pass.
+ */
+async function reapOrphanedProbeObjects(env: Env): Promise<SweepResult["probesReaped"]> {
+  // Absent binding: a test env (or a self-host with no shared bucket) has
+  // nothing to reap. Not an error.
+  if (!env.UPLOADS_DEFAULT) return { deleted: 0 };
+  const cutoff = Date.now() - PROBE_ORPHAN_MAX_AGE_MS;
+  let deleted = 0;
+  try {
+    let cursor: string | undefined;
+    for (let page = 0; page < PROBE_LIST_MAX_PAGES; page++) {
+      const listed = await env.UPLOADS_DEFAULT.list({
+        prefix: PROBE_PREFIX,
+        limit: 1000,
+        ...(cursor ? { cursor } : {}),
+      });
+      const stale = listed.objects
+        .filter((object) => object.uploaded.getTime() < cutoff)
+        .map((object) => object.key);
+      if (stale.length > 0) {
+        await env.UPLOADS_DEFAULT.delete(stale);
+        deleted += stale.length;
+      }
+      cursor = listed.truncated ? listed.cursor : undefined;
+      if (!cursor) break;
+    }
+    return { deleted };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    console.log(JSON.stringify({ message: "probe_orphan_sweep_failed", error }));
+    return { deleted, error };
+  }
+}
 
 export async function runRetentionSweep(env: Env): Promise<SweepResult> {
   let cursor: string | undefined;
@@ -203,6 +268,8 @@ export async function runRetentionSweep(env: Env): Promise<SweepResult> {
     );
   }
 
+  const probesReaped = await reapOrphanedProbeObjects(env);
+
   console.log(
     JSON.stringify({
       message: "retention_sweep",
@@ -211,7 +278,15 @@ export async function runRetentionSweep(env: Env): Promise<SweepResult> {
       purged,
       workspacesFinalized,
       orgsSwept,
+      probesReaped,
     }),
   );
-  return { workspacesScanned, workspacesWithRetention, purged, workspacesFinalized, orgsSwept };
+  return {
+    workspacesScanned,
+    workspacesWithRetention,
+    purged,
+    workspacesFinalized,
+    orgsSwept,
+    probesReaped,
+  };
 }

--- a/apps/api/src/routes/admin-active-content-probe.test.ts
+++ b/apps/api/src/routes/admin-active-content-probe.test.ts
@@ -1,0 +1,98 @@
+import { Hono } from "hono";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hostActiveContentKey } from "../active-content-hosts";
+import { respondError } from "../error-response";
+import { FakeR2Bucket } from "../../test/fake-r2";
+import { admin } from "./admin";
+
+const ADMIN_TOKEN = "test-admin-token";
+
+if (typeof crypto.subtle.timingSafeEqual !== "function") {
+  (
+    crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+  ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+    a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+/** In-memory REGISTRY KV stand-in — get/put over a Map. */
+function fakeRegistry(records: Record<string, unknown> = {}) {
+  const store = new Map(Object.entries(records));
+  return {
+    store,
+    get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+    put: (async (key: string, value: string) => {
+      store.set(key, JSON.parse(value));
+    }) as unknown as KVNamespace["put"],
+  };
+}
+
+const goodHeaders = {
+  "content-type": "image/svg+xml",
+  "content-security-policy": "default-src 'none'; sandbox",
+  "x-content-type-options": "nosniff",
+};
+
+function appWith(registry: ReturnType<typeof fakeRegistry>) {
+  const app = new Hono<{ Bindings: Env }>()
+    .route("/admin", admin)
+    .onError((err, c) => respondError(c, err));
+  const env = {
+    ADMIN_TOKEN,
+    REGISTRY: registry,
+    UPLOADS_DEFAULT: new FakeR2Bucket(),
+  } as unknown as Env;
+  return { app, env };
+}
+
+function probeRequest(bearer?: string) {
+  return new Request("https://api.uploads.sh/admin/active-content/probe", {
+    method: "POST",
+    headers: bearer ? { authorization: `Bearer ${bearer}` } : {},
+  });
+}
+
+/**
+ * `POST /admin/active-content/probe` (issue #929 final-review item 2) — the
+ * token-authed counterpart to the session-gated `/admin-ui/active-content
+ * /probe` route, so an operator holding only `ADMIN_TOKEN` (or an
+ * `operator:write` scoped token, via the shared `adminAuth` gate every
+ * route on this router goes through) can confirm a just-applied Transform
+ * Rule without a browser session.
+ */
+describe("POST /admin/active-content/probe", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("401s without a valid admin token", async () => {
+    const { app, env } = appWith(fakeRegistry());
+    const res = await app.request(probeRequest(), {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("runs the hosted-host sweep and returns + persists the fresh per-host records", async () => {
+    const registry = fakeRegistry();
+    const { app, env } = appWith(registry);
+    const fetchSpy = vi.fn(
+      async () => new Response("<svg/>", { status: 200, headers: goodHeaders }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const res = await app.request(probeRequest(ADMIN_TOKEN), {}, env);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      records: Record<string, { ok: boolean; verifiedAt: string }>;
+    };
+    expect(body.records["storage.uploads.sh"]).toMatchObject({ ok: true });
+    expect(body.records["store.uploads.sh"]).toMatchObject({ ok: true });
+    expect(body.records["embed.uploads.sh"]).toMatchObject({ ok: true });
+    expect(fetchSpy).toHaveBeenCalled();
+
+    // Same records the response carried are what `activeContentAllowed`
+    // (../active-content.ts) reads back out of REGISTRY.
+    expect(registry.store.get(hostActiveContentKey("storage.uploads.sh"))).toMatchObject({
+      ok: true,
+    });
+  });
+});

--- a/apps/api/src/routes/admin-active-content-probe.test.ts
+++ b/apps/api/src/routes/admin-active-content-probe.test.ts
@@ -26,11 +26,17 @@ function fakeRegistry(records: Record<string, unknown> = {}) {
   };
 }
 
-const goodHeaders = {
-  "content-type": "image/svg+xml",
-  "content-security-policy": "default-src 'none'; sandbox",
-  "x-content-type-options": "nosniff",
-};
+/** A passing response for either probe object — the probe writes an SVG and an XML one (issue #929 M-1). */
+function okProbeResponse(url: string): Response {
+  return new Response("<probe/>", {
+    status: 200,
+    headers: {
+      "content-type": String(url).endsWith(".xml") ? "application/xml" : "image/svg+xml",
+      "content-security-policy": "default-src 'none'; sandbox",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
 
 function appWith(registry: ReturnType<typeof fakeRegistry>) {
   const app = new Hono<{ Bindings: Env }>()
@@ -73,9 +79,7 @@ describe("POST /admin/active-content/probe", () => {
   it("runs the hosted-host sweep and returns + persists the fresh per-host records", async () => {
     const registry = fakeRegistry();
     const { app, env } = appWith(registry);
-    const fetchSpy = vi.fn(
-      async () => new Response("<svg/>", { status: 200, headers: goodHeaders }),
-    );
+    const fetchSpy = vi.fn(async (url: string) => okProbeResponse(url));
     vi.stubGlobal("fetch", fetchSpy);
 
     const res = await app.request(probeRequest(ADMIN_TOKEN), {}, env);

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -6,6 +6,7 @@
  * Workspaces slot on apps/web.
  */
 import { NOTE_MAX_CHARS } from "@uploads/comment-config";
+import { runActiveContentHostSweep } from "../active-content-hosts";
 import {
   ForbiddenError,
   NotFoundError,
@@ -1043,4 +1044,15 @@ export const adminUi = new Hono<SessionVars>()
     const to = resolvePreviewRecipient(c.get("sessionUser")?.email, body.to);
     const { subject } = await sendEmailPreview(c.env, type, to);
     return c.json({ ok: true, type, to, subject });
+  })
+
+  // On-demand run of the hosted-host SVG/XML sandboxing-CSP probe (issue
+  // #929) — the same sweep the daily cron runs (see index.ts's `scheduled`),
+  // exposed so an operator can confirm a just-applied Transform Rule without
+  // waiting for the next cron tick. Returns the fresh per-host records; each
+  // is also persisted to REGISTRY, which is what `activeContentAllowed`
+  // (../active-content.ts) reads.
+  .post("/active-content/probe", async (c) => {
+    const records = await runActiveContentHostSweep(c.env);
+    return c.json({ records });
   });

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -8,6 +8,7 @@ import {
 } from "@uploads/errors";
 import { Hono } from "hono";
 import { adminAuth } from "../admin";
+import { runActiveContentHostSweep } from "../active-content-hosts";
 import {
   DEFAULT_ENROLLMENT_SECONDS,
   DEFAULT_TOKEN_SECONDS,
@@ -492,6 +493,24 @@ export const admin = new Hono<{ Bindings: Env }>()
       const message = err instanceof Error ? err.message : String(err);
       throw new ValidationError(message, { cause: err });
     }
+  })
+
+  /**
+   * On-demand run of the hosted-host SVG/XML sandboxing-CSP probe (issue
+   * #929 final-review) — the same sweep the daily cron runs (`index.ts`'s
+   * `scheduled` handler) and the session-gated `POST /admin-ui/active-content
+   * /probe` route already exposes to a logged-in global admin. This is the
+   * token-authed counterpart: `adminAuth` above gates the whole router, and
+   * (being a POST) requires `operator:write` for a scoped token — same tier
+   * as every other mutating route here — so an operator holding only
+   * `ADMIN_TOKEN` or an `operator:write` token can confirm a just-applied
+   * Transform Rule without a browser session. Returns the fresh per-host
+   * records; each is also persisted to `REGISTRY`, which is what
+   * `activeContentAllowed` (`../active-content.ts`) reads.
+   */
+  .post("/active-content/probe", async (c) => {
+    const records = await runActiveContentHostSweep(c.env);
+    return c.json({ records });
   })
 
   /**

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -190,7 +190,15 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
   }
 
   const ws = c.get("workspace");
-  const policy = resolveUploadPolicy(ws, { activeContent: await activeContentAllowed(c.env, ws) });
+  // `activeContent: false` here is deliberate, not a placeholder: this
+  // policy is only ever consulted below for `maxBytes`/`maxVideoBytes` (the
+  // pre-buffer declared-length ceiling), and those are workspace-level
+  // overrides — a row's own tighter `maxBytes` (the gated SVG/XML rows'
+  // 4 MiB cap, issue #929 review) never feeds into them, so the real gate
+  // result would change nothing this call reads. `putObject`'s own
+  // `resolveUploadPolicy` call (files-core.ts) is what actually gates
+  // SVG/XML acceptance, against the fully-buffered body.
+  const policy = resolveUploadPolicy(ws, { activeContent: false });
   const declared = checkDeclaredLength(c.req.header("Content-Length"), policy);
   if (declared) throw declared.error;
 

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -21,6 +21,7 @@ import {
   normalizeDeclaredContentType,
   resolveDeclaredContentType,
   resolveUploadPolicy,
+  uploadLimits,
 } from "../guards";
 import { contentSha256Hex, splitUploadMetaHeaders } from "../provenance";
 import { createLaneResolver, objectPublicUrls, resolveObjectLane, storage } from "../storage";
@@ -190,16 +191,18 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
   }
 
   const ws = c.get("workspace");
-  // `activeContent: false` here is deliberate, not a placeholder: this
-  // policy is only ever consulted below for `maxBytes`/`maxVideoBytes` (the
-  // pre-buffer declared-length ceiling), and those are workspace-level
-  // overrides — a row's own tighter `maxBytes` (the gated SVG/XML rows'
-  // 4 MiB cap, issue #929 review) never feeds into them, so the real gate
-  // result would change nothing this call reads. `putObject`'s own
-  // `resolveUploadPolicy` call (files-core.ts) is what actually gates
-  // SVG/XML acceptance, against the fully-buffered body.
-  const policy = resolveUploadPolicy(ws, { activeContent: false });
-  const declared = checkDeclaredLength(c.req.header("Content-Length"), policy);
+  const finalKey = finalizeUploadKey(key, ws);
+  // Ceilings only, no admission decision — `putObject` is what actually gates
+  // SVG/XML acceptance, against the fully-buffered body (see `uploadLimits`).
+  // Passing the claimed type tightens this to that type's own ceiling, so a
+  // declared 50 MB SVG is refused before the body is buffered at all rather
+  // than after the gated rows' 4 MiB cap (issue #929) sees it.
+  const declaredContentType = resolveDeclaredContentType(c.req.header("Content-Type"), finalKey);
+  const declared = checkDeclaredLength(
+    c.req.header("Content-Length"),
+    uploadLimits(ws),
+    declaredContentType,
+  );
   if (declared) throw declared.error;
 
   const body = await c.req.arrayBuffer();
@@ -249,7 +252,6 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
   // Hash the body once, up front: it anchors the fingerprint and the reconcile
   // check, and is threaded into putObject so it isn't hashed a second time.
   const contentSha256 = await contentSha256Hex(bytes);
-  const finalKey = finalizeUploadKey(key, ws);
   const idempotentPutOpts = { ...putOpts, contentSha256 };
   let result;
   try {
@@ -263,7 +265,7 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
         visibility,
         replace: wantReplace,
         metadata,
-        declaredContentType: resolveDeclaredContentType(putOpts.declaredContentType, finalKey),
+        declaredContentType,
       },
       run: () => putObject(c.env, ws, key, bytes, workspaceName, idempotentPutOpts),
       reconcile: () =>

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -17,6 +17,7 @@ import {
 import { getFileMetadata, META_MAX_KEYS, setFileMetadata } from "../file-metadata";
 import {
   checkDeclaredLength,
+  isGatedContentType,
   maxBytesForContentType,
   normalizeDeclaredContentType,
   resolveDeclaredContentType,
@@ -33,6 +34,36 @@ import { dbFor, primaryDbFor } from "../db-session";
 
 /** Handler shape shared by the legacy bearer and canonical dual-auth routers. */
 export type SharedFilesHandler = Handler<WorkspaceVars>;
+
+/**
+ * Ceiling on a presigned URL's lifetime when the declared type is a gated
+ * SVG/XML one (issue #929 adversarial review L-5). Long enough for any
+ * realistic direct-to-bucket PUT, short enough that turning the gate off
+ * takes effect in minutes rather than the 24 hours every other type gets.
+ */
+const GATED_PRESIGN_MAX_EXPIRES_IN_S = 900;
+
+/** Default presigned-URL lifetime, and the ceiling an ungated type may ask for. */
+const DEFAULT_PRESIGN_EXPIRES_IN_S = 3600;
+const MAX_PRESIGN_EXPIRES_IN_S = 86_400;
+
+/**
+ * The lifetime a presigned URL actually gets. A request outside
+ * `(0, 86400]` — or none at all — falls back to an hour, exactly as it
+ * always has; a gated SVG/XML type is then capped at
+ * {@link GATED_PRESIGN_MAX_EXPIRES_IN_S}, because that URL writes to the
+ * bucket later with nothing on the write path able to re-ask the gate
+ * (issue #929 adversarial review L-5). Exported for direct testing: the
+ * route around it needs signable HTTP credentials to reach a response body
+ * at all, and this arithmetic is the whole of the rule.
+ */
+export function presignExpiresIn(requested: unknown, contentType: string): number {
+  const asked =
+    typeof requested === "number" && requested > 0 && requested <= MAX_PRESIGN_EXPIRES_IN_S
+      ? Math.floor(requested)
+      : DEFAULT_PRESIGN_EXPIRES_IN_S;
+  return isGatedContentType(contentType) ? Math.min(asked, GATED_PRESIGN_MAX_EXPIRES_IN_S) : asked;
+}
 
 export async function signFileHandler(c: Context<WorkspaceVars>) {
   const body = await c.req
@@ -83,10 +114,7 @@ export async function signFileHandler(c: Context<WorkspaceVars>) {
     typeof body.maxSize === "number" && body.maxSize > 0
       ? Math.min(body.maxSize, typeCeiling)
       : typeCeiling;
-  const expiresIn =
-    typeof body.expiresIn === "number" && body.expiresIn > 0 && body.expiresIn <= 86400
-      ? Math.floor(body.expiresIn)
-      : 3600;
+  const expiresIn = presignExpiresIn(body.expiresIn, contentType);
 
   try {
     // Two-lane storage: an existing object may live in a fallback lane

--- a/apps/api/src/routes/files-shared-handlers.ts
+++ b/apps/api/src/routes/files-shared-handlers.ts
@@ -5,6 +5,7 @@ import {
   ValidationError,
 } from "@uploads/errors";
 import type { Context, Handler } from "hono";
+import { activeContentAllowed } from "../active-content";
 import {
   badKey,
   finalizeUploadKey,
@@ -58,7 +59,7 @@ export async function signFileHandler(c: Context<WorkspaceVars>) {
   const ws = c.get("workspace");
   const key = finalizeUploadKey(rawKey, ws);
 
-  const policy = resolveUploadPolicy(ws);
+  const policy = resolveUploadPolicy(ws, { activeContent: await activeContentAllowed(c.env, ws) });
 
   // Content-type is required on presign: the direct-to-bucket PUT cannot
   // magic-byte sniff, so the allowlist must be enforced at mint time.
@@ -188,7 +189,8 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
     });
   }
 
-  const policy = resolveUploadPolicy(c.get("workspace"));
+  const ws = c.get("workspace");
+  const policy = resolveUploadPolicy(ws, { activeContent: await activeContentAllowed(c.env, ws) });
   const declared = checkDeclaredLength(c.req.header("Content-Length"), policy);
   if (declared) throw declared.error;
 
@@ -220,7 +222,6 @@ export async function putFileHandler(c: Context<WorkspaceVars>) {
     }
   }
   const bytes = new Uint8Array(body);
-  const ws = c.get("workspace");
   const workspaceName = c.get("workspaceName");
   const putOpts = {
     provenance,

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -2749,6 +2749,9 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
         bucket: "uploads-default",
         lanes: [],
         health: { ok: true },
+        // No `FLAGS` binding in this fixture, so the active-content gate
+        // (issue #929) is closed and says which check closed it.
+        activeContentReason: "flag_off",
       });
     });
 
@@ -2778,6 +2781,7 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
         verifiedAt: "2026-01-01T00:00:00.000Z",
         lanes: [],
         health: { ok: true },
+        activeContentReason: "flag_off",
       });
     });
   });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -460,4 +460,13 @@ export const me = new Hono<SessionVars>()
   )
   .delete("/workspaces/:name/storage", (c) =>
     forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/storage`),
+  )
+  // SVG/XML active-content lane check (issue #929) — same forward posture as
+  // the five routes above; the web settings page's "Check now" button calls
+  // this alias the same way it calls activate.
+  .post("/workspaces/:name/storage/lanes/:laneId/verify-active-content", (c) =>
+    forwardToWorkspaceSettings(
+      c,
+      `/${encodeURIComponent(c.req.param("name"))}/storage/lanes/${encodeURIComponent(c.req.param("laneId"))}/verify-active-content`,
+    ),
   );

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -74,6 +74,7 @@ import {
   attachmentsMarker,
   type AttachmentItem,
 } from "../github-comment-render";
+import { readHostActiveContent } from "../active-content-hosts";
 import { allowWrite } from "../guards";
 import {
   adminWorkspaceOr403,
@@ -118,6 +119,7 @@ import {
   storageStatusResponse,
   storageVerify,
   verifyLaneForActivate,
+  type StorageStatusResponse,
 } from "./workspace-storage";
 
 /** `?repo=` shape for the comment preview endpoint: exactly one `/`, no empty segments. */
@@ -432,7 +434,47 @@ export async function storageGetHandler(c: Context<SettingsVars>) {
   const name = c.req.param("workspace") ?? "";
   const record = await loadWorkspaceRecord(c.env, name);
   if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-  return c.json(storageStatusResponse(record, byoBucketAllowed(record)));
+  const status = storageStatusResponse(record, byoBucketAllowed(record));
+  return c.json(await withHostedActiveContent(c.env, status));
+}
+
+/** Hostname from a URL string, or `null` for an empty/unparseable one. */
+function hostOf(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Overlays the hosted host's daily-probed active-content verdict onto a
+ * `storageStatusResponse` projection (issue #929 "Hosted lane display").
+ * The pure projection (`workspace-storage.ts`) has no KV access and can only
+ * echo a *lane's own* `activeContentVerifiedAt` stamp — meaningless for a
+ * shared lane, which carries no stamp of its own and instead inherits
+ * whatever the daily cron most recently wrote for its host
+ * (`active-content-hosts.ts`). Applies to the top-level active lane when
+ * it's shared, and to every `lanes[]` entry that's shared too. Mutates and
+ * returns `status` in place.
+ */
+async function withHostedActiveContent(
+  env: Env,
+  status: StorageStatusResponse,
+): Promise<StorageStatusResponse> {
+  if (status.mode === "shared") {
+    const host = hostOf(status.publicBaseUrl);
+    const record = host ? await readHostActiveContent(env, host) : null;
+    status.activeContentVerifiedAt = record?.ok ? record.verifiedAt : undefined;
+  }
+  for (const lane of status.lanes) {
+    if (lane.mode !== "shared") continue;
+    const host = hostOf(lane.publicBaseUrl);
+    const record = host ? await readHostActiveContent(env, host) : null;
+    lane.activeContentVerifiedAt = record?.ok ? record.verifiedAt : undefined;
+  }
+  return status;
 }
 
 /**

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -74,7 +74,12 @@ import {
   attachmentsMarker,
   type AttachmentItem,
 } from "../github-comment-render";
-import { readHostActiveContent } from "../active-content-hosts";
+import { HOST_RECORD_MAX_AGE_MS } from "../active-content";
+import {
+  hostOf,
+  readHostActiveContent,
+  type HostActiveContentRecord,
+} from "../active-content-hosts";
 import { allowWrite } from "../guards";
 import {
   adminWorkspaceOr403,
@@ -438,14 +443,19 @@ export async function storageGetHandler(c: Context<SettingsVars>) {
   return c.json(await withHostedActiveContent(c.env, status));
 }
 
-/** Hostname from a URL string, or `null` for an empty/unparseable one. */
-function hostOf(url: string | undefined): string | null {
-  if (!url) return null;
-  try {
-    return new URL(url).hostname.toLowerCase();
-  } catch {
-    return null;
-  }
+/**
+ * A hosted host's KV record projects as `verifiedAt` only when it's both
+ * `ok` and within `HOST_RECORD_MAX_AGE_MS` — same freshness window
+ * `activeContentAllowed` (`../active-content.ts`) enforces before it actually
+ * lets SVG/XML through. Without this the settings page could show "Verified
+ * <date>" for a host whose stale record no longer gates anything, which
+ * reads as verified when the gate itself has already closed.
+ */
+function freshVerifiedAt(record: HostActiveContentRecord | null, now: Date): string | undefined {
+  if (!record?.ok) return undefined;
+  const t = Date.parse(record.verifiedAt);
+  if (!Number.isFinite(t)) return undefined;
+  return now.getTime() - t <= HOST_RECORD_MAX_AGE_MS ? record.verifiedAt : undefined;
 }
 
 /**
@@ -463,16 +473,17 @@ async function withHostedActiveContent(
   env: Env,
   status: StorageStatusResponse,
 ): Promise<StorageStatusResponse> {
+  const now = new Date();
   if (status.mode === "shared") {
     const host = hostOf(status.publicBaseUrl);
     const record = host ? await readHostActiveContent(env, host) : null;
-    status.activeContentVerifiedAt = record?.ok ? record.verifiedAt : undefined;
+    status.activeContentVerifiedAt = freshVerifiedAt(record, now);
   }
   for (const lane of status.lanes) {
     if (lane.mode !== "shared") continue;
     const host = hostOf(lane.publicBaseUrl);
     const record = host ? await readHostActiveContent(env, host) : null;
-    lane.activeContentVerifiedAt = record?.ok ? record.verifiedAt : undefined;
+    lane.activeContentVerifiedAt = freshVerifiedAt(record, now);
   }
   return status;
 }
@@ -622,7 +633,12 @@ export async function storagePutHandler(c: Context<SettingsVars>) {
   const nowIso = new Date().toISOString();
   // ok when the recommended `active-content-headers` check passed; absent
   // (no publicBaseUrl, or the check failed/never ran) counts as not-verified
-  // — SVG/XML stay off for this lane until a check actually succeeds.
+  // — SVG/XML stay off for this lane until a check actually succeeds. That
+  // includes inconclusive: unlike the dedicated verify route
+  // (`storageVerifyActiveContentHandler`), which leaves a prior stamp
+  // untouched on an inconclusive recheck, a save always makes a fresh
+  // determination from this result — inconclusive-on-save clears the stamp,
+  // fail-closed, by design.
   const activeContentVerifiedAt = activeContentStampFromVerify(result, nowIso);
   const updated = await mutateWorkspaceRecord(
     c.env,
@@ -774,6 +790,10 @@ export async function storageActivateHandler(c: Context<SettingsVars>) {
       return c.json(result, 422);
     }
     verifiedAt = nowIso;
+    // Same fail-closed posture as `storagePutHandler`: this re-verify is a
+    // fresh determination, so inconclusive-on-save clears the stamp rather
+    // than carrying the pre-re-verify value forward, unlike the dedicated
+    // verify route's leave-it-alone handling of an inconclusive recheck.
     activeContentVerifiedAt = activeContentStampFromVerify(result, nowIso);
   }
 
@@ -1008,15 +1028,19 @@ function resolveActiveContentLaneTarget(
  * #929) — runs only the SVG/XML sandboxing-CSP probe against one lane
  * (`laneActiveContentCheck`: upload the inert SVG probe through the lane's
  * own storage client, ask `checkActiveContentHeaders`, delete the probe),
- * then stamps the result:
+ * then stamps the result. This is a rule for *this on-demand route only* —
+ * `storagePutHandler`/`storageActivateHandler` run the same probe as part of
+ * a save and handle inconclusive differently (see the comment at each):
  *
  *  - probe passed → `activeContentVerifiedAt`/`storageActiveContentVerifiedAt` set to now.
  *  - probe failed (not inconclusive) → the stamp is cleared, even if it was
  *    previously fresh — a lane that used to pass and now doesn't must stop
  *    admitting SVG/XML immediately, not wait out `LANE_STAMP_MAX_AGE_MS`.
  *  - probe inconclusive (the fetch itself threw — same "unknown, not
- *    broken" semantics as the public-url check) → the stamp is left exactly
- *    as it was; `mutateWorkspaceRecord` isn't even called.
+ *    broken" semantics as the public-url check) → *this route* leaves the
+ *    stamp exactly as it was; `mutateWorkspaceRecord` isn't even called. An
+ *    on-demand recheck of an already-configured lane shouldn't punish a
+ *    transient network blip by revoking something that was working.
  *
  * `laneId` is either a saved lane's id (`storageLanes[].id`) or the active
  * lane, named either by the literal `active` or by its own id
@@ -1030,6 +1054,11 @@ export async function storageVerifyActiveContentHandler(c: Context<SettingsVars>
   const laneIdParam = c.req.param("laneId") ?? "";
   const record = await loadWorkspaceRecord(c.env, name);
   if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  if (!byoBucketAllowed(record)) {
+    throw new ForbiddenError("BYO storage is not enabled for this workspace", {
+      code: "byo_bucket_disabled",
+    });
+  }
 
   const target = resolveActiveContentLaneTarget(record, laneIdParam);
   if (!target) {

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -112,6 +112,7 @@ import {
   activeContentStampFromVerify,
   candidateFromBody,
   isByoRecord,
+  laneActiveContentCheck,
   listBuckets,
   storageReconcile,
   storageStatusResponse,
@@ -931,6 +932,146 @@ export async function storageDeleteHandler(c: Context<SettingsVars>) {
   return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));
 }
 
+/**
+ * True when `laneIdParam` names the record's *active* lane — either the
+ * literal `"active"`, or the active lane's own id (`record.storageLaneId`,
+ * absent on a record that predates lanes, in which case only the literal
+ * matches).
+ */
+function isActiveLaneParam(record: WorkspaceRecord, laneIdParam: string): boolean {
+  return (
+    laneIdParam === "active" || (!!record.storageLaneId && laneIdParam === record.storageLaneId)
+  );
+}
+
+/**
+ * Resolves `laneIdParam` to a `StorageLane`-shaped view of the target lane —
+ * the active lane's top-level fields (via `demoteActiveLane`, the same
+ * field mapping `storageDeleteHandler`'s detach path uses to turn the active
+ * fields into a lane shape) when it names the active lane, else a saved
+ * entry in `storageLanes`. `null` when nothing matches.
+ */
+function resolveActiveContentLaneTarget(
+  record: WorkspaceRecord,
+  laneIdParam: string,
+): StorageLane | null {
+  if (isActiveLaneParam(record, laneIdParam)) {
+    return demoteActiveLane(record, new Date().toISOString());
+  }
+  return (record.storageLanes ?? []).find((lane) => lane.id === laneIdParam) ?? null;
+}
+
+/**
+ * `POST /:workspace/storage/lanes/:laneId/verify-active-content` (issue
+ * #929) — runs only the SVG/XML sandboxing-CSP probe against one lane
+ * (`laneActiveContentCheck`: upload the inert SVG probe through the lane's
+ * own storage client, ask `checkActiveContentHeaders`, delete the probe),
+ * then stamps the result:
+ *
+ *  - probe passed → `activeContentVerifiedAt`/`storageActiveContentVerifiedAt` set to now.
+ *  - probe failed (not inconclusive) → the stamp is cleared, even if it was
+ *    previously fresh — a lane that used to pass and now doesn't must stop
+ *    admitting SVG/XML immediately, not wait out `LANE_STAMP_MAX_AGE_MS`.
+ *  - probe inconclusive (the fetch itself threw — same "unknown, not
+ *    broken" semantics as the public-url check) → the stamp is left exactly
+ *    as it was; `mutateWorkspaceRecord` isn't even called.
+ *
+ * `laneId` is either a saved lane's id (`storageLanes[].id`) or the active
+ * lane, named either by the literal `active` or by its own id
+ * (`record.storageLaneId`). A shared (platform-owned, binding-mode) lane
+ * 422s outright — its state comes from the hosted host's daily-probed KV
+ * record (`./active-content-hosts.ts`), never a per-workspace stamp — and so
+ * does a lane with no `publicBaseUrl` to probe at all.
+ */
+export async function storageVerifyActiveContentHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  const laneIdParam = c.req.param("laneId") ?? "";
+  const record = await loadWorkspaceRecord(c.env, name);
+  if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+
+  const target = resolveActiveContentLaneTarget(record, laneIdParam);
+  if (!target) {
+    throw new NotFoundError("storage lane not found", { code: "storage_lane_not_found" });
+  }
+
+  if (isSharedLane(target)) {
+    return c.json(
+      {
+        check: {
+          id: "active-content-headers",
+          ok: false,
+          required: false,
+          hint: "hosted lanes are verified by the platform, not per workspace — see the hosted host's status instead",
+        },
+      },
+      422,
+    );
+  }
+  if (!target.publicBaseUrl) {
+    return c.json(
+      {
+        check: {
+          id: "active-content-headers",
+          ok: false,
+          required: false,
+          hint: "this lane has no public base URL to verify — add one first",
+        },
+      },
+      422,
+    );
+  }
+  if (!(await allowWrite(c.env, name))) {
+    throw new RateLimitedError("rate limit exceeded");
+  }
+
+  const check = await laneActiveContentCheck(c.env, target);
+  const nowIso = new Date().toISOString();
+
+  // Inconclusive: leave the stamp exactly as it was — skip the write
+  // entirely rather than round-tripping a no-op mutation through KV.
+  const updated = check.inconclusive
+    ? record
+    : await mutateWorkspaceRecord(
+        c.env,
+        name,
+        (current) => {
+          if (isActiveLaneParam(current, laneIdParam)) {
+            const next: WorkspaceRecord = { ...current };
+            if (check.ok) next.storageActiveContentVerifiedAt = nowIso;
+            else delete next.storageActiveContentVerifiedAt;
+            return next;
+          }
+          const freshTarget = (current.storageLanes ?? []).find((lane) => lane.id === laneIdParam);
+          if (!freshTarget) {
+            throw new ConflictError("storage lane no longer exists", {
+              code: "storage_lane_not_found",
+            });
+          }
+          const storageLanes = (current.storageLanes ?? []).map((lane) => {
+            if (lane.id !== laneIdParam) return lane;
+            const nextLane: StorageLane = { ...lane };
+            if (check.ok) nextLane.activeContentVerifiedAt = nowIso;
+            else delete nextLane.activeContentVerifiedAt;
+            return nextLane;
+          });
+          return { ...current, storageLanes };
+        },
+        { requireServing: true },
+      );
+
+  console.log(
+    JSON.stringify({
+      event: "workspace_storage_active_content_checked",
+      workspace: name,
+      laneId: laneIdParam,
+      ok: check.ok,
+      inconclusive: check.inconclusive === true,
+    }),
+  );
+
+  return c.json({ check, status: storageStatusResponse(updated, byoBucketAllowed(updated)) });
+}
+
 /** `GET /:workspace/summary` — member-gated: membership + usage + public URL, one payload. */
 export async function summaryHandler(c: Context<SettingsVars>) {
   const name = c.req.param("workspace") ?? "";
@@ -1128,4 +1269,9 @@ export const workspaceSettings = new Hono<SettingsVars>()
   .put("/:workspace/storage", sessionAdminGate(), storagePutHandler)
   .post("/:workspace/storage/activate", sessionAdminGate(), storageActivateHandler)
   .delete("/:workspace/storage", sessionAdminGate(), storageDeleteHandler)
+  .post(
+    "/:workspace/storage/lanes/:laneId/verify-active-content",
+    sessionAdminGate(),
+    storageVerifyActiveContentHandler,
+  )
   .onError((err, c) => respondError(c, err));

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -737,7 +737,12 @@ export async function storagePutHandler(c: Context<SettingsVars>) {
 
   console.log(JSON.stringify({ event: "workspace_storage_saved", workspace: name, userId }));
 
-  return c.json({ ...storageStatusResponse(updated, true), verify: result });
+  const status = await withActiveContentStatus(
+    c.env,
+    updated,
+    storageStatusResponse(updated, true),
+  );
+  return c.json({ ...status, verify: result });
 }
 
 /**
@@ -847,7 +852,13 @@ export async function storageActivateHandler(c: Context<SettingsVars>) {
   // legacy attach/detach reconcile calls.
   await reconcileOffPath(c, updated, name, "workspace storage activate");
 
-  return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));
+  return c.json(
+    await withActiveContentStatus(
+      c.env,
+      updated,
+      storageStatusResponse(updated, byoBucketAllowed(updated)),
+    ),
+  );
 }
 
 /**
@@ -937,7 +948,13 @@ export async function storageDeleteHandler(c: Context<SettingsVars>) {
     console.log(
       JSON.stringify({ event: "workspace_storage_lane_removed", workspace: name, userId, laneId }),
     );
-    return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));
+    return c.json(
+      await withActiveContentStatus(
+        c.env,
+        updated,
+        storageStatusResponse(updated, byoBucketAllowed(updated)),
+      ),
+    );
   }
 
   const usage = await getWorkspaceUsage(dbFor(c.env), name);
@@ -1005,7 +1022,13 @@ export async function storageDeleteHandler(c: Context<SettingsVars>) {
     await reconcileOffPath(c, updated, name, "workspace storage detach");
   }
 
-  return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));
+  return c.json(
+    await withActiveContentStatus(
+      c.env,
+      updated,
+      storageStatusResponse(updated, byoBucketAllowed(updated)),
+    ),
+  );
 }
 
 /**
@@ -1140,7 +1163,12 @@ export async function storageVerifyActiveContentHandler(c: Context<SettingsVars>
     }),
   );
 
-  return c.json({ check, status: storageStatusResponse(updated, byoBucketAllowed(updated)) });
+  const status = await withActiveContentStatus(
+    c.env,
+    updated,
+    storageStatusResponse(updated, byoBucketAllowed(updated)),
+  );
+  return c.json({ check, status });
 }
 
 /** `GET /:workspace/summary` — member-gated: membership + usage + public URL, one payload. */

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -825,7 +825,7 @@ export async function storageActivateHandler(c: Context<SettingsVars>) {
         ...current,
         storageLanes: upsertDemotedLane(remaining, demoted),
       };
-      promoteLane(next, freshTarget, verifiedAt, activeContentVerifiedAt);
+      promoteLane(next, freshTarget, { verifiedAt, activeContentVerifiedAt });
       return next;
     },
     { requireServing: true },
@@ -983,8 +983,10 @@ export async function storageDeleteHandler(c: Context<SettingsVars>) {
           prefix: shared.prefix,
           publicBaseUrl: shared.publicBaseUrl,
         },
-        undefined,
-        undefined,
+        // A restored shared lane carries neither stamp: it was never verified
+        // as a customer lane, and its host's active-content state comes from
+        // the hosted-host records, not a per-workspace stamp.
+        {},
       );
       return next;
     },

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -59,7 +59,7 @@ import {
   RateLimitedError,
   ValidationError,
 } from "@uploads/errors";
-import { createStorage, type R2Jurisdiction } from "@uploads/storage";
+import { createStorage, hostOf, type R2Jurisdiction } from "@uploads/storage";
 import { dbFor } from "../db-session";
 import { Hono, type Context, type MiddlewareHandler } from "hono";
 import { usageWithLimits } from "../budget";
@@ -74,12 +74,13 @@ import {
   attachmentsMarker,
   type AttachmentItem,
 } from "../github-comment-render";
-import { HOST_RECORD_MAX_AGE_MS } from "../active-content";
 import {
-  hostOf,
-  readHostActiveContent,
-  type HostActiveContentRecord,
-} from "../active-content-hosts";
+  activeContentStatus,
+  fresh,
+  HOST_RECORD_MAX_AGE_MS,
+  LANE_STAMP_MAX_AGE_MS,
+} from "../active-content";
+import { readHostActiveContent } from "../active-content-hosts";
 import { allowWrite } from "../guards";
 import {
   adminWorkspaceOr403,
@@ -440,50 +441,61 @@ export async function storageGetHandler(c: Context<SettingsVars>) {
   const record = await loadWorkspaceRecord(c.env, name);
   if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
   const status = storageStatusResponse(record, byoBucketAllowed(record));
-  return c.json(await withHostedActiveContent(c.env, status));
+  return c.json(await withActiveContentStatus(c.env, record, status));
 }
 
 /**
- * A hosted host's KV record projects as `verifiedAt` only when it's both
- * `ok` and within `HOST_RECORD_MAX_AGE_MS` — same freshness window
- * `activeContentAllowed` (`../active-content.ts`) enforces before it actually
- * lets SVG/XML through. Without this the settings page could show "Verified
- * <date>" for a host whose stale record no longer gates anything, which
- * reads as verified when the gate itself has already closed.
+ * Replaces the stamps the pure `storageStatusResponse` projection
+ * (`workspace-storage.ts`) can echo with what SVG/XML acceptance actually
+ * turns on right now (issue #929).
+ *
+ * The active lane's row comes straight from `activeContentStatus` — the gate
+ * itself — so the page can never say "Verified" about a lane the gate has
+ * already closed, whatever closed it: the workspace opt-out, the Flagship
+ * flag, an unhealthy lane, a stale hosted-host record, the embed twin's
+ * record, or a BYO stamp past `LANE_STAMP_MAX_AGE_MS`. The raw stamp on the
+ * record is not that answer; the projection has no KV or flag access to find
+ * it out for itself, which is exactly why this lives at the handler.
+ *
+ * The other lanes aren't the gate's subject — none of them is serving
+ * anything — so each is judged on its own evidence: a shared lane by its
+ * host's daily-probed record, a BYO lane by its own stamp's freshness. Host
+ * records are read once per distinct host, in parallel, since several
+ * fallback lanes commonly share one.
  */
-function freshVerifiedAt(record: HostActiveContentRecord | null, now: Date): string | undefined {
-  if (!record?.ok) return undefined;
-  const t = Date.parse(record.verifiedAt);
-  if (!Number.isFinite(t)) return undefined;
-  return now.getTime() - t <= HOST_RECORD_MAX_AGE_MS ? record.verifiedAt : undefined;
-}
-
-/**
- * Overlays the hosted host's daily-probed active-content verdict onto a
- * `storageStatusResponse` projection (issue #929 "Hosted lane display").
- * The pure projection (`workspace-storage.ts`) has no KV access and can only
- * echo a *lane's own* `activeContentVerifiedAt` stamp — meaningless for a
- * shared lane, which carries no stamp of its own and instead inherits
- * whatever the daily cron most recently wrote for its host
- * (`active-content-hosts.ts`). Applies to the top-level active lane when
- * it's shared, and to every `lanes[]` entry that's shared too. Mutates and
- * returns `status` in place.
- */
-async function withHostedActiveContent(
+async function withActiveContentStatus(
   env: Env,
+  record: WorkspaceRecord,
   status: StorageStatusResponse,
 ): Promise<StorageStatusResponse> {
   const now = new Date();
-  if (status.mode === "shared") {
-    const host = hostOf(status.publicBaseUrl);
-    const record = host ? await readHostActiveContent(env, host) : null;
-    status.activeContentVerifiedAt = freshVerifiedAt(record, now);
-  }
+  const gate = await activeContentStatus(env, record, now);
+  status.activeContentVerifiedAt = gate.verifiedAt;
+  status.activeContentReason = gate.reason;
+
+  const hosts = new Set(
+    status.lanes.flatMap((lane) => {
+      if (lane.mode !== "shared") return [];
+      const host = hostOf(lane.publicBaseUrl);
+      return host ? [host] : [];
+    }),
+  );
+  const hostRecords = new Map(
+    await Promise.all(
+      [...hosts].map(async (host) => [host, await readHostActiveContent(env, host)] as const),
+    ),
+  );
   for (const lane of status.lanes) {
-    if (lane.mode !== "shared") continue;
-    const host = hostOf(lane.publicBaseUrl);
-    const record = host ? await readHostActiveContent(env, host) : null;
-    lane.activeContentVerifiedAt = freshVerifiedAt(record, now);
+    if (lane.mode === "shared") {
+      const host = hostOf(lane.publicBaseUrl);
+      const hostRecord = host ? hostRecords.get(host) : null;
+      lane.activeContentVerifiedAt =
+        hostRecord?.ok && fresh(hostRecord.verifiedAt, HOST_RECORD_MAX_AGE_MS, now)
+          ? hostRecord.verifiedAt
+          : undefined;
+    } else if (!fresh(lane.activeContentVerifiedAt, LANE_STAMP_MAX_AGE_MS, now)) {
+      lane.activeContentVerifiedAt = undefined;
+    }
   }
   return status;
 }
@@ -1065,31 +1077,17 @@ export async function storageVerifyActiveContentHandler(c: Context<SettingsVars>
     throw new NotFoundError("storage lane not found", { code: "storage_lane_not_found" });
   }
 
+  /** A 422 shaped like the check this route would have returned, so one client branch renders both. */
+  const reject422 = (hint: string) =>
+    c.json({ check: { id: "active-content-headers", ok: false, required: false, hint } }, 422);
+
   if (isSharedLane(target)) {
-    return c.json(
-      {
-        check: {
-          id: "active-content-headers",
-          ok: false,
-          required: false,
-          hint: "hosted lanes are verified by the platform, not per workspace — see the hosted host's status instead",
-        },
-      },
-      422,
+    return reject422(
+      "hosted lanes are verified by the platform, not per workspace — see the hosted host's status instead",
     );
   }
   if (!target.publicBaseUrl) {
-    return c.json(
-      {
-        check: {
-          id: "active-content-headers",
-          ok: false,
-          required: false,
-          hint: "this lane has no public base URL to verify — add one first",
-        },
-      },
-      422,
-    );
+    return reject422("this lane has no public base URL to verify — add one first");
   }
   if (!(await allowWrite(c.env, name))) {
     throw new RateLimitedError("rate limit exceeded");

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -1061,6 +1061,43 @@ function resolveActiveContentLaneTarget(
 }
 
 /**
+ * Minimum gap between two on-demand active-content checks of the same lane
+ * (issue #929 adversarial review L-3). A "Check now" button that a person
+ * actually presses never comes close; a script driving Worker-origin fetches
+ * at an arbitrary host does.
+ */
+export const ACTIVE_CONTENT_CHECK_COOLDOWN_MS = 60_000;
+
+/**
+ * The `storageActiveContentCheckedAt` key for the lane `laneIdParam` names.
+ * The active lane is keyed by its own id when it has one, so naming it
+ * `active` and naming it by id share a cooldown rather than each getting
+ * their own.
+ */
+function activeContentCooldownKey(record: WorkspaceRecord, laneIdParam: string): string {
+  return isActiveLaneParam(record, laneIdParam) ? (record.storageLaneId ?? "active") : laneIdParam;
+}
+
+/**
+ * The cooldown map with `key` stamped at `nowIso`, pruned to lanes that
+ * still exist (plus `active`) so a deleted lane's entry doesn't linger in the
+ * record forever.
+ */
+function nextActiveContentCheckedAt(
+  record: WorkspaceRecord,
+  key: string,
+  nowIso: string,
+): Record<string, string> {
+  const live = new Set<string>(["active", key]);
+  if (record.storageLaneId) live.add(record.storageLaneId);
+  for (const lane of record.storageLanes ?? []) live.add(lane.id);
+  return Object.fromEntries([
+    ...Object.entries(record.storageActiveContentCheckedAt ?? {}).filter(([k]) => live.has(k)),
+    [key, nowIso],
+  ]);
+}
+
+/**
  * `POST /:workspace/storage/lanes/:laneId/verify-active-content` (issue
  * #929) — runs only the SVG/XML sandboxing-CSP probe against one lane
  * (`laneActiveContentCheck`: upload the inert SVG probe through the lane's
@@ -1085,6 +1122,16 @@ function resolveActiveContentLaneTarget(
  * 422s outright — its state comes from the hosted host's daily-probed KV
  * record (`./active-content-hosts.ts`), never a per-workspace stamp — and so
  * does a lane with no `publicBaseUrl` to probe at all.
+ *
+ * Per-lane cooldown (issue #929 adversarial review L-3): every call makes
+ * this Worker fetch a URL the workspace's own admin chose, and the general
+ * write budget (60/60s per workspace) is far too generous for a button. A
+ * second check on the same lane inside {@link ACTIVE_CONTENT_CHECK_COOLDOWN_MS}
+ * is a 429 (`active_content_check_cooldown`) raised *before* any probe — and
+ * before the write limiter, so a rejected recheck doesn't spend the
+ * workspace's write budget either. The clock (`storageActiveContentCheckedAt`)
+ * records attempts, not passes, so a failing or inconclusive probe rate-limits
+ * the next one exactly as a passing one does.
  */
 export async function storageVerifyActiveContentHandler(c: Context<SettingsVars>) {
   const name = c.req.param("workspace") ?? "";
@@ -1114,6 +1161,21 @@ export async function storageVerifyActiveContentHandler(c: Context<SettingsVars>
   if (!target.publicBaseUrl) {
     return reject422("this lane has no public base URL to verify — add one first");
   }
+
+  const cooldownKey = activeContentCooldownKey(record, laneIdParam);
+  const lastCheckedAt = Date.parse(record.storageActiveContentCheckedAt?.[cooldownKey] ?? "");
+  if (
+    Number.isFinite(lastCheckedAt) &&
+    Date.now() - lastCheckedAt < ACTIVE_CONTENT_CHECK_COOLDOWN_MS
+  ) {
+    throw new RateLimitedError("this lane was checked moments ago — try again shortly", {
+      code: "active_content_check_cooldown",
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((ACTIVE_CONTENT_CHECK_COOLDOWN_MS - (Date.now() - lastCheckedAt)) / 1000),
+      ),
+    });
+  }
   if (!(await allowWrite(c.env, name))) {
     throw new RateLimitedError("rate limit exceeded");
   }
@@ -1121,37 +1183,43 @@ export async function storageVerifyActiveContentHandler(c: Context<SettingsVars>
   const check = await laneActiveContentCheck(c.env, target);
   const nowIso = new Date().toISOString();
 
-  // Inconclusive: leave the stamp exactly as it was — skip the write
-  // entirely rather than round-tripping a no-op mutation through KV.
-  const updated = check.inconclusive
-    ? record
-    : await mutateWorkspaceRecord(
-        c.env,
-        name,
-        (current) => {
-          if (isActiveLaneParam(current, laneIdParam)) {
-            const next: WorkspaceRecord = { ...current };
-            if (check.ok) next.storageActiveContentVerifiedAt = nowIso;
-            else delete next.storageActiveContentVerifiedAt;
-            return next;
-          }
-          const freshTarget = (current.storageLanes ?? []).find((lane) => lane.id === laneIdParam);
-          if (!freshTarget) {
-            throw new ConflictError("storage lane no longer exists", {
-              code: "storage_lane_not_found",
-            });
-          }
-          const storageLanes = (current.storageLanes ?? []).map((lane) => {
-            if (lane.id !== laneIdParam) return lane;
-            const nextLane: StorageLane = { ...lane };
-            if (check.ok) nextLane.activeContentVerifiedAt = nowIso;
-            else delete nextLane.activeContentVerifiedAt;
-            return nextLane;
-          });
-          return { ...current, storageLanes };
-        },
-        { requireServing: true },
-      );
+  // One write, always — the cooldown clock has to advance even for an
+  // inconclusive probe (an unreachable host is exactly the case that could
+  // otherwise be retried in a tight loop). The verification *stamp* is a
+  // separate question: inconclusive leaves it exactly as it was.
+  const updated = await mutateWorkspaceRecord(
+    c.env,
+    name,
+    (current) => {
+      const next: WorkspaceRecord = {
+        ...current,
+        storageActiveContentCheckedAt: nextActiveContentCheckedAt(current, cooldownKey, nowIso),
+      };
+      if (isActiveLaneParam(current, laneIdParam)) {
+        if (!check.inconclusive) {
+          if (check.ok) next.storageActiveContentVerifiedAt = nowIso;
+          else delete next.storageActiveContentVerifiedAt;
+        }
+        return next;
+      }
+      const freshTarget = (current.storageLanes ?? []).find((lane) => lane.id === laneIdParam);
+      if (!freshTarget) {
+        throw new ConflictError("storage lane no longer exists", {
+          code: "storage_lane_not_found",
+        });
+      }
+      if (check.inconclusive) return next;
+      next.storageLanes = (current.storageLanes ?? []).map((lane) => {
+        if (lane.id !== laneIdParam) return lane;
+        const nextLane: StorageLane = { ...lane };
+        if (check.ok) nextLane.activeContentVerifiedAt = nowIso;
+        else delete nextLane.activeContentVerifiedAt;
+        return nextLane;
+      });
+      return next;
+    },
+    { requireServing: true },
+  );
 
   console.log(
     JSON.stringify({

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -109,6 +109,7 @@ import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { planResponse, planSourceFor } from "../workspace-plan";
 import type { ListBucketsResult } from "../r2-list-buckets";
 import {
+  activeContentStampFromVerify,
   candidateFromBody,
   isByoRecord,
   listBuckets,
@@ -576,6 +577,10 @@ export async function storagePutHandler(c: Context<SettingsVars>) {
   }
 
   const nowIso = new Date().toISOString();
+  // ok when the recommended `active-content-headers` check passed; absent
+  // (no publicBaseUrl, or the check failed/never ran) counts as not-verified
+  // — SVG/XML stay off for this lane until a check actually succeeds.
+  const activeContentVerifiedAt = activeContentStampFromVerify(result, nowIso);
   const updated = await mutateWorkspaceRecord(
     c.env,
     name,
@@ -619,6 +624,8 @@ export async function storagePutHandler(c: Context<SettingsVars>) {
           next.forcePathStyle = candidate.forcePathStyle;
         }
         next.storageVerifiedAt = nowIso;
+        if (activeContentVerifiedAt) next.storageActiveContentVerifiedAt = activeContentVerifiedAt;
+        else delete next.storageActiveContentVerifiedAt;
         next.storageConfiguredAt = nowIso;
         next.storageConfiguredBy = userId;
         next.storageAccessKeyIdLast4 = accessKeyIdLast4;
@@ -638,6 +645,7 @@ export async function storagePutHandler(c: Context<SettingsVars>) {
         secretAccessKey: sealed.secretAccessKey,
         publicBaseUrl: candidate.publicBaseUrl,
         verifiedAt: nowIso,
+        activeContentVerifiedAt,
         storageConfiguredAt: nowIso,
         storageConfiguredBy: userId,
         storageAccessKeyIdLast4: accessKeyIdLast4,
@@ -710,6 +718,9 @@ export async function storageActivateHandler(c: Context<SettingsVars>) {
 
   const nowIso = new Date().toISOString();
   let verifiedAt = target.verifiedAt;
+  // Carried forward unless a re-verify below runs and settles it fresh —
+  // same "carry, or refresh from the fresh result" posture as `verifiedAt`.
+  let activeContentVerifiedAt = target.activeContentVerifiedAt;
   // A lane carrying a health flag (issue #826) is re-verified however fresh
   // its `verifiedAt` looks: the flag is later evidence than the stamp, and
   // `promoteLane` clears the flag unconditionally — so without this a broken
@@ -720,6 +731,7 @@ export async function storageActivateHandler(c: Context<SettingsVars>) {
       return c.json(result, 422);
     }
     verifiedAt = nowIso;
+    activeContentVerifiedAt = activeContentStampFromVerify(result, nowIso);
   }
 
   const updated = await mutateWorkspaceRecord(
@@ -738,7 +750,7 @@ export async function storageActivateHandler(c: Context<SettingsVars>) {
         ...current,
         storageLanes: upsertDemotedLane(remaining, demoted),
       };
-      promoteLane(next, freshTarget, verifiedAt);
+      promoteLane(next, freshTarget, verifiedAt, activeContentVerifiedAt);
       return next;
     },
     { requireServing: true },
@@ -896,6 +908,7 @@ export async function storageDeleteHandler(c: Context<SettingsVars>) {
           prefix: shared.prefix,
           publicBaseUrl: shared.publicBaseUrl,
         },
+        undefined,
         undefined,
       );
       return next;

--- a/apps/api/src/routes/workspace-storage.test.ts
+++ b/apps/api/src/routes/workspace-storage.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for `workspace-storage.ts` pieces too low-level for the route
+ * suite (`apps/api/test/routes-workspace-settings.test.ts`), which drives
+ * `laneActiveContentCheck` entirely through `setLaneActiveContentCheckForTests`
+ * and so never exercises the real implementation's own error handling.
+ */
+import { describe, expect, it } from "vitest";
+import { laneActiveContentCheck } from "./workspace-storage";
+import type { StorageLane } from "../workspace";
+
+function makeEnv(): Env {
+  return { WORKSPACE_SECRETS_KEY: "test-workspace-secrets-key-0000" } as unknown as Env;
+}
+
+describe("laneActiveContentCheck — fails soft on a storage-client error (issue #929 review)", () => {
+  it("returns an inconclusive check instead of throwing when the storage client can't even be built", async () => {
+    // A syntactically-present but shape-invalid s3 endpoint (a path
+    // segment) passes `storageConfig`'s bare presence check but fails
+    // `defaultStorageClientFactory`'s own stricter re-guard — a real,
+    // deterministic way to exercise "the client build/upload step throws"
+    // without mocking the network or crypto.
+    const lane: StorageLane = {
+      id: "lane_bad_s3",
+      provider: "s3",
+      bucket: "customer-bucket",
+      endpoint: "https://s3.example.com/not-a-bare-origin",
+      region: "us-east-1",
+      accessKeyId: "AKIDEXAMPLE1234",
+      secretAccessKey: "super-secret-value",
+      publicBaseUrl: "https://media.example.com",
+    };
+
+    const check = await laneActiveContentCheck(makeEnv(), lane);
+
+    expect(check).toEqual({
+      id: "active-content-headers",
+      ok: false,
+      required: false,
+      inconclusive: true,
+      hint: "could not write the SVG probe to this bucket — check the lane's credentials, then check again",
+    });
+  });
+});

--- a/apps/api/src/routes/workspace-storage.test.ts
+++ b/apps/api/src/routes/workspace-storage.test.ts
@@ -17,7 +17,7 @@ describe("laneActiveContentCheck — fails soft on a storage-client error (issue
     // A syntactically-present but shape-invalid s3 endpoint (a path
     // segment) passes `storageConfig`'s bare presence check but fails
     // `defaultStorageClientFactory`'s own stricter re-guard — a real,
-    // deterministic way to exercise "the client build/upload step throws"
+    // deterministic way to exercise "the client build step throws"
     // without mocking the network or crypto.
     const lane: StorageLane = {
       id: "lane_bad_s3",
@@ -37,7 +37,7 @@ describe("laneActiveContentCheck — fails soft on a storage-client error (issue
       ok: false,
       required: false,
       inconclusive: true,
-      hint: "could not write the SVG probe to this bucket — check the lane's credentials, then check again",
+      hint: "could not open this lane's storage — check the lane's credentials, then check again",
     });
   });
 });

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -17,6 +17,7 @@ import {
   defaultStorageClientFactory,
   PROBE_PREFIX,
   verifyStorageConfig,
+  type StorageProbeClient,
   type StorageVerifyCandidate,
   type StorageVerifyCheck,
   type StorageVerifyOptions,
@@ -433,20 +434,37 @@ export async function verifyLaneForActivate(
  * object in `finally` regardless of the outcome. The caller is responsible
  * for confirming `lane.publicBaseUrl` is set before calling this — it is not
  * re-checked here.
+ *
+ * Everything from opening the lane's credentials through the probe upload is
+ * wrapped in one try/catch (review follow-up, issue #929): bad/rotated
+ * credentials, an unreachable bucket, or any other storage-client error
+ * would otherwise escape as an unhandled rejection (a 500 at the route
+ * layer) instead of the same "unknown, not broken" `inconclusive` outcome
+ * `checkActiveContentHeaders` itself already returns for a thrown fetch —
+ * the route leaves the stamp untouched either way.
  */
 async function defaultLaneActiveContentCheck(
   env: Env,
   lane: StorageLane,
   fetchImpl: typeof fetch,
 ): Promise<StorageVerifyCheck> {
-  const candidate = await laneVerifyCandidate(env, lane);
-  const client = defaultStorageClientFactory(candidate);
   const probeKey = `${PROBE_PREFIX}${crypto.randomUUID()}.svg`;
+  let client: StorageProbeClient | undefined;
   try {
+    const candidate = await laneVerifyCandidate(env, lane);
+    client = defaultStorageClientFactory(candidate);
     await client.upload(probeKey, ACTIVE_CONTENT_PROBE_SVG, { contentType: "image/svg+xml" });
     return await checkActiveContentHeaders(candidate.publicBaseUrl ?? "", probeKey, fetchImpl);
+  } catch {
+    return {
+      id: "active-content-headers",
+      ok: false,
+      required: false,
+      inconclusive: true,
+      hint: "could not write the SVG probe to this bucket — check the lane's credentials, then check again",
+    };
   } finally {
-    await client.delete(probeKey).catch(() => {});
+    if (client) await client.delete(probeKey).catch(() => {});
   }
 }
 

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -57,6 +57,8 @@ export interface StorageLaneStatus {
   bucket: string;
   publicBaseUrl?: string;
   verifiedAt?: string;
+  /** Last successful `active-content-headers` verify check against this lane's public host (issue #929) — gates SVG/XML acceptance while this lane is active. */
+  activeContentVerifiedAt?: string;
   lastActiveAt?: string;
   accountIdMasked?: string;
   accessKeyIdLast4?: string;
@@ -89,6 +91,8 @@ export interface StorageStatusResponse {
   publicBaseUrl?: string;
   configuredAt?: string;
   verifiedAt?: string;
+  /** Active lane's last successful `active-content-headers` verify check (issue #929) — gates SVG/XML acceptance. */
+  activeContentVerifiedAt?: string;
   jurisdiction?: string;
   /** s3-only. Service endpoint origin of the active lane. */
   endpoint?: string;
@@ -155,6 +159,7 @@ function laneStatus(lane: StorageLane): StorageLaneStatus {
     bucket: lane.bucket,
     publicBaseUrl: lane.publicBaseUrl,
     verifiedAt: lane.verifiedAt,
+    activeContentVerifiedAt: lane.activeContentVerifiedAt,
     lastActiveAt: lane.lastActiveAt,
     // Never both — an s3 lane carries endpoint/region, never an accountId.
     ...providerFields(isS3, {
@@ -208,6 +213,7 @@ export function storageStatusResponse(
     accessKeyIdLast4: byo ? record.storageAccessKeyIdLast4 : undefined,
     configuredAt: record.storageConfiguredAt,
     verifiedAt: record.storageVerifiedAt,
+    activeContentVerifiedAt: record.storageActiveContentVerifiedAt,
     jurisdiction: byo && !isS3 ? record.jurisdiction : undefined,
     activeLaneId: record.storageLaneId,
     lanes: (record.storageLanes ?? []).map(laneStatus),
@@ -258,6 +264,22 @@ export function storageVerify(
   opts?: StorageVerifyOptions,
 ): Promise<StorageVerifyResult> {
   return runStorageVerify(candidate, opts);
+}
+
+/**
+ * Derives the active-content verification stamp from a verify pipeline
+ * result (issue #929): `nowIso` when the recommended `active-content-headers`
+ * check ran and passed, `undefined` otherwise — an absent check (no
+ * `publicBaseUrl`, or the public-url check itself failed) counts the same as
+ * a failing one. Callers stamp `StorageLane.activeContentVerifiedAt` /
+ * `WorkspaceRecord.storageActiveContentVerifiedAt` with the result.
+ */
+export function activeContentStampFromVerify(
+  result: StorageVerifyResult,
+  nowIso: string,
+): string | undefined {
+  const check = result.checks.find((c) => c.id === "active-content-headers");
+  return check?.ok ? nowIso : undefined;
 }
 
 /** Test-only: swap the verify implementation. Pass `undefined` to restore the real pipeline. */

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -12,8 +12,13 @@ import {
   type ListBucketsResult,
 } from "../r2-list-buckets";
 import {
+  ACTIVE_CONTENT_PROBE_SVG,
+  checkActiveContentHeaders,
+  defaultStorageClientFactory,
+  PROBE_PREFIX,
   verifyStorageConfig,
   type StorageVerifyCandidate,
+  type StorageVerifyCheck,
   type StorageVerifyOptions,
   type StorageVerifyResult,
 } from "../storage-verify";
@@ -414,4 +419,63 @@ export async function verifyLaneForActivate(
   lane: StorageLane,
 ): Promise<StorageVerifyResult> {
   return storageVerify(await laneVerifyCandidate(env, lane));
+}
+
+/**
+ * Runs *only* the active-content probe against `lane` (issue #929,
+ * `POST .../storage/lanes/:laneId/verify-active-content`) — unlike
+ * `verifyLaneForActivate`, this never runs the full shape/auth/round-trip
+ * pipeline, just: open the lane's (possibly sealed) credentials into a real
+ * client (`laneVerifyCandidate` + `defaultStorageClientFactory` — same
+ * client-building steps `verifyLaneForActivate` uses, minus the
+ * `verifyStorageConfig` wrapper), upload `ACTIVE_CONTENT_PROBE_SVG` under
+ * `PROBE_PREFIX`, ask `checkActiveContentHeaders`, and delete the probe
+ * object in `finally` regardless of the outcome. The caller is responsible
+ * for confirming `lane.publicBaseUrl` is set before calling this — it is not
+ * re-checked here.
+ */
+async function defaultLaneActiveContentCheck(
+  env: Env,
+  lane: StorageLane,
+  fetchImpl: typeof fetch,
+): Promise<StorageVerifyCheck> {
+  const candidate = await laneVerifyCandidate(env, lane);
+  const client = defaultStorageClientFactory(candidate);
+  const probeKey = `${PROBE_PREFIX}${crypto.randomUUID()}.svg`;
+  try {
+    await client.upload(probeKey, ACTIVE_CONTENT_PROBE_SVG, { contentType: "image/svg+xml" });
+    return await checkActiveContentHeaders(candidate.publicBaseUrl ?? "", probeKey, fetchImpl);
+  } finally {
+    await client.delete(probeKey).catch(() => {});
+  }
+}
+
+/**
+ * Indirected through this mutable binding for the same reason as
+ * `storageVerify`/`storageReconcile` above: building a real client resolves
+ * (possibly sealed) credentials and would otherwise hit the network, so
+ * route tests substitute a fake here instead. Restore the default with
+ * `setLaneActiveContentCheckForTests(undefined)` in an `afterEach`/`finally`.
+ */
+let runLaneActiveContentCheck: (
+  env: Env,
+  lane: StorageLane,
+  fetchImpl: typeof fetch,
+) => Promise<StorageVerifyCheck> = defaultLaneActiveContentCheck;
+
+export function laneActiveContentCheck(
+  env: Env,
+  lane: StorageLane,
+  fetchImpl: typeof fetch = fetch,
+): Promise<StorageVerifyCheck> {
+  return runLaneActiveContentCheck(env, lane, fetchImpl);
+}
+
+/** Test-only: swap the lane active-content check implementation. Pass `undefined` to restore the real one. */
+export function setLaneActiveContentCheckForTests(
+  fn:
+    | ((env: Env, lane: StorageLane, fetchImpl: typeof fetch) => Promise<StorageVerifyCheck>)
+    | undefined,
+): void {
+  runLaneActiveContentCheck = fn ?? defaultLaneActiveContentCheck;
 }

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -12,10 +12,8 @@ import {
   type ListBucketsResult,
 } from "../r2-list-buckets";
 import {
-  ACTIVE_CONTENT_PROBE_SVG,
-  checkActiveContentHeaders,
   defaultStorageClientFactory,
-  PROBE_PREFIX,
+  probeActiveContent,
   verifyStorageConfig,
   type StorageProbeClient,
   type StorageVerifyCandidate,
@@ -23,6 +21,7 @@ import {
   type StorageVerifyOptions,
   type StorageVerifyResult,
 } from "../storage-verify";
+import type { ActiveContentReason } from "../active-content";
 import { storageBudgetApplies } from "../budget";
 import { healthFromFields, storageHealth, type StorageHealth } from "../storage-health";
 import { reconcileWorkspaceUsage } from "../reconcile";
@@ -97,8 +96,17 @@ export interface StorageStatusResponse {
   publicBaseUrl?: string;
   configuredAt?: string;
   verifiedAt?: string;
-  /** Active lane's last successful `active-content-headers` verify check (issue #929) — gates SVG/XML acceptance. */
+  /**
+   * When SVG/XML acceptance is on for the active lane, the timestamp the
+   * gate is trusting (issue #929) — a hosted host's daily-probed record, or
+   * this lane's own `active-content-headers` stamp. Absent whenever
+   * acceptance is off, with `activeContentReason` saying which check said
+   * so. Both are filled in by the GET handler, which alone can ask the gate
+   * (`routes/workspace-settings.ts`); this projection is pure.
+   */
   activeContentVerifiedAt?: string;
+  /** Why SVG/XML acceptance is off for the active lane, when it is. */
+  activeContentReason?: ActiveContentReason;
   jurisdiction?: string;
   /** s3-only. Service endpoint origin of the active lane. */
   endpoint?: string;
@@ -426,46 +434,41 @@ export async function verifyLaneForActivate(
  * Runs *only* the active-content probe against `lane` (issue #929,
  * `POST .../storage/lanes/:laneId/verify-active-content`) — unlike
  * `verifyLaneForActivate`, this never runs the full shape/auth/round-trip
- * pipeline, just: open the lane's (possibly sealed) credentials into a real
- * client (`laneVerifyCandidate` + `defaultStorageClientFactory` — same
- * client-building steps `verifyLaneForActivate` uses, minus the
- * `verifyStorageConfig` wrapper), upload `ACTIVE_CONTENT_PROBE_SVG` under
- * `PROBE_PREFIX`, ask `checkActiveContentHeaders`, and delete the probe
- * object in `finally` regardless of the outcome. The caller is responsible
- * for confirming `lane.publicBaseUrl` is set before calling this — it is not
- * re-checked here.
+ * pipeline: it just opens the lane's (possibly sealed) credentials into a
+ * real client (`laneVerifyCandidate` + `defaultStorageClientFactory` — the
+ * same client-building steps `verifyLaneForActivate` uses, minus the
+ * `verifyStorageConfig` wrapper) and hands it to the shared
+ * `probeActiveContent`, which owns the write/fetch/delete. The caller is
+ * responsible for confirming `lane.publicBaseUrl` is set before calling
+ * this — it is not re-checked here.
  *
- * Everything from opening the lane's credentials through the probe upload is
- * wrapped in one try/catch (review follow-up, issue #929): bad/rotated
- * credentials, an unreachable bucket, or any other storage-client error
+ * Opening the credentials is wrapped in its own try/catch (review
+ * follow-up, issue #929): bad/rotated credentials or an unresolvable lane
  * would otherwise escape as an unhandled rejection (a 500 at the route
  * layer) instead of the same "unknown, not broken" `inconclusive` outcome
- * `checkActiveContentHeaders` itself already returns for a thrown fetch —
- * the route leaves the stamp untouched either way.
+ * the probe itself returns for a failed write or a thrown fetch — the route
+ * leaves the stamp untouched either way.
  */
 async function defaultLaneActiveContentCheck(
   env: Env,
   lane: StorageLane,
   fetchImpl: typeof fetch,
 ): Promise<StorageVerifyCheck> {
-  const probeKey = `${PROBE_PREFIX}${crypto.randomUUID()}.svg`;
-  let client: StorageProbeClient | undefined;
+  let candidate: StorageVerifyCandidate;
+  let client: StorageProbeClient;
   try {
-    const candidate = await laneVerifyCandidate(env, lane);
+    candidate = await laneVerifyCandidate(env, lane);
     client = defaultStorageClientFactory(candidate);
-    await client.upload(probeKey, ACTIVE_CONTENT_PROBE_SVG, { contentType: "image/svg+xml" });
-    return await checkActiveContentHeaders(candidate.publicBaseUrl ?? "", probeKey, fetchImpl);
   } catch {
     return {
       id: "active-content-headers",
       ok: false,
       required: false,
       inconclusive: true,
-      hint: "could not write the SVG probe to this bucket — check the lane's credentials, then check again",
+      hint: "could not open this lane's storage — check the lane's credentials, then check again",
     };
-  } finally {
-    if (client) await client.delete(probeKey).catch(() => {});
   }
+  return probeActiveContent(client, candidate.publicBaseUrl ?? "", fetchImpl);
 }
 
 /**

--- a/apps/api/src/self-serve-defaults.ts
+++ b/apps/api/src/self-serve-defaults.ts
@@ -15,6 +15,15 @@ import type { WorkspaceRecord } from "./workspace";
 
 const freeLimits = PLANS.free.defaultLimits;
 
+/**
+ * Public base URL every self-serve workspace is provisioned onto. Exported
+ * (issue #929) so the active-content host sweep
+ * (`apps/api/src/active-content-hosts.ts`) can fold this host into its
+ * hosted-host list without duplicating the literal — a self-hoster who
+ * changes this constant automatically changes what the sweep probes too.
+ */
+export const SELF_SERVE_PUBLIC_BASE_URL = "https://storage.uploads.sh";
+
 export const SELF_SERVE_LIMITS = {
   maxStorageBytes: freeLimits.maxStorageBytes!,
   maxUploadsPerPeriod: freeLimits.maxUploadsPerPeriod!,
@@ -38,7 +47,7 @@ export function selfServeWorkspaceRecord(args: {
     bucket: "uploads-default",
     binding: "UPLOADS_DEFAULT",
     prefix: `${args.name}/`,
-    publicBaseUrl: "https://storage.uploads.sh",
+    publicBaseUrl: SELF_SERVE_PUBLIC_BASE_URL,
     selfServe: true,
     createdByUserId: args.userId,
     createdAt: args.now.toISOString(),

--- a/apps/api/src/storage-health.test.ts
+++ b/apps/api/src/storage-health.test.ts
@@ -10,7 +10,8 @@ import {
 } from "./storage-health";
 import { demoteActiveLane, promoteLane } from "./workspace-lanes";
 import type { WorkspaceRecord } from "./workspace";
-import { storageStatusResponse } from "./routes/workspace-storage";
+import { activeContentStampFromVerify, storageStatusResponse } from "./routes/workspace-storage";
+import type { StorageVerifyResult } from "./storage-verify";
 
 /** A BYO (HTTP-credential, no binding) active-lane record. */
 function byoRecord(extra: Partial<WorkspaceRecord> = {}): WorkspaceRecord {
@@ -218,6 +219,7 @@ describe("lane transitions carry health", () => {
       next,
       { provider: "r2", bucket: "uploads-shared", binding: "BUCKET", prefix: "acme/" },
       undefined,
+      undefined,
     );
     expect(next.storageUnhealthyAt).toBeUndefined();
     expect(next.storageUnhealthyCode).toBeUndefined();
@@ -326,5 +328,68 @@ describe("storageStatusResponse health projection", () => {
       true,
     );
     expect(response.lanes[0]).not.toHaveProperty("health");
+  });
+});
+
+describe("storageStatusResponse — active-content stamp (issue #929)", () => {
+  it("projects the active lane's storageActiveContentVerifiedAt", () => {
+    const response = storageStatusResponse(
+      byoRecord({ storageActiveContentVerifiedAt: "2026-09-01T00:00:00.000Z" }),
+      true,
+    );
+    expect(response.activeContentVerifiedAt).toBe("2026-09-01T00:00:00.000Z");
+  });
+
+  it("omits the active-content stamp when the active lane has never passed the probe", () => {
+    const response = storageStatusResponse(byoRecord(), true);
+    expect(response.activeContentVerifiedAt).toBeUndefined();
+  });
+
+  it("projects a saved lane's own activeContentVerifiedAt in the lanes list", () => {
+    const response = storageStatusResponse(
+      sharedRecord({
+        storageLanes: [
+          {
+            id: "lane_0000beef",
+            provider: "r2",
+            bucket: "acme-media",
+            accountId: "a".repeat(32),
+            accessKeyId: "enc:v1:key",
+            secretAccessKey: "enc:v1:secret",
+            activeContentVerifiedAt: "2026-08-20T00:00:00.000Z",
+          },
+        ],
+      }),
+      true,
+    );
+    expect(response.lanes[0]?.activeContentVerifiedAt).toBe("2026-08-20T00:00:00.000Z");
+  });
+});
+
+describe("activeContentStampFromVerify (issue #929)", () => {
+  const nowIso = "2026-09-02T00:00:00.000Z";
+
+  it("returns nowIso when the active-content-headers check passed", () => {
+    const result: StorageVerifyResult = {
+      ok: true,
+      checks: [{ id: "active-content-headers", ok: true, required: false }],
+    };
+    expect(activeContentStampFromVerify(result, nowIso)).toBe(nowIso);
+  });
+
+  it("returns undefined when the active-content-headers check failed", () => {
+    const result: StorageVerifyResult = {
+      ok: true,
+      checks: [{ id: "active-content-headers", ok: false, required: false, hint: "missing csp" }],
+    };
+    expect(activeContentStampFromVerify(result, nowIso)).toBeUndefined();
+  });
+
+  it("returns undefined when the check never ran (no publicBaseUrl, or the public-url check failed)", () => {
+    const result: StorageVerifyResult = {
+      ok: true,
+      checks: [{ id: "public-url", ok: false, required: false, hint: "no public base URL" }],
+    };
+    expect(activeContentStampFromVerify(result, nowIso)).toBeUndefined();
   });
 });

--- a/apps/api/src/storage-health.test.ts
+++ b/apps/api/src/storage-health.test.ts
@@ -218,8 +218,7 @@ describe("lane transitions carry health", () => {
     promoteLane(
       next,
       { provider: "r2", bucket: "uploads-shared", binding: "BUCKET", prefix: "acme/" },
-      undefined,
-      undefined,
+      {},
     );
     expect(next.storageUnhealthyAt).toBeUndefined();
     expect(next.storageUnhealthyCode).toBeUndefined();

--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -772,6 +772,18 @@ describe("parseSandboxCsp", () => {
     expect(parseSandboxCsp("sandbox allow-scripts")).toMatchObject({ ok: false });
     expect(parseSandboxCsp("sandbox allow-same-origin allow-forms")).toMatchObject({ ok: false });
   });
+  // Two `Content-Security-Policy` response headers is legal CSP, and
+  // `Headers.get` joins repeated headers with ", " — so a `sandbox`
+  // directive sent on its own header must still parse out from the
+  // comma-joined string, not get swallowed into a neighboring directive.
+  it("parses a sandbox directive out of a comma-joined pair of CSP headers", () => {
+    expect(parseSandboxCsp("default-src 'none', sandbox").ok).toBe(true);
+  });
+  it("still rejects an unsafe sandbox token when the headers were comma-joined", () => {
+    expect(parseSandboxCsp("sandbox allow-scripts, default-src 'none'")).toMatchObject({
+      ok: false,
+    });
+  });
 });
 
 describe("checkActiveContentHeaders", () => {

--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  ACTIVE_CONTENT_PROBE_SVG,
+  checkActiveContentHeaders,
   defaultStorageClientFactory,
+  parseSandboxCsp,
   type StorageProbeClient,
   type StorageVerifyCandidate,
   verifyStorageConfig,
@@ -751,5 +754,120 @@ describe("verifyStorageConfig — s3 candidates", () => {
     const roundTrip = result.checks.find((c) => c.id === "round-trip")!;
     expect(roundTrip.ok).toBe(false);
     expect(roundTrip.hint).toMatch(/the R2 API token needs Object Read & Write, not read-only/);
+  });
+});
+
+describe("parseSandboxCsp", () => {
+  it("accepts the recommended policy, extra directives, and bare sandbox", () => {
+    expect(
+      parseSandboxCsp("default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox").ok,
+    ).toBe(true);
+    expect(parseSandboxCsp("sandbox; frame-ancestors 'none'").ok).toBe(true);
+    expect(parseSandboxCsp("sandbox").ok).toBe(true);
+    expect(parseSandboxCsp("SANDBOX allow-forms").ok).toBe(true);
+  });
+  it("rejects a missing header, a policy without sandbox, or a sandbox that re-enables script or origin", () => {
+    expect(parseSandboxCsp(null)).toMatchObject({ ok: false });
+    expect(parseSandboxCsp("default-src 'none'")).toMatchObject({ ok: false });
+    expect(parseSandboxCsp("sandbox allow-scripts")).toMatchObject({ ok: false });
+    expect(parseSandboxCsp("sandbox allow-same-origin allow-forms")).toMatchObject({ ok: false });
+  });
+});
+
+describe("checkActiveContentHeaders", () => {
+  const good = () =>
+    new Response(ACTIVE_CONTENT_PROBE_SVG, {
+      status: 200,
+      headers: {
+        "content-type": "image/svg+xml",
+        "content-security-policy": "default-src 'none'; sandbox",
+        "x-content-type-options": "nosniff",
+      },
+    });
+  it("passes when type, csp, and nosniff are all right", async () => {
+    const check = await checkActiveContentHeaders(
+      "https://cdn.example",
+      "_internal/x.svg",
+      async () => good(),
+    );
+    expect(check).toEqual({ id: "active-content-headers", ok: true, required: false });
+  });
+  it("fails on a rewritten content type, a missing csp, or a missing nosniff, naming the header", async () => {
+    const without = (h: string) => async () => {
+      const res = good();
+      const headers = new Headers(res.headers);
+      headers.delete(h);
+      return new Response(ACTIVE_CONTENT_PROBE_SVG, { status: 200, headers });
+    };
+    for (const h of ["content-security-policy", "x-content-type-options"]) {
+      const check = await checkActiveContentHeaders("https://cdn.example", "k.svg", without(h));
+      expect(check.ok).toBe(false);
+      expect(check.hint).toContain(h);
+    }
+    const typed = await checkActiveContentHeaders(
+      "https://cdn.example",
+      "k.svg",
+      async () =>
+        new Response("x", {
+          status: 200,
+          headers: {
+            "content-type": "text/plain",
+            "content-security-policy": "sandbox",
+            "x-content-type-options": "nosniff",
+          },
+        }),
+    );
+    expect(typed.ok).toBe(false);
+  });
+  it("is inconclusive when the fetch throws", async () => {
+    const check = await checkActiveContentHeaders("https://cdn.example", "k.svg", async () => {
+      throw new Error("boom");
+    });
+    expect(check).toMatchObject({ ok: false, inconclusive: true });
+  });
+});
+
+describe("verifyStorageConfig — active-content probe wiring", () => {
+  it("carries an active-content-headers check when the public-url check passes", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn(async (url: string) => {
+      const key = decodeURIComponent(new URL(url).pathname.slice(1));
+      const data = client.store.get(key);
+      if (!data) return new Response(null, { status: 404 });
+      if (key.endsWith(".svg")) {
+        return new Response(data, {
+          status: 200,
+          headers: {
+            "content-type": "image/svg+xml",
+            "content-security-policy": "default-src 'none'; sandbox",
+            "x-content-type-options": "nosniff",
+          },
+        });
+      }
+      return new Response(data, { status: 200 });
+    });
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(result.checks.find((c) => c.id === "public-url")!.ok).toBe(true);
+    const activeContent = result.checks.find((c) => c.id === "active-content-headers");
+    expect(activeContent).toBeDefined();
+    expect(activeContent!.ok).toBe(true);
+    // The SVG probe object is cleaned up alongside the round-trip probe.
+    expect(client.store.size).toBe(0);
+  });
+
+  it("does not run the active-content probe when the public-url check fails", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 404 }));
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(result.checks.find((c) => c.id === "public-url")!.ok).toBe(false);
+    expect(result.checks.find((c) => c.id === "active-content-headers")).toBeUndefined();
   });
 });

--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -4,6 +4,7 @@ import {
   checkActiveContentHeaders,
   defaultStorageClientFactory,
   parseSandboxCsp,
+  probeActiveContent,
   type StorageProbeClient,
   type StorageVerifyCandidate,
   verifyStorageConfig,
@@ -881,5 +882,30 @@ describe("verifyStorageConfig — active-content probe wiring", () => {
     );
     expect(result.checks.find((c) => c.id === "public-url")!.ok).toBe(false);
     expect(result.checks.find((c) => c.id === "active-content-headers")).toBeUndefined();
+  });
+});
+
+describe("probeActiveContent — cleanup on a failed write", () => {
+  it("still attempts to delete the probe key when the upload throws after landing", async () => {
+    const deletedKeys: string[] = [];
+    // Some clients throw after the object is already written (e.g. a
+    // timeout on the response) — record the key as "landed" before
+    // throwing, the same way such a client would.
+    let uploadedKey: string | undefined;
+    const client: Pick<StorageProbeClient, "upload" | "delete"> = {
+      async upload(key: string) {
+        uploadedKey = key;
+        throw new Error("timed out after write");
+      },
+      async delete(key: string) {
+        deletedKeys.push(key);
+      },
+    };
+
+    const check = await probeActiveContent(client, "https://media.example.com", fetch);
+
+    expect(check).toMatchObject({ ok: false, inconclusive: true });
+    expect(uploadedKey).toBeDefined();
+    expect(deletedKeys).toEqual([uploadedKey]);
   });
 });

--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -773,15 +773,25 @@ describe("parseSandboxCsp", () => {
     expect(parseSandboxCsp("sandbox allow-scripts")).toMatchObject({ ok: false });
     expect(parseSandboxCsp("sandbox allow-same-origin allow-forms")).toMatchObject({ ok: false });
   });
+  // A comma is legal *inside* a directive value, so it can't be a directive
+  // separator (issue #929 adversarial review L-1): splitting on it invented
+  // a `sandbox` directive out of a `report-uri` whose query happened to
+  // contain one.
+  it("does not read a sandbox directive out of a comma inside another directive's value", () => {
+    expect(parseSandboxCsp("report-uri /csp?tags=a,sandbox")).toMatchObject({ ok: false });
+    expect(parseSandboxCsp("frame-ancestors 'self',sandbox")).toMatchObject({ ok: false });
+  });
   // Two `Content-Security-Policy` response headers is legal CSP, and
-  // `Headers.get` joins repeated headers with ", " — so a `sandbox`
-  // directive sent on its own header must still parse out from the
-  // comma-joined string, not get swallowed into a neighboring directive.
-  it("parses a sandbox directive out of a comma-joined pair of CSP headers", () => {
-    expect(parseSandboxCsp("default-src 'none', sandbox").ok).toBe(true);
+  // `Headers.get` joins repeated headers with ", " — which now fails closed
+  // rather than being parsed apart. The hint says to send exactly one.
+  it("fails closed on a comma-joined pair of CSP headers", () => {
+    expect(parseSandboxCsp("default-src 'none', sandbox")).toMatchObject({ ok: false });
   });
   it("still rejects an unsafe sandbox token when the headers were comma-joined", () => {
     expect(parseSandboxCsp("sandbox allow-scripts, default-src 'none'")).toMatchObject({
+      ok: false,
+    });
+    expect(parseSandboxCsp("sandbox allow-same-origin, default-src 'none'")).toMatchObject({
       ok: false,
     });
   });
@@ -847,11 +857,13 @@ describe("verifyStorageConfig — active-content probe wiring", () => {
       const key = decodeURIComponent(new URL(url).pathname.slice(1));
       const data = client.store.get(key);
       if (!data) return new Response(null, { status: 404 });
-      if (key.endsWith(".svg")) {
+      // Both probe objects — the SVG and the XML (issue #929 M-1) — come
+      // back sandboxed, with the type each was written as.
+      if (key.endsWith(".svg") || key.endsWith(".xml")) {
         return new Response(data, {
           status: 200,
           headers: {
-            "content-type": "image/svg+xml",
+            "content-type": key.endsWith(".xml") ? "application/xml" : "image/svg+xml",
             "content-security-policy": "default-src 'none'; sandbox",
             "x-content-type-options": "nosniff",
           },
@@ -868,7 +880,40 @@ describe("verifyStorageConfig — active-content probe wiring", () => {
     const activeContent = result.checks.find((c) => c.id === "active-content-headers");
     expect(activeContent).toBeDefined();
     expect(activeContent!.ok).toBe(true);
-    // The SVG probe object is cleaned up alongside the round-trip probe.
+    // Both probe objects are cleaned up alongside the round-trip probe.
+    expect(client.store.size).toBe(0);
+  });
+
+  it("fails the check when the host sandboxes SVG but not XML (issue #929 M-1)", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn(async (url: string) => {
+      const key = decodeURIComponent(new URL(url).pathname.slice(1));
+      const data = client.store.get(key);
+      if (!data) return new Response(null, { status: 404 });
+      // An extension-scoped rule: `.svg` gets the headers, `.xml` doesn't.
+      if (key.endsWith(".svg")) {
+        return new Response(data, {
+          status: 200,
+          headers: {
+            "content-type": "image/svg+xml",
+            "content-security-policy": "default-src 'none'; sandbox",
+            "x-content-type-options": "nosniff",
+          },
+        });
+      }
+      if (key.endsWith(".xml")) {
+        return new Response(data, { status: 200, headers: { "content-type": "application/xml" } });
+      }
+      return new Response(data, { status: 200 });
+    });
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    const activeContent = result.checks.find((c) => c.id === "active-content-headers")!;
+    expect(activeContent.ok).toBe(false);
+    expect(activeContent.hint).toContain("application/xml probe");
     expect(client.store.size).toBe(0);
   });
 
@@ -882,6 +927,62 @@ describe("verifyStorageConfig — active-content probe wiring", () => {
     );
     expect(result.checks.find((c) => c.id === "public-url")!.ok).toBe(false);
     expect(result.checks.find((c) => c.id === "active-content-headers")).toBeUndefined();
+  });
+});
+
+describe("probeActiveContent — both probes must pass (issue #929 M-1)", () => {
+  const client: Pick<StorageProbeClient, "upload" | "delete"> = {
+    async upload() {},
+    async delete() {},
+  };
+  const sandboxed = (type: string) =>
+    new Response("<probe/>", {
+      status: 200,
+      headers: {
+        "content-type": type,
+        "content-security-policy": "default-src 'none'; sandbox",
+        "x-content-type-options": "nosniff",
+      },
+    });
+
+  it("is ok when both the SVG and the XML probe come back sandboxed", async () => {
+    const fetchImpl = (async (url: string) =>
+      sandboxed(
+        String(url).endsWith(".xml") ? "application/xml" : "image/svg+xml",
+      )) as unknown as typeof fetch;
+    expect(await probeActiveContent(client, "https://cdn.example", fetchImpl)).toEqual({
+      id: "active-content-headers",
+      ok: true,
+      required: false,
+    });
+  });
+
+  it("is not ok when only the SVG probe is sandboxed, and names the XML one", async () => {
+    const fetchImpl = (async (url: string) =>
+      String(url).endsWith(".xml")
+        ? new Response("<probe/>", { status: 200, headers: { "content-type": "application/xml" } })
+        : sandboxed("image/svg+xml")) as unknown as typeof fetch;
+    const check = await probeActiveContent(client, "https://cdn.example", fetchImpl);
+    expect(check.ok).toBe(false);
+    expect(check.hint).toContain("application/xml probe");
+  });
+
+  it("deletes both probe objects whatever the verdict", async () => {
+    const deleted: string[] = [];
+    const recording: Pick<StorageProbeClient, "upload" | "delete"> = {
+      async upload() {},
+      async delete(key: string) {
+        deleted.push(key);
+      },
+    };
+    const fetchImpl = (async (url: string) =>
+      sandboxed(
+        String(url).endsWith(".xml") ? "application/xml" : "image/svg+xml",
+      )) as unknown as typeof fetch;
+    await probeActiveContent(recording, "https://cdn.example", fetchImpl);
+    expect(deleted).toHaveLength(2);
+    expect(deleted.some((key) => key.endsWith(".svg"))).toBe(true);
+    expect(deleted.some((key) => key.endsWith(".xml"))).toBe(true);
   });
 });
 

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -495,11 +495,18 @@ export const ACTIVE_CONTENT_PROBE_SVG = new TextEncoder().encode(
  * directive puts the document in an opaque origin with script disabled;
  * `allow-scripts` and `allow-same-origin` each undo the part we rely on.
  * Any other directives are the host owner's business.
+ *
+ * Directives split on `/[;,]/`, not just `;`: two `Content-Security-Policy`
+ * response headers are legal (each adds its own restrictions), and the
+ * fetch API's `Headers.get` joins repeated headers with `", "` — so a
+ * `sandbox` directive sent on its own header, alongside an unrelated
+ * `default-src 'none'`, would otherwise vanish into one comma-joined token
+ * a plain `;`-split never separates back out.
  */
 export function parseSandboxCsp(header: string | null): { ok: boolean; reason?: string } {
   if (!header) return { ok: false, reason: "missing Content-Security-Policy" };
   const sandbox = header
-    .split(";")
+    .split(/[;,]/)
     .map((d) => d.trim().toLowerCase())
     .find((d) => d === "sandbox" || d.startsWith("sandbox "));
   if (!sandbox) return { ok: false, reason: "Content-Security-Policy has no sandbox directive" };

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -598,6 +598,11 @@ export async function probeActiveContent(
   try {
     await client.upload(probeKey, ACTIVE_CONTENT_PROBE_SVG, { contentType: "image/svg+xml" });
   } catch {
+    // A throw here doesn't mean nothing landed — some clients throw after
+    // the object is already written (e.g. a timeout on the response).
+    // Attempt the same best-effort cleanup as the happy path so a failed
+    // probe write never leaves an orphaned object behind.
+    await Promise.resolve(client.delete(probeKey)).catch(() => {});
     return {
       id: "active-content-headers",
       ok: false,

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -574,6 +574,45 @@ export async function checkActiveContentHeaders(
   }
 }
 
+/**
+ * The whole active-content probe, in one place (issue #929): write an inert
+ * SVG under {@link PROBE_PREFIX}, fetch it back through `publicBaseUrl` and
+ * check the headers it came with, then delete the object — always, whatever
+ * the outcome, and best-effort (a failed cleanup never changes the verdict).
+ * Every caller runs exactly this: the save-time pipeline below, the
+ * on-demand per-lane route (`routes/workspace-storage.ts`), and the
+ * hosted-host sweep (`active-content-hosts.ts`), which adapts its R2 binding
+ * to the two client methods this needs.
+ *
+ * A write that throws is `inconclusive`, not a failure — the same "unknown,
+ * not broken" verdict `checkActiveContentHeaders` returns for a thrown
+ * fetch, and for the same reason: nothing was learned about the host's
+ * headers. Inconclusive never enables SVG/XML for a lane.
+ */
+export async function probeActiveContent(
+  client: Pick<StorageProbeClient, "upload" | "delete">,
+  publicBaseUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<StorageVerifyCheck> {
+  const probeKey = `${PROBE_PREFIX}${crypto.randomUUID()}.svg`;
+  try {
+    await client.upload(probeKey, ACTIVE_CONTENT_PROBE_SVG, { contentType: "image/svg+xml" });
+  } catch {
+    return {
+      id: "active-content-headers",
+      ok: false,
+      required: false,
+      inconclusive: true,
+      hint: "could not write the SVG probe to this bucket — check the storage credentials, then check again",
+    };
+  }
+  try {
+    return await checkActiveContentHeaders(publicBaseUrl, probeKey, fetchImpl);
+  } finally {
+    await Promise.resolve(client.delete(probeKey)).catch(() => {});
+  }
+}
+
 /** Warning shown when no `publicBaseUrl` is configured — signed-only mode is allowed but degraded (issue #783 follow-up comment). */
 const NO_PUBLIC_URL_HINT =
   "no public base URL set — files will only be reachable through signed links that expire after an hour, and embeds/galleries won't work. Add one any time; it applies retroactively to files already uploaded (URLs are derived on request, nothing is stored per file).";
@@ -656,7 +695,6 @@ export async function verifyStorageConfig(
   let roundTripHint: string | undefined;
   let publicUrlCheck: StorageVerifyCheck | undefined;
   let publicUrlCacheControl: string | null | undefined;
-  let activeContentProbeKey: string | undefined;
   let activeContentCheck: StorageVerifyCheck | undefined;
   try {
     await client.upload(probeKey, probeBytes, { contentType: "application/octet-stream" });
@@ -671,15 +709,7 @@ export async function verifyStorageConfig(
       publicUrlCheck = probed.check;
       publicUrlCacheControl = probed.cacheControl;
       if (publicUrlCheck.ok) {
-        activeContentProbeKey = `${PROBE_PREFIX}${crypto.randomUUID()}.svg`;
-        await client.upload(activeContentProbeKey, ACTIVE_CONTENT_PROBE_SVG, {
-          contentType: "image/svg+xml",
-        });
-        activeContentCheck = await checkActiveContentHeaders(
-          candidate.publicBaseUrl,
-          activeContentProbeKey,
-          fetchImpl,
-        );
+        activeContentCheck = await probeActiveContent(client, candidate.publicBaseUrl, fetchImpl);
       }
     }
   } catch (err) {
@@ -699,13 +729,6 @@ export async function verifyStorageConfig(
       // Best-effort cleanup; a failed delete doesn't change the check result
       // above (round-trip already recorded), and we never want cleanup
       // failure to mask the real outcome.
-    }
-    if (activeContentProbeKey) {
-      try {
-        await client.delete(activeContentProbeKey);
-      } catch {
-        // Best-effort cleanup, same rationale as the round-trip probe above.
-      }
     }
   }
   checks.push({

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -485,10 +485,29 @@ function checkEmbedCache(cacheControl: string | null): StorageVerifyCheck {
   };
 }
 
-/** A 1×1 inert SVG; what the active-content probe writes and fetches. */
+/** A 1×1 inert SVG; the `image/svg+xml` half of the active-content probe. */
 export const ACTIVE_CONTENT_PROBE_SVG = new TextEncoder().encode(
   '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1"/></svg>',
 );
+
+/** An inert XML document; the `application/xml` half of the active-content probe. */
+export const ACTIVE_CONTENT_PROBE_XML = new TextEncoder().encode('<?xml version="1.0"?><probe/>');
+
+/**
+ * The two objects {@link probeActiveContent} writes and fetches back (issue
+ * #929 adversarial review M-1). SVG alone was never enough: the gate admits
+ * `image/svg+xml`, `application/xml` and `text/xml` together, but a host's
+ * rule can easily be extension-scoped (`ends_with ".svg"`) or list only the
+ * SVG content type — and an XML document served without the sandbox can run
+ * script through an `<?xml-stylesheet>` XSLT. `text/xml` has no probe of its
+ * own: it has no extension (so no key can claim it by name) and any rule
+ * shaped to catch `application/xml` catches it too, which is why the
+ * documented Transform Rule expression lists all three.
+ */
+const ACTIVE_CONTENT_PROBES: readonly { ext: string; contentType: string; body: Uint8Array }[] = [
+  { ext: "svg", contentType: "image/svg+xml", body: ACTIVE_CONTENT_PROBE_SVG },
+  { ext: "xml", contentType: "application/xml", body: ACTIVE_CONTENT_PROBE_XML },
+];
 
 /**
  * Does a Content-Security-Policy sandbox the document? The `sandbox`
@@ -496,36 +515,52 @@ export const ACTIVE_CONTENT_PROBE_SVG = new TextEncoder().encode(
  * `allow-scripts` and `allow-same-origin` each undo the part we rely on.
  * Any other directives are the host owner's business.
  *
- * Directives split on `/[;,]/`, not just `;`: two `Content-Security-Policy`
- * response headers are legal (each adds its own restrictions), and the
- * fetch API's `Headers.get` joins repeated headers with `", "` — so a
- * `sandbox` directive sent on its own header, alongside an unrelated
- * `default-src 'none'`, would otherwise vanish into one comma-joined token
- * a plain `;`-split never separates back out.
+ * Directives split on `;` only (issue #929 adversarial review L-1). A comma
+ * is a legal character *inside* a directive value — `report-uri
+ * /csp?tags=a,sandbox` is one `report-uri` directive, not a policy that
+ * sandboxes anything — so splitting on it invented a `sandbox` directive out
+ * of an entirely unsandboxed policy. The cost is that two
+ * `Content-Security-Policy` response headers (legal CSP; `Headers.get` joins
+ * them with `", "`) no longer parse apart and therefore fail closed, which
+ * is the right direction to fail and is what {@link ACTIVE_CONTENT_HINT}
+ * tells the host owner: send exactly one header.
+ *
+ * Within the sandbox directive, tokens split on whitespace *and* commas, so
+ * a comma-joined `sandbox allow-scripts, default-src 'none'` still reads
+ * `allow-scripts` as the token it is rather than passing as `allow-scripts,`.
  */
 export function parseSandboxCsp(header: string | null): { ok: boolean; reason?: string } {
   if (!header) return { ok: false, reason: "missing Content-Security-Policy" };
   const sandbox = header
-    .split(/[;,]/)
+    .split(";")
     .map((d) => d.trim().toLowerCase())
     .find((d) => d === "sandbox" || d.startsWith("sandbox "));
   if (!sandbox) return { ok: false, reason: "Content-Security-Policy has no sandbox directive" };
-  const tokens = new Set(sandbox.split(/\s+/).slice(1));
+  const tokens = new Set(sandbox.split(/[\s,]+/).slice(1));
   if (tokens.has("allow-scripts")) return { ok: false, reason: "sandbox allows scripts" };
   if (tokens.has("allow-same-origin")) return { ok: false, reason: "sandbox allows same-origin" };
   return { ok: true };
 }
 
 const ACTIVE_CONTENT_HINT =
-  "serve SVG/XML with `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox` and `X-Content-Type-Options: nosniff` on this host, then check again";
+  "serve SVG *and* XML with `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox` and `X-Content-Type-Options: nosniff` on this host — one Content-Security-Policy header, not two (repeated headers are joined with a comma and can't be read apart) — then check again";
 
-/** Recommended check: the public host serves SVG sandboxed. Never required; gates SVG/XML acceptance per lane. */
+/**
+ * Recommended check: the public host serves one probe object with the
+ * sandboxing CSP, `nosniff`, and the content type it was written with.
+ * `expectedType` is the type this particular probe was uploaded as
+ * (`image/svg+xml` or `application/xml`) — a host that rewrites the type
+ * fails, since the gate's whole premise is that the browser sees the type
+ * the rule was written for. Never required; gates SVG/XML acceptance per lane.
+ */
 export async function checkActiveContentHeaders(
   publicBaseUrl: string,
   probeKey: string,
   fetchImpl: typeof fetch,
+  expectedType = "image/svg+xml",
 ): Promise<StorageVerifyCheck> {
   const id = "active-content-headers";
+  const label = `${expectedType} probe`;
   const url = `${publicBaseUrl.replace(/\/$/, "")}/${probeKey}`;
   try {
     const res = await fetchImpl(url, {
@@ -537,15 +572,15 @@ export async function checkActiveContentHeaders(
         id,
         ok: false,
         required: false,
-        hint: `fetching the SVG probe returned HTTP ${res.status} — ${ACTIVE_CONTENT_HINT}`,
+        hint: `fetching the ${label} returned HTTP ${res.status} — ${ACTIVE_CONTENT_HINT}`,
       };
     const type = (res.headers.get("content-type") ?? "").toLowerCase();
-    if (!type.startsWith("image/svg+xml"))
+    if (!type.startsWith(expectedType))
       return {
         id,
         ok: false,
         required: false,
-        hint: `the host served the SVG probe as ${type || "no content-type"} instead of image/svg+xml — ${ACTIVE_CONTENT_HINT}`,
+        hint: `the host served the ${label} as ${type || "no content-type"} instead of ${expectedType} — ${ACTIVE_CONTENT_HINT}`,
       };
     const csp = parseSandboxCsp(res.headers.get("content-security-policy"));
     if (!csp.ok)
@@ -553,14 +588,14 @@ export async function checkActiveContentHeaders(
         id,
         ok: false,
         required: false,
-        hint: `${csp.reason} (content-security-policy) — ${ACTIVE_CONTENT_HINT}`,
+        hint: `${csp.reason} (content-security-policy) on the ${label} — ${ACTIVE_CONTENT_HINT}`,
       };
     if ((res.headers.get("x-content-type-options") ?? "").toLowerCase() !== "nosniff")
       return {
         id,
         ok: false,
         required: false,
-        hint: `missing x-content-type-options: nosniff — ${ACTIVE_CONTENT_HINT}`,
+        hint: `missing x-content-type-options: nosniff on the ${label} — ${ACTIVE_CONTENT_HINT}`,
       };
     return { id, ok: true, required: false };
   } catch {
@@ -569,20 +604,24 @@ export async function checkActiveContentHeaders(
       ok: false,
       required: false,
       inconclusive: true,
-      hint: "we couldn't fetch the SVG probe from here (Cloudflare-fronted domains are often unreachable as a server-side request); SVG/XML stay off for this lane until a check succeeds",
+      hint: `we couldn't fetch the ${label} from here (Cloudflare-fronted domains are often unreachable as a server-side request); SVG/XML stay off for this lane until a check succeeds`,
     };
   }
 }
 
 /**
- * The whole active-content probe, in one place (issue #929): write an inert
- * SVG under {@link PROBE_PREFIX}, fetch it back through `publicBaseUrl` and
- * check the headers it came with, then delete the object — always, whatever
- * the outcome, and best-effort (a failed cleanup never changes the verdict).
- * Every caller runs exactly this: the save-time pipeline below, the
- * on-demand per-lane route (`routes/workspace-storage.ts`), and the
- * hosted-host sweep (`active-content-hosts.ts`), which adapts its R2 binding
- * to the two client methods this needs.
+ * The whole active-content probe, in one place (issue #929): write the inert
+ * probe objects under {@link PROBE_PREFIX} — one SVG *and* one XML, since
+ * the gate opens all three gated types together and a host can sandbox one
+ * without the other — fetch each back through `publicBaseUrl`, check the
+ * headers each came with, then delete both — always, whatever the outcome,
+ * and best-effort (a failed cleanup never changes the verdict). The single
+ * `active-content-headers` check is `ok` only when *both* pass, and its hint
+ * names the probe that failed. Every caller runs exactly this: the save-time
+ * pipeline below, the on-demand per-lane route
+ * (`routes/workspace-storage.ts`), and the hosted-host sweep
+ * (`active-content-hosts.ts`), which adapts its R2 binding to the two client
+ * methods this needs.
  *
  * A write that throws is `inconclusive`, not a failure — the same "unknown,
  * not broken" verdict `checkActiveContentHeaders` returns for a thrown
@@ -594,27 +633,42 @@ export async function probeActiveContent(
   publicBaseUrl: string,
   fetchImpl: typeof fetch,
 ): Promise<StorageVerifyCheck> {
-  const probeKey = `${PROBE_PREFIX}${crypto.randomUUID()}.svg`;
+  // One uuid, one key per probe type: the fetches are independent, and a
+  // shared stem keeps a stranded pair recognizable as one probe run.
+  const stem = `${PROBE_PREFIX}${crypto.randomUUID()}`;
+  const probes = ACTIVE_CONTENT_PROBES.map((probe) => ({ ...probe, key: `${stem}.${probe.ext}` }));
+  // Every key we attempted to write, cleaned up in `finally` — a throwing
+  // upload doesn't mean nothing landed (some clients throw after the object
+  // is already written, e.g. a timeout on the response), so an attempted key
+  // is a key to delete.
+  const written: string[] = [];
   try {
-    await client.upload(probeKey, ACTIVE_CONTENT_PROBE_SVG, { contentType: "image/svg+xml" });
-  } catch {
-    // A throw here doesn't mean nothing landed — some clients throw after
-    // the object is already written (e.g. a timeout on the response).
-    // Attempt the same best-effort cleanup as the happy path so a failed
-    // probe write never leaves an orphaned object behind.
-    await Promise.resolve(client.delete(probeKey)).catch(() => {});
-    return {
-      id: "active-content-headers",
-      ok: false,
-      required: false,
-      inconclusive: true,
-      hint: "could not write the SVG probe to this bucket — check the storage credentials, then check again",
-    };
-  }
-  try {
-    return await checkActiveContentHeaders(publicBaseUrl, probeKey, fetchImpl);
+    for (const probe of probes) {
+      written.push(probe.key);
+      try {
+        await client.upload(probe.key, probe.body, { contentType: probe.contentType });
+      } catch {
+        return {
+          id: "active-content-headers",
+          ok: false,
+          required: false,
+          inconclusive: true,
+          hint: `could not write the ${probe.contentType} probe to this bucket — check the storage credentials, then check again`,
+        };
+      }
+    }
+    for (const probe of probes) {
+      const check = await checkActiveContentHeaders(
+        publicBaseUrl,
+        probe.key,
+        fetchImpl,
+        probe.contentType,
+      );
+      if (!check.ok) return check;
+    }
+    return { id: "active-content-headers", ok: true, required: false };
   } finally {
-    await Promise.resolve(client.delete(probeKey)).catch(() => {});
+    await Promise.all(written.map((key) => Promise.resolve(client.delete(key)).catch(() => {})));
   }
 }
 

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -142,8 +142,14 @@ export interface StorageVerifyOptions {
   fetch?: typeof fetch;
 }
 
-/** Prefix every verify probe object lives under, excluded from the empty-bucket count. */
-const PROBE_PREFIX = "_internal/uploads-verify/";
+/**
+ * Prefix every verify probe object lives under, excluded from the
+ * empty-bucket count. Exported so the on-demand per-lane active-content
+ * check route (`routes/workspace-settings.ts`, issue #929) writes its probe
+ * SVG under the same prefix `verifyStorageConfig`'s own active-content
+ * sub-probe uses, rather than inventing a second one.
+ */
+export const PROBE_PREFIX = "_internal/uploads-verify/";
 
 /** Deadline for the recommended public-URL probe; a stalled customer domain must not stall verify. */
 const PUBLIC_URL_PROBE_TIMEOUT_MS = 5_000;

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -52,7 +52,7 @@ export interface StorageVerifyCandidate {
 }
 
 export interface StorageVerifyCheck {
-  /** Stable identifier — `"shape" | "auth" | "round-trip" | "not-empty" | "public-url" | "embed-cache"`. */
+  /** Stable identifier — `"shape" | "auth" | "round-trip" | "not-empty" | "public-url" | "embed-cache" | "active-content-headers"`. */
   id: string;
   ok: boolean;
   /** Required checks gate `StorageVerifyResult.ok`; recommended ones only ever warn. */
@@ -479,6 +479,88 @@ function checkEmbedCache(cacheControl: string | null): StorageVerifyCheck {
   };
 }
 
+/** A 1×1 inert SVG; what the active-content probe writes and fetches. */
+export const ACTIVE_CONTENT_PROBE_SVG = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1"/></svg>',
+);
+
+/**
+ * Does a Content-Security-Policy sandbox the document? The `sandbox`
+ * directive puts the document in an opaque origin with script disabled;
+ * `allow-scripts` and `allow-same-origin` each undo the part we rely on.
+ * Any other directives are the host owner's business.
+ */
+export function parseSandboxCsp(header: string | null): { ok: boolean; reason?: string } {
+  if (!header) return { ok: false, reason: "missing Content-Security-Policy" };
+  const sandbox = header
+    .split(";")
+    .map((d) => d.trim().toLowerCase())
+    .find((d) => d === "sandbox" || d.startsWith("sandbox "));
+  if (!sandbox) return { ok: false, reason: "Content-Security-Policy has no sandbox directive" };
+  const tokens = new Set(sandbox.split(/\s+/).slice(1));
+  if (tokens.has("allow-scripts")) return { ok: false, reason: "sandbox allows scripts" };
+  if (tokens.has("allow-same-origin")) return { ok: false, reason: "sandbox allows same-origin" };
+  return { ok: true };
+}
+
+const ACTIVE_CONTENT_HINT =
+  "serve SVG/XML with `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox` and `X-Content-Type-Options: nosniff` on this host, then check again";
+
+/** Recommended check: the public host serves SVG sandboxed. Never required; gates SVG/XML acceptance per lane. */
+export async function checkActiveContentHeaders(
+  publicBaseUrl: string,
+  probeKey: string,
+  fetchImpl: typeof fetch,
+): Promise<StorageVerifyCheck> {
+  const id = "active-content-headers";
+  const url = `${publicBaseUrl.replace(/\/$/, "")}/${probeKey}`;
+  try {
+    const res = await fetchImpl(url, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(PUBLIC_URL_PROBE_TIMEOUT_MS),
+    });
+    if (!res.ok)
+      return {
+        id,
+        ok: false,
+        required: false,
+        hint: `fetching the SVG probe returned HTTP ${res.status} — ${ACTIVE_CONTENT_HINT}`,
+      };
+    const type = (res.headers.get("content-type") ?? "").toLowerCase();
+    if (!type.startsWith("image/svg+xml"))
+      return {
+        id,
+        ok: false,
+        required: false,
+        hint: `the host served the SVG probe as ${type || "no content-type"} instead of image/svg+xml — ${ACTIVE_CONTENT_HINT}`,
+      };
+    const csp = parseSandboxCsp(res.headers.get("content-security-policy"));
+    if (!csp.ok)
+      return {
+        id,
+        ok: false,
+        required: false,
+        hint: `${csp.reason} (content-security-policy) — ${ACTIVE_CONTENT_HINT}`,
+      };
+    if ((res.headers.get("x-content-type-options") ?? "").toLowerCase() !== "nosniff")
+      return {
+        id,
+        ok: false,
+        required: false,
+        hint: `missing x-content-type-options: nosniff — ${ACTIVE_CONTENT_HINT}`,
+      };
+    return { id, ok: true, required: false };
+  } catch {
+    return {
+      id,
+      ok: false,
+      required: false,
+      inconclusive: true,
+      hint: "we couldn't fetch the SVG probe from here (Cloudflare-fronted domains are often unreachable as a server-side request); SVG/XML stay off for this lane until a check succeeds",
+    };
+  }
+}
+
 /** Warning shown when no `publicBaseUrl` is configured — signed-only mode is allowed but degraded (issue #783 follow-up comment). */
 const NO_PUBLIC_URL_HINT =
   "no public base URL set — files will only be reachable through signed links that expire after an hour, and embeds/galleries won't work. Add one any time; it applies retroactively to files already uploaded (URLs are derived on request, nothing is stored per file).";
@@ -561,6 +643,8 @@ export async function verifyStorageConfig(
   let roundTripHint: string | undefined;
   let publicUrlCheck: StorageVerifyCheck | undefined;
   let publicUrlCacheControl: string | null | undefined;
+  let activeContentProbeKey: string | undefined;
+  let activeContentCheck: StorageVerifyCheck | undefined;
   try {
     await client.upload(probeKey, probeBytes, { contentType: "application/octet-stream" });
     const downloaded = await client.download(probeKey);
@@ -573,6 +657,17 @@ export async function verifyStorageConfig(
       const probed = await checkPublicUrl(candidate.publicBaseUrl, probeKey, probeBytes, fetchImpl);
       publicUrlCheck = probed.check;
       publicUrlCacheControl = probed.cacheControl;
+      if (publicUrlCheck.ok) {
+        activeContentProbeKey = `${PROBE_PREFIX}${crypto.randomUUID()}.svg`;
+        await client.upload(activeContentProbeKey, ACTIVE_CONTENT_PROBE_SVG, {
+          contentType: "image/svg+xml",
+        });
+        activeContentCheck = await checkActiveContentHeaders(
+          candidate.publicBaseUrl,
+          activeContentProbeKey,
+          fetchImpl,
+        );
+      }
     }
   } catch (err) {
     if (errorCode(err) === "Unauthorized") {
@@ -591,6 +686,13 @@ export async function verifyStorageConfig(
       // Best-effort cleanup; a failed delete doesn't change the check result
       // above (round-trip already recorded), and we never want cleanup
       // failure to mask the real outcome.
+    }
+    if (activeContentProbeKey) {
+      try {
+        await client.delete(activeContentProbeKey);
+      } catch {
+        // Best-effort cleanup, same rationale as the round-trip probe above.
+      }
     }
   }
   checks.push({
@@ -625,6 +727,9 @@ export async function verifyStorageConfig(
     // top of an unreachable-domain public-url failure.
     if (publicUrlCacheControl !== undefined) {
       checks.push(checkEmbedCache(publicUrlCacheControl));
+    }
+    if (activeContentCheck) {
+      checks.push(activeContentCheck);
     }
   } else {
     // Signed-only mode is allowed, but it's a degraded state, not a neutral

--- a/apps/api/src/workspace-lanes.test.ts
+++ b/apps/api/src/workspace-lanes.test.ts
@@ -58,7 +58,9 @@ function r2ActiveRecord(extra: Partial<WorkspaceRecord> = {}): WorkspaceRecord {
 describe("promoteLane", () => {
   it("promotes an s3 standby lane: active record gets provider s3 plus endpoint/region/forcePathStyle", () => {
     const next: WorkspaceRecord = { provider: "r2", bucket: "old-shared", binding: "BUCKET" };
-    promoteLane(next, s3StandbyLane() as PromotableLane, "2026-08-30T00:00:00.000Z", undefined);
+    promoteLane(next, s3StandbyLane() as PromotableLane, {
+      verifiedAt: "2026-08-30T00:00:00.000Z",
+    });
     expect(next.provider).toBe("s3");
     expect(next.bucket).toBe("acme-s3-bucket-2");
     expect(next.endpoint).toBe("https://s3.eu-west-2.amazonaws.com");
@@ -82,7 +84,7 @@ describe("promoteLane", () => {
       secretAccessKey: "enc:v1:y",
       jurisdiction: "fedramp",
     };
-    promoteLane(next, r2Lane, "2026-08-30T00:00:00.000Z", undefined);
+    promoteLane(next, r2Lane, { verifiedAt: "2026-08-30T00:00:00.000Z" });
     expect(next.provider).toBe("r2");
     expect(next.accountId).toBe("b".repeat(32));
     expect(next.jurisdiction).toBe("fedramp");
@@ -127,7 +129,9 @@ describe("promote/demote round trip", () => {
     const s3Lane = s3StandbyLane();
     const demotedR2 = demoteActiveLane(record, "2026-08-30T00:00:00.000Z");
     const afterFirstSwitch: WorkspaceRecord = { ...record, storageLanes: [demotedR2] };
-    promoteLane(afterFirstSwitch, s3Lane as PromotableLane, "2026-08-30T00:01:00.000Z", undefined);
+    promoteLane(afterFirstSwitch, s3Lane as PromotableLane, {
+      verifiedAt: "2026-08-30T00:01:00.000Z",
+    });
 
     expect(afterFirstSwitch.provider).toBe("s3");
     expect(afterFirstSwitch.endpoint).toBe(s3Lane.endpoint);
@@ -144,12 +148,9 @@ describe("promote/demote round trip", () => {
       ...afterFirstSwitch,
       storageLanes: [demotedS3],
     };
-    promoteLane(
-      afterSecondSwitch,
-      demotedR2 as PromotableLane,
-      "2026-08-30T00:03:00.000Z",
-      undefined,
-    );
+    promoteLane(afterSecondSwitch, demotedR2 as PromotableLane, {
+      verifiedAt: "2026-08-30T00:03:00.000Z",
+    });
 
     // Back on r2, with the original r2 fields intact.
     expect(afterSecondSwitch.provider).toBe("r2");
@@ -185,20 +186,20 @@ describe("activeContentVerifiedAt (issue #929)", () => {
 
   it("promoteLane stamps storageActiveContentVerifiedAt when passed a value", () => {
     const next: WorkspaceRecord = { provider: "r2", bucket: "old-shared", binding: "BUCKET" };
-    promoteLane(
-      next,
-      s3StandbyLane() as PromotableLane,
-      "2026-08-30T00:00:00.000Z",
-      "2026-08-30T00:00:00.000Z",
-    );
+    promoteLane(next, s3StandbyLane() as PromotableLane, {
+      verifiedAt: "2026-08-30T00:00:00.000Z",
+      activeContentVerifiedAt: "2026-08-30T00:00:00.000Z",
+    });
     expect(next.storageActiveContentVerifiedAt).toBe("2026-08-30T00:00:00.000Z");
   });
 
-  it("promoteLane clears storageActiveContentVerifiedAt when passed undefined, even if the record carried one before", () => {
+  it("promoteLane clears storageActiveContentVerifiedAt when the stamp is omitted, even if the record carried one before", () => {
     const next: WorkspaceRecord = r2ActiveRecord({
       storageActiveContentVerifiedAt: "2026-08-01T00:00:00.000Z",
     });
-    promoteLane(next, s3StandbyLane() as PromotableLane, "2026-08-30T00:00:00.000Z", undefined);
+    promoteLane(next, s3StandbyLane() as PromotableLane, {
+      verifiedAt: "2026-08-30T00:00:00.000Z",
+    });
     expect(next.storageActiveContentVerifiedAt).toBeUndefined();
   });
 
@@ -206,12 +207,10 @@ describe("activeContentVerifiedAt (issue #929)", () => {
     const record = r2ActiveRecord({ storageActiveContentVerifiedAt: "2026-09-01T00:00:00.000Z" });
     const demoted = demoteActiveLane(record, "2026-09-02T00:00:00.000Z");
     const next: WorkspaceRecord = { provider: "r2", bucket: "placeholder" };
-    promoteLane(
-      next,
-      demoted as PromotableLane,
-      "2026-09-02T00:01:00.000Z",
-      demoted.activeContentVerifiedAt,
-    );
+    promoteLane(next, demoted as PromotableLane, {
+      verifiedAt: "2026-09-02T00:01:00.000Z",
+      activeContentVerifiedAt: demoted.activeContentVerifiedAt,
+    });
     expect(next.storageActiveContentVerifiedAt).toBe("2026-09-01T00:00:00.000Z");
   });
 });

--- a/apps/api/src/workspace-lanes.test.ts
+++ b/apps/api/src/workspace-lanes.test.ts
@@ -58,7 +58,7 @@ function r2ActiveRecord(extra: Partial<WorkspaceRecord> = {}): WorkspaceRecord {
 describe("promoteLane", () => {
   it("promotes an s3 standby lane: active record gets provider s3 plus endpoint/region/forcePathStyle", () => {
     const next: WorkspaceRecord = { provider: "r2", bucket: "old-shared", binding: "BUCKET" };
-    promoteLane(next, s3StandbyLane() as PromotableLane, "2026-08-30T00:00:00.000Z");
+    promoteLane(next, s3StandbyLane() as PromotableLane, "2026-08-30T00:00:00.000Z", undefined);
     expect(next.provider).toBe("s3");
     expect(next.bucket).toBe("acme-s3-bucket-2");
     expect(next.endpoint).toBe("https://s3.eu-west-2.amazonaws.com");
@@ -82,7 +82,7 @@ describe("promoteLane", () => {
       secretAccessKey: "enc:v1:y",
       jurisdiction: "fedramp",
     };
-    promoteLane(next, r2Lane, "2026-08-30T00:00:00.000Z");
+    promoteLane(next, r2Lane, "2026-08-30T00:00:00.000Z", undefined);
     expect(next.provider).toBe("r2");
     expect(next.accountId).toBe("b".repeat(32));
     expect(next.jurisdiction).toBe("fedramp");
@@ -127,7 +127,7 @@ describe("promote/demote round trip", () => {
     const s3Lane = s3StandbyLane();
     const demotedR2 = demoteActiveLane(record, "2026-08-30T00:00:00.000Z");
     const afterFirstSwitch: WorkspaceRecord = { ...record, storageLanes: [demotedR2] };
-    promoteLane(afterFirstSwitch, s3Lane as PromotableLane, "2026-08-30T00:01:00.000Z");
+    promoteLane(afterFirstSwitch, s3Lane as PromotableLane, "2026-08-30T00:01:00.000Z", undefined);
 
     expect(afterFirstSwitch.provider).toBe("s3");
     expect(afterFirstSwitch.endpoint).toBe(s3Lane.endpoint);
@@ -144,7 +144,12 @@ describe("promote/demote round trip", () => {
       ...afterFirstSwitch,
       storageLanes: [demotedS3],
     };
-    promoteLane(afterSecondSwitch, demotedR2 as PromotableLane, "2026-08-30T00:03:00.000Z");
+    promoteLane(
+      afterSecondSwitch,
+      demotedR2 as PromotableLane,
+      "2026-08-30T00:03:00.000Z",
+      undefined,
+    );
 
     // Back on r2, with the original r2 fields intact.
     expect(afterSecondSwitch.provider).toBe("r2");
@@ -162,5 +167,51 @@ describe("promote/demote round trip", () => {
     expect(demotedS3.region).toBe(s3Lane.region);
     expect(demotedS3.forcePathStyle).toBe(s3Lane.forcePathStyle);
     expect(demotedS3.accountId).toBeUndefined();
+  });
+});
+
+describe("activeContentVerifiedAt (issue #929)", () => {
+  it("demoteActiveLane carries storageActiveContentVerifiedAt onto the fallback lane's activeContentVerifiedAt", () => {
+    const current = r2ActiveRecord({ storageActiveContentVerifiedAt: "2026-09-01T00:00:00.000Z" });
+    const demoted = demoteActiveLane(current, "2026-09-02T00:00:00.000Z");
+    expect(demoted.activeContentVerifiedAt).toBe("2026-09-01T00:00:00.000Z");
+  });
+
+  it("demoteActiveLane leaves activeContentVerifiedAt absent when the active lane never passed the probe", () => {
+    const current = r2ActiveRecord();
+    const demoted = demoteActiveLane(current, "2026-09-02T00:00:00.000Z");
+    expect(demoted.activeContentVerifiedAt).toBeUndefined();
+  });
+
+  it("promoteLane stamps storageActiveContentVerifiedAt when passed a value", () => {
+    const next: WorkspaceRecord = { provider: "r2", bucket: "old-shared", binding: "BUCKET" };
+    promoteLane(
+      next,
+      s3StandbyLane() as PromotableLane,
+      "2026-08-30T00:00:00.000Z",
+      "2026-08-30T00:00:00.000Z",
+    );
+    expect(next.storageActiveContentVerifiedAt).toBe("2026-08-30T00:00:00.000Z");
+  });
+
+  it("promoteLane clears storageActiveContentVerifiedAt when passed undefined, even if the record carried one before", () => {
+    const next: WorkspaceRecord = r2ActiveRecord({
+      storageActiveContentVerifiedAt: "2026-08-01T00:00:00.000Z",
+    });
+    promoteLane(next, s3StandbyLane() as PromotableLane, "2026-08-30T00:00:00.000Z", undefined);
+    expect(next.storageActiveContentVerifiedAt).toBeUndefined();
+  });
+
+  it("round-trips the stamp through demote then promote, same as verifiedAt", () => {
+    const record = r2ActiveRecord({ storageActiveContentVerifiedAt: "2026-09-01T00:00:00.000Z" });
+    const demoted = demoteActiveLane(record, "2026-09-02T00:00:00.000Z");
+    const next: WorkspaceRecord = { provider: "r2", bucket: "placeholder" };
+    promoteLane(
+      next,
+      demoted as PromotableLane,
+      "2026-09-02T00:01:00.000Z",
+      demoted.activeContentVerifiedAt,
+    );
+    expect(next.storageActiveContentVerifiedAt).toBe("2026-09-01T00:00:00.000Z");
   });
 });

--- a/apps/api/src/workspace-lanes.ts
+++ b/apps/api/src/workspace-lanes.ts
@@ -77,17 +77,19 @@ export type PromotableLane = StorageLaneFields &
  * `binding`/`prefix`; BYO → shared must drop the credential fields). A
  * `lane.id` of `undefined` (the laneless shared target) clears
  * `next.storageLaneId` instead of setting it — the restored shared lane has
- * no id until a future activate demotes it again. `activeContentVerifiedAt`
- * is a separate stamp from `verifiedAt` (issue #929) — a lane can pass
+ * no id until a future activate demotes it again.
+ *
+ * `stamps` are the two verification timestamps, passed together and
+ * independently of `lane`: whoever promotes a lane has just decided what
+ * they should be (carried forward from the lane, refreshed from a re-verify
+ * result, or cleared), and they don't move together — a lane can pass
  * overall verification while still failing the recommended SVG/XML
- * sandboxing-CSP probe, so callers pass it independently rather than
- * deriving it from `lane`.
+ * sandboxing-CSP probe (issue #929). An omitted stamp clears the field.
  */
 export function promoteLane(
   next: WorkspaceRecord,
   lane: PromotableLane,
-  verifiedAt: string | undefined,
-  activeContentVerifiedAt: string | undefined,
+  stamps: { verifiedAt?: string; activeContentVerifiedAt?: string },
 ): void {
   // The incoming lane's own provider, never hardcoded — promoting an s3
   // standby (or reactivating a demoted s3 fallback) must land as an s3
@@ -124,10 +126,11 @@ export function promoteLane(
   else delete next.storageConfiguredBy;
   if (lane.storageAccessKeyIdLast4) next.storageAccessKeyIdLast4 = lane.storageAccessKeyIdLast4;
   else delete next.storageAccessKeyIdLast4;
-  if (verifiedAt) next.storageVerifiedAt = verifiedAt;
+  if (stamps.verifiedAt) next.storageVerifiedAt = stamps.verifiedAt;
   else delete next.storageVerifiedAt;
-  if (activeContentVerifiedAt) next.storageActiveContentVerifiedAt = activeContentVerifiedAt;
-  else delete next.storageActiveContentVerifiedAt;
+  if (stamps.activeContentVerifiedAt) {
+    next.storageActiveContentVerifiedAt = stamps.activeContentVerifiedAt;
+  } else delete next.storageActiveContentVerifiedAt;
   // A lane only ever becomes active after it has been proven to work — a
   // binding-mode (shared) lane needs no proof, and an HTTP-credential lane is
   // re-verified by `storageActivateHandler` before the swap (which forces a

--- a/apps/api/src/workspace-lanes.ts
+++ b/apps/api/src/workspace-lanes.ts
@@ -41,6 +41,7 @@ export function demoteActiveLane(current: WorkspaceRecord, nowIso: string): Stor
     forcePathStyle: current.forcePathStyle,
     lastActiveAt: nowIso,
     verifiedAt: current.storageVerifiedAt,
+    activeContentVerifiedAt: current.storageActiveContentVerifiedAt,
     storageConfiguredAt: current.storageConfiguredAt,
     storageConfiguredBy: current.storageConfiguredBy,
     storageAccessKeyIdLast4: current.storageAccessKeyIdLast4,
@@ -76,12 +77,17 @@ export type PromotableLane = StorageLaneFields &
  * `binding`/`prefix`; BYO → shared must drop the credential fields). A
  * `lane.id` of `undefined` (the laneless shared target) clears
  * `next.storageLaneId` instead of setting it — the restored shared lane has
- * no id until a future activate demotes it again.
+ * no id until a future activate demotes it again. `activeContentVerifiedAt`
+ * is a separate stamp from `verifiedAt` (issue #929) — a lane can pass
+ * overall verification while still failing the recommended SVG/XML
+ * sandboxing-CSP probe, so callers pass it independently rather than
+ * deriving it from `lane`.
  */
 export function promoteLane(
   next: WorkspaceRecord,
   lane: PromotableLane,
   verifiedAt: string | undefined,
+  activeContentVerifiedAt: string | undefined,
 ): void {
   // The incoming lane's own provider, never hardcoded — promoting an s3
   // standby (or reactivating a demoted s3 fallback) must land as an s3
@@ -120,6 +126,8 @@ export function promoteLane(
   else delete next.storageAccessKeyIdLast4;
   if (verifiedAt) next.storageVerifiedAt = verifiedAt;
   else delete next.storageVerifiedAt;
+  if (activeContentVerifiedAt) next.storageActiveContentVerifiedAt = activeContentVerifiedAt;
+  else delete next.storageActiveContentVerifiedAt;
   // A lane only ever becomes active after it has been proven to work — a
   // binding-mode (shared) lane needs no proof, and an HTTP-credential lane is
   // re-verified by `storageActivateHandler` before the swap (which forces a

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -223,6 +223,21 @@ export interface WorkspaceRecord {
   storageVerifiedAt?: string;
   /** ISO timestamp of the active lane's most recent successful `active-content-headers` check (issue #929) — mirrors `StorageLane.activeContentVerifiedAt` for the currently-active lane. Absent means the active lane has never passed the sandboxing-CSP probe. */
   storageActiveContentVerifiedAt?: string;
+  /**
+   * When each lane's on-demand "Check now" probe last *ran*, keyed by lane id
+   * (the active lane under its `storageLaneId`, or the literal `active`
+   * before it has one). Purely a per-lane cooldown clock for
+   * `storageVerifyActiveContentHandler` (issue #929 adversarial review L-3):
+   * unlike `storageActiveContentVerifiedAt` it records attempts, not
+   * successes, so a failing or inconclusive probe still rate-limits the next
+   * one — the route drives an outbound fetch at an owner-supplied URL, and
+   * that has to cost more than one button press per minute. Deliberately not
+   * a `StorageLane` field: nothing about a lane's identity or verification
+   * state lives here, and threading a rate-limit clock through
+   * `demoteActiveLane`/`promoteLane` would only invite it being mistaken for
+   * one. Pruned to live lane ids on every write.
+   */
+  storageActiveContentCheckedAt?: Record<string, string>;
   /** Better Auth user id that most recently configured this workspace's storage via the self-serve flow. */
   storageConfiguredBy?: string;
   /**

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -195,6 +195,15 @@ export interface WorkspaceRecord {
    * workspaces" (Flagship) and "nothing" (removing the MEDIA binding).
    */
   videoPosterEnabled?: boolean;
+  /**
+   * Per-workspace opt-out for SVG/XML "active content" uploads (issue
+   * #929). Default (undefined/true) allows them once the active lane's
+   * host is verified. `false` turns them off for this workspace
+   * regardless of lane verification state — the surgical kill switch
+   * between "every eligible workspace" (Flagship) and "this one workspace"
+   * (precedent: `videoPosterEnabled`).
+   */
+  activeContentUploads?: boolean;
   /** Set by `DELETE /admin/workspaces/:name` (default/soft mode). Present → the workspace is soft-deleted. */
   deletedAt?: string;
   /** `deletedAt` + the grace window (`WORKSPACE_DELETE_GRACE_DAYS`); the retention sweep finalizes at/after this. */
@@ -212,6 +221,8 @@ export interface WorkspaceRecord {
   storageConfiguredAt?: string;
   /** ISO timestamp of the most recent successful storage verification (either at save time or a standalone re-verify). Powers the settings UI's "verified ✓ N days ago" line. */
   storageVerifiedAt?: string;
+  /** ISO timestamp of the active lane's most recent successful `active-content-headers` check (issue #929) — mirrors `StorageLane.activeContentVerifiedAt` for the currently-active lane. Absent means the active lane has never passed the sandboxing-CSP probe. */
+  storageActiveContentVerifiedAt?: string;
   /** Better Auth user id that most recently configured this workspace's storage via the self-serve flow. */
   storageConfiguredBy?: string;
   /**
@@ -311,6 +322,14 @@ export interface StorageLane extends StorageLaneFields {
   unhealthyAt?: string;
   /** `StorageHealthCode`, widened to `string` — see `WorkspaceRecord.storageUnhealthyCode`. */
   unhealthyCode?: string;
+  /**
+   * Last successful `active-content-headers` verify check against this
+   * lane's public host (issue #929) — the SVG/XML acceptance gate reads
+   * this (via `WorkspaceRecord.storageActiveContentVerifiedAt` when the
+   * lane is active), not `verifiedAt`, since a lane can verify overall
+   * while its host still fails the sandboxing-CSP probe.
+   */
+  activeContentVerifiedAt?: string;
 }
 
 /** New lane id: "lane_" + 8 lowercase hex chars from crypto.getRandomValues. */

--- a/apps/api/test/files-core-server-copy.test.ts
+++ b/apps/api/test/files-core-server-copy.test.ts
@@ -1,24 +1,43 @@
 /**
- * `putObject`'s `opts.serverCopy` (issue #929 review): a server-side copy of
- * bytes already stored in this workspace (attach/promote/rotate, via
- * `putOptsFromStoredObject`) bypasses the active-content lane gate — same
- * active lane, same serving host, so a copy changes nothing about exposure.
- * Everything else `inspectUpload` checks (size, sniffing, plausibility) still
- * applies; this only ever widens the allowlist.
+ * `putObject`'s `opts.serverCopy` (issue #929 review, tightened by the
+ * adversarial review's M-2): a server-side copy of bytes already stored in
+ * this workspace (attach/promote/rotate, via `putOptsFromStoredObject`) is
+ * judged by `activeContentAllowedForCopy` rather than the ordinary gate —
+ * same active lane, same serving host, so a *freshness* close changes
+ * nothing about exposure, but a *policy* close (workspace opt-out, Flagship
+ * kill switch, unhealthy lane) still refuses. Everything else
+ * `inspectUpload` checks (size, sniffing, plausibility/reputation) applies to
+ * a copy exactly as it does to a direct put.
  */
 import { describe, expect, it } from "vitest";
 import { makePosterEnv, WORKSPACE } from "./poster-fixtures";
+import { HOSTED_ACTIVE_CONTENT_HOSTS } from "../src/active-content-hosts";
+import { HOST_RECORD_MAX_AGE_MS } from "../src/active-content";
 import { putObject } from "../src/files-core";
 
 const INERT_SVG = new TextEncoder().encode(
   '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>',
 );
 
-describe("putObject serverCopy bypasses the active-content lane gate", () => {
-  it("a serverCopy put of SVG bytes succeeds on an unverified workspace", async () => {
+const SCRIPTED_SVG = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+);
+
+/** A REGISTRY stand-in seeded with one `host-active-content:*` record per hosted host. */
+function registryWithHostRecords(record: { ok: boolean; verifiedAt: string }) {
+  const store = new Map<string, unknown>(
+    HOSTED_ACTIVE_CONTENT_HOSTS.map((host) => [`host-active-content:${host}`, record]),
+  );
+  return {
+    get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+  } as unknown as KVNamespace;
+}
+
+describe("putObject serverCopy — freshness closes are tolerated", () => {
+  it("a serverCopy put of SVG bytes succeeds on a lane with no host record at all", async () => {
     // makePosterEnv's env has no REGISTRY, so a shared-lane workspace's
-    // active-content gate is unconditionally false here (fail-closed) —
-    // exactly the "unverified lane" case `serverCopy` needs to bypass.
+    // gate closes with `host_missing` — a freshness reason, so the copy of
+    // already-stored bytes still lands.
     const { env, bucket, ws } = makePosterEnv();
     const result = await putObject(env, ws, "diagrams/copy.svg", INERT_SVG, WORKSPACE, {
       declaredContentType: "image/svg+xml",
@@ -28,11 +47,86 @@ describe("putObject serverCopy bypasses the active-content lane gate", () => {
     expect(bucket.store.get(`default/${result.key}`)?.contentType).toBe("image/svg+xml");
   });
 
+  it("a serverCopy put succeeds when the only problem is a stale host record", async () => {
+    const { env, ws } = makePosterEnv();
+    const stale = {
+      ok: true,
+      verifiedAt: new Date(Date.now() - HOST_RECORD_MAX_AGE_MS - 1000).toISOString(),
+    };
+    const e = { ...env, REGISTRY: registryWithHostRecords(stale) } as unknown as Env;
+    const result = await putObject(e, ws, "diagrams/stale.svg", INERT_SVG, WORKSPACE, {
+      declaredContentType: "image/svg+xml",
+      serverCopy: true,
+    });
+    expect(result.contentType).toBe("image/svg+xml");
+  });
+
   it("the same put without serverCopy 415s on the same unverified workspace", async () => {
     const { env, ws } = makePosterEnv();
     await expect(
       putObject(env, ws, "diagrams/direct.svg", INERT_SVG, WORKSPACE, {
         declaredContentType: "image/svg+xml",
+      }),
+    ).rejects.toMatchObject({ status: 415 });
+  });
+});
+
+describe("putObject serverCopy — policy closes still refuse (issue #929 M-2)", () => {
+  it("415s a serverCopy when the Flagship kill switch is off", async () => {
+    const { env, ws } = makePosterEnv();
+    const e = {
+      ...env,
+      FLAGS: { getBooleanValue: async (_k: string, def: boolean) => def },
+    } as unknown as Env;
+    await expect(
+      putObject(e, ws, "diagrams/killed.svg", INERT_SVG, WORKSPACE, {
+        declaredContentType: "image/svg+xml",
+        serverCopy: true,
+      }),
+    ).rejects.toMatchObject({ status: 415 });
+  });
+
+  it("415s a serverCopy for a workspace that opted out", async () => {
+    const { env, ws } = makePosterEnv();
+    await expect(
+      putObject(
+        env,
+        { ...ws, activeContentUploads: false },
+        "diagrams/opted-out.svg",
+        INERT_SVG,
+        WORKSPACE,
+        { declaredContentType: "image/svg+xml", serverCopy: true },
+      ),
+    ).rejects.toMatchObject({ status: 415 });
+  });
+
+  it("415s a serverCopy onto a lane flagged unhealthy", async () => {
+    const { env, ws } = makePosterEnv();
+    await expect(
+      putObject(
+        env,
+        { ...ws, storageUnhealthyAt: new Date().toISOString() },
+        "diagrams/unhealthy.svg",
+        INERT_SVG,
+        WORKSPACE,
+        { declaredContentType: "image/svg+xml", serverCopy: true },
+      ),
+    ).rejects.toMatchObject({ status: 415 });
+  });
+});
+
+/**
+ * The reputation pre-filter is not part of the lane gate, so `serverCopy`
+ * never widened it — the comment in `guards.ts` that claimed otherwise was
+ * wrong (issue #929 adversarial review L-6). This is that claim, tested.
+ */
+describe("putObject serverCopy still runs the reputation pre-filter", () => {
+  it("415s a copy of SVG bytes containing a <script> tag", async () => {
+    const { env, ws } = makePosterEnv();
+    await expect(
+      putObject(env, ws, "diagrams/scripted.svg", SCRIPTED_SVG, WORKSPACE, {
+        declaredContentType: "image/svg+xml",
+        serverCopy: true,
       }),
     ).rejects.toMatchObject({ status: 415 });
   });

--- a/apps/api/test/files-core-server-copy.test.ts
+++ b/apps/api/test/files-core-server-copy.test.ts
@@ -1,0 +1,39 @@
+/**
+ * `putObject`'s `opts.serverCopy` (issue #929 review): a server-side copy of
+ * bytes already stored in this workspace (attach/promote/rotate, via
+ * `putOptsFromStoredObject`) bypasses the active-content lane gate — same
+ * active lane, same serving host, so a copy changes nothing about exposure.
+ * Everything else `inspectUpload` checks (size, sniffing, plausibility) still
+ * applies; this only ever widens the allowlist.
+ */
+import { describe, expect, it } from "vitest";
+import { makePosterEnv, WORKSPACE } from "./poster-fixtures";
+import { putObject } from "../src/files-core";
+
+const INERT_SVG = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>',
+);
+
+describe("putObject serverCopy bypasses the active-content lane gate", () => {
+  it("a serverCopy put of SVG bytes succeeds on an unverified workspace", async () => {
+    // makePosterEnv's env has no REGISTRY, so a shared-lane workspace's
+    // active-content gate is unconditionally false here (fail-closed) —
+    // exactly the "unverified lane" case `serverCopy` needs to bypass.
+    const { env, bucket, ws } = makePosterEnv();
+    const result = await putObject(env, ws, "diagrams/copy.svg", INERT_SVG, WORKSPACE, {
+      declaredContentType: "image/svg+xml",
+      serverCopy: true,
+    });
+    expect(result.contentType).toBe("image/svg+xml");
+    expect(bucket.store.get(`default/${result.key}`)?.contentType).toBe("image/svg+xml");
+  });
+
+  it("the same put without serverCopy 415s on the same unverified workspace", async () => {
+    const { env, ws } = makePosterEnv();
+    await expect(
+      putObject(env, ws, "diagrams/direct.svg", INERT_SVG, WORKSPACE, {
+        declaredContentType: "image/svg+xml",
+      }),
+    ).rejects.toMatchObject({ status: 415 });
+  });
+});

--- a/apps/api/test/guards-video.test.ts
+++ b/apps/api/test/guards-video.test.ts
@@ -7,12 +7,18 @@ const WEBM = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 1, 2, 3, 4, 5, 6, 7, 8]);
 
 describe("per-type upload size", () => {
   it("allows a small image under maxUploadBytes", () => {
-    const policy = resolveUploadPolicy({ maxUploadBytes: 100, maxVideoUploadBytes: 4 });
+    const policy = resolveUploadPolicy(
+      { maxUploadBytes: 100, maxVideoUploadBytes: 4 },
+      { activeContent: false },
+    );
     expect(inspectUpload(PNG, policy).ok).toBe(true);
   });
 
   it("rejects video over maxVideoUploadBytes even if maxUploadBytes is higher", () => {
-    const policy = resolveUploadPolicy({ maxUploadBytes: 1000, maxVideoUploadBytes: 4 });
+    const policy = resolveUploadPolicy(
+      { maxUploadBytes: 1000, maxVideoUploadBytes: 4 },
+      { activeContent: false },
+    );
     const result = inspectUpload(WEBM, policy);
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -23,7 +29,7 @@ describe("per-type upload size", () => {
   });
 
   it("uses maxUploadBytes for video when maxVideoUploadBytes is unset", () => {
-    const policy = resolveUploadPolicy({ maxUploadBytes: 100 });
+    const policy = resolveUploadPolicy({ maxUploadBytes: 100 }, { activeContent: false });
     expect(policy.maxVideoBytes).toBe(100);
     expect(inspectUpload(WEBM, policy).ok).toBe(true);
   });

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -126,6 +126,21 @@ describe("checkDeclaredLength", () => {
     expect(checkDeclaredLength(undefined, policy)).toBeNull();
     expect(checkDeclaredLength("not-a-number", policy)).toBeNull();
   });
+
+  it("never tightens the ceiling for a declared type with no row-level cap of its own", () => {
+    // image/png carries no row `maxBytes` (issue #929 review): the ceiling
+    // stays the general max(maxBytes, maxVideoBytes) = 100 MB, not the
+    // tighter 25 MB image cap.
+    const limits = { maxBytes: 25_000_000, maxVideoBytes: 100_000_000 };
+    expect(checkDeclaredLength("60000000", limits, "image/png")).toBeNull();
+  });
+
+  it("tightens the ceiling to the row's own cap for a gated type", () => {
+    const limits = { maxBytes: 25_000_000, maxVideoBytes: 100_000_000 };
+    const result = checkDeclaredLength(String(5 * 1024 * 1024), limits, "image/svg+xml");
+    expect(result?.status).toBe(413);
+    expect(result?.error.details).toMatchObject({ maxBytes: 4 * 1024 * 1024 });
+  });
 });
 
 describe("resolveUploadPolicy", () => {

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -168,19 +168,22 @@ describe("resolveUploadPolicy", () => {
   });
 
   it("resolves pro-plan defaults for both image and video caps when unset", () => {
-    const policy = resolveUploadPolicy({ plan: "pro" });
+    const policy = resolveUploadPolicy({ plan: "pro" }, { activeContent: false });
     expect(policy.maxBytes).toBe(100_000_000);
     expect(policy.maxVideoBytes).toBe(100_000_000);
   });
 
   it("resolves free-plan defaults for both image and video caps when unset", () => {
-    const policy = resolveUploadPolicy({ plan: "free" });
+    const policy = resolveUploadPolicy({ plan: "free" }, { activeContent: false });
     expect(policy.maxBytes).toBe(25_000_000);
     expect(policy.maxVideoBytes).toBe(25_000_000);
   });
 
   it("an explicit override beats the plan default", () => {
-    const policy = resolveUploadPolicy({ plan: "pro", maxUploadBytes: 1000 });
+    const policy = resolveUploadPolicy(
+      { plan: "pro", maxUploadBytes: 1000 },
+      { activeContent: false },
+    );
     expect(policy.maxBytes).toBe(1000);
     // video has no override of its own, so it resolves independently to the
     // plan's video default (not to the overridden maxBytes).
@@ -188,19 +191,25 @@ describe("resolveUploadPolicy", () => {
   });
 
   it("an explicit video override beats the plan default independently of maxBytes", () => {
-    const policy = resolveUploadPolicy({ plan: "pro", maxVideoUploadBytes: 5000 });
+    const policy = resolveUploadPolicy(
+      { plan: "pro", maxVideoUploadBytes: 5000 },
+      { activeContent: false },
+    );
     expect(policy.maxBytes).toBe(100_000_000);
     expect(policy.maxVideoBytes).toBe(5000);
   });
 
   it("falls back to the legacy DEFAULT_MAX_UPLOAD_BYTES when no plan is stamped", () => {
-    const policy = resolveUploadPolicy({});
+    const policy = resolveUploadPolicy({}, { activeContent: false });
     expect(policy.maxBytes).toBe(DEFAULT_MAX_UPLOAD_BYTES);
     expect(policy.maxVideoBytes).toBe(DEFAULT_MAX_UPLOAD_BYTES);
   });
 
   it("video falls back to maxBytes when only the video field is unresolved", () => {
-    const policy = resolveUploadPolicy({ plan: "pro", maxVideoUploadBytes: 0 });
+    const policy = resolveUploadPolicy(
+      { plan: "pro", maxVideoUploadBytes: 0 },
+      { activeContent: false },
+    );
     expect(policy.maxBytes).toBe(100_000_000);
     expect(policy.maxVideoBytes).toBe(100_000_000);
   });

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
   checkDeclaredLength,
+  containsActiveMarkup,
   contentTypeFromKey,
   DEFAULT_ALLOWED_CONTENT_TYPES,
   DEFAULT_MAX_UPLOAD_BYTES,
   detectContentType,
   detectImageDimensions,
   extensionForContentType,
+  GATED_CONTENT_TYPES,
   inspectUpload,
+  looksLikeSvg,
   looksLikeText,
+  looksLikeXml,
   resolveDeclaredContentType,
   resolveUploadPolicy,
   TEXT_CONTENT_TYPES,
@@ -104,7 +108,7 @@ describe("detectImageDimensions", () => {
 });
 
 describe("checkDeclaredLength", () => {
-  const policy = resolveUploadPolicy({ maxUploadBytes: 100 });
+  const policy = resolveUploadPolicy({ maxUploadBytes: 100 }, { activeContent: false });
 
   it("rejects a Content-Length over the cap with 413", () => {
     expect(checkDeclaredLength("999", policy)?.status).toBe(413);
@@ -119,28 +123,34 @@ describe("checkDeclaredLength", () => {
 
 describe("resolveUploadPolicy", () => {
   it("uses defaults when the record omits overrides", () => {
-    const policy = resolveUploadPolicy({});
+    const policy = resolveUploadPolicy({}, { activeContent: false });
     expect(policy.maxBytes).toBe(DEFAULT_MAX_UPLOAD_BYTES);
     expect([...policy.allowed].sort()).toEqual([...DEFAULT_ALLOWED_CONTENT_TYPES].sort());
   });
 
   it("applies per-workspace overrides", () => {
-    const policy = resolveUploadPolicy({
-      maxUploadBytes: 1000,
-      allowedContentTypes: ["image/png"],
-    });
+    const policy = resolveUploadPolicy(
+      {
+        maxUploadBytes: 1000,
+        allowedContentTypes: ["image/png"],
+      },
+      { activeContent: false },
+    );
     expect(policy.maxBytes).toBe(1000);
     expect([...policy.allowed]).toEqual(["image/png"]);
   });
 
   it("ignores empty or non-positive overrides and falls back", () => {
-    const policy = resolveUploadPolicy({ maxUploadBytes: 0, allowedContentTypes: [] });
+    const policy = resolveUploadPolicy(
+      { maxUploadBytes: 0, allowedContentTypes: [] },
+      { activeContent: false },
+    );
     expect(policy.maxBytes).toBe(DEFAULT_MAX_UPLOAD_BYTES);
     expect(policy.allowed.size).toBe(DEFAULT_ALLOWED_CONTENT_TYPES.length);
   });
 
   it("default allowlist includes the non-media families and quicktime", () => {
-    const { allowed } = resolveUploadPolicy({});
+    const { allowed } = resolveUploadPolicy({}, { activeContent: false });
     for (const t of [
       "application/pdf",
       "application/zip",
@@ -196,6 +206,44 @@ describe("resolveUploadPolicy", () => {
   });
 });
 
+describe("resolveUploadPolicy — active-content gate (issue #929)", () => {
+  it("gated types are absent from the default allowlist when the gate is closed", () => {
+    const policy = resolveUploadPolicy({}, { activeContent: false });
+    for (const t of GATED_CONTENT_TYPES) expect(policy.allowed.has(t), t).toBe(false);
+  });
+
+  it("gated types join the default allowlist when the gate is open", () => {
+    const policy = resolveUploadPolicy({}, { activeContent: true });
+    for (const t of GATED_CONTENT_TYPES) expect(policy.allowed.has(t), t).toBe(true);
+    // Ungated defaults are still present too — the gate only adds, never replaces.
+    for (const t of DEFAULT_ALLOWED_CONTENT_TYPES) expect(policy.allowed.has(t), t).toBe(true);
+  });
+
+  it("an allowedContentTypes override naming a gated type is stripped without the gate", () => {
+    const policy = resolveUploadPolicy(
+      { allowedContentTypes: ["image/png", "image/svg+xml"] },
+      { activeContent: false },
+    );
+    expect([...policy.allowed]).toEqual(["image/png"]);
+  });
+
+  it("an allowedContentTypes override naming a gated type keeps it with the gate open", () => {
+    const policy = resolveUploadPolicy(
+      { allowedContentTypes: ["image/png", "image/svg+xml"] },
+      { activeContent: true },
+    );
+    expect([...policy.allowed].sort()).toEqual(["image/png", "image/svg+xml"]);
+  });
+
+  it("an override cannot smuggle in a gated type it never named, even with the gate open", () => {
+    const policy = resolveUploadPolicy(
+      { allowedContentTypes: ["image/png"] },
+      { activeContent: true },
+    );
+    expect(policy.allowed.has("application/xml")).toBe(false);
+  });
+});
+
 describe("looksLikeText", () => {
   const enc = (s: string) => new TextEncoder().encode(s);
 
@@ -227,6 +275,70 @@ describe("looksLikeText", () => {
   });
 });
 
+describe("looksLikeSvg", () => {
+  const enc = (s: string) => new TextEncoder().encode(s);
+
+  it("accepts a bare <svg> root", () => {
+    expect(looksLikeSvg(enc('<svg xmlns="http://www.w3.org/2000/svg"></svg>'))).toBe(true);
+  });
+
+  it("accepts <svg> preceded by an XML prolog, a comment, and a DOCTYPE, in any order", () => {
+    expect(
+      looksLikeSvg(enc('<?xml version="1.0" encoding="UTF-8"?>\n<!-- generated --><svg></svg>')),
+    ).toBe(true);
+    expect(
+      looksLikeSvg(
+        enc(
+          '<?xml version="1.0"?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg></svg>',
+        ),
+      ),
+    ).toBe(true);
+    expect(looksLikeSvg(enc("<!-- a --><!-- b -->\n<svg></svg>"))).toBe(true);
+  });
+
+  it("strips a leading BOM before checking", () => {
+    expect(looksLikeSvg(new Uint8Array([0xef, 0xbb, 0xbf, ...enc("<svg></svg>")]))).toBe(true);
+  });
+
+  it("rejects a non-SVG root element and non-text bytes", () => {
+    expect(looksLikeSvg(enc("<html><body>hi</body></html>"))).toBe(false);
+    expect(looksLikeSvg(enc('{"svg": true}'))).toBe(false);
+    expect(looksLikeSvg(new Uint8Array([0x00, 0x01, 0x02]))).toBe(false);
+  });
+});
+
+describe("looksLikeXml", () => {
+  const enc = (s: string) => new TextEncoder().encode(s);
+
+  it("accepts text whose first non-whitespace character is <", () => {
+    expect(looksLikeXml(enc('<?xml version="1.0"?><report></report>'))).toBe(true);
+    expect(looksLikeXml(enc("\n\n  <root/>"))).toBe(true);
+  });
+
+  it("rejects text not starting with < and non-text bytes", () => {
+    expect(looksLikeXml(enc("hello <world/>"))).toBe(false);
+    expect(looksLikeXml(new Uint8Array([0x00, 0x01]))).toBe(false);
+  });
+});
+
+describe("containsActiveMarkup", () => {
+  it("flags script tags, event handlers, javascript: URLs, foreignObject, and xml-stylesheet", () => {
+    expect(containsActiveMarkup("<svg><script>alert(1)</script></svg>")).toBe(true);
+    expect(containsActiveMarkup('<svg onload="alert(1)"></svg>')).toBe(true);
+    expect(containsActiveMarkup('<a href="javascript:alert(1)">x</a>')).toBe(true);
+    expect(containsActiveMarkup("<svg><foreignObject></foreignObject></svg>")).toBe(true);
+    expect(containsActiveMarkup('<?xml-stylesheet href="x.xsl"?><a/>')).toBe(true);
+    expect(containsActiveMarkup("<SCRIPT>x</SCRIPT>")).toBe(true);
+  });
+
+  it("passes inert markup", () => {
+    expect(containsActiveMarkup('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>')).toBe(
+      false,
+    );
+    expect(containsActiveMarkup("<report><item>one</item></report>")).toBe(false);
+  });
+});
+
 describe("the upload-type table", () => {
   it("is coherent: every allowed type round-trips through its canonical extension, and text types are allowed", () => {
     for (const type of DEFAULT_ALLOWED_CONTENT_TYPES) {
@@ -237,6 +349,16 @@ describe("the upload-type table", () => {
     for (const type of TEXT_CONTENT_TYPES) {
       expect(DEFAULT_ALLOWED_CONTENT_TYPES, type).toContain(type);
     }
+  });
+
+  it("gated types with an extension round-trip too; text/xml is declaration-only and has none", () => {
+    expect(GATED_CONTENT_TYPES).toEqual(["image/svg+xml", "application/xml", "text/xml"]);
+    for (const type of ["image/svg+xml", "application/xml"]) {
+      const ext = extensionForContentType(type);
+      expect(ext, type).toBeDefined();
+      expect(contentTypeFromKey(`a/file.${ext}`), type).toBe(type);
+    }
+    expect(extensionForContentType("text/xml")).toBeUndefined();
   });
 });
 
@@ -256,11 +378,15 @@ describe("contentTypeFromKey", () => {
     expect(contentTypeFromKey("a/shot.png")).toBe("image/png");
   });
 
-  it("returns undefined for unknown or missing extensions and never maps html/svg", () => {
+  it("returns undefined for unknown or missing extensions and never maps html", () => {
     expect(contentTypeFromKey("a/blob")).toBeUndefined();
     expect(contentTypeFromKey("a/page.html")).toBeUndefined();
-    expect(contentTypeFromKey("a/icon.svg")).toBeUndefined();
     expect(contentTypeFromKey("a/dir.v2/")).toBeUndefined();
+  });
+
+  it("maps the gated extensions (issue #929) as a claim only — acceptance is separately gated", () => {
+    expect(contentTypeFromKey("a/icon.svg")).toBe("image/svg+xml");
+    expect(contentTypeFromKey("a/report.xml")).toBe("application/xml");
   });
 
   it("does not resolve through inherited Object.prototype keys", () => {
@@ -289,7 +415,7 @@ describe("resolveDeclaredContentType", () => {
 });
 
 describe("inspectUpload", () => {
-  const policy = resolveUploadPolicy({});
+  const policy = resolveUploadPolicy({}, { activeContent: false });
 
   it("accepts an allowed type and returns the sniffed content type", () => {
     const result = inspectUpload(PNG, policy);
@@ -297,21 +423,27 @@ describe("inspectUpload", () => {
   });
 
   it("rejects payloads over the size cap with 413", () => {
-    const small = resolveUploadPolicy({ maxUploadBytes: 4 });
+    const small = resolveUploadPolicy({ maxUploadBytes: 4 }, { activeContent: false });
     const result = inspectUpload(PNG, small);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.status).toBe(413);
   });
 
   it("rejects a disallowed sniffed type with 415", () => {
-    const imagesOnly = resolveUploadPolicy({ allowedContentTypes: ["image/png"] });
+    const imagesOnly = resolveUploadPolicy(
+      { allowedContentTypes: ["image/png"] },
+      { activeContent: false },
+    );
     const result = inspectUpload(ZIP, imagesOnly);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.status).toBe(415);
   });
 
   it("rejects a real image whose type is excluded by policy with 415", () => {
-    const gifOnly = resolveUploadPolicy({ allowedContentTypes: ["image/gif"] });
+    const gifOnly = resolveUploadPolicy(
+      { allowedContentTypes: ["image/gif"] },
+      { activeContent: false },
+    );
     const result = inspectUpload(PNG, gifOnly);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.status).toBe(415);
@@ -354,7 +486,10 @@ describe("inspectUpload", () => {
   });
 
   it("honors a workspace allowlist that excludes text", () => {
-    const imagesOnly = resolveUploadPolicy({ allowedContentTypes: ["image/png"] });
+    const imagesOnly = resolveUploadPolicy(
+      { allowedContentTypes: ["image/png"] },
+      { activeContent: false },
+    );
     const result = inspectUpload(text, imagesOnly, "text/plain");
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.status).toBe(415);
@@ -370,7 +505,10 @@ describe("inspectUpload", () => {
   });
 
   it("caps non-media at maxBytes with kind file, and MOV at maxVideoBytes", () => {
-    const tight = resolveUploadPolicy({ maxUploadBytes: 4, maxVideoUploadBytes: 1000 });
+    const tight = resolveUploadPolicy(
+      { maxUploadBytes: 4, maxVideoUploadBytes: 1000 },
+      { activeContent: false },
+    );
     const pdf = inspectUpload(PDF, tight);
     expect(pdf.ok).toBe(false);
     if (!pdf.ok) {
@@ -379,5 +517,69 @@ describe("inspectUpload", () => {
     }
     const mov = inspectUpload(MOV, tight);
     expect(mov).toEqual({ ok: true, contentType: "video/quicktime" });
+  });
+});
+
+describe("inspectUpload — gated SVG/XML types (issue #929)", () => {
+  const enc = (s: string) => new TextEncoder().encode(s);
+  const gated = resolveUploadPolicy({}, { activeContent: true });
+
+  it("accepts an inert declared SVG, with or without a prolog/comment", () => {
+    expect(inspectUpload(enc("<svg></svg>"), gated, "image/svg+xml")).toEqual({
+      ok: true,
+      contentType: "image/svg+xml",
+    });
+    expect(
+      inspectUpload(enc('<?xml version="1.0"?>\n<!-- x --><svg></svg>'), gated, "image/svg+xml"),
+    ).toEqual({ ok: true, contentType: "image/svg+xml" });
+  });
+
+  it("415s a declared SVG containing <script>", () => {
+    const result = inspectUpload(
+      enc("<svg><script>alert(1)</script></svg>"),
+      gated,
+      "image/svg+xml",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(415);
+  });
+
+  it("415s a declared SVG whose root is not <svg>", () => {
+    const result = inspectUpload(enc("<html></html>"), gated, "image/svg+xml");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(415);
+  });
+
+  it("stores real PNG bytes as png even when declared as svg", () => {
+    expect(inspectUpload(PNG, gated, "image/svg+xml")).toEqual({
+      ok: true,
+      contentType: "image/png",
+    });
+  });
+
+  it("accepts declared application/xml starting with an XML prolog", () => {
+    expect(
+      inspectUpload(enc('<?xml version="1.0"?><report></report>'), gated, "application/xml"),
+    ).toEqual({ ok: true, contentType: "application/xml" });
+  });
+
+  it("415s a declared application/xml containing active markup", () => {
+    const result = inspectUpload(enc('<report onload="x()"></report>'), gated, "application/xml");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(415);
+  });
+
+  it("a .log key with an XML-looking body declared text/plain stays text/plain, not xml", () => {
+    const result = inspectUpload(enc('<?xml version="1.0"?><a/>'), gated, "text/plain");
+    expect(result).toEqual({ ok: true, contentType: "text/plain" });
+  });
+
+  it("415s every gated type when the gate is closed, even for an otherwise-inert body", () => {
+    const closed = resolveUploadPolicy({}, { activeContent: false });
+    for (const declared of ["image/svg+xml", "application/xml", "text/xml"] as const) {
+      const result = inspectUpload(enc("<svg></svg>"), closed, declared);
+      expect(result.ok, declared).toBe(false);
+      if (!result.ok) expect(result.status).toBe(415);
+    }
   });
 });

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -582,4 +582,54 @@ describe("inspectUpload — gated SVG/XML types (issue #929)", () => {
       if (!result.ok) expect(result.status).toBe(415);
     }
   });
+
+  it("413s an oversize declared SVG at its own 4 MiB cap, before plausibility ever runs (review follow-up)", () => {
+    // Not a valid <svg> root at all — if `plausible` ran on this body it
+    // would 415 (bad shape), not 413. Getting 413 back proves the size gate
+    // rejects it first, without ever decoding/regex-scanning the body.
+    const oversize = new Uint8Array(4 * 1024 * 1024 + 1).fill(0x61); // "aaaa…"
+    const result = inspectUpload(oversize, gated, "image/svg+xml");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(413);
+      expect(result.error.details).toMatchObject({ maxBytes: 4 * 1024 * 1024 });
+    }
+  });
+
+  it("the gated 4 MiB cap holds even when the workspace's own maxUploadBytes is far higher", () => {
+    const roomyGated = resolveUploadPolicy(
+      { maxUploadBytes: 100 * 1024 * 1024 },
+      { activeContent: true },
+    );
+    const oversize = new Uint8Array(4 * 1024 * 1024 + 1).fill(0x61);
+    const result = inspectUpload(oversize, roomyGated, "application/xml");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(413);
+      expect(result.error.details).toMatchObject({ maxBytes: 4 * 1024 * 1024 });
+    }
+  });
+
+  it("reports details.reason 'active_markup' when the shape passes but the reputation filter fails", () => {
+    const result = inspectUpload(
+      enc("<svg><script>alert(1)</script></svg>"),
+      gated,
+      "image/svg+xml",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.details).toMatchObject({ reason: "active_markup" });
+  });
+
+  it("reports details.reason 'lane_not_verified' for a gated type declared on an unverified lane", () => {
+    const closed = resolveUploadPolicy({}, { activeContent: false });
+    const result = inspectUpload(enc("<svg></svg>"), closed, "image/svg+xml");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.details).toMatchObject({ reason: "lane_not_verified" });
+  });
+
+  it("carries no reason for an unrelated 415 (wrong root element, gate open)", () => {
+    const result = inspectUpload(enc("<html></html>"), gated, "image/svg+xml");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.details).not.toHaveProperty("reason");
+  });
 });

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -578,6 +578,15 @@ describe("inspectUpload — gated SVG/XML types (issue #929)", () => {
     if (!result.ok) expect(result.status).toBe(415);
   });
 
+  it("accepts declared text/xml with a plausible XML body on a gated (activeContent: true) policy", () => {
+    // text/xml has no extension of its own (declaration-only) — this is the
+    // one gated type that can only ever be claimed by an explicit
+    // Content-Type header, never a key's extension.
+    expect(inspectUpload(enc('<?xml version="1.0"?><report></report>'), gated, "text/xml")).toEqual(
+      { ok: true, contentType: "text/xml" },
+    );
+  });
+
   it("a .log key with an XML-looking body declared text/plain stays text/plain, not xml", () => {
     const result = inspectUpload(enc('<?xml version="1.0"?><a/>'), gated, "text/plain");
     expect(result).toEqual({ ok: true, contentType: "text/plain" });

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -15,10 +15,17 @@ import {
   looksLikeXml,
   resolveDeclaredContentType,
   resolveUploadPolicy,
-  TEXT_CONTENT_TYPES,
 } from "../src/guards";
 import { gifOf, pngOf } from "./helpers/image-fixtures";
 import { AVIF, ftyp, GZIP, MOV, PDF, ZIP, ZIP_EMPTY } from "./helpers/media-fixtures";
+
+/**
+ * The ungated declared-only rows — the types guards.ts admits on a plain
+ * `looksLikeText` and nothing else. Spelled out here rather than derived from
+ * the table: nothing in production reads this set, and an assertion that
+ * re-derives its subject from the code under test asserts nothing.
+ */
+const TEXT_CONTENT_TYPES = ["text/plain", "text/markdown", "text/csv", "application/json"];
 
 const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
 const JPEG = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0, 0]);

--- a/apps/api/test/index-scheduled.test.ts
+++ b/apps/api/test/index-scheduled.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index";
 import { getFileMetadata, replaceFileMetadata } from "../src/file-metadata";
 import type { WorkspaceRecord } from "../src/workspace";
@@ -137,6 +137,67 @@ describe("scheduled handler — no staging reaper (#421)", () => {
       expect(
         sqlite.db.prepare("SELECT key_hash FROM idempotency_requests ORDER BY key_hash").all(),
       ).toEqual([{ key_hash: "current" }]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+/**
+ * Regression guard for #929: the daily hosted-host SVG/XML sandboxing-CSP
+ * sweep (`runActiveContentHostSweep`, apps/api/src/active-content-hosts.ts)
+ * joins the same `scheduled` cron as retention/observability/idempotency/
+ * usage-alert — driven end to end here for the same reason as the block
+ * above (a removed or renamed cron task is caught even if this file never
+ * imports the sweep module by name).
+ */
+describe("scheduled handler — active-content host sweep (#929)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("invokes the daily hosted-host sandboxing-CSP probe and writes host records", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      const uploadsDefault = new FakeR2Bucket();
+      const registry = fakeRegistry({ [`ws:${WS}`]: RECORD });
+      const env = {
+        REGISTRY: registry,
+        BUCKET: bucket,
+        UPLOADS_DEFAULT: uploadsDefault,
+        DB: database(sqlite),
+      } as unknown as Env;
+
+      const fetchSpy = vi.fn(
+        async () =>
+          new Response("<svg/>", {
+            status: 200,
+            headers: {
+              "content-type": "image/svg+xml",
+              "content-security-policy": "default-src 'none'; sandbox",
+              "x-content-type-options": "nosniff",
+            },
+          }),
+      );
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const { ctx, settle } = fakeExecutionContext();
+      await worker.scheduled({} as ScheduledController, env, ctx);
+      await settle();
+
+      expect(fetchSpy).toHaveBeenCalled();
+      expect(registry.store.get("host-active-content:storage.uploads.sh")).toMatchObject({
+        ok: true,
+      });
+      expect(registry.store.get("host-active-content:store.uploads.sh")).toMatchObject({
+        ok: true,
+      });
+      expect(registry.store.get("host-active-content:embed.uploads.sh")).toMatchObject({
+        ok: true,
+      });
+      // The probe object is never left behind in the shared bucket.
+      expect(uploadsDefault.store.size).toBe(0);
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/index-scheduled.test.ts
+++ b/apps/api/test/index-scheduled.test.ts
@@ -169,12 +169,14 @@ describe("scheduled handler — active-content host sweep (#929)", () => {
         DB: database(sqlite),
       } as unknown as Env;
 
+      // The probe writes an SVG *and* an XML object and requires each to
+      // come back with the type it was written as (issue #929 M-1).
       const fetchSpy = vi.fn(
-        async () =>
-          new Response("<svg/>", {
+        async (url: string) =>
+          new Response("<probe/>", {
             status: 200,
             headers: {
-              "content-type": "image/svg+xml",
+              "content-type": String(url).endsWith(".xml") ? "application/xml" : "image/svg+xml",
               "content-security-policy": "default-src 'none'; sandbox",
               "x-content-type-options": "nosniff",
             },

--- a/apps/api/test/retention-sweep.test.ts
+++ b/apps/api/test/retention-sweep.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { runRetentionSweep } from "../src/retention-sweep";
+import { PROBE_PREFIX } from "../src/storage-verify";
 import type { PurgedTombstone, WorkspaceRecord } from "../src/workspace";
 import { FakeR2Bucket } from "./fake-r2";
 import { SqliteD1, database } from "./helpers/sqlite-d1";
@@ -80,17 +81,93 @@ function makeEnv(opts: {
   bucket?: FakeR2Bucket;
   db: SqliteD1;
   auth?: { fetch: unknown };
+  uploadsDefault?: FakeR2Bucket;
 }) {
-  const { kvRecords, bucket = new FakeR2Bucket(), db, auth } = opts;
+  const { kvRecords, bucket = new FakeR2Bucket(), db, auth, uploadsDefault } = opts;
   const registry = fakeRegistry(kvRecords);
   const env = {
     REGISTRY: registry,
     BUCKET: bucket,
     DB: database(db),
+    ...(uploadsDefault ? { UPLOADS_DEFAULT: uploadsDefault } : {}),
     ...(auth ? { AUTH: auth } : {}),
   } as unknown as Env;
   return { env, registry, bucket };
 }
+
+/**
+ * Orphaned storage-verify probe objects (issue #929 adversarial review L-4).
+ * Every probe deletes its own object in a `finally`, best-effort — so
+ * anything still under `PROBE_PREFIX` a day later is the residue of a delete
+ * that failed, and the hosted-host sweep writes several probe objects a day.
+ * Nothing else covers this prefix: it belongs to no workspace, and
+ * `verifyStorageConfig`'s not-empty check deliberately filters it out.
+ */
+describe("runRetentionSweep — orphaned probe objects (#929)", () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  it("deletes probe objects older than a day and leaves fresh ones and other keys alone", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const uploadsDefault = new FakeR2Bucket();
+      await uploadsDefault.put(`${PROBE_PREFIX}old.svg`, new Uint8Array([1]));
+      await uploadsDefault.put(`${PROBE_PREFIX}old.xml`, new Uint8Array([1]));
+      await uploadsDefault.put(`${PROBE_PREFIX}fresh.svg`, new Uint8Array([1]));
+      await uploadsDefault.put("acme/keep.png", new Uint8Array([1]));
+      uploadsDefault.setUploaded(`${PROBE_PREFIX}old.svg`, new Date(Date.now() - DAY_MS - 1000));
+      uploadsDefault.setUploaded(`${PROBE_PREFIX}old.xml`, new Date(Date.now() - DAY_MS - 1000));
+
+      const { env } = makeEnv({ kvRecords: {}, db: sqlite, uploadsDefault });
+
+      const result = await runRetentionSweep(env);
+
+      expect(result.probesReaped).toEqual({ deleted: 2 });
+      expect(uploadsDefault.store.has(`${PROBE_PREFIX}old.svg`)).toBe(false);
+      expect(uploadsDefault.store.has(`${PROBE_PREFIX}old.xml`)).toBe(false);
+      expect(uploadsDefault.store.has(`${PROBE_PREFIX}fresh.svg`)).toBe(true);
+      expect(uploadsDefault.store.has("acme/keep.png")).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("reports zero, and never throws, when no shared bucket is bound", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const { env } = makeEnv({ kvRecords: {}, db: sqlite });
+      expect((await runRetentionSweep(env)).probesReaped).toEqual({ deleted: 0 });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("never lets a probe-reap failure abort the retention sweep", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const uploadsDefault = new FakeR2Bucket();
+      uploadsDefault.list = (async () => {
+        throw new Error("r2 unavailable");
+      }) as unknown as FakeR2Bucket["list"];
+      const record: WorkspaceRecord = { ...RECORD, retentionDays: 30 };
+      const { env } = makeEnv({
+        kvRecords: { "ws:acme": record },
+        db: sqlite,
+        uploadsDefault,
+      });
+
+      const result = await runRetentionSweep(env);
+
+      // The retention pass still ran and reported normally...
+      expect(result.workspacesScanned).toBe(1);
+      expect(result.workspacesWithRetention).toBe(1);
+      // ...and the reap failure is reported, not thrown.
+      expect(result.probesReaped.deleted).toBe(0);
+      expect(result.probesReaped.error).toBeTruthy();
+    } finally {
+      sqlite.close();
+    }
+  });
+});
 
 describe("runRetentionSweep — soft-delete finalization (#247)", () => {
   it("fully tears down a past-purgeAt workspace and writes a purged tombstone", async () => {

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -104,6 +104,20 @@ async function makeEnv(
     rateLimitOk?: boolean;
     scopedToken?: { rawToken: string; scopes: string[]; mintingUserId?: string };
     extraBindings?: Record<string, FakeR2Bucket>;
+    /**
+     * Flagship stand-in for the active-content gate (issue #929). Omitted =
+     * no `FLAGS` binding at all, which `activeContentAllowed` treats as
+     * fail-closed — every existing test keeps its pre-#929 behavior with no
+     * change here.
+     */
+    flags?: { getBooleanValue: (key: string, def: boolean) => Promise<boolean> };
+    /**
+     * Extra `REGISTRY` KV rows beyond the workspace record itself — keyed
+     * exactly as the real binding would be, e.g.
+     * `"host-active-content:storage.uploads.sh"` for a hosted host's
+     * active-content probe record (`./active-content-hosts.ts`).
+     */
+    registryExtra?: Record<string, unknown>;
   } = {},
 ) {
   const record: WorkspaceRecord = {
@@ -129,8 +143,16 @@ async function makeEnv(
         }
       : undefined,
   );
+  const registryExtra = opts.registryExtra ?? {};
   const env = {
-    REGISTRY: { get: async () => record, put: async () => undefined },
+    REGISTRY: {
+      // Every `ws:*` lookup (workspace load) resolves to the fixture record
+      // regardless of workspace name; anything else (e.g. a
+      // `host-active-content:*` probe record) comes from `registryExtra`,
+      // keyed exactly as written.
+      get: async (key: string) => (key.startsWith("ws:") ? record : (registryExtra[key] ?? null)),
+      put: async () => undefined,
+    },
     // No D1 token: force the legacy token path. run/batch no-op for usage
     // metering; file_metadata reads/writes are backed by makeFakeDB's store.
     DB: db,
@@ -147,6 +169,7 @@ async function makeEnv(
           headers: { "content-type": "application/json" },
         }),
     },
+    ...(opts.flags ? { FLAGS: opts.flags } : {}),
   };
   return { env, bucket, db };
 }
@@ -520,6 +543,61 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
   });
 });
 
+const INERT_SVG = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>',
+);
+
+/** A fresh, passing `host-active-content:*` KV record for the default fixture's shared host. */
+const FRESH_HOST_RECORD = { ok: true, verifiedAt: new Date().toISOString() };
+const FLAGS_ON = { getBooleanValue: async () => true };
+
+describe("PUT /v1/:workspace/files SVG/XML active-content gate (issue #929)", () => {
+  it("415s a declared SVG on a workspace with no active-content verification", async () => {
+    const { env } = await makeEnv();
+    const res = await putShot(env, {
+      key: "diagrams/a.svg",
+      body: INERT_SVG,
+      headers: { "Content-Type": "image/svg+xml" },
+    });
+    expect(res.status).toBe(415);
+  });
+
+  it("201s an inert declared SVG once the flag is on and the shared host's probe record is fresh", async () => {
+    const { env, bucket } = await makeEnv(
+      {},
+      {
+        flags: FLAGS_ON,
+        registryExtra: { "host-active-content:storage.uploads.sh": FRESH_HOST_RECORD },
+      },
+    );
+    const res = await putShot(env, {
+      key: "diagrams/a.svg",
+      body: INERT_SVG,
+      headers: { "Content-Type": "image/svg+xml" },
+    });
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { contentType: string };
+    expect(json.contentType).toBe("image/svg+xml");
+    expect(bucket.store.get("default/diagrams/a.svg")?.contentType).toBe("image/svg+xml");
+  });
+
+  it("still 415s an SVG carrying <script> even on a fully verified lane", async () => {
+    const { env } = await makeEnv(
+      {},
+      {
+        flags: FLAGS_ON,
+        registryExtra: { "host-active-content:storage.uploads.sh": FRESH_HOST_RECORD },
+      },
+    );
+    const res = await putShot(env, {
+      key: "diagrams/evil.svg",
+      body: new TextEncoder().encode("<svg><script>alert(1)</script></svg>"),
+      headers: { "Content-Type": "image/svg+xml" },
+    });
+    expect(res.status).toBe(415);
+  });
+});
+
 describe("POST /v1/:workspace/files/sign strict-overwrite gate (review follow-up)", () => {
   it("refuses to sign an overwrite of an existing strict key without replace", async () => {
     const { env } = await makeEnv();
@@ -677,6 +755,35 @@ describe("POST /v1/:workspace/files/sign content-type policy", () => {
     expect(json.error.type).toBe("unsupported_media_type");
     // Must not echo provider internals via details.detail (presign_unavailable path).
     expect(json.error.details?.detail).toBeUndefined();
+  });
+
+  it("passes the content-type gate for image/svg+xml once the lane is verified (mirrors the PUT gate, issue #929)", async () => {
+    const { env } = await makeEnv(
+      {},
+      {
+        flags: FLAGS_ON,
+        registryExtra: { "host-active-content:storage.uploads.sh": FRESH_HOST_RECORD },
+      },
+    );
+    const res = await app.request(
+      "/v1/default/files/sign",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({
+          key: "diagrams/a.svg",
+          contentType: "image/svg+xml",
+        }),
+      },
+      env,
+    );
+    // Binding-mode (shared) storage has no HTTP credentials to presign
+    // against, so this still can't succeed end to end — but it must now fail
+    // on `presign_unavailable`, not `unsupported_media_type`: proof the
+    // content-type gate itself passed once the lane verified.
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("presign_unavailable");
   });
 
   it("rejects text/html", async () => {

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -333,6 +333,23 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     expect(res.status).toBe(413);
   });
 
+  it("rejects a declared SVG over the gated row's own cap before buffering (issue #929)", async () => {
+    // Well under this workspace's 25 MiB ceiling, so only the declared
+    // type's own 4 MiB cap can reject it — and it must do so from the
+    // Content-Length alone, before the body is read.
+    const { env } = await makeEnv();
+    const res = await putShot(env, {
+      key: "diagrams/a.svg",
+      headers: {
+        "Content-Type": "image/svg+xml",
+        "Content-Length": String(5 * 1024 * 1024),
+      },
+    });
+    expect(res.status).toBe(413);
+    const json = (await res.json()) as { error: { details?: { maxBytes?: number } } };
+    expect(json.error.details?.maxBytes).toBe(4 * 1024 * 1024);
+  });
+
   it("rejects an empty body with 400", async () => {
     const { env } = await makeEnv();
     const res = await putShot(env, { body: new Uint8Array(0) });
@@ -592,6 +609,53 @@ describe("PUT /v1/:workspace/files SVG/XML active-content gate (issue #929)", ()
     const json = (await res.json()) as { contentType: string };
     expect(json.contentType).toBe("image/svg+xml");
     expect(bucket.store.get("default/diagrams/a.svg")?.contentType).toBe("image/svg+xml");
+  });
+
+  it("never evaluates the gate for a put that claims an ungated type", async () => {
+    // The gate costs a Flagship evaluation and a KV read, and can only ever
+    // change whether the (declared-only) SVG/XML rows are admitted — so a
+    // PNG put must not reach `FLAGS` at all. This fake throws rather than
+    // counts: `activeContentAllowed` swallows a thrown evaluation, so a
+    // counter alone couldn't tell "evaluated and failed closed" apart from
+    // "never evaluated".
+    let evaluated = 0;
+    const { env } = await makeEnv(
+      {},
+      {
+        flags: {
+          getBooleanValue: async () => {
+            evaluated += 1;
+            throw new Error("the gate must not be evaluated for a PNG put");
+          },
+        },
+        registryExtra: FRESH_HOST_RECORDS,
+      },
+    );
+    expect((await putShot(env)).status).toBe(201);
+    expect(evaluated).toBe(0);
+  });
+
+  it("evaluates the gate for a put that claims a gated type", async () => {
+    let evaluated = 0;
+    const { env } = await makeEnv(
+      {},
+      {
+        flags: {
+          getBooleanValue: async () => {
+            evaluated += 1;
+            return true;
+          },
+        },
+        registryExtra: FRESH_HOST_RECORDS,
+      },
+    );
+    const res = await putShot(env, {
+      key: "diagrams/a.svg",
+      body: INERT_SVG,
+      headers: { "Content-Type": "image/svg+xml" },
+    });
+    expect(res.status).toBe(201);
+    expect(evaluated).toBe(1);
   });
 
   it("still 415s an SVG carrying <script> even on a fully verified lane", async () => {

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -549,6 +549,19 @@ const INERT_SVG = new TextEncoder().encode(
 
 /** A fresh, passing `host-active-content:*` KV record for the default fixture's shared host. */
 const FRESH_HOST_RECORD = { ok: true, verifiedAt: new Date().toISOString() };
+
+/**
+ * Fresh, passing `host-active-content:*` records for *both* hosts the
+ * default fixture's shared object is reachable through (issue #929
+ * final-review item 1): `storage.uploads.sh` (`publicBaseUrl` above) and its
+ * `embed.uploads.sh` twin (`DEFAULT_EMBEDDABLE_HOSTS`, `resolveEmbedBaseUrl`)
+ * — `activeContentAllowed` now requires both to be fresh and `ok`, not just
+ * the stable host.
+ */
+const FRESH_HOST_RECORDS = {
+  "host-active-content:storage.uploads.sh": FRESH_HOST_RECORD,
+  "host-active-content:embed.uploads.sh": FRESH_HOST_RECORD,
+};
 const FLAGS_ON = { getBooleanValue: async () => true };
 
 describe("PUT /v1/:workspace/files SVG/XML active-content gate (issue #929)", () => {
@@ -567,7 +580,7 @@ describe("PUT /v1/:workspace/files SVG/XML active-content gate (issue #929)", ()
       {},
       {
         flags: FLAGS_ON,
-        registryExtra: { "host-active-content:storage.uploads.sh": FRESH_HOST_RECORD },
+        registryExtra: FRESH_HOST_RECORDS,
       },
     );
     const res = await putShot(env, {
@@ -586,7 +599,7 @@ describe("PUT /v1/:workspace/files SVG/XML active-content gate (issue #929)", ()
       {},
       {
         flags: FLAGS_ON,
-        registryExtra: { "host-active-content:storage.uploads.sh": FRESH_HOST_RECORD },
+        registryExtra: FRESH_HOST_RECORDS,
       },
     );
     const res = await putShot(env, {
@@ -762,7 +775,7 @@ describe("POST /v1/:workspace/files/sign content-type policy", () => {
       {},
       {
         flags: FLAGS_ON,
-        registryExtra: { "host-active-content:storage.uploads.sh": FRESH_HOST_RECORD },
+        registryExtra: FRESH_HOST_RECORDS,
       },
     );
     const res = await app.request(

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -4,8 +4,10 @@ import { PDF, ZIP } from "./helpers/media-fixtures";
 import { DeleteUsageClaimsTable } from "./helpers/fake-delete-usage-claims-table";
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
 import { app } from "../src/index";
+import { presignExpiresIn } from "../src/routes/files-shared-handlers";
 import { getFileMetadata } from "../src/file-metadata";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { HOSTED_ACTIVE_CONTENT_HOSTS } from "../src/active-content-hosts";
 
 const TOKEN = "secret-token";
 
@@ -568,17 +570,16 @@ const INERT_SVG = new TextEncoder().encode(
 const FRESH_HOST_RECORD = { ok: true, verifiedAt: new Date().toISOString() };
 
 /**
- * Fresh, passing `host-active-content:*` records for *both* hosts the
- * default fixture's shared object is reachable through (issue #929
- * final-review item 1): `storage.uploads.sh` (`publicBaseUrl` above) and its
- * `embed.uploads.sh` twin (`DEFAULT_EMBEDDABLE_HOSTS`, `resolveEmbedBaseUrl`)
- * — `activeContentAllowed` now requires both to be fresh and `ok`, not just
- * the stable host.
+ * Fresh, passing `host-active-content:*` records for every host the default
+ * fixture's shared object is reachable through (issue #929 adversarial
+ * review H-1): the hosted host set the daily sweep covers — which includes
+ * `store.uploads.sh`, the shared bucket's second custom domain — plus this
+ * workspace's `storage.uploads.sh` and its `embed.uploads.sh` twin.
+ * `activeContentAllowed` requires all of them to be fresh and `ok`.
  */
-const FRESH_HOST_RECORDS = {
-  "host-active-content:storage.uploads.sh": FRESH_HOST_RECORD,
-  "host-active-content:embed.uploads.sh": FRESH_HOST_RECORD,
-};
+const FRESH_HOST_RECORDS = Object.fromEntries(
+  HOSTED_ACTIVE_CONTENT_HOSTS.map((host) => [`host-active-content:${host}`, FRESH_HOST_RECORD]),
+);
 const FLAGS_ON = { getBooleanValue: async () => true };
 
 describe("PUT /v1/:workspace/files SVG/XML active-content gate (issue #929)", () => {
@@ -861,6 +862,38 @@ describe("POST /v1/:workspace/files/sign content-type policy", () => {
     expect(res.status).toBe(400);
     const json = (await res.json()) as { error: { code: string } };
     expect(json.error.code).toBe("presign_unavailable");
+  });
+
+  // A presigned URL is minted against the gate's answer *now* and writes
+  // straight to the bucket later, with nothing on the write path able to
+  // re-check — so a gated type's URL is capped at 15 minutes rather than the
+  // 24 hours everything else gets (issue #929 adversarial review L-5). The
+  // rule is tested directly: reaching a 200 from this route needs signable
+  // HTTP credentials, which the binding-mode fixture above deliberately
+  // doesn't have.
+  describe("gated-type TTL cap (presignExpiresIn)", () => {
+    it("caps a gated type at 900s however long a TTL is asked for", () => {
+      expect(presignExpiresIn(86400, "image/svg+xml")).toBe(900);
+      expect(presignExpiresIn(3600, "application/xml")).toBe(900);
+      expect(presignExpiresIn(901, "text/xml")).toBe(900);
+    });
+
+    it("caps a gated type that asked for nothing (the 3600s default)", () => {
+      expect(presignExpiresIn(undefined, "image/svg+xml")).toBe(900);
+      // Out-of-range values fall back to the default first, then cap.
+      expect(presignExpiresIn(0, "image/svg+xml")).toBe(900);
+      expect(presignExpiresIn(86401, "image/svg+xml")).toBe(900);
+    });
+
+    it("honors a shorter explicit TTL on a gated type", () => {
+      expect(presignExpiresIn(120, "image/svg+xml")).toBe(120);
+    });
+
+    it("leaves an ungated type's full 24-hour ceiling and 1-hour default alone", () => {
+      expect(presignExpiresIn(86400, "image/png")).toBe(86400);
+      expect(presignExpiresIn(undefined, "image/png")).toBe(3600);
+      expect(presignExpiresIn(86401, "image/png")).toBe(3600);
+    });
   });
 
   it("rejects text/html", async () => {

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -655,6 +655,20 @@ describe("GET /public/files/:workspace/:key?download=1", () => {
     expect(bytes).toEqual(PNG);
   });
 
+  // `api.uploads.sh` is a first-party origin, unlike the bare storage hosts,
+  // and this is the one route there that streams object bytes. The
+  // attachment disposition is no longer the only thing standing between a
+  // stored SVG and a rendered document (issue #929 adversarial review L-2).
+  it("sends nosniff and a sandboxing CSP on every download, whatever the type", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env);
+
+    const res = await app.request("/public/files/default/screenshots/shot.png?download=1", {}, env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Content-Security-Policy")).toBe("sandbox");
+  });
+
   it("401s with auth_required for a private object, without streaming bytes", async () => {
     const { env } = await makeEnv();
     await seedShot(env, { "X-Uploads-Visibility": "private" });

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -6,6 +6,7 @@
  * (phase 3, invites/members).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { hostActiveContentKey } from "../src/active-content-hosts";
 import { app } from "../src/index";
 import {
   setLaneActiveContentCheckForTests,
@@ -500,6 +501,85 @@ describe("storage vertical (self-serve BYO bucket)", () => {
       expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
         "settings_requires_session",
       );
+    });
+
+    // "Hosted lane display" (issue #929): the pure `storageStatusResponse`
+    // projection has no KV access and only ever echoes a lane's *own*
+    // `activeContentVerifiedAt` stamp — meaningless for a shared lane, which
+    // instead inherits the daily-cron-probed verdict for its host. The
+    // handler overlays that verdict on top for shared lanes only.
+    it("reflects the hosted host's active-content record on the shared active lane", async () => {
+      const { env } = makeEnv({
+        role: "admin",
+        record: { ...SHARED_RECORD, publicBaseUrl: "https://storage.uploads.sh" },
+      });
+      await env.REGISTRY.put(
+        hostActiveContentKey("storage.uploads.sh"),
+        JSON.stringify({ ok: true, verifiedAt: "2026-08-20T00:00:00.000Z" }),
+      );
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { headers: sessionHeaders },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { mode: string; activeContentVerifiedAt?: string };
+      expect(body.mode).toBe("shared");
+      expect(body.activeContentVerifiedAt).toBe("2026-08-20T00:00:00.000Z");
+    });
+
+    it("omits activeContentVerifiedAt on a shared active lane when the host record has never probed ok", async () => {
+      const { env } = makeEnv({
+        role: "admin",
+        record: { ...SHARED_RECORD, publicBaseUrl: "https://storage.uploads.sh" },
+      });
+      await env.REGISTRY.put(
+        hostActiveContentKey("storage.uploads.sh"),
+        JSON.stringify({ ok: false, verifiedAt: "2026-08-20T00:00:00.000Z", detail: "no sandbox" }),
+      );
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { headers: sessionHeaders },
+        env,
+      );
+      const body = (await res.json()) as { activeContentVerifiedAt?: string };
+      expect(body.activeContentVerifiedAt).toBeUndefined();
+    });
+
+    it("reflects the hosted host's active-content record on a shared entry in lanes[]", async () => {
+      const { env } = makeEnv({
+        role: "owner",
+        record: {
+          ...BYO_RECORD,
+          storageLanes: [
+            {
+              id: "lane_sharedfallback",
+              provider: "r2",
+              bucket: "uploads-default",
+              binding: "UPLOADS_FALLBACK",
+              publicBaseUrl: "https://storage.uploads.sh",
+              lastActiveAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        },
+      });
+      await env.REGISTRY.put(
+        hostActiveContentKey("storage.uploads.sh"),
+        JSON.stringify({ ok: true, verifiedAt: "2026-08-21T00:00:00.000Z" }),
+      );
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { headers: sessionHeaders },
+        env,
+      );
+      const body = (await res.json()) as {
+        lanes: Array<{ laneId: string; mode: string; activeContentVerifiedAt?: string }>;
+      };
+      const lane = body.lanes.find((l) => l.laneId === "lane_sharedfallback");
+      expect(lane).toMatchObject({
+        mode: "shared",
+        activeContentVerifiedAt: "2026-08-21T00:00:00.000Z",
+      });
     });
   });
 
@@ -1707,6 +1787,10 @@ describe("storage vertical (self-serve BYO bucket)", () => {
 });
 
 describe("/me alias forwards (issue #613 phase 3)", () => {
+  afterEach(() => {
+    setLaneActiveContentCheckForTests(undefined);
+  });
+
   it("GET /me/workspaces/:name/summary matches the canonical shape", async () => {
     const { env } = makeEnv({ sessionUser: MEMBER, role: "member", usage: { objects: 0 } });
     const canonical = await app.request(
@@ -1820,6 +1904,44 @@ describe("/me alias forwards (issue #613 phase 3)", () => {
     );
     expect(alias.status).toBe(200);
     expect(await alias.json()).toEqual(await canonical.json());
+  });
+
+  // The verify-active-content stamp is time-dependent (`new Date().toISOString()`
+  // at write time), so this checks the alias runs the same handler and has
+  // the same effect rather than diffing two live-timestamped bodies.
+  it("POST /me/workspaces/:name/storage/lanes/:laneId/verify-active-content forwards to the canonical route", async () => {
+    const BYO_RECORD = {
+      provider: "r2",
+      bucket: "customer-bucket",
+      accountId: "a".repeat(32),
+      accessKeyId: "enc:v1:sealed-key-id",
+      secretAccessKey: "enc:v1:already-sealed",
+      publicBaseUrl: "https://media.example.com",
+      byoBucketEnabled: true,
+      storageAccessKeyIdLast4: "1234",
+    };
+    const { env, registry } = makeEnv({ role: "owner", record: BYO_RECORD });
+    setLaneActiveContentCheckForTests(async () => ({
+      id: "active-content-headers",
+      ok: true,
+      required: false,
+    }));
+    const res = await app.request(
+      "/me/workspaces/acme/storage/lanes/active/verify-active-content",
+      { method: "POST", headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      check: { ok: boolean };
+      status: { activeContentVerifiedAt?: string };
+    };
+    expect(body.check.ok).toBe(true);
+    expect(body.status.activeContentVerifiedAt).toBeTruthy();
+    expect(
+      registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+        ?.storageActiveContentVerifiedAt,
+    ).toBeTruthy();
   });
 
   it("resolves the session exactly once per forwarded request (summary)", async () => {

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -5,9 +5,10 @@
  * composed `app` (index.ts) — same style as `routes-workspace-members.test.ts`
  * (phase 3, invites/members).
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { app } from "../src/index";
 import {
+  setLaneActiveContentCheckForTests,
   setStorageReconcileForTests,
   setStorageVerifyForTests,
 } from "../src/routes/workspace-storage";
@@ -391,6 +392,7 @@ describe("storage vertical (self-serve BYO bucket)", () => {
   afterEach(() => {
     setStorageVerifyForTests(undefined);
     setStorageReconcileForTests(undefined);
+    setLaneActiveContentCheckForTests(undefined);
   });
 
   describe("GET /v1/workspaces/:workspace/storage", () => {
@@ -1550,6 +1552,156 @@ describe("storage vertical (self-serve BYO bucket)", () => {
         env,
       );
       expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /v1/workspaces/:workspace/storage/lanes/:laneId/verify-active-content (issue #929)", () => {
+    const okCheck = { id: "active-content-headers", ok: true, required: false };
+    const failedCheck = {
+      id: "active-content-headers",
+      ok: false,
+      required: false,
+      hint: "missing x-content-type-options: nosniff",
+    };
+    const inconclusiveCheck = {
+      id: "active-content-headers",
+      ok: false,
+      required: false,
+      inconclusive: true,
+      hint: "we couldn't fetch the SVG probe from here",
+    };
+
+    function verifyActiveContent(laneId: string, env: Env) {
+      return app.request(
+        `/v1/workspaces/acme/storage/lanes/${laneId}/verify-active-content`,
+        { method: "POST", headers: sessionHeaders },
+        env,
+      );
+    }
+
+    it("stamps storageActiveContentVerifiedAt on the active lane (named by the literal 'active') when the probe passes", async () => {
+      const { env, registry } = makeEnv({ role: "owner", record: BYO_RECORD });
+      let seenLane: { publicBaseUrl?: string } | undefined;
+      setLaneActiveContentCheckForTests(async (_env, lane) => {
+        seenLane = lane;
+        return okCheck;
+      });
+      const res = await verifyActiveContent("active", env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        check: typeof okCheck;
+        status: { activeContentVerifiedAt?: string };
+      };
+      expect(body.check).toEqual(okCheck);
+      expect(body.status.activeContentVerifiedAt).toBeTruthy();
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBeTruthy();
+      // The active lane's own fields (publicBaseUrl, in particular) reached
+      // the check — proof `resolveActiveContentLaneTarget` built the right
+      // lane view, not an empty one.
+      expect(seenLane?.publicBaseUrl).toBe(BYO_RECORD.publicBaseUrl);
+    });
+
+    it("also resolves the active lane by its own storageLaneId, not just the literal 'active'", async () => {
+      const record = { ...BYO_RECORD, storageLaneId: "lane_active1" };
+      const { env, registry } = makeEnv({ role: "owner", record });
+      setLaneActiveContentCheckForTests(async () => okCheck);
+      const res = await verifyActiveContent("lane_active1", env);
+      expect(res.status).toBe(200);
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBeTruthy();
+    });
+
+    it("clears a previously-fresh stamp on the active lane when the probe fails", async () => {
+      const record = { ...BYO_RECORD, storageActiveContentVerifiedAt: "2020-01-01T00:00:00.000Z" };
+      const { env, registry } = makeEnv({ role: "owner", record });
+      setLaneActiveContentCheckForTests(async () => failedCheck);
+      const res = await verifyActiveContent("active", env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { check: typeof failedCheck };
+      expect(body.check).toEqual(failedCheck);
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBeUndefined();
+    });
+
+    it("leaves the stamp unchanged, with no KV write, when the probe is inconclusive", async () => {
+      const record = { ...BYO_RECORD, storageActiveContentVerifiedAt: "2020-01-01T00:00:00.000Z" };
+      const { env, registry } = makeEnv({ role: "owner", record });
+      const putsBefore = registry.puts.length;
+      setLaneActiveContentCheckForTests(async () => inconclusiveCheck);
+      const res = await verifyActiveContent("active", env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { check: typeof inconclusiveCheck };
+      expect(body.check).toEqual(inconclusiveCheck);
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBe("2020-01-01T00:00:00.000Z");
+      expect(registry.puts.length).toBe(putsBefore);
+    });
+
+    it("stamps a saved (non-active) lane's own activeContentVerifiedAt, not the top-level one", async () => {
+      const lane = await standbyLane();
+      const record = { ...SHARED_RECORD, byoBucketEnabled: true, storageLanes: [lane] };
+      const { env, registry } = makeEnv({ role: "owner", record });
+      setLaneActiveContentCheckForTests(async () => okCheck);
+      const res = await verifyActiveContent("lane_standby1", env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        status: { lanes: Array<{ laneId: string; activeContentVerifiedAt?: string }> };
+      };
+      expect(body.status.lanes[0]).toMatchObject({
+        laneId: "lane_standby1",
+        activeContentVerifiedAt: expect.any(String),
+      });
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBeUndefined();
+      const savedLane = registry.record<{
+        storageLanes?: Array<{ activeContentVerifiedAt?: string }>;
+      }>("acme")?.storageLanes?.[0];
+      expect(savedLane?.activeContentVerifiedAt).toBeTruthy();
+    });
+
+    it("422s a shared (hosted) lane instead of running the probe", async () => {
+      const { env } = makeEnv({ role: "owner", record: SHARED_RECORD });
+      const check = vi.fn();
+      setLaneActiveContentCheckForTests(check);
+      const res = await verifyActiveContent("active", env);
+      expect(res.status).toBe(422);
+      const body = (await res.json()) as { check: { ok: boolean } };
+      expect(body.check.ok).toBe(false);
+      expect(check).not.toHaveBeenCalled();
+    });
+
+    it("422s a lane with no publicBaseUrl to verify", async () => {
+      const { publicBaseUrl: _unused, ...noUrlRecord } = BYO_RECORD;
+      const { env } = makeEnv({ role: "owner", record: noUrlRecord });
+      const check = vi.fn();
+      setLaneActiveContentCheckForTests(check);
+      const res = await verifyActiveContent("active", env);
+      expect(res.status).toBe(422);
+      expect(check).not.toHaveBeenCalled();
+    });
+
+    it("404s an unknown laneId", async () => {
+      const { env } = makeEnv({ role: "owner", record: BYO_RECORD });
+      const res = await verifyActiveContent("lane_nonexistent", env);
+      expect(res.status).toBe(404);
+    });
+
+    it("429s when the write rate limit is exceeded", async () => {
+      const { env } = makeEnv({ role: "owner", record: BYO_RECORD, writeLimiterOk: false });
+      setLaneActiveContentCheckForTests(async () => okCheck);
+      const res = await verifyActiveContent("active", env);
+      expect(res.status).toBe(429);
     });
   });
 });

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -6,6 +6,7 @@
  * (phase 3, invites/members).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { HOST_RECORD_MAX_AGE_MS } from "../src/active-content";
 import { hostActiveContentKey } from "../src/active-content-hosts";
 import { app } from "../src/index";
 import {
@@ -513,9 +514,10 @@ describe("storage vertical (self-serve BYO bucket)", () => {
         role: "admin",
         record: { ...SHARED_RECORD, publicBaseUrl: "https://storage.uploads.sh" },
       });
+      const verifiedAt = new Date(Date.now() - 1000).toISOString();
       await env.REGISTRY.put(
         hostActiveContentKey("storage.uploads.sh"),
-        JSON.stringify({ ok: true, verifiedAt: "2026-08-20T00:00:00.000Z" }),
+        JSON.stringify({ ok: true, verifiedAt }),
       );
       const res = await app.request(
         "/v1/workspaces/acme/storage",
@@ -525,7 +527,7 @@ describe("storage vertical (self-serve BYO bucket)", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as { mode: string; activeContentVerifiedAt?: string };
       expect(body.mode).toBe("shared");
-      expect(body.activeContentVerifiedAt).toBe("2026-08-20T00:00:00.000Z");
+      expect(body.activeContentVerifiedAt).toBe(verifiedAt);
     });
 
     it("omits activeContentVerifiedAt on a shared active lane when the host record has never probed ok", async () => {
@@ -535,7 +537,38 @@ describe("storage vertical (self-serve BYO bucket)", () => {
       });
       await env.REGISTRY.put(
         hostActiveContentKey("storage.uploads.sh"),
-        JSON.stringify({ ok: false, verifiedAt: "2026-08-20T00:00:00.000Z", detail: "no sandbox" }),
+        JSON.stringify({
+          ok: false,
+          verifiedAt: new Date(Date.now() - 1000).toISOString(),
+          detail: "no sandbox",
+        }),
+      );
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { headers: sessionHeaders },
+        env,
+      );
+      const body = (await res.json()) as { activeContentVerifiedAt?: string };
+      expect(body.activeContentVerifiedAt).toBeUndefined();
+    });
+
+    // Item 6 (issue #929 final-review): the hosted host's record projects
+    // as `verifiedAt` only within `HOST_RECORD_MAX_AGE_MS` — the same
+    // freshness window `activeContentAllowed` (../src/active-content.ts)
+    // enforces before it actually lets SVG/XML through. A stale-but-ok
+    // record must not read as "Verified" on the settings page when the gate
+    // itself has already stopped trusting it.
+    it("omits activeContentVerifiedAt on a shared active lane when the host record is ok but stale (older than HOST_RECORD_MAX_AGE_MS)", async () => {
+      const { env } = makeEnv({
+        role: "admin",
+        record: { ...SHARED_RECORD, publicBaseUrl: "https://storage.uploads.sh" },
+      });
+      await env.REGISTRY.put(
+        hostActiveContentKey("storage.uploads.sh"),
+        JSON.stringify({
+          ok: true,
+          verifiedAt: new Date(Date.now() - (HOST_RECORD_MAX_AGE_MS + 1000)).toISOString(),
+        }),
       );
       const res = await app.request(
         "/v1/workspaces/acme/storage",
@@ -563,9 +596,10 @@ describe("storage vertical (self-serve BYO bucket)", () => {
           ],
         },
       });
+      const verifiedAt = new Date(Date.now() - 1000).toISOString();
       await env.REGISTRY.put(
         hostActiveContentKey("storage.uploads.sh"),
-        JSON.stringify({ ok: true, verifiedAt: "2026-08-21T00:00:00.000Z" }),
+        JSON.stringify({ ok: true, verifiedAt }),
       );
       const res = await app.request(
         "/v1/workspaces/acme/storage",
@@ -578,7 +612,7 @@ describe("storage vertical (self-serve BYO bucket)", () => {
       const lane = body.lanes.find((l) => l.laneId === "lane_sharedfallback");
       expect(lane).toMatchObject({
         mode: "shared",
-        activeContentVerifiedAt: "2026-08-21T00:00:00.000Z",
+        activeContentVerifiedAt: verifiedAt,
       });
     });
   });
@@ -1658,6 +1692,23 @@ describe("storage vertical (self-serve BYO bucket)", () => {
         env,
       );
     }
+
+    // Item 4 (issue #929 final-review): same 403 `byo_bucket_disabled` gate
+    // every sibling storage route enforces (`storageVerifyHandler`,
+    // `storagePutHandler`, ...) — this route was missing it, so a workspace
+    // with BYO storage turned off could still trigger a real probe against
+    // its own lane's credentials.
+    it("403s (byo_bucket_disabled) when the workspace flag is explicitly off", async () => {
+      const { env } = makeEnv({
+        role: "owner",
+        record: { ...BYO_RECORD, byoBucketEnabled: false },
+      });
+      const res = await verifyActiveContent("active", env);
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+        "byo_bucket_disabled",
+      );
+    });
 
     it("stamps storageActiveContentVerifiedAt on the active lane (named by the literal 'active') when the probe passes", async () => {
       const { env, registry } = makeEnv({ role: "owner", record: BYO_RECORD });

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -7,7 +7,8 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HOST_RECORD_MAX_AGE_MS, LANE_STAMP_MAX_AGE_MS } from "../src/active-content";
-import { hostActiveContentKey } from "../src/active-content-hosts";
+import { HOSTED_ACTIVE_CONTENT_HOSTS, hostActiveContentKey } from "../src/active-content-hosts";
+import { ACTIVE_CONTENT_CHECK_COOLDOWN_MS } from "../src/routes/workspace-settings";
 import { app } from "../src/index";
 import {
   setLaneActiveContentCheckForTests,
@@ -535,7 +536,10 @@ describe("storage vertical (self-serve BYO bucket)", () => {
         activeContentFlag: true,
       });
       const verifiedAt = new Date(Date.now() - 1000).toISOString();
-      for (const host of ["storage.uploads.sh", "embed.uploads.sh"]) {
+      // Every hosted host, not just this workspace's URL and its embed twin
+      // — `store.uploads.sh` serves the same bucket (issue #929 adversarial
+      // review H-1).
+      for (const host of HOSTED_ACTIVE_CONTENT_HOSTS) {
         await env.REGISTRY.put(
           hostActiveContentKey(host),
           JSON.stringify({ ok: true, verifiedAt }),
@@ -567,7 +571,10 @@ describe("storage vertical (self-serve BYO bucket)", () => {
         activeContentFlag: false,
       });
       const verifiedAt = new Date(Date.now() - 1000).toISOString();
-      for (const host of ["storage.uploads.sh", "embed.uploads.sh"]) {
+      // Every hosted host, not just this workspace's URL and its embed twin
+      // — `store.uploads.sh` serves the same bucket (issue #929 adversarial
+      // review H-1).
+      for (const host of HOSTED_ACTIVE_CONTENT_HOSTS) {
         await env.REGISTRY.put(
           hostActiveContentKey(host),
           JSON.stringify({ ok: true, verifiedAt }),
@@ -1918,20 +1925,69 @@ describe("storage vertical (self-serve BYO bucket)", () => {
       ).toBeUndefined();
     });
 
-    it("leaves the stamp unchanged, with no KV write, when the probe is inconclusive", async () => {
+    // Inconclusive leaves the *stamp* alone but still advances the cooldown
+    // clock (issue #929 adversarial review L-3) — an unreachable host is
+    // exactly the case that could otherwise be retried in a tight loop — so
+    // there is one KV write, and it doesn't touch the verification stamp.
+    it("leaves the stamp unchanged when the probe is inconclusive, writing only the cooldown clock", async () => {
       const record = { ...BYO_RECORD, storageActiveContentVerifiedAt: "2020-01-01T00:00:00.000Z" };
       const { env, registry } = makeEnv({ role: "owner", record });
-      const putsBefore = registry.puts.length;
       setLaneActiveContentCheckForTests(async () => inconclusiveCheck);
       const res = await verifyActiveContent("active", env);
       expect(res.status).toBe(200);
       const body = (await res.json()) as { check: typeof inconclusiveCheck };
       expect(body.check).toEqual(inconclusiveCheck);
+      const stored = registry.record<{
+        storageActiveContentVerifiedAt?: string;
+        storageActiveContentCheckedAt?: Record<string, string>;
+      }>("acme");
+      expect(stored?.storageActiveContentVerifiedAt).toBe("2020-01-01T00:00:00.000Z");
+      expect(stored?.storageActiveContentCheckedAt?.active).toBeTruthy();
+    });
+
+    it("429s a second check of the same lane inside the cooldown window (issue #929 L-3)", async () => {
+      const { env, registry } = makeEnv({ role: "owner", record: BYO_RECORD });
+      let calls = 0;
+      setLaneActiveContentCheckForTests(async () => {
+        calls += 1;
+        return okCheck;
+      });
+      expect((await verifyActiveContent("active", env)).status).toBe(200);
+      const second = await verifyActiveContent("active", env);
+      expect(second.status).toBe(429);
+      expect(((await second.json()) as { error: { code: string } }).error.code).toBe(
+        "active_content_check_cooldown",
+      );
+      // The probe never ran a second time — the 429 is raised before it.
+      expect(calls).toBe(1);
       expect(
-        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
-          ?.storageActiveContentVerifiedAt,
-      ).toBe("2020-01-01T00:00:00.000Z");
-      expect(registry.puts.length).toBe(putsBefore);
+        registry.record<{ storageActiveContentCheckedAt?: Record<string, string> }>("acme")
+          ?.storageActiveContentCheckedAt?.active,
+      ).toBeTruthy();
+    });
+
+    it("lets a check through once the recorded cooldown stamp is older than the window", async () => {
+      const record = {
+        ...BYO_RECORD,
+        storageActiveContentCheckedAt: {
+          active: new Date(Date.now() - ACTIVE_CONTENT_CHECK_COOLDOWN_MS - 1000).toISOString(),
+        },
+      };
+      const { env } = makeEnv({ role: "owner", record });
+      setLaneActiveContentCheckForTests(async () => okCheck);
+      expect((await verifyActiveContent("active", env)).status).toBe(200);
+    });
+
+    it("cools down each lane separately", async () => {
+      const lane = await standbyLane();
+      const record = { ...BYO_RECORD, storageLanes: [lane] };
+      const { env } = makeEnv({ role: "owner", record });
+      setLaneActiveContentCheckForTests(async () => okCheck);
+      expect((await verifyActiveContent("active", env)).status).toBe(200);
+      // A different lane has its own clock, so it is not caught by the
+      // active lane's fresh stamp.
+      expect((await verifyActiveContent(lane.id, env)).status).toBe(200);
+      expect((await verifyActiveContent(lane.id, env)).status).toBe(429);
     });
 
     it("stamps a saved (non-active) lane's own activeContentVerifiedAt, not the top-level one", async () => {

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -363,6 +363,31 @@ describe("storage vertical (self-serve BYO bucket)", () => {
     publicBaseUrl: "https://media.example.com",
   };
 
+  const SECRETS_KEY = "test-workspace-secrets-key-0000";
+
+  /**
+   * Real (not placeholder) sealed credentials — activate opens them for
+   * the stale-verify re-check, so a fake `enc:v1:` string that isn't
+   * actually valid ciphertext would 503 (`storage_credentials_unreadable`)
+   * on every test that reaches a stale lane, not just the ones testing it.
+   */
+  async function standbyLane(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      id: "lane_standby1",
+      provider: "r2",
+      bucket: "customer-bucket",
+      accountId: "a".repeat(32),
+      accessKeyId: await encryptSecret(SECRETS_KEY, "AKIDEXAMPLE1234"),
+      secretAccessKey: await encryptSecret(SECRETS_KEY, "super-secret-value"),
+      publicBaseUrl: "https://media.example.com",
+      // Fresh by default — a test that wants the stale-verify path
+      // overrides this with a timestamp older than LANE_VERIFY_STALE_MS.
+      verifiedAt: new Date().toISOString(),
+      storageAccessKeyIdLast4: "1234",
+      ...overrides,
+    };
+  }
+
   afterEach(() => {
     setStorageVerifyForTests(undefined);
     setStorageReconcileForTests(undefined);
@@ -1042,31 +1067,6 @@ describe("storage vertical (self-serve BYO bucket)", () => {
   });
 
   describe("POST /v1/workspaces/:workspace/storage/activate", () => {
-    const SECRETS_KEY = "test-workspace-secrets-key-0000";
-
-    /**
-     * Real (not placeholder) sealed credentials — activate opens them for
-     * the stale-verify re-check, so a fake `enc:v1:` string that isn't
-     * actually valid ciphertext would 503 (`storage_credentials_unreadable`)
-     * on every test that reaches a stale lane, not just the ones testing it.
-     */
-    async function standbyLane(overrides: Partial<Record<string, unknown>> = {}) {
-      return {
-        id: "lane_standby1",
-        provider: "r2",
-        bucket: "customer-bucket",
-        accountId: "a".repeat(32),
-        accessKeyId: await encryptSecret(SECRETS_KEY, "AKIDEXAMPLE1234"),
-        secretAccessKey: await encryptSecret(SECRETS_KEY, "super-secret-value"),
-        publicBaseUrl: "https://media.example.com",
-        // Fresh by default — a test that wants the stale-verify path
-        // overrides this with a timestamp older than LANE_VERIFY_STALE_MS.
-        verifiedAt: new Date().toISOString(),
-        storageAccessKeyIdLast4: "1234",
-        ...overrides,
-      };
-    }
-
     it("promotes a standby lane to active and demotes the outgoing shared config to a fallback lane", async () => {
       const record = {
         ...SHARED_RECORD,
@@ -1283,6 +1283,188 @@ describe("storage vertical (self-serve BYO bucket)", () => {
         env,
       );
       expect(res.status).toBe(403);
+    });
+  });
+
+  describe("active-content verification stamp (issue #929)", () => {
+    const okVerifyResultWithActiveContent = {
+      ...okVerifyResult,
+      checks: [
+        ...okVerifyResult.checks,
+        { id: "active-content-headers", ok: true, required: false },
+      ],
+    };
+    const okVerifyResultWithFailedActiveContent = {
+      ...okVerifyResult,
+      checks: [
+        ...okVerifyResult.checks,
+        { id: "active-content-headers", ok: false, required: false, hint: "nope" },
+      ],
+    };
+
+    it("PUT stamps a new standby lane's activeContentVerifiedAt when the check passed", async () => {
+      const { env, registry } = makeEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+        usage: { objects: 0 },
+      });
+      setStorageVerifyForTests(async () => okVerifyResultWithActiveContent);
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        lanes: Array<{ activeContentVerifiedAt?: string }>;
+      };
+      expect(body.lanes[0]?.activeContentVerifiedAt).toBeTruthy();
+      const savedLane = registry.record<{
+        storageLanes?: Array<{ activeContentVerifiedAt?: string }>;
+      }>("acme")?.storageLanes?.[0];
+      expect(savedLane?.activeContentVerifiedAt).toBeTruthy();
+    });
+
+    it("PUT leaves a new standby lane's activeContentVerifiedAt unset when the check is absent", async () => {
+      const { env, registry } = makeEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+        usage: { objects: 0 },
+      });
+      setStorageVerifyForTests(async () => okVerifyResult);
+      await app.request(
+        "/v1/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      const savedLane = registry.record<{
+        storageLanes?: Array<{ activeContentVerifiedAt?: string }>;
+      }>("acme")?.storageLanes?.[0];
+      expect(savedLane?.activeContentVerifiedAt).toBeUndefined();
+    });
+
+    it("PUT rotating the active BYO lane stamps storageActiveContentVerifiedAt when the check passed", async () => {
+      const { env, registry } = makeEnv({ role: "owner", record: BYO_RECORD });
+      setStorageVerifyForTests(async () => okVerifyResultWithActiveContent);
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ ...CANDIDATE_BODY, accessKeyId: "AKIDROTATED0000" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBeTruthy();
+    });
+
+    it("PUT rotating the active BYO lane clears a stale storageActiveContentVerifiedAt when the fresh check fails", async () => {
+      const { env, registry } = makeEnv({
+        role: "owner",
+        record: { ...BYO_RECORD, storageActiveContentVerifiedAt: "2026-01-01T00:00:00.000Z" },
+      });
+      setStorageVerifyForTests(async () => okVerifyResultWithFailedActiveContent);
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ ...CANDIDATE_BODY, accessKeyId: "AKIDROTATED0000" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBeUndefined();
+    });
+
+    it("activate carries the target lane's own activeContentVerifiedAt when the fresh-verifiedAt lane skips re-verify", async () => {
+      const record = {
+        ...SHARED_RECORD,
+        byoBucketEnabled: true,
+        storageLanes: [await standbyLane({ activeContentVerifiedAt: "2026-08-15T00:00:00.000Z" })],
+      };
+      const { env, registry } = makeEnv({ role: "owner", record });
+      setStorageVerifyForTests(async () => okVerifyResult);
+      const res = await app.request(
+        "/v1/workspaces/acme/storage/activate",
+        {
+          method: "POST",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ laneId: "lane_standby1" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { activeContentVerifiedAt?: string };
+      expect(body.activeContentVerifiedAt).toBe("2026-08-15T00:00:00.000Z");
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBe("2026-08-15T00:00:00.000Z");
+    });
+
+    it("activate derives a fresh activeContentVerifiedAt from the re-verify result for a stale lane", async () => {
+      const staleLane = await standbyLane({ verifiedAt: "2020-01-01T00:00:00.000Z" });
+      const record = { ...SHARED_RECORD, byoBucketEnabled: true, storageLanes: [staleLane] };
+      const { env, registry } = makeEnv({ role: "owner", record });
+      setStorageVerifyForTests(async () => okVerifyResultWithActiveContent);
+      const res = await app.request(
+        "/v1/workspaces/acme/storage/activate",
+        {
+          method: "POST",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ laneId: "lane_standby1" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { activeContentVerifiedAt?: string };
+      expect(body.activeContentVerifiedAt).toBeTruthy();
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBeTruthy();
+    });
+
+    it("activate clears activeContentVerifiedAt when a stale lane re-verifies but the active-content check fails", async () => {
+      const staleLane = await standbyLane({
+        verifiedAt: "2020-01-01T00:00:00.000Z",
+        activeContentVerifiedAt: "2026-01-01T00:00:00.000Z",
+      });
+      const record = { ...SHARED_RECORD, byoBucketEnabled: true, storageLanes: [staleLane] };
+      const { env, registry } = makeEnv({ role: "owner", record });
+      setStorageVerifyForTests(async () => okVerifyResultWithFailedActiveContent);
+      const res = await app.request(
+        "/v1/workspaces/acme/storage/activate",
+        {
+          method: "POST",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ laneId: "lane_standby1" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { activeContentVerifiedAt?: string };
+      expect(body.activeContentVerifiedAt).toBeUndefined();
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBeUndefined();
     });
   });
 

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -616,7 +616,9 @@ describe("storage vertical (self-serve BYO bucket)", () => {
         activeContentReason?: string;
       };
       expect(body.activeContentVerifiedAt).toBeUndefined();
-      expect(body.activeContentReason).toBe("host_missing");
+      // A record that exists but failed its probe is distinct from no
+      // record at all (`host_missing`) — see `active-content.ts`.
+      expect(body.activeContentReason).toBe("host_not_ok");
     });
 
     // Item 6 (issue #929 final-review): the hosted host's record projects
@@ -1637,7 +1639,7 @@ describe("storage vertical (self-serve BYO bucket)", () => {
         byoBucketEnabled: true,
         storageLanes: [await standbyLane({ activeContentVerifiedAt: "2026-08-15T00:00:00.000Z" })],
       };
-      const { env, registry } = makeEnv({ role: "owner", record });
+      const { env, registry } = makeEnv({ role: "owner", record, activeContentFlag: true });
       setStorageVerifyForTests(async () => okVerifyResult);
       const res = await app.request(
         "/v1/workspaces/acme/storage/activate",
@@ -1660,7 +1662,7 @@ describe("storage vertical (self-serve BYO bucket)", () => {
     it("activate derives a fresh activeContentVerifiedAt from the re-verify result for a stale lane", async () => {
       const staleLane = await standbyLane({ verifiedAt: "2020-01-01T00:00:00.000Z" });
       const record = { ...SHARED_RECORD, byoBucketEnabled: true, storageLanes: [staleLane] };
-      const { env, registry } = makeEnv({ role: "owner", record });
+      const { env, registry } = makeEnv({ role: "owner", record, activeContentFlag: true });
       setStorageVerifyForTests(async () => okVerifyResultWithActiveContent);
       const res = await app.request(
         "/v1/workspaces/acme/storage/activate",
@@ -1834,7 +1836,11 @@ describe("storage vertical (self-serve BYO bucket)", () => {
     });
 
     it("stamps storageActiveContentVerifiedAt on the active lane (named by the literal 'active') when the probe passes", async () => {
-      const { env, registry } = makeEnv({ role: "owner", record: BYO_RECORD });
+      const { env, registry } = makeEnv({
+        role: "owner",
+        record: BYO_RECORD,
+        activeContentFlag: true,
+      });
       let seenLane: { publicBaseUrl?: string } | undefined;
       setLaneActiveContentCheckForTests(async (_env, lane) => {
         seenLane = lane;
@@ -1856,6 +1862,34 @@ describe("storage vertical (self-serve BYO bucket)", () => {
       // the check — proof `resolveActiveContentLaneTarget` built the right
       // lane view, not an empty one.
       expect(seenLane?.publicBaseUrl).toBe(BYO_RECORD.publicBaseUrl);
+    });
+
+    // The response's `status` is the live gate projection (issue #929
+    // review), not an echo of the stamp this route just wrote — a
+    // workspace-level opt-out still closes the gate even though the probe
+    // itself passed and the stamp was written.
+    it("reports opted_out on the status even when the probe passes, for a workspace that opted out", async () => {
+      const { env, registry } = makeEnv({
+        role: "owner",
+        record: { ...BYO_RECORD, activeContentUploads: false },
+        activeContentFlag: true,
+      });
+      setLaneActiveContentCheckForTests(async () => okCheck);
+      const res = await verifyActiveContent("active", env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        check: typeof okCheck;
+        status: { activeContentVerifiedAt?: string; activeContentReason?: string };
+      };
+      expect(body.check).toEqual(okCheck);
+      expect(body.status.activeContentVerifiedAt).toBeUndefined();
+      expect(body.status.activeContentReason).toBe("opted_out");
+      // The probe still wrote its own stamp — only the live gate's
+      // projection is suppressed by the opt-out, not the underlying write.
+      expect(
+        registry.record<{ storageActiveContentVerifiedAt?: string }>("acme")
+          ?.storageActiveContentVerifiedAt,
+      ).toBeTruthy();
     });
 
     it("also resolves the active lane by its own storageLaneId, not just the literal 'active'", async () => {
@@ -2094,7 +2128,11 @@ describe("/me alias forwards (issue #613 phase 3)", () => {
       byoBucketEnabled: true,
       storageAccessKeyIdLast4: "1234",
     };
-    const { env, registry } = makeEnv({ role: "owner", record: BYO_RECORD });
+    const { env, registry } = makeEnv({
+      role: "owner",
+      record: BYO_RECORD,
+      activeContentFlag: true,
+    });
     setLaneActiveContentCheckForTests(async () => ({
       id: "active-content-headers",
       ok: true,

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -6,7 +6,7 @@
  * (phase 3, invites/members).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { HOST_RECORD_MAX_AGE_MS } from "../src/active-content";
+import { HOST_RECORD_MAX_AGE_MS, LANE_STAMP_MAX_AGE_MS } from "../src/active-content";
 import { hostActiveContentKey } from "../src/active-content-hosts";
 import { app } from "../src/index";
 import {
@@ -43,9 +43,24 @@ interface EnvOpts {
   getSessionCalls?: { count: number };
   secretsKey?: string;
   writeLimiterOk?: boolean;
+  /**
+   * Flagship stand-in for the active-content gate (issue #929). Omitted = no
+   * `FLAGS` binding, which the gate treats as fail-closed — every test that
+   * doesn't care keeps its pre-#929 behavior.
+   */
+  activeContentFlag?: boolean;
 }
 
 const SHARED_RECORD = { provider: "r2", bucket: "uploads-default", prefix: "acme/" };
+
+/**
+ * The platform binding a real shared-bucket workspace carries. Spread into
+ * `SHARED_RECORD` by the active-content display tests (issue #929), which
+ * read the gate itself — and the gate calls a lane shared by its *binding*
+ * (`isSharedLane`), not by the absence of credentials the way the masked
+ * projection's `mode` does.
+ */
+const SHARED_LANE = { binding: "UPLOADS_DEFAULT" };
 
 function makeEnv(opts: EnvOpts = {}) {
   const {
@@ -58,6 +73,7 @@ function makeEnv(opts: EnvOpts = {}) {
     getSessionCalls,
     secretsKey = "test-workspace-secrets-key-0000",
     writeLimiterOk = true,
+    activeContentFlag,
   } = opts;
 
   const db = new UsageFakeD1();
@@ -104,6 +120,9 @@ function makeEnv(opts: EnvOpts = {}) {
       REGISTRY: registry,
       WORKSPACE_SECRETS_KEY: secretsKey,
       WRITE_LIMITER: { limit: async () => ({ success: writeLimiterOk }) },
+      ...(activeContentFlag === undefined
+        ? {}
+        : { FLAGS: { getBooleanValue: async () => activeContentFlag } }),
     } as unknown as Env,
     registry,
     db,
@@ -505,35 +524,73 @@ describe("storage vertical (self-serve BYO bucket)", () => {
     });
 
     // "Hosted lane display" (issue #929): the pure `storageStatusResponse`
-    // projection has no KV access and only ever echoes a lane's *own*
-    // `activeContentVerifiedAt` stamp — meaningless for a shared lane, which
-    // instead inherits the daily-cron-probed verdict for its host. The
-    // handler overlays that verdict on top for shared lanes only.
+    // projection has no KV or flag access, so the active lane's row comes
+    // from the gate itself (`activeContentStatus`) — the page can only ever
+    // say "Verified" about a lane SVG/XML is actually accepted on, including
+    // the embed twin's own host record.
     it("reflects the hosted host's active-content record on the shared active lane", async () => {
       const { env } = makeEnv({
         role: "admin",
-        record: { ...SHARED_RECORD, publicBaseUrl: "https://storage.uploads.sh" },
+        record: { ...SHARED_RECORD, ...SHARED_LANE, publicBaseUrl: "https://storage.uploads.sh" },
+        activeContentFlag: true,
       });
       const verifiedAt = new Date(Date.now() - 1000).toISOString();
-      await env.REGISTRY.put(
-        hostActiveContentKey("storage.uploads.sh"),
-        JSON.stringify({ ok: true, verifiedAt }),
-      );
+      for (const host of ["storage.uploads.sh", "embed.uploads.sh"]) {
+        await env.REGISTRY.put(
+          hostActiveContentKey(host),
+          JSON.stringify({ ok: true, verifiedAt }),
+        );
+      }
       const res = await app.request(
         "/v1/workspaces/acme/storage",
         { headers: sessionHeaders },
         env,
       );
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { mode: string; activeContentVerifiedAt?: string };
+      const body = (await res.json()) as {
+        mode: string;
+        activeContentVerifiedAt?: string;
+        activeContentReason?: string;
+      };
       expect(body.mode).toBe("shared");
       expect(body.activeContentVerifiedAt).toBe(verifiedAt);
+      expect(body.activeContentReason).toBeUndefined();
+    });
+
+    it("reports the gate's reason on the active lane when a fresh host record isn't enough", async () => {
+      // Everything the host-record check wants is in place; the kill switch
+      // is off. The page must say so rather than showing "Verified <date>"
+      // for uploads the gate is refusing.
+      const { env } = makeEnv({
+        role: "admin",
+        record: { ...SHARED_RECORD, ...SHARED_LANE, publicBaseUrl: "https://storage.uploads.sh" },
+        activeContentFlag: false,
+      });
+      const verifiedAt = new Date(Date.now() - 1000).toISOString();
+      for (const host of ["storage.uploads.sh", "embed.uploads.sh"]) {
+        await env.REGISTRY.put(
+          hostActiveContentKey(host),
+          JSON.stringify({ ok: true, verifiedAt }),
+        );
+      }
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { headers: sessionHeaders },
+        env,
+      );
+      const body = (await res.json()) as {
+        activeContentVerifiedAt?: string;
+        activeContentReason?: string;
+      };
+      expect(body.activeContentVerifiedAt).toBeUndefined();
+      expect(body.activeContentReason).toBe("flag_off");
     });
 
     it("omits activeContentVerifiedAt on a shared active lane when the host record has never probed ok", async () => {
       const { env } = makeEnv({
         role: "admin",
-        record: { ...SHARED_RECORD, publicBaseUrl: "https://storage.uploads.sh" },
+        record: { ...SHARED_RECORD, ...SHARED_LANE, publicBaseUrl: "https://storage.uploads.sh" },
+        activeContentFlag: true,
       });
       await env.REGISTRY.put(
         hostActiveContentKey("storage.uploads.sh"),
@@ -543,13 +600,23 @@ describe("storage vertical (self-serve BYO bucket)", () => {
           detail: "no sandbox",
         }),
       );
+      // The embed twin is fine — only the stable host's failing record is
+      // allowed to explain the omission.
+      await env.REGISTRY.put(
+        hostActiveContentKey("embed.uploads.sh"),
+        JSON.stringify({ ok: true, verifiedAt: new Date(Date.now() - 1000).toISOString() }),
+      );
       const res = await app.request(
         "/v1/workspaces/acme/storage",
         { headers: sessionHeaders },
         env,
       );
-      const body = (await res.json()) as { activeContentVerifiedAt?: string };
+      const body = (await res.json()) as {
+        activeContentVerifiedAt?: string;
+        activeContentReason?: string;
+      };
       expect(body.activeContentVerifiedAt).toBeUndefined();
+      expect(body.activeContentReason).toBe("host_missing");
     });
 
     // Item 6 (issue #929 final-review): the hosted host's record projects
@@ -561,7 +628,8 @@ describe("storage vertical (self-serve BYO bucket)", () => {
     it("omits activeContentVerifiedAt on a shared active lane when the host record is ok but stale (older than HOST_RECORD_MAX_AGE_MS)", async () => {
       const { env } = makeEnv({
         role: "admin",
-        record: { ...SHARED_RECORD, publicBaseUrl: "https://storage.uploads.sh" },
+        record: { ...SHARED_RECORD, ...SHARED_LANE, publicBaseUrl: "https://storage.uploads.sh" },
+        activeContentFlag: true,
       });
       await env.REGISTRY.put(
         hostActiveContentKey("storage.uploads.sh"),
@@ -570,13 +638,21 @@ describe("storage vertical (self-serve BYO bucket)", () => {
           verifiedAt: new Date(Date.now() - (HOST_RECORD_MAX_AGE_MS + 1000)).toISOString(),
         }),
       );
+      await env.REGISTRY.put(
+        hostActiveContentKey("embed.uploads.sh"),
+        JSON.stringify({ ok: true, verifiedAt: new Date(Date.now() - 1000).toISOString() }),
+      );
       const res = await app.request(
         "/v1/workspaces/acme/storage",
         { headers: sessionHeaders },
         env,
       );
-      const body = (await res.json()) as { activeContentVerifiedAt?: string };
+      const body = (await res.json()) as {
+        activeContentVerifiedAt?: string;
+        activeContentReason?: string;
+      };
       expect(body.activeContentVerifiedAt).toBeUndefined();
+      expect(body.activeContentReason).toBe("host_stale");
     });
 
     it("reflects the hosted host's active-content record on a shared entry in lanes[]", async () => {
@@ -614,6 +690,53 @@ describe("storage vertical (self-serve BYO bucket)", () => {
         mode: "shared",
         activeContentVerifiedAt: verifiedAt,
       });
+    });
+
+    it("drops a BYO lane entry's own stamp once it is past LANE_STAMP_MAX_AGE_MS", async () => {
+      // Same window the gate would apply if this lane were the active one —
+      // a lapsed stamp reads as "not verified" in the list too, rather than
+      // showing a date that no longer means anything (issue #929 simplify).
+      const fresh = new Date(Date.now() - 1000).toISOString();
+      const { env } = makeEnv({
+        role: "owner",
+        record: {
+          ...BYO_RECORD,
+          storageLanes: [
+            {
+              id: "lane_stale",
+              provider: "r2",
+              bucket: "old-bucket",
+              accountId: "a".repeat(32),
+              publicBaseUrl: "https://old.example.com",
+              activeContentVerifiedAt: new Date(
+                Date.now() - (LANE_STAMP_MAX_AGE_MS + 1000),
+              ).toISOString(),
+            },
+            {
+              id: "lane_fresh",
+              provider: "r2",
+              bucket: "new-bucket",
+              accountId: "b".repeat(32),
+              publicBaseUrl: "https://new.example.com",
+              activeContentVerifiedAt: fresh,
+            },
+          ],
+        },
+      });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { headers: sessionHeaders },
+        env,
+      );
+      const body = (await res.json()) as {
+        lanes: Array<{ laneId: string; activeContentVerifiedAt?: string }>;
+      };
+      expect(
+        body.lanes.find((l) => l.laneId === "lane_stale")?.activeContentVerifiedAt,
+      ).toBeUndefined();
+      expect(body.lanes.find((l) => l.laneId === "lane_fresh")?.activeContentVerifiedAt).toBe(
+        fresh,
+      );
     });
   });
 

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -599,7 +599,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       annotations: mcpDestroyPublic,
       securitySchemes: mcpOAuthWrite,
       description:
-        "Upload a file (or files) and get a public URL plus GitHub-ready markdown. Prefer the returned `embedUrl` in GitHub markdown. All uploads are public. Pass `pr`+`repo` to attach to a PR (stable key + managed comment). Pass `branch`+`repo` to stage for a PR that does not exist yet. When the bytes are already at a public HTTPS URL, pass `contentUrl` instead of base64 — the server fetches them. Accepts images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and text (plain, markdown, CSV, JSON). HTML and SVG are rejected.",
+        "Upload a file (or files) and get a public URL plus GitHub-ready markdown. Prefer the returned `embedUrl` in GitHub markdown. All uploads are public. Pass `pr`+`repo` to attach to a PR (stable key + managed comment). Pass `branch`+`repo` to stage for a PR that does not exist yet. When the bytes are already at a public HTTPS URL, pass `contentUrl` instead of base64 — the server fetches them. Accepts images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and text (plain, markdown, CSV, JSON). SVG and XML are accepted only on storage lanes verified to serve them sandboxed (see the workspace's storage settings); HTML is rejected.",
       inputSchema: {
         type: "object",
         properties: {
@@ -847,10 +847,12 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
 
         // `activeContent: false` here is deliberate, not a placeholder: this
         // policy is only ever consulted below for `maxBytes`/`maxVideoBytes`
-        // (the pre-decode size ceiling), and the gated SVG/XML rows carry no
-        // byte-cap of their own — the real gate result would change nothing
-        // this call reads. `putObject`'s own `resolveUploadPolicy` call
-        // (files-core.ts) is what actually gates SVG/XML acceptance.
+        // (the pre-decode size ceiling), and those are workspace-level
+        // overrides — a row's own tighter `maxBytes` (the gated SVG/XML
+        // rows' 4 MiB cap, issue #929 review) never feeds into them, so the
+        // real gate result would change nothing this call reads. `putObject`'s
+        // own `resolveUploadPolicy` call (files-core.ts) is what actually
+        // gates SVG/XML acceptance.
         const policy = resolveUploadPolicy(workspace, { activeContent: false });
         // Pre-decode uses the policy ceiling (video may exceed maxBytes);
         // putObject's inspectUpload enforces the content-specific limit.

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -845,7 +845,13 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           }
         }
 
-        const policy = resolveUploadPolicy(workspace);
+        // `activeContent: false` here is deliberate, not a placeholder: this
+        // policy is only ever consulted below for `maxBytes`/`maxVideoBytes`
+        // (the pre-decode size ceiling), and the gated SVG/XML rows carry no
+        // byte-cap of their own — the real gate result would change nothing
+        // this call reads. `putObject`'s own `resolveUploadPolicy` call
+        // (files-core.ts) is what actually gates SVG/XML acceptance.
+        const policy = resolveUploadPolicy(workspace, { activeContent: false });
         // Pre-decode uses the policy ceiling (video may exceed maxBytes);
         // putObject's inspectUpload enforces the content-specific limit.
         const maxBytes = Math.max(policy.maxBytes, policy.maxVideoBytes);

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -856,18 +856,21 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         // SVG/XML acceptance (see `uploadLimits`, guards.ts).
         const limits = uploadLimits(workspace);
         /**
-         * Pre-decode ceiling for one file: the type its filename claims
-         * (the gated SVG/XML rows cap at 4 MiB however high the workspace
-         * ceiling is, issue #929), or — for a name that claims nothing —
-         * the loosest the workspace allows, since video may exceed
-         * `maxBytes`. `putObject`'s `inspectUpload` enforces the
-         * content-specific limit against the decoded bytes either way.
+         * Pre-decode ceiling for one file: the loosest the workspace allows
+         * (since video may exceed `maxBytes`), *tightened* only when the
+         * filename claims a gated type (the SVG/XML rows cap at 4 MiB
+         * however high the workspace ceiling is, issue #929). A name
+         * claiming an ordinary, ungated type never narrows below the
+         * workspace's general ceiling. `putObject`'s `inspectUpload`
+         * enforces the content-specific limit against the decoded bytes
+         * either way.
          */
         const maxBytesFor = (name: string | undefined): number => {
           const claimed = name ? contentTypeFromKey(name) : undefined;
-          return claimed !== undefined
-            ? maxBytesForContentType(limits, claimed)
-            : Math.max(limits.maxBytes, limits.maxVideoBytes);
+          const general = Math.max(limits.maxBytes, limits.maxVideoBytes);
+          return claimed !== undefined && isGatedContentType(claimed)
+            ? Math.min(general, maxBytesForContentType(limits, claimed))
+            : general;
         };
         const alt = optString(args, "alt");
         const width = optPosInt(args, "width");

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -101,7 +101,14 @@ import {
 import { parseExternalReference } from "@uploads/api/external-references";
 import { publicUrl, storage, storageConfig } from "@uploads/api/storage";
 import { deleteObject, listObjects, putObject } from "@uploads/api/files";
-import { allowWrite, resolveUploadPolicy } from "@uploads/api/guards";
+import { activeContentAllowed } from "@uploads/api/active-content";
+import {
+  allowWrite,
+  contentTypeFromKey,
+  isGatedContentType,
+  maxBytesForContentType,
+  uploadLimits,
+} from "@uploads/api/guards";
 import { usageWithLimits } from "@uploads/api/budget";
 import { reconcileWorkspaceUsage } from "@uploads/api/reconcile";
 import { purgeExpiredObjects } from "@uploads/api/retention";
@@ -845,18 +852,23 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           }
         }
 
-        // `activeContent: false` here is deliberate, not a placeholder: this
-        // policy is only ever consulted below for `maxBytes`/`maxVideoBytes`
-        // (the pre-decode size ceiling), and those are workspace-level
-        // overrides — a row's own tighter `maxBytes` (the gated SVG/XML
-        // rows' 4 MiB cap, issue #929 review) never feeds into them, so the
-        // real gate result would change nothing this call reads. `putObject`'s
-        // own `resolveUploadPolicy` call (files-core.ts) is what actually
-        // gates SVG/XML acceptance.
-        const policy = resolveUploadPolicy(workspace, { activeContent: false });
-        // Pre-decode uses the policy ceiling (video may exceed maxBytes);
-        // putObject's inspectUpload enforces the content-specific limit.
-        const maxBytes = Math.max(policy.maxBytes, policy.maxVideoBytes);
+        // Ceilings only, no admission decision — `putObject` is what gates
+        // SVG/XML acceptance (see `uploadLimits`, guards.ts).
+        const limits = uploadLimits(workspace);
+        /**
+         * Pre-decode ceiling for one file: the type its filename claims
+         * (the gated SVG/XML rows cap at 4 MiB however high the workspace
+         * ceiling is, issue #929), or — for a name that claims nothing —
+         * the loosest the workspace allows, since video may exceed
+         * `maxBytes`. `putObject`'s `inspectUpload` enforces the
+         * content-specific limit against the decoded bytes either way.
+         */
+        const maxBytesFor = (name: string | undefined): number => {
+          const claimed = name ? contentTypeFromKey(name) : undefined;
+          return claimed !== undefined
+            ? maxBytesForContentType(limits, claimed)
+            : Math.max(limits.maxBytes, limits.maxVideoBytes);
+        };
         const alt = optString(args, "alt");
         const width = optPosInt(args, "width");
         // Strict overwrite (issue #174) only on non-gh/ keys.
@@ -865,6 +877,29 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           metadata !== undefined || replaceArg
             ? { metadata, replace: replaceArg, surface: "mcp" as const }
             : { surface: "mcp" as const };
+
+        // Resolved at most once per tool call and shared by every file in a
+        // batch (same memo shape as `resolveGhPrefixOnce` below): the gate is
+        // a workspace-level answer — a Flagship evaluation plus a KV read —
+        // so a 20-SVG batch shouldn't pay for it 20 times. Never resolved at
+        // all unless some file actually claims a gated type.
+        let activeContentPromise: Promise<boolean> | undefined;
+        function activeContentOnce(): Promise<boolean> {
+          activeContentPromise ??= activeContentAllowed(env, workspace);
+          return activeContentPromise;
+        }
+
+        /**
+         * `putObject` options for one file: the shared bag, plus the
+         * active-content gate result when this file's name claims one of the
+         * gated SVG/XML types (issue #929). Any other name leaves the gate
+         * unresolved — `putObject` wouldn't consult it either.
+         */
+        async function putOptsForFile(name: string) {
+          const claimed = contentTypeFromKey(name);
+          if (claimed === undefined || !isGatedContentType(claimed)) return putOpts;
+          return { ...putOpts, activeContent: await activeContentOnce() };
+        }
 
         // Resolved once per tool call, cached across every file in a batch
         // (issue #631) — `resolveGhKeyContext` itself is fail-open (any
@@ -921,7 +956,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           // Bounded fan-out: 20 parallel Worker fetches would pin isolate RAM.
           const decoded = await mapBounded(items, PUT_CONCURRENCY, async (item, i) => {
             try {
-              return await bytesFromPutSource(item, maxBytes);
+              return await bytesFromPutSource(item, maxBytesFor(item.filename));
             } catch (err) {
               usage(
                 `files[${i}] (${item.filename}): ${err instanceof Error ? err.message : String(err)}`,
@@ -954,7 +989,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
                 keys[i]!,
                 decoded[i]!,
                 workspaceName,
-                putOpts,
+                await putOptsForFile(item.filename),
               );
               const markdown =
                 result.url === null
@@ -986,9 +1021,19 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           return { workspace: workspaceName, uploads, failures, ...extras };
         }
 
-        const bytes = await bytesFromPutSource({ contentBase64, contentUrl }, maxBytes);
+        const bytes = await bytesFromPutSource(
+          { contentBase64, contentUrl },
+          maxBytesFor(filename),
+        );
         const key = await resolveKey(filename!, bytes);
-        const result = await putObject(env, workspace, key, bytes, workspaceName, putOpts);
+        const result = await putObject(
+          env,
+          workspace,
+          key,
+          bytes,
+          workspaceName,
+          await putOptsForFile(filename!),
+        );
         const markdown =
           result.url === null
             ? undefined

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1054,6 +1054,52 @@ describe("mcp worker", () => {
     expect(bucket.store.size).toBe(2);
   });
 
+  it("evaluates the active-content gate once for a whole SVG batch (issue #929)", async () => {
+    // The gate is a workspace-level answer costing a Flagship evaluation plus
+    // a KV read — one tool call must resolve it once, not once per file.
+    const { env: base, bucket } = await makeEnv();
+    let evaluated = 0;
+    const registry = base.REGISTRY;
+    const env = {
+      ...base,
+      REGISTRY: {
+        ...registry,
+        get: async (key: string, type?: unknown) =>
+          key === "host-active-content:storage.example.com"
+            ? { ok: true, verifiedAt: new Date().toISOString() }
+            : (registry.get as (k: string, t?: unknown) => Promise<unknown>)(key, type),
+      },
+      FLAGS: {
+        getBooleanValue: async () => {
+          evaluated += 1;
+          return true;
+        },
+      },
+    } as unknown as Env;
+    const svg = btoa('<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>');
+    const result = await callTool(env, "put", {
+      files: [
+        { filename: "one.svg", contentBase64: svg },
+        { filename: "two.svg", contentBase64: svg },
+        { filename: "three.svg", contentBase64: svg },
+      ],
+      prefix: "diagrams",
+    });
+    expect(result.isError).toBe(false);
+    const body = result.structuredContent as {
+      uploads: Array<{ file: string; contentType: string }>;
+      failures: unknown[];
+    };
+    expect(body.failures).toEqual([]);
+    expect(body.uploads.map((u) => u.contentType)).toEqual([
+      "image/svg+xml",
+      "image/svg+xml",
+      "image/svg+xml",
+    ]);
+    expect(bucket.store.size).toBe(3);
+    expect(evaluated).toBe(1);
+  });
+
   it("multi-file put returns partial failures without aborting the batch", async () => {
     const { env, bucket } = await makeEnv();
     // Unrecognized extension + non-sniffable bytes: no declared type resolves

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1064,8 +1064,11 @@ describe("mcp worker", () => {
       ...base,
       REGISTRY: {
         ...registry,
+        // Every hosted host, plus this fixture's own — the shared-lane gate
+        // requires a fresh `ok` record for all of them (issue #929
+        // adversarial review H-1), not just the workspace's public host.
         get: async (key: string, type?: unknown) =>
-          key === "host-active-content:storage.example.com"
+          key.startsWith("host-active-content:")
             ? { ok: true, verifiedAt: new Date().toISOString() }
             : (registry.get as (k: string, t?: unknown) => Promise<unknown>)(key, type),
       },

--- a/apps/web/public/.well-known/openapi.json
+++ b/apps/web/public/.well-known/openapi.json
@@ -979,7 +979,12 @@
           "key": { "type": "string" },
           "contentType": { "type": "string" },
           "maxSize": { "type": "integer", "minimum": 1 },
-          "expiresIn": { "type": "integer", "minimum": 1, "maximum": 86400 },
+          "expiresIn": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 86400,
+            "description": "Seconds until the signed URL expires. Capped at 900 for SVG and XML content types (issue #929)."
+          },
           "replace": { "type": "boolean", "default": false }
         }
       },

--- a/apps/web/src/components/MediaStage.astro
+++ b/apps/web/src/components/MediaStage.astro
@@ -89,12 +89,6 @@ const {
         {kind === "file" && url && (
           <MediaFallback title="Preview unavailable" href={url} filename={filename} />
         )}
-        {kind === "unsupported" && (
-          <MediaFallback
-            title="Unsupported media type"
-            body="This file cannot be previewed inline."
-          />
-        )}
         {kind === "missing" && (
           <MediaFallback
             title="Removed or expired"

--- a/apps/web/src/components/settings/ActiveContentDetails.astro
+++ b/apps/web/src/components/settings/ActiveContentDetails.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * The "Serve SVG and XML" panel on a BYO lane card (issue #929): the two
+ * headers that lane's public host has to send, a "Check now" button that runs
+ * the probe against it, and the status line the probe writes back.
+ *
+ * One template, rendered once per lane card on the storage settings page —
+ * the active-BYO card and the saved-but-not-in-use card show the identical
+ * panel and differ only in which ids their script wires up, so `idPrefix`
+ * ("storage-byo" / "storage-saved") is the whole difference.
+ *
+ * Hosted (shared) lanes get no panel at all: their host is probed by a daily
+ * cron and nobody in a workspace can set headers on it.
+ */
+interface Props {
+  /** Element-id prefix for this lane card — `<prefix>-active-content`, `-btn`, `-status`. */
+  idPrefix: string;
+}
+
+const { idPrefix } = Astro.props;
+---
+
+<details
+  class="storage-active-content max-w-[32rem] rounded-md border border-border px-4 py-2.5 text-[13px] mt-3"
+  id={`${idPrefix}-active-content`}
+>
+  <summary class="cursor-pointer text-foreground font-medium">Serve SVG and XML</summary>
+  <p class="mt-2 mb-1 text-muted-foreground">
+    Set these headers on this bucket's public host, then check:
+  </p>
+  <pre
+    class="storage-active-content__headers rounded-md border border-border bg-muted/40 p-2.5 text-xs overflow-x-auto"><code>Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox
+X-Content-Type-Options: nosniff</code></pre>
+  <div class="storage-actions flex flex-wrap items-center gap-3 mt-2">
+    <button type="button" class="ul-btn" id={`${idPrefix}-check-active-content-btn`}
+      >Check now</button
+    >
+  </div>
+  <p
+    class="muted mt-2 data-[state=error]:text-destructive data-[state=ok]:text-success"
+    id={`${idPrefix}-active-content-status`}
+    role="status"
+  >
+  </p>
+</details>

--- a/apps/web/src/content/docs/byo-bucket.mdx
+++ b/apps/web/src/content/docs/byo-bucket.mdx
@@ -100,10 +100,19 @@ Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src 
 X-Content-Type-Options: nosniff
 ```
 
+Two things decide whether the check passes:
+
+- **The headers must cover XML, not only SVG.** A rule scoped to the `.svg` extension leaves XML
+  documents free to run script through an `<?xml-stylesheet>` XSLT. Scope yours by content type
+  (`image/svg+xml`, `application/xml`, `text/xml`) or add the extensions.
+- **Send exactly one `Content-Security-Policy` header.** Two are legal CSP, but repeated headers
+  arrive comma-joined and the check can't read them apart, so it fails closed.
+
 Then, on the workspace settings page, open the bucket's **Serve SVG and XML** details and click
-**Check now** — it uploads an inert SVG, fetches it back through your public URL, checks the headers,
-and deletes it. A passing check is good for 30 days; after that (or if the check ever fails) SVG and
-XML go back to 415ing until you check again.
+**Check now** — it uploads an inert SVG and an inert XML file, fetches both back through your public
+URL, checks the headers on each, and deletes them. Both have to pass. A passing check is good for 30
+days; after that (or if the check ever fails) SVG and XML go back to 415ing until you check again.
+Checks are limited to one a minute per bucket.
 
 </section>
 

--- a/apps/web/src/content/docs/byo-bucket.mdx
+++ b/apps/web/src/content/docs/byo-bucket.mdx
@@ -89,6 +89,22 @@ clean pass saves. Saving never changes where uploads go — the bucket sits on y
   not.
 </div>
 
+### 5. Optional: serve SVG and XML
+
+By default, SVG and XML uploads 415 on a BYO bucket the same way they do everywhere else — served
+inline with no Worker in front, either format could otherwise run a script with your bucket's origin.
+Set two headers on your bucket's public host to open them up:
+
+```text
+Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox
+X-Content-Type-Options: nosniff
+```
+
+Then, on the workspace settings page, open the bucket's **Serve SVG and XML** details and click
+**Check now** — it uploads an inert SVG, fetches it back through your public URL, checks the headers,
+and deletes it. A passing check is good for 30 days; after that (or if the check ever fails) SVG and
+XML go back to 415ing until you check again.
+
 </section>
 
 <section id="s3-compatible">

--- a/apps/web/src/content/docs/limits.mdx
+++ b/apps/web/src/content/docs/limits.mdx
@@ -77,9 +77,10 @@ attachment caps never apply.
   free GitHub plans, and <PlanValue of="proMaxVideo" /> on <PlanValue of="proName" /> even when the
   repository is on a free GitHub plan.
 - **Formats:** images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and
-  text (plain, markdown, CSV, JSON, logs). SVG and HTML are not accepted — served inline, either
-  can run script; SVG support is planned behind a sandboxing header. Uploads are public: scrub
-  secrets out of logs, JSON, and other text files before uploading.
+  text (plain, markdown, CSV, JSON, logs). SVG and XML are accepted only on storage lanes verified
+  to serve them sandboxed (see [Bring your own bucket](/docs/byo-bucket#svg-xml)); HTML is not
+  accepted because served inline it can run script. Uploads are public: scrub secrets out of logs,
+  JSON, and other text files before uploading.
 
 <div class="note">
   One difference to know: GitHub renders inline video players only for its own uploads. Videos

--- a/apps/web/src/content/docs/limits.mdx
+++ b/apps/web/src/content/docs/limits.mdx
@@ -77,9 +77,10 @@ attachment caps never apply.
   free GitHub plans, and <PlanValue of="proMaxVideo" /> on <PlanValue of="proName" /> even when the
   repository is on a free GitHub plan.
 - **Formats:** images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and
-  text (plain, markdown, CSV, JSON, logs). SVG and XML are accepted only on storage lanes verified
-  to serve them sandboxed (see [Bring your own bucket](/docs/byo-bucket#setup)); HTML is not
-  accepted because served inline it can run script. Uploads are public: scrub secrets out of logs,
+  text (plain, markdown, CSV, JSON, logs). SVG and XML are accepted on hosted storage once the
+  platform verifies its hosts serve them sandboxed, and on your own bucket after you set the
+  headers (see [Bring your own bucket](/docs/byo-bucket#setup)); HTML is not accepted because
+  served inline it can run script. Uploads are public: scrub secrets out of logs,
   JSON, and other text files before uploading.
 
 <div class="note">

--- a/apps/web/src/content/docs/limits.mdx
+++ b/apps/web/src/content/docs/limits.mdx
@@ -78,7 +78,7 @@ attachment caps never apply.
   repository is on a free GitHub plan.
 - **Formats:** images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and
   text (plain, markdown, CSV, JSON, logs). SVG and XML are accepted only on storage lanes verified
-  to serve them sandboxed (see [Bring your own bucket](/docs/byo-bucket#svg-xml)); HTML is not
+  to serve them sandboxed (see [Bring your own bucket](/docs/byo-bucket#setup)); HTML is not
   accepted because served inline it can run script. Uploads are public: scrub secrets out of logs,
   JSON, and other text files before uploading.
 

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -27,6 +27,7 @@ import {
   searchWorkspaceFiles,
   setFileVisibility,
   updateWorkspaceMemberRole,
+  verifyLaneActiveContent,
   verifyWorkspaceStorage,
   type StorageCandidate,
 } from "./api-client";
@@ -1959,5 +1960,43 @@ describe("deleteWorkspaceStorage", () => {
       kind: "conflict",
       message: "this workspace still has files on its BYO bucket — pass force to detach anyway",
     });
+  });
+});
+
+/**
+ * The on-demand SVG/XML check is cooled down per lane (issue #929
+ * adversarial review L-3). A 429 is not a server problem — it reports as a
+ * `rejected` check, the same branch the 422s take, so the settings panel
+ * renders one explanatory line rather than "couldn't reach the server".
+ */
+describe("verifyLaneActiveContent — per-lane cooldown", () => {
+  it("reports a 429 as a rejected check with a try-again hint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          { error: { code: "active_content_check_cooldown", message: "Too many requests." } },
+          { status: 429 },
+        ),
+      ),
+    );
+
+    const result = await verifyLaneActiveContent("http://127.0.0.1:8787", "acme", "active");
+
+    expect(result.kind).toBe("rejected");
+    if (result.kind !== "rejected") throw new Error("expected a rejected result");
+    expect(result.check.ok).toBe(false);
+    expect(result.check.hint).toContain("try again");
+  });
+
+  it("still reports a real server error as unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("boom", { status: 500 })),
+    );
+
+    await expect(
+      verifyLaneActiveContent("http://127.0.0.1:8787", "acme", "active"),
+    ).resolves.toEqual({ kind: "unavailable", reason: "server" });
   });
 });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -2369,6 +2369,14 @@ export type VerifyLaneActiveContentResult =
   | { kind: "rejected"; check: StorageVerifyCheck }
   | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
 
+/** The 429 cooldown, shaped as the same `check` the 422 rejections carry so the UI keeps one branch. */
+const ACTIVE_CONTENT_COOLDOWN_CHECK: StorageVerifyCheck = {
+  id: "active-content-headers",
+  ok: false,
+  required: false,
+  hint: "this lane was checked moments ago — try again in a minute",
+};
+
 /**
  * POST /v1/workspaces/:name/storage/lanes/:laneId/verify-active-content
  * (issue #929) — runs only the SVG/XML sandboxing-CSP probe against one
@@ -2394,6 +2402,10 @@ export async function verifyLaneActiveContent(
     if (check) return { kind: "rejected", check };
     return { kind: "unavailable", reason: "server" };
   }
+  // 429 — the per-lane cooldown (issue #929 adversarial review L-3). Not a
+  // server problem and not worth a branch of its own: report it the way the
+  // 422 rejections are reported, with a hint that says what to do.
+  if (response.status === 429) return { kind: "rejected", check: ACTIVE_CONTENT_COOLDOWN_CHECK };
   if (response.status === 403) return { kind: "unavailable", reason: "forbidden" };
   if (response.status === 404) return { kind: "unavailable", reason: "not_found" };
   if (!response.ok) return { kind: "unavailable", reason: "server" };

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1951,8 +1951,10 @@ export interface WorkspaceStorageStatus {
   publicBaseUrl?: string;
   configuredAt?: string;
   verifiedAt?: string;
-  /** Active lane's last successful SVG/XML sandboxing-CSP check (issue #929) — gates SVG/XML acceptance. For a shared active lane this is the hosted host's daily-probed verdict, not a per-workspace stamp. */
+  /** Active lane's last successful SVG/XML sandboxing-CSP check (issue #929) — gates SVG/XML acceptance. For a shared active lane this is the hosted host's daily-probed verdict, not a per-workspace stamp. Absent whenever acceptance is off, with `activeContentReason` saying which check said so. */
   activeContentVerifiedAt?: string;
+  /** Why SVG/XML acceptance is off for the active lane, when it is: `"opted_out" | "flag_off" | "unhealthy" | "host_stale" | "host_missing" | "lane_stale" | "lane_missing"`. Widened to `string` — an unrecognized value just falls back to the generic "Not verified" copy. */
+  activeContentReason?: string;
   jurisdiction?: string;
   /** s3-only. Service endpoint origin of the active lane. */
   endpoint?: string;
@@ -2044,6 +2046,8 @@ function toWorkspaceStorageStatus(body: unknown): WorkspaceStorageStatus | null 
     verifiedAt: typeof b.verifiedAt === "string" ? b.verifiedAt : undefined,
     activeContentVerifiedAt:
       typeof b.activeContentVerifiedAt === "string" ? b.activeContentVerifiedAt : undefined,
+    activeContentReason:
+      typeof b.activeContentReason === "string" ? b.activeContentReason : undefined,
     jurisdiction: typeof b.jurisdiction === "string" ? b.jurisdiction : undefined,
     endpoint: typeof b.endpoint === "string" ? b.endpoint : undefined,
     region: typeof b.region === "string" ? b.region : undefined,

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1908,6 +1908,8 @@ export interface WorkspaceStorageLane {
   bucket: string;
   publicBaseUrl?: string;
   verifiedAt?: string;
+  /** Last successful SVG/XML sandboxing-CSP check against this lane's public host (issue #929) — gates SVG/XML acceptance while this lane is active. For a shared lane this is the hosted host's daily-probed verdict, not a per-lane stamp. */
+  activeContentVerifiedAt?: string;
   lastActiveAt?: string;
   accountIdMasked?: string;
   accessKeyIdLast4?: string;
@@ -1949,6 +1951,8 @@ export interface WorkspaceStorageStatus {
   publicBaseUrl?: string;
   configuredAt?: string;
   verifiedAt?: string;
+  /** Active lane's last successful SVG/XML sandboxing-CSP check (issue #929) — gates SVG/XML acceptance. For a shared active lane this is the hosted host's daily-probed verdict, not a per-workspace stamp. */
+  activeContentVerifiedAt?: string;
   jurisdiction?: string;
   /** s3-only. Service endpoint origin of the active lane. */
   endpoint?: string;
@@ -1986,6 +1990,8 @@ function toWorkspaceStorageLane(value: unknown): WorkspaceStorageLane | null {
     bucket: v.bucket,
     publicBaseUrl: typeof v.publicBaseUrl === "string" ? v.publicBaseUrl : undefined,
     verifiedAt: typeof v.verifiedAt === "string" ? v.verifiedAt : undefined,
+    activeContentVerifiedAt:
+      typeof v.activeContentVerifiedAt === "string" ? v.activeContentVerifiedAt : undefined,
     lastActiveAt: typeof v.lastActiveAt === "string" ? v.lastActiveAt : undefined,
     accountIdMasked: typeof v.accountIdMasked === "string" ? v.accountIdMasked : undefined,
     accessKeyIdLast4: typeof v.accessKeyIdLast4 === "string" ? v.accessKeyIdLast4 : undefined,
@@ -2036,6 +2042,8 @@ function toWorkspaceStorageStatus(body: unknown): WorkspaceStorageStatus | null 
     publicBaseUrl: typeof b.publicBaseUrl === "string" ? b.publicBaseUrl : undefined,
     configuredAt: typeof b.configuredAt === "string" ? b.configuredAt : undefined,
     verifiedAt: typeof b.verifiedAt === "string" ? b.verifiedAt : undefined,
+    activeContentVerifiedAt:
+      typeof b.activeContentVerifiedAt === "string" ? b.activeContentVerifiedAt : undefined,
     jurisdiction: typeof b.jurisdiction === "string" ? b.jurisdiction : undefined,
     endpoint: typeof b.endpoint === "string" ? b.endpoint : undefined,
     region: typeof b.region === "string" ? b.region : undefined,
@@ -2100,32 +2108,33 @@ export interface StorageVerifyResult {
   jurisdiction?: string;
 }
 
+/** Parses one `StorageVerifyCheck` — shared by the multi-check result parser below and `verifyLaneActiveContent`'s single-check `{ check }` body. */
+function toStorageVerifyCheck(value: unknown): StorageVerifyCheck | null {
+  if (!value || typeof value !== "object") return null;
+  const check = value as Record<string, unknown>;
+  if (
+    typeof check.id !== "string" ||
+    typeof check.ok !== "boolean" ||
+    typeof check.required !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    id: check.id,
+    ok: check.ok,
+    required: check.required,
+    // Normalized rather than passed through: a non-string hint would
+    // reach the checklist renderer typed as string.
+    hint: typeof check.hint === "string" ? check.hint : undefined,
+    inconclusive: check.inconclusive === true ? true : undefined,
+  };
+}
+
 function toStorageVerifyResult(body: unknown): StorageVerifyResult | null {
   if (!body || typeof body !== "object") return null;
   const b = body as Record<string, unknown>;
   if (typeof b.ok !== "boolean" || !Array.isArray(b.checks)) return null;
-  const checks = b.checks.flatMap((c): StorageVerifyCheck[] => {
-    if (!c || typeof c !== "object") return [];
-    const check = c as Record<string, unknown>;
-    if (
-      typeof check.id !== "string" ||
-      typeof check.ok !== "boolean" ||
-      typeof check.required !== "boolean"
-    ) {
-      return [];
-    }
-    return [
-      {
-        id: check.id,
-        ok: check.ok,
-        required: check.required,
-        // Normalized rather than passed through: a non-string hint would
-        // reach the checklist renderer typed as string.
-        hint: typeof check.hint === "string" ? check.hint : undefined,
-        inconclusive: check.inconclusive === true ? true : undefined,
-      },
-    ];
-  });
+  const checks = b.checks.flatMap((c) => toStorageVerifyCheck(c) ?? []);
   return {
     ok: b.ok,
     checks,
@@ -2348,6 +2357,50 @@ export async function activateWorkspaceStorage(
   const status = toWorkspaceStorageStatus(await response.json().catch(() => null));
   if (!status) return { kind: "unavailable", reason: "server" };
   return { kind: "ok", status };
+}
+
+export type VerifyLaneActiveContentResult =
+  | { kind: "ok"; check: StorageVerifyCheck; status: WorkspaceStorageStatus }
+  /** 422 — a shared lane, or a lane with no `publicBaseUrl` to probe. No `status` to re-apply; `check.hint` explains why. */
+  | { kind: "rejected"; check: StorageVerifyCheck }
+  | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
+
+/**
+ * POST /v1/workspaces/:name/storage/lanes/:laneId/verify-active-content
+ * (issue #929) — runs only the SVG/XML sandboxing-CSP probe against one
+ * lane (`laneId`: a saved lane's id, or the active lane via `"active"` or
+ * its own id) and stamps the result. `laneId` is path-encoded like
+ * `activateWorkspaceStorage`'s.
+ */
+export async function verifyLaneActiveContent(
+  apiOrigin: string,
+  name: string,
+  laneId: string,
+): Promise<VerifyLaneActiveContentResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/v1/workspaces/${encodeURIComponent(name)}/storage/lanes/${encodeURIComponent(laneId)}/verify-active-content`,
+    { method: "POST", credentials: "include", cache: "no-store" },
+    { timeoutMs: STORAGE_PIPELINE_TIMEOUT_MS },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (response.status === 422) {
+    const rejectedBody = (await response.json().catch(() => null)) as { check?: unknown } | null;
+    const check = toStorageVerifyCheck(rejectedBody?.check);
+    if (check) return { kind: "rejected", check };
+    return { kind: "unavailable", reason: "server" };
+  }
+  if (response.status === 403) return { kind: "unavailable", reason: "forbidden" };
+  if (response.status === 404) return { kind: "unavailable", reason: "not_found" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const body = (await response.json().catch(() => null)) as {
+    check?: unknown;
+    status?: unknown;
+  } | null;
+  const check = toStorageVerifyCheck(body?.check);
+  const status = toWorkspaceStorageStatus(body?.status);
+  if (!check || !status) return { kind: "unavailable", reason: "server" };
+  return { kind: "ok", check, status };
 }
 
 export type StorageDetachResult =

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -236,10 +236,10 @@ describe("key safety + path building", () => {
 });
 
 describe("fileKind", () => {
-  it("maps images and videos, treats svg as unsupported, else file", () => {
+  it("maps images (including svg) and videos, else file", () => {
     expect(fileKind("image/png")).toBe("image");
     expect(fileKind("video/mp4")).toBe("video");
-    expect(fileKind("image/svg+xml")).toBe("unsupported");
+    expect(fileKind("image/svg+xml")).toBe("image");
     expect(fileKind("application/pdf")).toBe("file");
     expect(fileKind("video/quicktime")).toBe("video");
     expect(fileKind("text/plain")).toBe("file");

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -57,16 +57,22 @@ export type FileFetchResult =
   | { status: "unavailable" };
 
 /** How a file should be presented in the page's media stage. */
-export type MediaKind = "image" | "video" | "file" | "unsupported";
+export type MediaKind = "image" | "video" | "file";
 
-const imageTypes = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"]);
+const imageTypes = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "image/svg+xml",
+]);
 const videoTypes = new Set(["video/mp4", "video/webm", "video/quicktime"]);
 
-/** Classify a content type for rendering; SVG is unsupported per upload policy. */
+/** Classify a content type for rendering. SVG renders through `<img>` like any other image — never inline (#929). */
 export function fileKind(contentType: string): MediaKind {
   if (imageTypes.has(contentType)) return "image";
   if (videoTypes.has(contentType)) return "video";
-  if (contentType === "image/svg+xml") return "unsupported";
   return "file";
 }
 

--- a/apps/web/src/lib/public-gallery.ts
+++ b/apps/web/src/lib/public-gallery.ts
@@ -53,7 +53,7 @@ export type GalleryFetchResult =
   | { status: "not_found" }
   | { status: "unavailable" };
 
-export type MediaKind = "image" | "video" | "file" | "unsupported" | "missing";
+export type MediaKind = "image" | "video" | "file" | "missing";
 
 /** Gallery variant of `fileKind` (public-file.ts): one shared classifier plus tombstones. */
 export function mediaKind(item: PublicGalleryItem): MediaKind {

--- a/apps/web/src/lib/workspace-file-row.test.ts
+++ b/apps/web/src/lib/workspace-file-row.test.ts
@@ -54,14 +54,14 @@ describe("pickThumbnail", () => {
     ).toEqual({ kind: "none" });
   });
 
-  it("renders no tile for an unsupported image type (svg)", () => {
+  it("renders a real thumbnail for svg, same as any other image (#929)", () => {
     expect(
       pickThumbnail({
         contentType: "image/svg+xml",
         url: "https://s/x.svg",
         embedUrl: "https://e/x.svg",
       }),
-    ).toEqual({ kind: "none" });
+    ).toEqual({ kind: "image", src: "https://e/x.svg" });
   });
 
   it("treats a missing contentType as a plain file (no tile)", () => {

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -37,6 +37,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       <div id="storage-error" class="ul-callout" data-state="error" role="alert" hidden></div>
 
       <div id="storage-shared">
+        <!-- SVG/XML readiness of the hosted host (issue #929). Ops-owned:
+             a daily cron probes storage.uploads.sh and friends, so there is
+             no "Check now" here — that button lives on BYO lane cards
+             below, which each own their own host. -->
+        <p class="settings-note muted mb-3" id="storage-shared-active-content"></p>
+
         <!-- Empty state: shared `Empty` card shape (kept in sync with
              packages/ui/src/components/ui/empty.tsx, same convention as
              renderEmptyStateHtml in workspace-ui.ts), centered inside the
@@ -130,6 +136,29 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             </div>
           </div>
           <dl class="kv" id="storage-saved-details"></dl>
+          <details
+            class="storage-active-content max-w-[32rem] rounded-md border border-border px-4 py-2.5 text-[13px] mt-3"
+            id="storage-saved-active-content"
+          >
+            <summary class="cursor-pointer text-foreground font-medium">Serve SVG and XML</summary>
+            <p class="mt-2 mb-1 text-muted-foreground">
+              Set these headers on this bucket's public host, then check:
+            </p>
+            <pre
+              class="storage-active-content__headers rounded-md border border-border bg-muted/40 p-2.5 text-xs overflow-x-auto"><code>Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox
+X-Content-Type-Options: nosniff</code></pre>
+            <div class="storage-actions flex flex-wrap items-center gap-3 mt-2">
+              <button type="button" class="ul-btn" id="storage-saved-check-active-content-btn"
+                >Check now</button
+              >
+            </div>
+            <p
+              class="muted mt-2 data-[state=error]:text-destructive data-[state=ok]:text-success"
+              id="storage-saved-active-content-status"
+              role="status"
+            >
+            </p>
+          </details>
           <div
             class="storage-actions flex flex-wrap items-center gap-3 mt-3"
             id="storage-saved-actions"
@@ -231,6 +260,29 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         </div>
 
         <dl class="kv" id="storage-byo-details"></dl>
+        <details
+          class="storage-active-content max-w-[32rem] rounded-md border border-border px-4 py-2.5 text-[13px] mt-3"
+          id="storage-byo-active-content"
+        >
+          <summary class="cursor-pointer text-foreground font-medium">Serve SVG and XML</summary>
+          <p class="mt-2 mb-1 text-muted-foreground">
+            Set these headers on this bucket's public host, then check:
+          </p>
+          <pre
+            class="storage-active-content__headers rounded-md border border-border bg-muted/40 p-2.5 text-xs overflow-x-auto"><code>Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox
+X-Content-Type-Options: nosniff</code></pre>
+          <div class="storage-actions flex flex-wrap items-center gap-3 mt-2">
+            <button type="button" class="ul-btn" id="storage-byo-check-active-content-btn"
+              >Check now</button
+            >
+          </div>
+          <p
+            class="muted mt-2 data-[state=error]:text-destructive data-[state=ok]:text-success"
+            id="storage-byo-active-content-status"
+            role="status"
+          >
+          </p>
+        </details>
         <div
           class="storage-confirm max-w-[32rem] mt-3 flex flex-col gap-2.5 rounded-md border border-border px-4 py-3"
           id="storage-byo-confirm"
@@ -459,6 +511,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       getWorkspaceStorageStatus,
       listWorkspaceStorageBuckets,
       putWorkspaceStorage,
+      verifyLaneActiveContent,
       verifyWorkspaceStorage,
       type StorageCandidate,
       type StorageVerifyResult,
@@ -515,6 +568,28 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const storageSharedEl = requireElement<HTMLElement>("#storage-shared", page);
       const storageByoEl = requireElement<HTMLElement>("#storage-byo", page);
       const storageByoDetails = requireElement<HTMLElement>("#storage-byo-details", page);
+      // SVG/XML readiness (issue #929): the hosted-host row plus each BYO
+      // lane's own "Check now" details block.
+      const storageSharedActiveContent = requireElement<HTMLElement>(
+        "#storage-shared-active-content",
+        page,
+      );
+      const storageByoCheckActiveContentBtn = requireElement<HTMLButtonElement>(
+        "#storage-byo-check-active-content-btn",
+        page,
+      );
+      const storageByoActiveContentStatus = requireElement<HTMLElement>(
+        "#storage-byo-active-content-status",
+        page,
+      );
+      const storageSavedCheckActiveContentBtn = requireElement<HTMLButtonElement>(
+        "#storage-saved-check-active-content-btn",
+        page,
+      );
+      const storageSavedActiveContentStatus = requireElement<HTMLElement>(
+        "#storage-saved-active-content-status",
+        page,
+      );
       const storageConnectBtn = requireElement<HTMLButtonElement>("#storage-connect-btn", page);
       const storageIntro = requireElement<HTMLElement>("#storage-intro", page);
       const storageReplaceBtn = requireElement<HTMLButtonElement>("#storage-replace-btn", page);
@@ -675,11 +750,24 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       }
 
       /**
+       * "SVG & XML" row value (issue #929): the lane's last successful
+       * sandboxing-CSP check, or a nudge toward the header block + "Check
+       * now" button under the details panel.
+       */
+      function activeContentRowValue(verifiedAt: string | undefined): string {
+        if (verifiedAt) return escapeHtml(`Verified ${formatTimestamp(verifiedAt)}`);
+        return (
+          `<span class="ul-badge ul-badge--accent">Not verified</span> ` +
+          `<span class="storage-signed-only-note block mt-1 text-xs text-muted-foreground">set the headers below, then Check now.</span>`
+        );
+      }
+
+      /**
        * Shared row-list builder for the active-BYO and saved-lane detail
        * panels: same fields, same order (bucket → provider-specific id →
-       * access key → public URL → verified), just a different source object
-       * and an optional trailing jurisdiction row the saved-lane panel never
-       * shows.
+       * access key → public URL → verified → SVG & XML), just a different
+       * source object and an optional trailing jurisdiction row the
+       * saved-lane panel never shows.
        */
       function buildStorageRows(
         fields: Pick<
@@ -692,6 +780,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           | "accessKeyIdLast4"
           | "publicBaseUrl"
           | "verifiedAt"
+          | "activeContentVerifiedAt"
         >,
         jurisdiction?: string,
       ): [string, string][] {
@@ -709,6 +798,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         ]);
         rows.push(["Public base URL", publicBaseUrlRowValue(fields.publicBaseUrl)]);
         rows.push(["Verified", escapeHtml(formatTimestamp(fields.verifiedAt))]);
+        rows.push(["SVG & XML", activeContentRowValue(fields.activeContentVerifiedAt)]);
         if (!isS3 && jurisdiction) rows.push(["Jurisdiction", escapeHtml(jurisdiction)]);
         return rows;
       }
@@ -725,6 +815,19 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 
       function renderSavedDetails(lane: WorkspaceStorageLane): void {
         renderStorageRows(storageSavedDetails, buildStorageRows(lane));
+      }
+
+      /**
+       * The hosted host's own SVG/XML row (issue #929) — shown once at the
+       * top of `#storage-shared`, above whichever sub-state (empty intro or
+       * saved-lane card) is visible. `status.activeContentVerifiedAt` is
+       * already the hosted host's verdict here: `storageGetHandler`
+       * overlays it from the host record whenever the active lane is shared.
+       */
+      function renderSharedActiveContent(status: WorkspaceStorageStatus): void {
+        storageSharedActiveContent.innerHTML =
+          `<strong class="text-foreground">SVG &amp; XML:</strong> ` +
+          activeContentRowValue(status.activeContentVerifiedAt);
       }
 
       /**
@@ -1322,6 +1425,62 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         );
       });
 
+      /**
+       * "Check now" for the SVG/XML sandboxing-CSP probe (issue #929) — same
+       * shape on the active-BYO card and the saved (not-in-use) lane card,
+       * just a different `laneId` and status line. Re-applies the returned
+       * `status` on success (200 or the 422 rejections both carry a real
+       * `check`) so the new "SVG & XML" row updates immediately.
+       */
+      async function checkActiveContent(
+        laneId: string,
+        button: HTMLButtonElement,
+        statusEl: HTMLElement,
+      ): Promise<void> {
+        button.disabled = true;
+        statusEl.textContent = "Checking…";
+        statusEl.removeAttribute("data-state");
+        const result = await verifyLaneActiveContent(apiOrigin, workspaceName, laneId);
+        if (!stillHere()) return;
+        button.disabled = false;
+        if (result.kind === "ok") {
+          // `applyStatus` re-renders the "SVG & XML" row from the fresh
+          // status and clears this very status line (same reset every other
+          // action in this panel applies) — so the confirmation text below
+          // has to be set *after* it, not before.
+          applyStatus(result.status);
+          statusEl.textContent = result.check.ok
+            ? "Verified."
+            : (result.check.hint ?? "Not verified yet.");
+          statusEl.dataset.state = result.check.ok ? "ok" : "error";
+          return;
+        }
+        if (result.kind === "rejected") {
+          statusEl.textContent = result.check.hint ?? "Couldn’t check this lane.";
+          statusEl.dataset.state = "error";
+          return;
+        }
+        statusEl.textContent = "Couldn’t reach the server. Try again.";
+        statusEl.dataset.state = "error";
+      }
+
+      storageByoCheckActiveContentBtn.addEventListener("click", () => {
+        void checkActiveContent(
+          "active",
+          storageByoCheckActiveContentBtn,
+          storageByoActiveContentStatus,
+        );
+      });
+
+      storageSavedCheckActiveContentBtn.addEventListener("click", () => {
+        if (!savedLaneId) return;
+        void checkActiveContent(
+          savedLaneId,
+          storageSavedCheckActiveContentBtn,
+          storageSavedActiveContentStatus,
+        );
+      });
+
       storageDisconnectBtn.addEventListener("click", () => {
         void (async () => {
           if (sharedFallbackLaneId) {
@@ -1404,6 +1563,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         closeMenus();
         storageActionStatus.textContent = "";
         storageActionStatus.removeAttribute("data-state");
+        storageByoActiveContentStatus.textContent = "";
+        storageByoActiveContentStatus.removeAttribute("data-state");
+        storageSavedActiveContentStatus.textContent = "";
+        storageSavedActiveContentStatus.removeAttribute("data-state");
         storageSavedConfirm.hidden = true;
         storageByoConfirm.hidden = true;
         renderPreviousLine(status);
@@ -1424,6 +1587,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         } else {
           storageByoEl.hidden = true;
           storageSharedEl.hidden = false;
+          renderSharedActiveContent(status);
           const standby = status.lanes.find((lane) => lane.role === "standby");
           if (standby) {
             savedLaneId = standby.laneId;

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -15,6 +15,7 @@
  * sits inline at equal weight.
  */
 import WorkspaceLayout from "../../../../../layouts/WorkspaceLayout.astro";
+import ActiveContentDetails from "../../../../../components/settings/ActiveContentDetails.astro";
 import { isBrowseWorkspace } from "../../../../../lib/workspace-browse-url";
 
 export const prerender = false;
@@ -136,29 +137,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             </div>
           </div>
           <dl class="kv" id="storage-saved-details"></dl>
-          <details
-            class="storage-active-content max-w-[32rem] rounded-md border border-border px-4 py-2.5 text-[13px] mt-3"
-            id="storage-saved-active-content"
-          >
-            <summary class="cursor-pointer text-foreground font-medium">Serve SVG and XML</summary>
-            <p class="mt-2 mb-1 text-muted-foreground">
-              Set these headers on this bucket's public host, then check:
-            </p>
-            <pre
-              class="storage-active-content__headers rounded-md border border-border bg-muted/40 p-2.5 text-xs overflow-x-auto"><code>Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox
-X-Content-Type-Options: nosniff</code></pre>
-            <div class="storage-actions flex flex-wrap items-center gap-3 mt-2">
-              <button type="button" class="ul-btn" id="storage-saved-check-active-content-btn"
-                >Check now</button
-              >
-            </div>
-            <p
-              class="muted mt-2 data-[state=error]:text-destructive data-[state=ok]:text-success"
-              id="storage-saved-active-content-status"
-              role="status"
-            >
-            </p>
-          </details>
+          <ActiveContentDetails idPrefix="storage-saved" />
           <div
             class="storage-actions flex flex-wrap items-center gap-3 mt-3"
             id="storage-saved-actions"
@@ -260,29 +239,7 @@ X-Content-Type-Options: nosniff</code></pre>
         </div>
 
         <dl class="kv" id="storage-byo-details"></dl>
-        <details
-          class="storage-active-content max-w-[32rem] rounded-md border border-border px-4 py-2.5 text-[13px] mt-3"
-          id="storage-byo-active-content"
-        >
-          <summary class="cursor-pointer text-foreground font-medium">Serve SVG and XML</summary>
-          <p class="mt-2 mb-1 text-muted-foreground">
-            Set these headers on this bucket's public host, then check:
-          </p>
-          <pre
-            class="storage-active-content__headers rounded-md border border-border bg-muted/40 p-2.5 text-xs overflow-x-auto"><code>Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox
-X-Content-Type-Options: nosniff</code></pre>
-          <div class="storage-actions flex flex-wrap items-center gap-3 mt-2">
-            <button type="button" class="ul-btn" id="storage-byo-check-active-content-btn"
-              >Check now</button
-            >
-          </div>
-          <p
-            class="muted mt-2 data-[state=error]:text-destructive data-[state=ok]:text-success"
-            id="storage-byo-active-content-status"
-            role="status"
-          >
-          </p>
-        </details>
+        <ActiveContentDetails idPrefix="storage-byo" />
         <div
           class="storage-confirm max-w-[32rem] mt-3 flex flex-col gap-2.5 rounded-md border border-border px-4 py-3"
           id="storage-byo-confirm"
@@ -750,15 +707,41 @@ X-Content-Type-Options: nosniff</code></pre>
       }
 
       /**
-       * "SVG & XML" row value (issue #929): the lane's last successful
-       * sandboxing-CSP check, or a nudge toward the header block + "Check
-       * now" button under the details panel.
+       * Plain words for each reason the server can give for SVG/XML being off
+       * (`activeContentReason`, issue #929). Unrecognized values fall through
+       * to the generic "Not verified" line — a reason we can't phrase is
+       * worse than none.
        */
-      function activeContentRowValue(verifiedAt: string | undefined): string {
+      const ACTIVE_CONTENT_REASONS: Record<string, string> = {
+        opted_out: "turned off for this workspace",
+        flag_off: "not available yet",
+        unhealthy: "this bucket isn't working right now",
+        host_missing: "this host hasn't passed the check",
+        host_stale: "this host's last check has expired",
+        lane_missing: "not checked yet",
+        lane_stale: "the last check has expired",
+      };
+
+      /**
+       * "SVG & XML" row value (issue #929): the timestamp the gate is
+       * trusting, or "Not verified" with whatever the server said closed it
+       * (`reason`) and, on a lane the workspace can actually fix, a nudge
+       * toward the header block and "Check now" button below the row.
+       */
+      function activeContentRowValue(
+        verifiedAt: string | undefined,
+        opts: { reason?: string; nudge?: boolean } = {},
+      ): string {
         if (verifiedAt) return escapeHtml(`Verified ${formatTimestamp(verifiedAt)}`);
+        const why = opts.reason ? ACTIVE_CONTENT_REASONS[opts.reason] : undefined;
+        const note = [why, opts.nudge ? "set the headers below, then Check now." : undefined]
+          .filter(Boolean)
+          .join(" — ");
         return (
           `<span class="ul-badge ul-badge--accent">Not verified</span> ` +
-          `<span class="storage-signed-only-note block mt-1 text-xs text-muted-foreground">set the headers below, then Check now.</span>`
+          (note
+            ? `<span class="storage-signed-only-note block mt-1 text-xs text-muted-foreground">${escapeHtml(note)}</span>`
+            : "")
         );
       }
 
@@ -782,7 +765,7 @@ X-Content-Type-Options: nosniff</code></pre>
           | "verifiedAt"
           | "activeContentVerifiedAt"
         >,
-        jurisdiction?: string,
+        opts: { jurisdiction?: string; activeContentReason?: string } = {},
       ): [string, string][] {
         const isS3 = fields.provider === "s3";
         const rows: [string, string][] = [["Bucket", escapeHtml(fields.bucket ?? "—")]];
@@ -798,8 +781,14 @@ X-Content-Type-Options: nosniff</code></pre>
         ]);
         rows.push(["Public base URL", publicBaseUrlRowValue(fields.publicBaseUrl)]);
         rows.push(["Verified", escapeHtml(formatTimestamp(fields.verifiedAt))]);
-        rows.push(["SVG & XML", activeContentRowValue(fields.activeContentVerifiedAt)]);
-        if (!isS3 && jurisdiction) rows.push(["Jurisdiction", escapeHtml(jurisdiction)]);
+        rows.push([
+          "SVG & XML",
+          activeContentRowValue(fields.activeContentVerifiedAt, {
+            reason: opts.activeContentReason,
+            nudge: true,
+          }),
+        ]);
+        if (!isS3 && opts.jurisdiction) rows.push(["Jurisdiction", escapeHtml(opts.jurisdiction)]);
         return rows;
       }
 
@@ -810,9 +799,18 @@ X-Content-Type-Options: nosniff</code></pre>
       }
 
       function renderByoDetails(status: WorkspaceStorageStatus): void {
-        renderStorageRows(storageByoDetails, buildStorageRows(status, status.jurisdiction));
+        renderStorageRows(
+          storageByoDetails,
+          buildStorageRows(status, {
+            jurisdiction: status.jurisdiction,
+            activeContentReason: status.activeContentReason,
+          }),
+        );
       }
 
+      // A saved lane isn't the one serving anything, so there is no gate
+      // reason for it — only its own stamp's freshness, which the server
+      // already applied.
       function renderSavedDetails(lane: WorkspaceStorageLane): void {
         renderStorageRows(storageSavedDetails, buildStorageRows(lane));
       }
@@ -820,14 +818,17 @@ X-Content-Type-Options: nosniff</code></pre>
       /**
        * The hosted host's own SVG/XML row (issue #929) — shown once at the
        * top of `#storage-shared`, above whichever sub-state (empty intro or
-       * saved-lane card) is visible. `status.activeContentVerifiedAt` is
-       * already the hosted host's verdict here: `storageGetHandler`
-       * overlays it from the host record whenever the active lane is shared.
+       * saved-lane card) is visible. The fields come from the gate itself
+       * (`storageGetHandler`), so this row always matches what uploads
+       * actually do. No nudge: nobody in a workspace can set headers on a
+       * hosted host, and there is no "Check now" here to point at.
        */
       function renderSharedActiveContent(status: WorkspaceStorageStatus): void {
         storageSharedActiveContent.innerHTML =
           `<strong class="text-foreground">SVG &amp; XML:</strong> ` +
-          activeContentRowValue(status.activeContentVerifiedAt);
+          activeContentRowValue(status.activeContentVerifiedAt, {
+            reason: status.activeContentReason,
+          });
       }
 
       /**

--- a/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings/storage.astro
@@ -717,6 +717,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         flag_off: "not available yet",
         unhealthy: "this bucket isn't working right now",
         host_missing: "this host hasn't passed the check",
+        host_not_ok: "this host failed its last check",
         host_stale: "this host's last check has expired",
         lane_missing: "not checked yet",
         lane_stale: "the last check has expired",
@@ -781,11 +782,17 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         ]);
         rows.push(["Public base URL", publicBaseUrlRowValue(fields.publicBaseUrl)]);
         rows.push(["Verified", escapeHtml(formatTimestamp(fields.verifiedAt))]);
+        // No point nudging toward the header block and "Check now" button
+        // when the reason SVG/XML are off has nothing to do with this
+        // lane's headers — the workspace opted out, or the feature itself
+        // is off (issue #929 review).
+        const nudge =
+          opts.activeContentReason !== "flag_off" && opts.activeContentReason !== "opted_out";
         rows.push([
           "SVG & XML",
           activeContentRowValue(fields.activeContentVerifiedAt, {
             reason: opts.activeContentReason,
-            nudge: true,
+            nudge,
           }),
         ]);
         if (!isS3 && opts.jurisdiction) rows.push(["Jurisdiction", escapeHtml(opts.jurisdiction)]);

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -558,11 +558,9 @@ const ogImage = file
               compare={compare}
             >
               <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
-                {kind(file.contentType) !== "unsupported" && (
-                  <a class="original" href={file.url} rel="noopener noreferrer">
-                    Open original ↗
-                  </a>
-                )}
+                <a class="original" href={file.url} rel="noopener noreferrer">
+                  Open original ↗
+                </a>
               </CopyAsControls>
               {railRows && (
                 <div>

--- a/apps/web/src/pages/g/[id].astro
+++ b/apps/web/src/pages/g/[id].astro
@@ -326,13 +326,6 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
                             filename={item.filename}
                           />
                         )}
-                        {mediaKind === "unsupported" && (
-                          <MediaFallback
-                            compact
-                            title="Unsupported media type"
-                            body="This item cannot be opened inline."
-                          />
-                        )}
                         {mediaKind === "missing" && (
                           <MediaFallback
                             compact
@@ -347,7 +340,7 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
                         <a class="original" href={itemPage(item)}>
                           View page
                         </a>
-                        {item.status === "available" && mediaKind !== "unsupported" && (
+                        {item.status === "available" && (
                           <a class="original" href={item.url!} rel="noopener noreferrer">
                             Open original
                           </a>

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -333,7 +333,7 @@ const footnoteLine = footnoteParts.join(" · ");
               {item.caption && <div class="caption">{item.caption}</div>}
               {item.status === "available" && (
                 <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
-                  {kind(item) !== "unsupported" && item.url && (
+                  {item.url && (
                     <a class="original" href={item.url} rel="noopener noreferrer">
                       Open original ↗
                     </a>

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -81,16 +81,38 @@ checks, `apps/api/src/active-content-hosts.ts` is the hosted-lane half below.
 `embed.uploads.sh`):**
 
 1. Rules → Transform Rules → Modify Response Header:
-   - When:
+   - When — **validate this expression in the rule editor before relying on
+     it**; the editor's own syntax check catches an unescaped `+` or a plan
+     that can't evaluate it before the rule ever ships:
      ```
-     (http.host in {"storage.uploads.sh" "store.uploads.sh" "embed.uploads.sh"}) and (any(http.response.headers["content-type"][*] matches "^(image/svg\+xml|application/xml|text/xml)"))
+     (http.host in {"storage.uploads.sh" "store.uploads.sh" "embed.uploads.sh"}) and (any(http.response.headers["content-type"][*] matches "^(image/svg\\+xml|application/xml|text/xml)"))
+     ```
+     The `\+` is written `\\+` here because the Rules language, like most
+     expression languages, needs its own escape character escaped inside a
+     double-quoted string — a lone `\+` is a syntax error in the editor.
+     `matches` (regex) on response headers needs a Cloudflare plan with
+     regex support in Transform Rules; if the zone doesn't have one, use this
+     equivalent expression instead, which needs no regex:
+     ```
+     (http.host in {"storage.uploads.sh" "store.uploads.sh" "embed.uploads.sh"}) and (any(http.response.headers["content-type"][*] eq "image/svg+xml") or any(http.response.headers["content-type"][*] eq "application/xml") or any(http.response.headers["content-type"][*] eq "text/xml"))
      ```
    - Set:
      - `Content-Security-Policy` =
        `default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox`
      - `X-Content-Type-Options` = `nosniff`
-2. Confirm it worked — run the on-demand probe (below) and check the KV
-   record it writes.
+2. Confirm it worked:
+   ```bash
+   curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+     https://api.uploads.sh/admin/active-content/probe
+   ```
+   Check the response: all three hosts (`storage.uploads.sh`,
+   `store.uploads.sh`, `embed.uploads.sh`) must read `ok: true`. Then spot-check
+   the headers directly against a real `.svg` on each host:
+   ```bash
+   curl -I https://storage.uploads.sh/<workspace-prefix>/<some-key>.svg
+   curl -I https://store.uploads.sh/<workspace-prefix>/<some-key>.svg
+   curl -I https://embed.uploads.sh/<workspace-prefix>/<some-key>.svg
+   ```
 
 **Daily sweep:** the Worker's `scheduled` handler (`0 6 * * *`, `index.ts`)
 calls `runActiveContentHostSweep` for every hosted host, writing
@@ -100,11 +122,13 @@ as untrusted — one missed cron tick doesn't flip every workspace on that
 host off, but a genuinely broken Transform Rule closes the gate within two
 days.
 
-**On-demand probe:** `POST /admin-ui/active-content/probe` (session,
-global admin — reachable from the `/admin` panel) runs the same sweep
-immediately, so a just-applied Transform Rule can be confirmed without
-waiting for the next cron tick. Returns the fresh per-host records; each is
-also persisted to `REGISTRY`, same as the cron.
+**On-demand probe:** two equivalent routes run the same sweep immediately, so
+a just-applied Transform Rule can be confirmed without waiting for the next
+cron tick — both return the fresh per-host records, each also persisted to
+`REGISTRY`, same as the cron: `POST /admin-ui/active-content/probe` (session,
+global admin — reachable from the `/admin` panel) for a logged-in operator,
+and `POST /admin/active-content/probe` (the `curl` above — `ADMIN_TOKEN` or
+an `operator:write` scoped token) for scripted/CI use.
 
 **Kill switch:** Flagship flag `active-content-uploads`, same app as
 `video-poster-generation` above:

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -66,6 +66,61 @@ attachments comment prefer `embedUrl` for `<img src>`.
 
 No Worker proxies image bytes — dual host is DNS + zone rules only.
 
+## SVG and XML on the hosted hosts (issue #929)
+
+SVG and XML (`image/svg+xml`, `application/xml`, `text/xml`) are gated
+uploads: a lane only accepts them once its public host is **verified** to
+serve them behind a sandboxing Content-Security-Policy — these are bare R2
+custom domains with no Worker in front, so a malicious SVG's script would
+otherwise run with an origin. See
+`docs/superpowers/specs/2026-09-02-svg-xml-active-content-design.md` for the
+full design; `apps/api/src/active-content.ts` is the gate every write path
+checks, `apps/api/src/active-content-hosts.ts` is the hosted-lane half below.
+
+**Setup (once per hosted host — `storage.uploads.sh`, `store.uploads.sh`,
+`embed.uploads.sh`):**
+
+1. Rules → Transform Rules → Modify Response Header:
+   - When:
+     ```
+     (http.host in {"storage.uploads.sh" "store.uploads.sh" "embed.uploads.sh"}) and (any(http.response.headers["content-type"][*] matches "^(image/svg\+xml|application/xml|text/xml)"))
+     ```
+   - Set:
+     - `Content-Security-Policy` =
+       `default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox`
+     - `X-Content-Type-Options` = `nosniff`
+2. Confirm it worked — run the on-demand probe (below) and check the KV
+   record it writes.
+
+**Daily sweep:** the Worker's `scheduled` handler (`0 6 * * *`, `index.ts`)
+calls `runActiveContentHostSweep` for every hosted host, writing
+`host-active-content:<host>` to `REGISTRY` as `{ ok, verifiedAt, detail? }`.
+`activeContentAllowed` (`active-content.ts`) treats a record older than 48h
+as untrusted — one missed cron tick doesn't flip every workspace on that
+host off, but a genuinely broken Transform Rule closes the gate within two
+days.
+
+**On-demand probe:** `POST /admin-ui/active-content/probe` (session,
+global admin — reachable from the `/admin` panel) runs the same sweep
+immediately, so a just-applied Transform Rule can be confirmed without
+waiting for the next cron tick. Returns the fresh per-host records; each is
+also persisted to `REGISTRY`, same as the cron.
+
+**Kill switch:** Flagship flag `active-content-uploads`, same app as
+`video-poster-generation` above:
+
+```bash
+wrangler flagship flags update 8371bfe7-9767-4b4d-b75a-37b94d2724f7 \
+  active-content-uploads --default off
+```
+
+Fails closed like the poster flag — a missing binding, a disabled flag, or a
+thrown evaluation are all indistinguishable from "off"
+(`activeContentAllowed`). A BYO lane's own verification is unaffected by
+this Transform Rule: its owner sets the headers on their own host, and its
+`storageActiveContentVerifiedAt` stamp comes from the lane-verify pipeline
+or the settings page's "Check now" button, never this sweep.
+
 ## Cloudflare error pages
 
 Errors Cloudflare produces itself never reach `apps/web`, so the Astro

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -100,27 +100,51 @@ checks, `apps/api/src/active-content-hosts.ts` is the hosted-lane half below.
      - `Content-Security-Policy` =
        `default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox`
      - `X-Content-Type-Options` = `nosniff`
+
+   Set exactly **one** `Content-Security-Policy` header. Two CSP response
+   headers are legal CSP, but `Headers.get` joins repeated headers with a
+   comma and the probe (`parseSandboxCsp`) splits directives on `;` only — so
+   a policy split across two headers fails the check.
+
+   The rule must cover **XML as well as SVG**. The expression above already
+   lists `application/xml` and `text/xml`; an extension-scoped variant
+   (`ends_with ".svg"`) would pass an SVG-only probe while leaving XML
+   documents free to run script through an `<?xml-stylesheet>` XSLT. The
+   probe writes both an SVG and an XML object and requires both to come back
+   sandboxed, so a rule that misses XML now fails outright.
+
 2. Confirm it worked:
    ```bash
    curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
      https://api.uploads.sh/admin/active-content/probe
    ```
    Check the response: all three hosts (`storage.uploads.sh`,
-   `store.uploads.sh`, `embed.uploads.sh`) must read `ok: true`. Then spot-check
-   the headers directly against a real `.svg` on each host:
+   `store.uploads.sh`, `embed.uploads.sh`) must read `ok: true`. **Every one of
+   them**, not just the one a given workspace's URLs name — `storage.` and
+   `store.uploads.sh` are two custom domains of the same bucket (same keys,
+   same bytes), so the gate closes for every shared-lane workspace as soon as
+   any hosted host's record is missing, failing, or stale. Then spot-check the
+   headers directly against a real `.svg` and a real `.xml` on each host:
    ```bash
    curl -I https://storage.uploads.sh/<workspace-prefix>/<some-key>.svg
    curl -I https://store.uploads.sh/<workspace-prefix>/<some-key>.svg
    curl -I https://embed.uploads.sh/<workspace-prefix>/<some-key>.svg
+   curl -I https://storage.uploads.sh/<workspace-prefix>/<some-key>.xml
    ```
 
 **Daily sweep:** the Worker's `scheduled` handler (`0 6 * * *`, `index.ts`)
 calls `runActiveContentHostSweep` for every hosted host, writing
 `host-active-content:<host>` to `REGISTRY` as `{ ok, verifiedAt, detail? }`.
-`activeContentAllowed` (`active-content.ts`) treats a record older than 48h
-as untrusted — one missed cron tick doesn't flip every workspace on that
-host off, but a genuinely broken Transform Rule closes the gate within two
-days.
+Each probe writes an inert SVG _and_ an inert XML object under
+`_internal/uploads-verify/`, fetches both back through the host, and deletes
+them; the record is `ok` only when both pass. `activeContentAllowed`
+(`active-content.ts`) treats a record older than 48h as untrusted — one
+missed cron tick doesn't flip every workspace on that host off, but a
+genuinely broken Transform Rule closes the gate within two days.
+
+The same `scheduled` handler's retention sweep also reaps any
+`_internal/uploads-verify/` object older than 24h from the shared bucket, so
+a probe whose own cleanup failed can't accumulate.
 
 **On-demand probe:** two equivalent routes run the same sweep immediately, so
 a just-applied Transform Rule can be confirmed without waiting for the next

--- a/docs/superpowers/plans/2026-09-02-svg-xml-active-content.md
+++ b/docs/superpowers/plans/2026-09-02-svg-xml-active-content.md
@@ -1,0 +1,355 @@
+# SVG/XML active content Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Accept `image/svg+xml`, `application/xml`, and `text/xml` uploads on a storage lane only while that lane's public host is verified to serve them with a sandboxing CSP and `nosniff`.
+
+**Architecture:** One probe (`checkActiveContentHeaders`) verifies a public host. It runs inside the existing BYO lane verify and stamps the lane; a daily cron runs it against the hosted hosts and stamps a KV host record. `activeContentAllowed(env, ws)` combines a fail-closed Flagship flag, a workspace opt-out, and the lane stamp. `resolveUploadPolicy` strips gated rows from every allowlist (including overrides) unless the gate passes. The three types are declared-only rows with their own plausibility predicate plus a reputation pre-filter; the CSP is the control.
+
+**Tech Stack:** TypeScript, Hono on Cloudflare Workers, KV (`REGISTRY`), Flagship (`FLAGS`), vitest, Astro settings page.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-svg-xml-active-content-design.md`
+
+## Global Constraints
+
+- Branch `claude/issue-929-svg-xml` in worktree `/Users/zachdunn/Code/uploads/.claude/worktrees/svg-xml-929`, stacked on `claude/issue-925-planning-13dccd` (PR #928). Do not rebase onto main until #928 merges.
+- Gated types, exactly: `image/svg+xml`, `application/xml`, `text/xml`. HTML stays out.
+- Probe acceptance: CSP has a `sandbox` directive with neither `allow-scripts` nor `allow-same-origin`; `X-Content-Type-Options: nosniff` present; response `Content-Type` starts with `image/svg+xml`. Fetch uses `redirect: "manual"` and the existing 5 s timeout; a thrown fetch is `inconclusive` and never enables.
+- Freshness: hosted host record ≤ 48 h; BYO lane stamp ≤ 30 days and no `storageUnhealthyAt`.
+- Flag name `active-content-uploads`, fail-closed exactly like `POSTER_FLAG`.
+- Gated types are declared-only (never sniffed). A `.log` starting with `<?xml` stays `text/plain`.
+- Every `resolveUploadPolicy` caller passes the gate result; an `allowedContentTypes` override cannot bypass it.
+- Probe objects live under `_internal/uploads-csp-verify/` and are deleted in `finally`.
+- Commit messages: no attribution lines. `pnpm run check` before each commit; the hook runs `pnpm types`.
+
+---
+
+### Task 1: CSP parser and the header probe
+
+**Files:**
+
+- Modify: `apps/api/src/storage-verify.ts` (new exports after `checkEmbedCache`; wire into `verifyStorageConfig` after the public-url branch)
+- Test: `apps/api/src/storage-verify.test.ts` (find the existing test file for this module; if it is under `apps/api/test/`, add there)
+
+**Interfaces:**
+
+- Produces: `parseSandboxCsp(header: string | null): { ok: boolean; reason?: string }`, `ACTIVE_CONTENT_PROBE_SVG: Uint8Array`, `checkActiveContentHeaders(publicBaseUrl: string, probeKey: string, fetchImpl: typeof fetch): Promise<StorageVerifyCheck>` with `id: "active-content-headers"`, `required: false`. `StorageVerifyCheck.id` doc comment lists the new id.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("parseSandboxCsp", () => {
+  it("accepts the recommended policy, extra directives, and bare sandbox", () => {
+    expect(
+      parseSandboxCsp("default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox").ok,
+    ).toBe(true);
+    expect(parseSandboxCsp("sandbox; frame-ancestors 'none'").ok).toBe(true);
+    expect(parseSandboxCsp("sandbox").ok).toBe(true);
+    expect(parseSandboxCsp("SANDBOX allow-forms").ok).toBe(true);
+  });
+  it("rejects a missing header, a policy without sandbox, or a sandbox that re-enables script or origin", () => {
+    expect(parseSandboxCsp(null)).toMatchObject({ ok: false });
+    expect(parseSandboxCsp("default-src 'none'")).toMatchObject({ ok: false });
+    expect(parseSandboxCsp("sandbox allow-scripts")).toMatchObject({ ok: false });
+    expect(parseSandboxCsp("sandbox allow-same-origin allow-forms")).toMatchObject({ ok: false });
+  });
+});
+
+describe("checkActiveContentHeaders", () => {
+  const good = () =>
+    new Response(ACTIVE_CONTENT_PROBE_SVG, {
+      status: 200,
+      headers: {
+        "content-type": "image/svg+xml",
+        "content-security-policy": "default-src 'none'; sandbox",
+        "x-content-type-options": "nosniff",
+      },
+    });
+  it("passes when type, csp, and nosniff are all right", async () => {
+    const check = await checkActiveContentHeaders(
+      "https://cdn.example",
+      "_internal/x.svg",
+      async () => good(),
+    );
+    expect(check).toEqual({ id: "active-content-headers", ok: true, required: false });
+  });
+  it("fails on a rewritten content type, a missing csp, or a missing nosniff, naming the header", async () => {
+    const without = (h: string) => async () => {
+      const res = good();
+      const headers = new Headers(res.headers);
+      headers.delete(h);
+      return new Response(ACTIVE_CONTENT_PROBE_SVG, { status: 200, headers });
+    };
+    for (const h of ["content-security-policy", "x-content-type-options"]) {
+      const check = await checkActiveContentHeaders("https://cdn.example", "k.svg", without(h));
+      expect(check.ok).toBe(false);
+      expect(check.hint).toContain(h);
+    }
+    const typed = await checkActiveContentHeaders(
+      "https://cdn.example",
+      "k.svg",
+      async () =>
+        new Response("x", {
+          status: 200,
+          headers: {
+            "content-type": "text/plain",
+            "content-security-policy": "sandbox",
+            "x-content-type-options": "nosniff",
+          },
+        }),
+    );
+    expect(typed.ok).toBe(false);
+  });
+  it("is inconclusive when the fetch throws", async () => {
+    const check = await checkActiveContentHeaders("https://cdn.example", "k.svg", async () => {
+      throw new Error("boom");
+    });
+    expect(check).toMatchObject({ ok: false, inconclusive: true });
+  });
+});
+```
+
+Also assert in the existing `verifyStorageConfig` tests that a candidate whose public-url check passes now carries an `active-content-headers` check (ok or not), and one whose public-url fails does not.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @uploads/api test storage-verify`
+
+- [ ] **Step 3: Implement**
+
+```ts
+/** A 1×1 inert SVG; what the active-content probe writes and fetches. */
+export const ACTIVE_CONTENT_PROBE_SVG = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1"/></svg>',
+);
+
+/**
+ * Does a Content-Security-Policy sandbox the document? The `sandbox`
+ * directive puts the document in an opaque origin with script disabled;
+ * `allow-scripts` and `allow-same-origin` each undo the part we rely on.
+ * Any other directives are the host owner's business.
+ */
+export function parseSandboxCsp(header: string | null): { ok: boolean; reason?: string } {
+  if (!header) return { ok: false, reason: "missing Content-Security-Policy" };
+  const sandbox = header
+    .split(";")
+    .map((d) => d.trim().toLowerCase())
+    .find((d) => d === "sandbox" || d.startsWith("sandbox "));
+  if (!sandbox) return { ok: false, reason: "Content-Security-Policy has no sandbox directive" };
+  const tokens = new Set(sandbox.split(/\s+/).slice(1));
+  if (tokens.has("allow-scripts")) return { ok: false, reason: "sandbox allows scripts" };
+  if (tokens.has("allow-same-origin")) return { ok: false, reason: "sandbox allows same-origin" };
+  return { ok: true };
+}
+
+const ACTIVE_CONTENT_HINT =
+  "serve SVG/XML with `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox` and `X-Content-Type-Options: nosniff` on this host, then check again";
+
+/** Recommended check: the public host serves SVG sandboxed. Never required; gates SVG/XML acceptance per lane. */
+export async function checkActiveContentHeaders(
+  publicBaseUrl: string,
+  probeKey: string,
+  fetchImpl: typeof fetch,
+): Promise<StorageVerifyCheck> {
+  const id = "active-content-headers";
+  const url = `${publicBaseUrl.replace(/\/$/, "")}/${probeKey}`;
+  try {
+    const res = await fetchImpl(url, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(PUBLIC_URL_PROBE_TIMEOUT_MS),
+    });
+    if (!res.ok)
+      return {
+        id,
+        ok: false,
+        required: false,
+        hint: `fetching the SVG probe returned HTTP ${res.status} — ${ACTIVE_CONTENT_HINT}`,
+      };
+    const type = (res.headers.get("content-type") ?? "").toLowerCase();
+    if (!type.startsWith("image/svg+xml"))
+      return {
+        id,
+        ok: false,
+        required: false,
+        hint: `the host served the SVG probe as ${type || "no content-type"} instead of image/svg+xml — ${ACTIVE_CONTENT_HINT}`,
+      };
+    const csp = parseSandboxCsp(res.headers.get("content-security-policy"));
+    if (!csp.ok)
+      return {
+        id,
+        ok: false,
+        required: false,
+        hint: `${csp.reason} (content-security-policy) — ${ACTIVE_CONTENT_HINT}`,
+      };
+    if ((res.headers.get("x-content-type-options") ?? "").toLowerCase() !== "nosniff")
+      return {
+        id,
+        ok: false,
+        required: false,
+        hint: `missing x-content-type-options: nosniff — ${ACTIVE_CONTENT_HINT}`,
+      };
+    return { id, ok: true, required: false };
+  } catch {
+    return {
+      id,
+      ok: false,
+      required: false,
+      inconclusive: true,
+      hint: "we couldn't fetch the SVG probe from here (Cloudflare-fronted domains are often unreachable as a server-side request); SVG/XML stay off for this lane until a check succeeds",
+    };
+  }
+}
+```
+
+Wire-up in `verifyStorageConfig`: inside the round-trip `try`, after `publicUrlCheck` is set and `ok`, upload `ACTIVE_CONTENT_PROBE_SVG` to `${PROBE_PREFIX}${crypto.randomUUID()}.svg` with `contentType: "image/svg+xml"`, run `checkActiveContentHeaders`, store the result, delete the SVG probe in the same `finally` (best-effort). Push the check right after the `embed-cache` check.
+
+- [ ] **Step 4: Run to verify pass**, then `pnpm run check`.
+- [ ] **Step 5: Commit** — `feat(api): probe a public host for a sandboxing CSP on SVG`
+
+### Task 2: Lane and workspace state
+
+**Files:**
+
+- Modify: `apps/api/src/workspace.ts` (`StorageLane.activeContentVerifiedAt?`, `WorkspaceRecord.storageActiveContentVerifiedAt?`, `WorkspaceRecord.activeContentUploads?: boolean` with a doc comment mirroring `videoPosterEnabled`)
+- Modify: `apps/api/src/workspace-lanes.ts` (`demoteActiveLane` copies `storageActiveContentVerifiedAt` → `activeContentVerifiedAt`; `promoteLane` takes it back; `PromotableLane` type if needed)
+- Modify: `apps/api/src/routes/workspace-settings.ts` (`storagePutHandler`: set `lane.activeContentVerifiedAt = nowIso` when the verify result has `active-content-headers` ok, else leave unset; `storageActivateHandler`: when re-verify ran, derive the stamp the same way and pass it to `promoteLane`; when it did not run, carry `target.activeContentVerifiedAt`)
+- Modify: `apps/api/src/routes/workspace-storage.ts` (`StorageLaneStatus.activeContentVerifiedAt?`, active-lane status field of the same name in `storageStatusResponse`)
+- Test: `apps/api/src/workspace-lanes.test.ts`, the storage settings route tests
+
+**Interfaces:**
+
+- Produces: `activeContentStampFromVerify(result: StorageVerifyResult, nowIso: string): string | undefined` exported from `workspace-storage.ts` (ok check → `nowIso`, else `undefined`).
+
+- [ ] Steps: tests for demote/promote round-trip of the stamp; PUT saves the stamp only when the check passed; activate carries or refreshes it; status response exposes it. Implement, run `pnpm --filter @uploads/api test workspace-lanes workspace-settings workspace-storage`, commit `feat(api): stamp lanes with the active-content verification`.
+
+### Task 3: Hosted host sweep and admin probe
+
+**Files:**
+
+- Create: `apps/api/src/active-content-hosts.ts`
+- Modify: `apps/api/src/index.ts` (`scheduled`: one more `ctx.waitUntil(runActiveContentHostSweep(env).catch(...))` logging `active_content_sweep_failed`)
+- Modify: `apps/api/src/routes/admin-ui.ts` (`.post("/active-content/probe", ...)` → runs the sweep, returns the host records)
+- Test: `apps/api/src/active-content-hosts.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export interface HostActiveContentRecord {
+  ok: boolean;
+  verifiedAt: string;
+  detail?: string;
+}
+export function hostActiveContentKey(host: string): string; // `host-active-content:${host}`
+export const HOSTED_ACTIVE_CONTENT_HOSTS: readonly string[]; // ["storage.uploads.sh", "store.uploads.sh", "embed.uploads.sh"], overridable via env for self-host (read EMBED_PUBLIC_BASE_URL / the self-serve default publicBaseUrl if present)
+export async function probeHostActiveContent(
+  env: Env,
+  host: string,
+  fetchImpl?: typeof fetch,
+): Promise<HostActiveContentRecord>;
+export async function runActiveContentHostSweep(
+  env: Env,
+  fetchImpl?: typeof fetch,
+): Promise<Record<string, HostActiveContentRecord>>;
+export async function readHostActiveContent(
+  env: Env,
+  host: string,
+): Promise<HostActiveContentRecord | null>;
+```
+
+- `probeHostActiveContent` writes `ACTIVE_CONTENT_PROBE_SVG` to `env.UPLOADS_DEFAULT` at `_internal/uploads-csp-verify/<uuid>.svg` with `httpMetadata: { contentType: "image/svg+xml" }`, calls `checkActiveContentHeaders(`https://${host}`, key, fetchImpl)`, deletes the object in `finally`, and `REGISTRY.put`s the record (no TTL; freshness is judged by the reader).
+
+- [ ] Steps: tests with a fake `UPLOADS_DEFAULT` (put/delete spy) and fake `REGISTRY`; ok and failing probes both write a record; the sweep covers every host and never throws for one host's failure. Commit `feat(api): probe the hosted storage hosts for the SVG sandbox headers daily`.
+
+### Task 4: The gate
+
+**Files:**
+
+- Create: `apps/api/src/active-content.ts`
+- Test: `apps/api/src/active-content.test.ts` (model on `poster-gate.test.ts`)
+
+```ts
+export const ACTIVE_CONTENT_FLAG = "active-content-uploads";
+export const HOST_RECORD_MAX_AGE_MS = 48 * 60 * 60 * 1000;
+export const LANE_STAMP_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export async function activeContentAllowed(
+  env: Env,
+  ws: WorkspaceRecord,
+  now = new Date(),
+): Promise<boolean> {
+  if (ws.activeContentUploads === false) return false;
+  if (!env.FLAGS) return false;
+  try {
+    if (!(await env.FLAGS.getBooleanValue(ACTIVE_CONTENT_FLAG, false))) return false;
+  } catch {
+    return false;
+  }
+  if (ws.storageUnhealthyAt) return false;
+  if (isSharedLane(ws)) {
+    const host = hostOf(ws.publicBaseUrl);
+    if (!host) return false;
+    const record = await readHostActiveContent(env, host);
+    return !!record && record.ok && fresh(record.verifiedAt, HOST_RECORD_MAX_AGE_MS, now);
+  }
+  return fresh(ws.storageActiveContentVerifiedAt, LANE_STAMP_MAX_AGE_MS, now);
+}
+```
+
+- [ ] Steps: tests for opt-out, missing flag, flag off, thrown flag, unhealthy, shared fresh/stale/missing/not-ok, BYO fresh/stale/missing. Commit `feat(api): activeContentAllowed gate`.
+
+### Task 5: Guards, pre-filter, and caller wiring
+
+**Files:**
+
+- Modify: `apps/api/src/guards.ts`
+- Modify: `apps/api/src/files-core.ts` (`putObject`: `const policy = resolveUploadPolicy(ws, { activeContent: await activeContentAllowed(env, ws) })`)
+- Modify: `apps/api/src/routes/files-shared-handlers.ts` (presign + PUT: same)
+- Modify: `apps/api/src/github-ingest.ts`, `apps/mcp/src/tools.ts` (ceiling only; pass `{ activeContent: false }` there since the ceiling does not depend on it)
+- Test: `apps/api/test/guards.test.ts`, `apps/api/test/routes-files.test.ts`
+
+**Interfaces:**
+
+- `UploadTypeRow` gains `gate?: "active-content"` and `plausible?: (bytes: Uint8Array) => boolean` (declared rows only; text rows use `looksLikeText`).
+- `resolveUploadPolicy(record, opts: { activeContent: boolean })` — second argument required so no caller forgets it.
+- `export function containsActiveMarkup(text: string): boolean` — `/<script|\bon[a-z]+\s*=|javascript:|<foreignobject|<\?xml-stylesheet/i`.
+- `export function looksLikeSvg(bytes: Uint8Array): boolean` — `looksLikeText` and, in the first 4 KiB decoded, after stripping a BOM, `<?xml … ?>`, `<!-- … -->`, and `<!DOCTYPE …>` prefixes, the text starts with `<svg`.
+- `export function looksLikeXml(bytes: Uint8Array): boolean` — `looksLikeText` and first non-whitespace char is `<`.
+- SVG/XML rows' `plausible` = the above AND `!containsActiveMarkup(decodedHead)` where the decoded text is the whole body (they are small; `maxBytes` still applies).
+- `DEFAULT_ALLOWED_CONTENT_TYPES` stays the ungated list (so existing tests and docs are unchanged); add `GATED_CONTENT_TYPES`.
+
+- [ ] Tests: gated rows absent by default; present with `activeContent: true`; an override `["image/png","image/svg+xml"]` yields only png without the gate; `inspectUpload` with declared `image/svg+xml`: inert SVG ok (with and without prolog/comment), SVG with `<script>` 415, `<html>` 415, PNG bytes declared svg → stored png; declared `application/xml` with `<?xml…` ok; `.log` key + `<?xml` body + declared text/plain → text/plain; route test: PUT `.svg` 415 on an unverified workspace, 201 with `FLAGS` on + fake host record fresh; presign `image/svg+xml` mirrors that.
+- [ ] Commit `feat(api): accept SVG and XML only on lanes verified for active content`.
+
+### Task 6: On-demand lane check route
+
+**Files:**
+
+- Modify: `apps/api/src/routes/workspace-settings.ts` — `.post("/:workspace/storage/lanes/:laneId/verify-active-content", sessionAdminGate(), ...)`; `laneId` may be the active lane's `storageLaneId` or the literal `active`. Runs only the probe (upload SVG probe through the lane's storage client, `checkActiveContentHeaders`, delete), then `mutateWorkspaceRecord` to set or clear the stamp, returns `{ check, status }`. Rate-limited with `allowWrite`.
+- Test: route test for ok (stamp set), fail (stamp cleared), inconclusive (stamp unchanged).
+- [ ] Commit `feat(api): on-demand active-content check per lane`.
+
+### Task 7: Web
+
+**Files:**
+
+- Modify: `apps/web/src/lib/public-file.ts` (`fileKind("image/svg+xml") → "image"`; remove `unsupported` from `MediaKind` if nothing else produces it — grep `public-gallery.ts` and `MediaStage.astro`), `apps/web/src/components/MediaStage.astro` (drop the branch), tests.
+- Modify: `apps/web/src/lib/api-client.ts` — `verifyLaneActiveContent(apiOrigin, workspace, laneId)` next to `activateWorkspaceStorage`.
+- Modify: `apps/web/src/pages/account/workspaces/[name]/settings/storage.astro` — in `buildStorageRows`, add a row `["SVG & XML", …]` reading `activeContentVerifiedAt`: "Verified <date>" or "Not verified — set the headers below"; under the BYO lane card a small `<details>` with the two header lines and a "Check now" button wired like the activate button but calling the new client function and re-applying status. The hosted lane row reads the same field from the status response (the API fills it from the host record for shared lanes).
+- [ ] Commit `feat(web): show and re-check SVG/XML readiness per storage lane`.
+
+### Task 8: CLI, docs, ops
+
+**Files:**
+
+- `packages/comment-render/src/index.ts` map: `xml: "application/xml"`; regenerate; `.changeset/svg-xml-active-content.md` (`"@buildinternet/uploads": minor`).
+- `docs/ops.md`: new subsection "SVG and XML on the hosted hosts" with the Transform Rule: When `(http.host in {"storage.uploads.sh" "store.uploads.sh" "embed.uploads.sh"}) and (any(http.response.headers["content-type"][*] matches "^(image/svg\\+xml|application/xml|text/xml)"))` → set `Content-Security-Policy` and `X-Content-Type-Options`; the daily sweep and `POST /admin/active-content/probe`; the flag name.
+- `apps/web/src/content/docs/byo-bucket.mdx`: "### 5. Optional: serve SVG and XML" with the header values, the check-now button, and the 30-day re-check.
+- `apps/web/src/content/docs/limits.mdx`: SVG/XML "on lanes verified for sandboxed serving".
+- [ ] Commit `docs: SVG and XML behind a verified sandboxing CSP`.
+
+### Task 9: Verification and PR
+
+- `pnpm run check && pnpm types && pnpm test`.
+- Open a PR against `claude/issue-925-planning-13dccd` marked draft until #928 merges, then rebase onto main and retarget. Body: link #929, list the decisions, and the prod checklist from the spec's Testing section.

--- a/docs/superpowers/specs/2026-09-02-svg-xml-active-content-design.md
+++ b/docs/superpowers/specs/2026-09-02-svg-xml-active-content-design.md
@@ -70,7 +70,10 @@ override too, so an override can no longer smuggle SVG onto an unverified lane. 
 
 A reputation pre-filter `containsActiveMarkup(text)` rejects SVG/XML bodies containing
 `<script`, `on[a-z]+\s*=`, `javascript:`, `<foreignObject`, or `<?xml-stylesheet`. It is documented
-as reputation defense, not the control; the CSP is the control.
+as reputation defense, not the control; the CSP is the control. It only ever runs on a body a
+server handler actually buffers (PUT, MCP, server-side copies) — a presigned upload goes straight
+to the bucket with no server inspection at all, which is exactly why the CSP, not this filter, is
+the control.
 
 ### Gate (`apps/api/src/active-content.ts`, new)
 

--- a/docs/superpowers/specs/2026-09-02-svg-xml-active-content-design.md
+++ b/docs/superpowers/specs/2026-09-02-svg-xml-active-content-design.md
@@ -1,0 +1,152 @@
+# SVG and XML behind a verified sandboxing CSP (issue #929)
+
+## Problem
+
+#928 opened uploads to PDF, zip, gzip, MOV, and text but kept SVG and XML out. Served inline, either
+can run script (`<script>`, `on*` handlers, `<foreignObject>`, XSLT). GitHub accepts SVG; agents
+produce SVG diagrams and XML reports. The storage hosts are bare R2 custom domains with no Worker,
+so this repo cannot set response headers there; zone Transform Rules can. A BYO bucket's public
+host is the owner's, and only they can set headers on it.
+
+## Decision: one mechanism, per lane
+
+An "active content" type (`image/svg+xml`, `application/xml`, `text/xml`) is accepted on a
+storage lane only while that lane's public host is **verified** to serve those types with a
+sandboxing CSP and `nosniff`. Verification is a probe: write an inert SVG under
+`_internal/uploads-csp-verify/<uuid>.svg`, fetch it through the lane's public base URL, check the
+headers, delete the object. The same probe runs against hosted and BYO lanes; only who sets the
+header differs.
+
+- **Hosted lanes** (`storage.uploads.sh`, `store.uploads.sh`, plus the `embed.uploads.sh` twin):
+  ops sets the header with a zone Transform Rule (documented in `docs/ops.md`). A daily cron
+  probes each hosted host and writes the result to KV. Every workspace on that host inherits it.
+- **BYO lanes:** the owner sets the header on their host however they like. The probe runs as
+  part of the existing lane verify (configure and activate) as a new recommended check, and on
+  demand from the settings page. The result is stamped on the lane. Nothing is enabled until the
+  probe passes; a failing probe later turns it back off.
+- **Kill switch:** a Flagship flag `active-content-uploads`, fail-closed like the poster flag.
+- **Workspace opt-out:** `activeContentUploads: false` on the workspace record turns it off for
+  that workspace regardless of lane state. Off by admin edit (same surface as `videoPosterEnabled`).
+
+### What the probe accepts
+
+`Content-Security-Policy` must contain a `sandbox` directive with neither `allow-scripts` nor
+`allow-same-origin` tokens, and `X-Content-Type-Options: nosniff` must be present. Any other CSP
+directives are the owner's business; a stricter or differently shaped policy still passes. The
+response `Content-Type` must start with `image/svg+xml` (a host that rewrites the type fails).
+The fetch uses `redirect: "manual"` with the existing 5 s timeout; a thrown fetch is
+`inconclusive` (same semantics as the public-url check: unknown, not broken). Inconclusive never
+enables.
+
+Recommended header values for the docs and the ops rule:
+
+```
+Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox
+X-Content-Type-Options: nosniff
+```
+
+## Server
+
+### Guards (`apps/api/src/guards.ts`)
+
+Three new rows in `UPLOAD_TYPES`, all `kind: "file"` except SVG (`image`), `verify: "declared"`,
+and a new `gate: "active-content"`:
+
+| Type              | Extensions | Plausibility                                                                |
+| ----------------- | ---------- | --------------------------------------------------------------------------- |
+| `image/svg+xml`   | svg        | `looksLikeText` and `<svg` within the first 4 KiB after any prolog/comments |
+| `application/xml` | xml        | `looksLikeText` and first non-whitespace char is `<`                        |
+| `text/xml`        | (none)     | same as `application/xml`; accepted by declaration only                     |
+
+Declared-only, not sniffed, on purpose: a `.log` that starts with `<?xml` keeps being
+`text/plain`, and a `.png` carrying SVG bytes still 415s. The row's plausibility predicate replaces
+the single `looksLikeText` call in `inspectUpload` (each declared row names its own check; the
+text rows keep `looksLikeText`).
+
+`resolveUploadPolicy(record, { activeContent: boolean })`: gated rows are removed from the
+allowlist unless `activeContent` is true. This applies to a workspace's own `allowedContentTypes`
+override too, so an override can no longer smuggle SVG onto an unverified lane. All callers
+(`putObject`, presign, ingest, MCP ceiling) pass the gate result.
+
+A reputation pre-filter `containsActiveMarkup(text)` rejects SVG/XML bodies containing
+`<script`, `on[a-z]+\s*=`, `javascript:`, `<foreignObject`, or `<?xml-stylesheet`. It is documented
+as reputation defense, not the control; the CSP is the control.
+
+### Gate (`apps/api/src/active-content.ts`, new)
+
+```ts
+export async function activeContentAllowed(env: Env, ws: WorkspaceRecord): Promise<boolean>;
+```
+
+Order, cheapest first: `ws.activeContentUploads === false` → false; `!env.FLAGS` → false; flag
+false or thrown → false; then the lane check:
+
+- shared lane (`isSharedLane(ws)`): read KV `REGISTRY` key `host-active-content:<host>` where host
+  is the hostname of `ws.publicBaseUrl`; allowed when `ok` and `verifiedAt` within 48 h.
+- BYO lane: `ws.storageActiveContentVerifiedAt` within 30 days and no `storageUnhealthyAt`.
+
+Host records: `{ ok: boolean; verifiedAt: string; detail?: string }`.
+
+### Probe (`apps/api/src/storage-verify.ts`)
+
+`checkActiveContentHeaders(publicBaseUrl, probeKey, fetchImpl)` returns a `StorageVerifyCheck`
+with id `active-content-headers`, `required: false`. `verifyStorageConfig` runs it after the
+public-url check succeeds (it reuses the round-trip client to upload/delete the SVG probe). A
+shared helper `parseSandboxCsp(header)` does the token check and is unit tested on its own.
+
+### Lane state
+
+- `StorageLane.activeContentVerifiedAt?: string` and top-level
+  `WorkspaceRecord.storageActiveContentVerifiedAt?: string`; `promoteLane`/`demoteActiveLane` carry
+  it like `verifiedAt`. `storagePutHandler` and `storageActivateHandler` set or clear it from the
+  verify result. `StorageLaneStatus` and the active-lane status gain `activeContentVerifiedAt`.
+- New route `POST /v1/workspaces/:name/storage/lanes/:laneId/verify-active-content` (session
+  admin gate, write-limited): runs only the probe against that lane and updates the stamp.
+- Hosted hosts: `runActiveContentHostSweep(env)` joins the daily cron; it probes each hosted host
+  (the set from `packages/storage` `DEFAULT_EMBEDDABLE_HOSTS` plus the embed host) via a
+  dedicated probe object in the default bucket and writes the KV host records. An admin route
+  `POST /admin/active-content/probe` runs it on demand.
+
+### Web
+
+- `fileKind("image/svg+xml")` → `image`; the `unsupported` branch is retired. `/f/` renders SVG
+  through `<img>` (never inline). `thumbUrl` keeps skipping `.svg`. XML is `file`.
+- Settings → Storage: each lane card shows an "SVG and XML" row: "Verified <date>", or "Not
+  verified" with the two header lines and a "Check now" button that calls the new route. The
+  hosted lane shows the host record's state.
+- Docs: `/docs/byo-bucket` gains a "Serving SVG and XML" section with the header values and the
+  probe semantics; `/docs/limits` lists SVG/XML as "on verified lanes". `docs/ops.md` gets the
+  Transform Rule expression and the cron/admin probe.
+
+### CLI / renderer
+
+`inferContentType` gains `xml` → `application/xml` (svg already present). The optimizer already
+passes SVG through. The managed comment embeds SVG as `<img>` (GitHub's Camo serves it with its
+own CSP); confirm on prod before the copy says so.
+
+## Testing
+
+- `parseSandboxCsp`: passes on the recommended value, on a policy with extra directives, on
+  `sandbox` alone; fails on missing `sandbox`, `sandbox allow-scripts`, `sandbox allow-same-origin`.
+- `checkActiveContentHeaders`: ok / wrong content type / missing nosniff / thrown fetch →
+  inconclusive.
+- `activeContentAllowed`: opt-out, missing flag, flag off, thrown flag, shared host fresh/stale/
+  missing, BYO fresh/stale/unhealthy.
+- Guards: gated rows absent by default and present only with `activeContent: true`; override
+  containing svg still stripped without the gate; SVG plausibility (prolog + comment then `<svg`
+  passes; `<html` fails); `containsActiveMarkup` matrix; `.log` starting with `<?xml` stays
+  `text/plain`; `.png` named SVG bytes 415.
+- Routes: PUT `.svg` 415 on an unverified workspace, 201 on a verified one (fake KV host record +
+  flag on); presign same; the verify route updates the lane stamp; cron sweep writes host records.
+- Web: `fileKind` cases; settings page renders the row.
+- Prod: set the Transform Rule, run the admin probe, confirm the KV record, upload an SVG with a
+  `<script>` (expect 415) and an inert one (expect 201), navigate to it in Chrome/Firefox/Safari
+  and confirm no script runs and the document has an opaque origin (`window.origin === "null"`
+  from devtools). Confirm Camo renders it in a PR comment.
+
+## Out of scope
+
+- Sanitizer-based acceptance.
+- HTML.
+- Automatic header setup on BYO hosts.
+- Per-workspace custom CSP values (the probe accepts any sandboxing policy).

--- a/docs/superpowers/specs/2026-09-02-svg-xml-active-content-design.md
+++ b/docs/superpowers/specs/2026-09-02-svg-xml-active-content-design.md
@@ -153,3 +153,5 @@ own CSP); confirm on prod before the copy says so.
 - HTML.
 - Automatic header setup on BYO hosts.
 - Per-workspace custom CSP values (the probe accepts any sandboxing policy).
+
+> **Record note (2026-09-02, post-review):** the shipped implementation probes an SVG and an XML object (both must pass), requires every hosted host to be verified for shared lanes, lets `serverCopy` bypass only freshness reasons, splits CSP directives on `;` only, adds a 60 s per-lane cooldown to the on-demand check, reaps orphaned probe objects daily, caps gated presigns at 900 s, and adds `nosniff` + `sandbox` to download responses. `docs/ops.md` and `/docs/byo-bucket` carry the live behavior.

--- a/packages/comment-render/src/index.ts
+++ b/packages/comment-render/src/index.ts
@@ -118,6 +118,7 @@ const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
   markdown: "text/markdown",
   csv: "text/csv",
   json: "application/json",
+  xml: "application/xml",
 };
 
 export function inferContentType(filename: string): string {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -156,8 +156,13 @@ export function publicUrl(config: StorageConfig, key: string): string | null {
  */
 export const DEFAULT_EMBED_PUBLIC_BASE_URL = "https://embed.uploads.sh";
 
-/** Hosts that get an automatic embed twin when no override is set. */
-const DEFAULT_EMBEDDABLE_HOSTS = new Set(["storage.uploads.sh", "store.uploads.sh"]);
+/**
+ * Hosts that get an automatic embed twin when no override is set. Exported
+ * (issue #929) so the API's daily active-content host sweep
+ * (`apps/api/src/active-content-hosts.ts`) derives its hosted-host list from
+ * this instead of duplicating the literal hostnames.
+ */
+export const DEFAULT_EMBEDDABLE_HOSTS = new Set(["storage.uploads.sh", "store.uploads.sh"]);
 
 export type EmbedUrlOptions = {
   /**

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -164,6 +164,21 @@ export const DEFAULT_EMBED_PUBLIC_BASE_URL = "https://embed.uploads.sh";
  */
 export const DEFAULT_EMBEDDABLE_HOSTS = new Set(["storage.uploads.sh", "store.uploads.sh"]);
 
+/**
+ * Hostname of a URL string, lowercased; `null` for an empty, missing, or
+ * unparseable one. The one copy of this two-line helper — the embed
+ * resolution below and the API's active-content host records (issue #929)
+ * both key off exactly this normalization, and each used to carry its own.
+ */
+export function hostOf(url: string | undefined | null): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
 export type EmbedUrlOptions = {
   /**
    * Embed CDN base.
@@ -183,13 +198,8 @@ export function resolveEmbedBaseUrl(
     const trimmed = embedBaseUrl.trim();
     return trimmed ? trimmed.replace(/\/$/, "") : null;
   }
-  if (!publicBaseUrl) return null;
-  try {
-    const host = new URL(publicBaseUrl).hostname.toLowerCase();
-    if (DEFAULT_EMBEDDABLE_HOSTS.has(host)) return DEFAULT_EMBED_PUBLIC_BASE_URL;
-  } catch {
-    return null;
-  }
+  const host = hostOf(publicBaseUrl);
+  if (host && DEFAULT_EMBEDDABLE_HOSTS.has(host)) return DEFAULT_EMBED_PUBLIC_BASE_URL;
   return null;
 }
 
@@ -205,13 +215,11 @@ export function embedUrlFromPublic(
 
   let publicBaseUrl = opts.publicBaseUrl ?? null;
   if (!publicBaseUrl) {
-    try {
+    const host = hostOf(publicObjectUrl);
+    if (!host) return null;
+    if (DEFAULT_EMBEDDABLE_HOSTS.has(host)) {
       const u = new URL(publicObjectUrl);
-      if (DEFAULT_EMBEDDABLE_HOSTS.has(u.hostname.toLowerCase())) {
-        publicBaseUrl = `${u.protocol}//${u.host}`;
-      }
-    } catch {
-      return null;
+      publicBaseUrl = `${u.protocol}//${u.host}`;
     }
   }
 

--- a/packages/uploads/src/comment-render.generated.ts
+++ b/packages/uploads/src/comment-render.generated.ts
@@ -120,6 +120,7 @@ const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
   markdown: "text/markdown",
   csv: "text/csv",
   json: "application/json",
+  xml: "application/xml",
 };
 
 export function inferContentType(filename: string): string {

--- a/packages/uploads/src/embed.ts
+++ b/packages/uploads/src/embed.ts
@@ -6,9 +6,12 @@
  * `comment-render.generated.ts`), so the CLI and the managed-comment renderer
  * cannot drift apart. Re-exported from this module because every existing
  * caller imports them from `./embed.js`. That map mirrors the upload table in
- * apps/api/src/guards.ts; keep the two in step. `svg` is the one deliberate
- * difference — it stays here only so the optimizer can pass it through, and
- * the server rejects it.
+ * apps/api/src/guards.ts; keep the two in step. `svg` maps to
+ * `image/svg+xml` here same as any other type (issue #929): the server no
+ * longer rejects it outright — it accepts SVG only on a storage lane
+ * verified to serve it behind a sandboxing CSP (`apps/api/src/active-content.ts`),
+ * so whether a given upload actually lands depends on that lane's state,
+ * not on anything this map decides.
  */
 export { fileKindFromName, inferContentType } from "./comment-render.generated.js";
 

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -403,7 +403,7 @@ export function createUploadsMcpTools(opts: {
       annotations: mcpDestroyPublic,
       securitySchemes: mcpOAuthWrite,
       description:
-        "Upload one or more files and get a public URL plus GitHub-ready markdown. Prefer `embedUrl` in GitHub markdown. Pass `contentUrl` for a public HTTPS file, or http://localhost on this machine, instead of a local path. With `pr`/`issue`, keys are stable and the managed comment is synced. All uploads are public. Accepts images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and text (plain, markdown, CSV, JSON). HTML and SVG are rejected.",
+        "Upload one or more files and get a public URL plus GitHub-ready markdown. Prefer `embedUrl` in GitHub markdown. Pass `contentUrl` for a public HTTPS file, or http://localhost on this machine, instead of a local path. With `pr`/`issue`, keys are stable and the managed comment is synced. All uploads are public. Accepts images (PNG, JPEG, GIF, WebP, AVIF), video (MP4, WebM, MOV), PDF, zip, gzip, and text (plain, markdown, CSV, JSON). SVG and XML are accepted only on storage lanes verified to serve them sandboxed (see the workspace's storage settings); HTML is rejected.",
       inputSchema: {
         type: "object",
         properties: {


### PR DESCRIPTION
Closes #929. Design: [spec](docs/superpowers/specs/2026-09-02-svg-xml-active-content-design.md) · [plan](docs/superpowers/plans/2026-09-02-svg-xml-active-content.md).

SVG, `application/xml`, and `text/xml` are accepted on a storage lane only while that lane's public host is verified to serve SVG with a sandboxing CSP and `nosniff`. The header is the control (the raw.githubusercontent.com model); nothing in this PR sanitizes.

## How it works

- **One probe, every lane.** `probeActiveContent` writes an inert SVG and an inert XML object under `_internal/uploads-verify/`, fetches each through the lane's public base URL, and accepts only when both echo their content type, carry a `sandbox` CSP directive (no `allow-scripts` / `allow-same-origin`, one CSP header), and `X-Content-Type-Options: nosniff`. A thrown fetch or write is `inconclusive` and never enables. Orphaned probe objects are reaped daily.
- **Hosted lanes:** ops sets the header with a zone Transform Rule (`docs/ops.md`). A daily cron probes `storage.uploads.sh`, `store.uploads.sh`, and `embed.uploads.sh` and writes KV host records; `POST /admin/active-content/probe` (operator token) runs it on demand. The gate requires fresh (≤ 48 h) `ok` records for **all three** hosted hosts, since they front the same bucket.
- **BYO lanes:** the owner sets the header any way they like. The probe runs inside lane verify (save and activate) and from a "Check now" button on the storage settings page; the stamp is good for 30 days. Any sandboxing CSP passes.
- **Gate:** `activeContentAllowed(env, ws)` = workspace opt-out → Flagship flag `active-content-uploads` (fail-closed) → lane health → lane/host freshness. `resolveUploadPolicy(record, { activeContent })` makes the second argument required and strips the gated rows from every allowlist, including an `allowedContentTypes` override.
- **Guard:** the three types are declared-only, never sniffed, with per-row plausibility (SVG root must be `<svg`; XML must start with `<`), a 4 MiB row cap checked before the body scan, and a reputation pre-filter (`<script`, `on*=`, `javascript:`, `<foreignObject`, XSLT) that returns `reason: "active_markup"`. Unverified lanes return `reason: "lane_not_verified"`. Server-side copies (attach, promote, prefix rotation) carry `serverCopy` and skip only the freshness checks (same lane, same host, no new exposure); the kill switch, workspace opt-out, and lane health still apply, and promote/rotation skip-and-record a rejected object rather than wedging. The gate is evaluated lazily, only when the declared type is gated, and once per MCP batch.
- **Web:** `/f/` renders SVG through `<img>` only; `thumbUrl` still skips `.svg`; settings shows per-lane readiness from the same status the gate uses (with a reason when closed) and a Check-now button with a 60 s per-lane cooldown. Downloads via `?download=1` carry `nosniff` and a `sandbox` CSP; presigned URLs for gated types expire in 15 minutes. Docs: BYO setup step 5, limits page, ops runbook.

## Rollout (flag stays off at merge)

1. Merge. With the flag off, SVG/XML keep 415ing exactly as today (now with `reason: "lane_not_verified"`). The only always-on behavior is three probe objects written and deleted daily in the shared bucket.
2. Add the Transform Rule to all three hosted hosts; validate the expression in the rule editor (`docs/ops.md` has the escaped regex and an `eq` fallback), then `curl -I` a real `.svg` on each host.
3. `curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" https://api.uploads.sh/admin/active-content/probe` and confirm three `ok: true` records.
4. Turn on `active-content-uploads`. Upload an inert SVG and open it in Chrome, Firefox, and Safari: `window.origin === "null"`, no script. Upload one with `<script>` and expect 415 `active_markup`. Confirm Camo renders an SVG in a PR comment.
5. The flag is the rollback.

## Review trail

Four batches, each reviewed (Opus on the guard batches), one fix round on the guard batch, a whole-branch Opus review with one fix wave, a four-angle simplify pass with one fix round, and an adversarial security review (Opus; Codex refused the brief under its cyber policy) with one fix wave. Every fix wave was re-reviewed. Deferred minors are collected in #936.
