### PR TITLE
feat(api): D1 attachment index, phase 1 (dual-write) (#934)

### DIFF
--- a/apps/api/migrations/20260903120000_github_attachments.sql
+++ b/apps/api/migrations/20260903120000_github_attachments.sql
@@ -1,0 +1,38 @@
+-- Server-written index of PR/issue attachments (one row per attachment
+-- object), replacing the per-prefix R2 fan-out in gatherAttachments (#934).
+-- NEVER written from client-supplied gh.* metadata: every row is derived
+-- from the final object key plus the server-resolved target. `gh.*` is
+-- client-settable (see file-metadata.ts) — a writer that shortcuts to
+-- opts.metadata["gh.ref"] would let any files:write token render an
+-- arbitrary object in a public PR comment.
+CREATE TABLE github_attachments (
+  workspace   TEXT NOT NULL,
+  repo        TEXT NOT NULL,     -- lowercased owner/name
+  kind        TEXT NOT NULL,     -- 'pull' | 'issues' (GhTarget.kind spelling,
+                                 -- NOT the singular 'issue' used by gh.kind
+                                 -- metadata) so the read query can bind
+                                 -- target.kind directly
+  num         INTEGER NOT NULL,
+  object_key  TEXT NOT NULL,
+  prefix_id   TEXT,              -- NULL = plain gh/ prefix; else 32-hex private id
+  lane_id     TEXT,              -- storage lane the object was written to; NULL = active/origin
+  source      TEXT NOT NULL,     -- put | attach | promote | adopt | rotate | backfill | reconcile
+  created_at  TEXT NOT NULL,
+  updated_at  TEXT NOT NULL,
+  detached_at TEXT,              -- mirrors gh.detached; hidden from the render
+  PRIMARY KEY (workspace, object_key)
+);
+
+-- The hot read. Partial so detached rows are never scanned, and
+-- object_key-terminated so ORDER BY object_key needs no sort.
+CREATE INDEX github_attachments_target_idx
+  ON github_attachments (workspace, repo, kind, num, object_key)
+  WHERE detached_at IS NULL;
+
+-- Rotation sweep + repair: every row still pointing at a retired prefix id.
+CREATE INDEX github_attachments_prefix_idx
+  ON github_attachments (workspace, prefix_id);
+
+-- Ops/reconcile entry by coordinate when the workspace is resolved later.
+CREATE INDEX github_attachments_repo_idx
+  ON github_attachments (repo, kind, num);

--- a/apps/api/migrations/20260903120000_github_attachments.sql
+++ b/apps/api/migrations/20260903120000_github_attachments.sql
@@ -16,7 +16,7 @@ CREATE TABLE github_attachments (
   object_key  TEXT NOT NULL,
   prefix_id   TEXT,              -- NULL = plain gh/ prefix; else 32-hex private id
   lane_id     TEXT,              -- storage lane the object was written to; NULL = active/origin
-  source      TEXT NOT NULL,     -- put | attach | promote | adopt | rotate | backfill | reconcile
+  source      TEXT NOT NULL,     -- put | attach | promote | adopt | backfill | reconcile
   created_at  TEXT NOT NULL,
   updated_at  TEXT NOT NULL,
   detached_at TEXT,              -- mirrors gh.detached; hidden from the render

--- a/apps/api/migrations/20260903120000_github_attachments.sql
+++ b/apps/api/migrations/20260903120000_github_attachments.sql
@@ -1,10 +1,7 @@
 -- Server-written index of PR/issue attachments (one row per attachment
 -- object), replacing the per-prefix R2 fan-out in gatherAttachments (#934).
--- NEVER written from client-supplied gh.* metadata: every row is derived
--- from the final object key plus the server-resolved target. `gh.*` is
--- client-settable (see file-metadata.ts) — a writer that shortcuts to
--- opts.metadata["gh.ref"] would let any files:write token render an
--- arbitrary object in a public PR comment.
+-- NEVER written from client-supplied gh.* metadata — see the trust-boundary
+-- rationale in apps/api/src/github-attachment-index.ts's header doc comment.
 CREATE TABLE github_attachments (
   workspace   TEXT NOT NULL,
   repo        TEXT NOT NULL,     -- lowercased owner/name

--- a/apps/api/migrations/20260903120000_github_attachments.sql
+++ b/apps/api/migrations/20260903120000_github_attachments.sql
@@ -30,8 +30,11 @@ CREATE INDEX github_attachments_target_idx
   WHERE detached_at IS NULL;
 
 -- Rotation sweep + repair: every row still pointing at a retired prefix id.
+-- Partial: most rows are plain-key rows with prefix_id NULL, which this
+-- index has no use for (rotation only ever looks up a specific non-NULL id).
 CREATE INDEX github_attachments_prefix_idx
-  ON github_attachments (workspace, prefix_id);
+  ON github_attachments (workspace, prefix_id)
+  WHERE prefix_id IS NOT NULL;
 
 -- Ops/reconcile entry by coordinate when the workspace is resolved later.
 CREATE INDEX github_attachments_repo_idx

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -1031,7 +1031,7 @@ export async function listFacets(
  * had enough path groups to send 100 keys plus the workspace and meta-key binds.
  * The test fake (test/helpers/sqlite-d1.ts) enforces the same ceiling.
  */
-const D1_MAX_BOUND_PARAMS = 100;
+export const D1_MAX_BOUND_PARAMS = 100;
 
 /**
  * Max object keys bound into one `object_key IN (...)` statement, given how

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -1291,11 +1291,6 @@ export async function deleteObject(
   const configs = await storageConfigs(env, ws);
   const { hits, failures } = await deleteFromEveryLane(configs, key);
   await deleteFileMetadata(dbFor(env), workspaceName, key);
-  // The attachment index (issue #934) is keyed by (workspace, object_key)
-  // just like file_metadata, so it is cleaned up in exactly the same place.
-  // Best-effort: a stale row costs a broken image in a managed comment
-  // until reconcile, never a failed delete.
-  await deleteAttachmentSafe(dbFor(env), workspaceName, key);
 
   if (hits.length > 0) {
     // Single-winner claim (issue #570): concurrent DELETEs can both observe
@@ -1324,6 +1319,13 @@ export async function deleteObject(
   // rejected lane's delete get to fail the request, so a partial failure
   // never looks like nothing happened.
   if (failures.length > 0) throw failures[0];
+
+  // The attachment index (issue #934) row goes only once every lane's delete
+  // succeeded: a lane that still holds the object must stay indexed, or the
+  // surviving attachment silently drops out of the managed comment.
+  // Best-effort past that point: a stale row costs a broken image until
+  // reconcile, never a failed delete.
+  await deleteAttachmentSafe(dbFor(env), workspaceName, key);
 
   // Derived poster (issue #299), best-effort: a missing one is the norm for
   // every non-video object. Guarded so a transient poster-cleanup failure

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -1291,6 +1291,11 @@ export async function deleteObject(
   const configs = await storageConfigs(env, ws);
   const { hits, failures } = await deleteFromEveryLane(configs, key);
   await deleteFileMetadata(dbFor(env), workspaceName, key);
+  // The attachment index (issue #934) is keyed by (workspace, object_key)
+  // just like file_metadata, so it is cleaned up in exactly the same place.
+  // Best-effort: a stale row costs a broken image in a managed comment
+  // until reconcile, never a failed delete.
+  await deleteAttachmentSafe(dbFor(env), workspaceName, key);
 
   if (hits.length > 0) {
     // Single-winner claim (issue #570): concurrent DELETEs can both observe

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -30,6 +30,7 @@ import {
   inheritableMetaForHash,
   recordContentHash,
 } from "./content-hash";
+import { deleteAttachmentSafe, recordAttachmentForKeySafe } from "./github-attachment-index";
 import { recordPrActivityFromMetadata } from "./github-pr-activity";
 import { noteStorageFailure, noteStorageSuccess } from "./storage-health";
 import {
@@ -738,6 +739,26 @@ export async function putObject(
   // the object is durably stored by now, so a failed index write costs a later
   // inheritance rather than this upload.
   await recordContentHash(dbFor(env), workspaceName, finalKey, contentSha256);
+
+  // Attachment index (issue #934): the single choke point covering every
+  // putObject caller — REST PUT, the idempotent PUT and its reconcile,
+  // attach, promote, and rotation. Derived ONLY from the final key plus a
+  // server-resolved repo (the key's own owner/name, or the
+  // github_private_prefixes row that minted the prefix id), NEVER from
+  // `opts.metadata["gh.repo"]`/`gh.ref` — those are client-settable, and
+  // trusting them would let any files:write token render an arbitrary
+  // object in someone else's public PR comment. `lane_id` is the active
+  // lane this write went to (`storage(env, ws)` above), which is the same
+  // value `storageConfigs` labels the active lane with. Best-effort and
+  // last, like recordContentHash: the object is durably stored by now.
+  if (isManagedGithubKey(finalKey)) {
+    await recordAttachmentForKeySafe(dbFor(env), {
+      workspace: workspaceName,
+      objectKey: finalKey,
+      source: "put",
+      laneId: ws.storageLaneId ?? null,
+    });
+  }
 
   // After the metadata replace, never before: replaceFileMetadata is
   // delete-then-insert and would wipe the server-owned video.*/image.* rows.

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -742,14 +742,9 @@ export async function putObject(
 
   // Attachment index (issue #934): the single choke point covering every
   // putObject caller — REST PUT, the idempotent PUT and its reconcile,
-  // attach, promote, and rotation. Derived ONLY from the final key plus a
-  // server-resolved repo (the key's own owner/name, or the
-  // github_private_prefixes row that minted the prefix id), NEVER from
-  // `opts.metadata["gh.repo"]`/`gh.ref` — those are client-settable, and
-  // trusting them would let any files:write token render an arbitrary
-  // object in someone else's public PR comment. `lane_id` is the active
-  // lane this write went to (`storage(env, ws)` above), which is the same
-  // value `storageConfigs` labels the active lane with. Best-effort and
+  // attach, promote, and rotation. See github-attachment-index.ts's header
+  // doc comment for the trust-boundary rationale. `lane_id` is the active
+  // lane this write went to (`storage(env, ws)` above). Best-effort and
   // last, like recordContentHash: the object is durably stored by now.
   if (isManagedGithubKey(finalKey)) {
     await recordAttachmentForKeySafe(dbFor(env), {

--- a/apps/api/src/github-attach.ts
+++ b/apps/api/src/github-attach.ts
@@ -36,6 +36,7 @@ import {
   sanitizeKeyBasename,
 } from "./files-core";
 import { getFileMetadata, setFileMetadata } from "./file-metadata";
+import { recordAttachmentForKeySafe } from "./github-attachment-index";
 import { resolveGhKeyContextSafe } from "./github-private-prefix-service";
 import { storage, storageConfig } from "./storage";
 import { webOrigin } from "./web-url";
@@ -220,6 +221,20 @@ export async function attachExistingObject(
     "gh.number": String(req.target.num),
     "gh.ref": ref,
     "gh.attached-at": nowIso,
+  });
+
+  // Attachment index (issue #934): putObject above already wrote a
+  // `source: "put"` row for destKey; re-record it as an attach with the
+  // repo the CALLER resolved (req.target.repo), which is authoritative and
+  // not lossy the way a plain key's sanitized owner/name segments are.
+  // Never derived from the gh.* metadata stamped just above — that bag is
+  // client-influenced on the source object.
+  await recordAttachmentForKeySafe(dbFor(env), {
+    workspace: workspaceName,
+    objectKey: destKey,
+    source: "attach",
+    laneId: ws.storageLaneId ?? null,
+    repo: req.target.repo,
   });
 
   if (req.move) {

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -17,6 +17,7 @@
  */
 import { GH_PRIVATE_ROOT, parseGhPrivateKey } from "@uploads/comment-render";
 import { type D1Queryable } from "./db-session";
+import { repoForPrefixId } from "./github-private-prefixes";
 
 /** Which server-side path wrote (or last updated) an index row. */
 export type AttachmentSource =
@@ -388,5 +389,65 @@ export async function rekeyAttachmentSafe(
 ): Promise<void> {
   await safely("attachment index: rekey failed", { workspace, fromKey, toKey }, () =>
     rekeyAttachment(db, workspace, fromKey, toKey, newPrefixId, now),
+  );
+}
+
+/**
+ * The one entry point every write path should use: parse the FINAL key,
+ * resolve the repo server-side, upsert. Never throws.
+ *
+ * Repo resolution order, all server-side:
+ *  1. `args.repo` — the caller already resolved the target (attach, promote,
+ *     adopt know it from the request/webhook). Preferred, because a plain
+ *     key's owner/name segments are the SANITIZED spelling, which is lossy.
+ *  2. The plain key's own `gh/<owner>/<name>/…` segments.
+ *  3. For a private key, the `github_private_prefixes` row that minted the
+ *     id (`repoForPrefixId`) — a prefix id belongs to exactly one repo.
+ *
+ * `gh.repo`/`gh.ref` file_metadata is DELIBERATELY not consulted at any
+ * step: it is client-settable, and trusting it would let any files:write
+ * token pin an arbitrary object to someone else's PR comment.
+ *
+ * A key that parses but whose repo cannot be resolved (an orphaned private
+ * prefix id) writes NO row — reconcile repairs it rather than this guessing.
+ */
+export async function recordAttachmentForKeySafe(
+  db: D1Queryable,
+  args: {
+    workspace: string;
+    objectKey: string;
+    source: AttachmentSource;
+    laneId: string | null;
+    /** Server-resolved repo, when the caller already knows it. */
+    repo?: string;
+  },
+  now = new Date(),
+): Promise<void> {
+  const parsed = parseAttachmentKey(args.objectKey);
+  if (!parsed) return;
+  await safely(
+    "attachment index: record-for-key failed",
+    { workspace: args.workspace, objectKey: args.objectKey },
+    async () => {
+      let repo = args.repo ?? parsed.repo;
+      if (!repo && parsed.prefixId) {
+        repo = await repoForPrefixId(db, parsed.prefixId);
+      }
+      if (!repo) return;
+      await recordAttachment(
+        db,
+        {
+          workspace: args.workspace,
+          repo,
+          kind: parsed.kind,
+          num: parsed.num,
+          objectKey: args.objectKey,
+          prefixId: parsed.prefixId,
+          laneId: args.laneId,
+          source: args.source,
+        },
+        now,
+      );
+    },
   );
 }

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -61,8 +61,13 @@ const PLAIN_ATTACHMENT_RE = /^gh\/([^/]+)\/([^/]+)\/(pull|issues)\/([1-9][0-9]*)
 export function parseAttachmentKey(key: string): ParsedAttachmentKey | undefined {
   if (key.startsWith(GH_PRIVATE_ROOT)) {
     const parsed = parseGhPrivateKey(key);
-    if (!parsed) return undefined;
-    return { kind: parsed.kind, num: parsed.num, prefixId: parsed.prefixId, repo: null };
+    if (parsed) {
+      return { kind: parsed.kind, num: parsed.num, prefixId: parsed.prefixId, repo: null };
+    }
+    // Not a real private key (e.g. the 32-hex id slot didn't match) — fall
+    // through to the plain parse, since `private` is a legal GitHub owner
+    // login and `gh/private/web/...` is that owner's plain-key shape, not a
+    // malformed private key.
   }
   const match = PLAIN_ATTACHMENT_RE.exec(key);
   if (!match) return undefined;

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -293,3 +293,100 @@ export async function rekeyAttachment(
     .bind(toKey, newPrefixId, now.toISOString(), workspace, fromKey)
     .run();
 }
+
+/**
+ * Index writes are BEST-EFFORT, exactly like `recordUsageSafe` and
+ * `recordPrActivityFromMetadata`: the object is already durably stored by
+ * the time any of these runs, so a D1 failure must cost a stale index (which
+ * the phase-2 shadow diff and the reconcile job repair) rather than a failed
+ * upload.
+ */
+async function safely(message: string, context: Record<string, unknown>, run: () => Promise<void>) {
+  try {
+    await run();
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message,
+        ...context,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+}
+
+export async function recordAttachmentSafe(
+  db: D1Queryable,
+  row: Omit<AttachmentIndexRow, "createdAt" | "updatedAt" | "detachedAt">,
+  now = new Date(),
+): Promise<void> {
+  await safely(
+    "attachment index: record failed",
+    { workspace: row.workspace, objectKey: row.objectKey, source: row.source },
+    () => recordAttachment(db, row, now),
+  );
+}
+
+export async function detachAttachmentSafe(
+  db: D1Queryable,
+  workspace: string,
+  objectKey: string,
+  now = new Date(),
+): Promise<void> {
+  await safely("attachment index: detach failed", { workspace, objectKey }, () =>
+    detachAttachment(db, workspace, objectKey, now),
+  );
+}
+
+export async function reattachAttachmentSafe(
+  db: D1Queryable,
+  workspace: string,
+  objectKey: string,
+  now = new Date(),
+): Promise<void> {
+  await safely("attachment index: reattach failed", { workspace, objectKey }, () =>
+    reattachAttachment(db, workspace, objectKey, now),
+  );
+}
+
+export async function deleteAttachmentSafe(
+  db: D1Queryable,
+  workspace: string,
+  objectKey: string,
+): Promise<void> {
+  await safely("attachment index: delete failed", { workspace, objectKey }, () =>
+    deleteAttachment(db, workspace, objectKey),
+  );
+}
+
+export async function deleteAttachmentsForKeysSafe(
+  db: D1Queryable,
+  workspace: string,
+  keys: string[],
+): Promise<void> {
+  await safely("attachment index: batch delete failed", { workspace, keys: keys.length }, () =>
+    deleteAttachmentsForKeys(db, workspace, keys),
+  );
+}
+
+export async function deleteAttachmentsForWorkspaceSafe(
+  db: D1Queryable,
+  workspace: string,
+): Promise<void> {
+  await safely("attachment index: workspace delete failed", { workspace }, () =>
+    deleteAttachmentsForWorkspace(db, workspace),
+  );
+}
+
+export async function rekeyAttachmentSafe(
+  db: D1Queryable,
+  workspace: string,
+  fromKey: string,
+  toKey: string,
+  newPrefixId: string | null,
+  now = new Date(),
+): Promise<void> {
+  await safely("attachment index: rekey failed", { workspace, fromKey, toKey }, () =>
+    rekeyAttachment(db, workspace, fromKey, toKey, newPrefixId, now),
+  );
+}

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -288,15 +288,16 @@ export async function rekeyAttachment(
   fromKey: string,
   toKey: string,
   newPrefixId: string | null,
+  laneId: string | null,
   now = new Date(),
 ): Promise<void> {
   await deleteAttachment(db, workspace, toKey);
   await db
     .prepare(
-      `UPDATE github_attachments SET object_key = ?, prefix_id = ?, updated_at = ?
+      `UPDATE github_attachments SET object_key = ?, prefix_id = ?, lane_id = ?, updated_at = ?
        WHERE workspace = ? AND object_key = ?`,
     )
-    .bind(toKey, newPrefixId, now.toISOString(), workspace, fromKey)
+    .bind(toKey, newPrefixId, laneId, now.toISOString(), workspace, fromKey)
     .run();
 }
 
@@ -390,10 +391,11 @@ export async function rekeyAttachmentSafe(
   fromKey: string,
   toKey: string,
   newPrefixId: string | null,
+  laneId: string | null,
   now = new Date(),
 ): Promise<void> {
   await safely("attachment index: rekey failed", { workspace, fromKey, toKey }, () =>
-    rekeyAttachment(db, workspace, fromKey, toKey, newPrefixId, now),
+    rekeyAttachment(db, workspace, fromKey, toKey, newPrefixId, laneId, now),
   );
 }
 

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -1,0 +1,75 @@
+/**
+ * Server-written index of PR/issue attachments (`github_attachments` D1
+ * table, issue #934). One row per attachment object, keyed by
+ * (workspace, object_key).
+ *
+ * TRUST BOUNDARY: every row is derived from the FINAL OBJECT KEY plus a
+ * server-resolved repo — never from `gh.*` file_metadata, which is
+ * client-settable (see file-metadata.ts). A writer that shortcut to
+ * `opts.metadata["gh.ref"]` would let any files:write token stamp one row
+ * and have an arbitrary object rendered in a public PR comment. The repo
+ * comes from the key's own owner/name segments (plain keys) or from the
+ * `github_private_prefixes` row that minted the prefix id (private keys) —
+ * a prefix id is minted server-side for exactly one repo, so that lookup is
+ * authoritative.
+ *
+ * Phase 1 is write-only: nothing reads this table yet.
+ */
+import { GH_PRIVATE_ROOT, parseGhPrivateKey } from "@uploads/comment-render";
+import { type D1Queryable } from "./db-session";
+
+/** Which server-side path wrote (or last updated) an index row. */
+export type AttachmentSource =
+  | "put"
+  | "attach"
+  | "promote"
+  | "adopt"
+  | "rotate"
+  | "backfill"
+  | "reconcile";
+
+export interface ParsedAttachmentKey {
+  kind: "pull" | "issues";
+  num: number;
+  /** 32-hex private prefix id, or null for a plain `gh/<owner>/<name>/…` key. */
+  prefixId: string | null;
+  /**
+   * Lowercased owner/name recovered from a plain key, or null for a private
+   * key (which deliberately omits the repo). NOTE: the key's segments are
+   * the SANITIZED spelling (`sanitizeKeySegment`), which is lossy — a caller
+   * that knows the real repo should pass it rather than trust this.
+   */
+  repo: string | null;
+}
+
+/** `gh/<owner>/<name>/<pull|issues>/<num>/<filename>` — the plain layout built by `ghKeyPrefix`. */
+const PLAIN_ATTACHMENT_RE = /^gh\/([^/]+)\/([^/]+)\/(pull|issues)\/([1-9][0-9]*)\/(.+)$/;
+
+/**
+ * Parses an attachment key back into its target coordinates, or undefined
+ * for any key that is not a managed attachment.
+ *
+ * Deliberately undefined for GitHub-native INGEST keys
+ * (`gh/<owner>-<name>/<kind>-<num>/…` and
+ * `gh/private/<id>/ingest/<kind>-<num>/…`, see github-ingest.ts): ingested
+ * assets are an index only and live outside the comment's prefix on
+ * purpose. Also undefined for branch-staged keys
+ * (`gh/<owner>/<name>/branch/<branch>/…`, `gh/private/<id>/branch/…`),
+ * which are not attachments until promoted.
+ */
+export function parseAttachmentKey(key: string): ParsedAttachmentKey | undefined {
+  if (key.startsWith(GH_PRIVATE_ROOT)) {
+    const parsed = parseGhPrivateKey(key);
+    if (!parsed) return undefined;
+    return { kind: parsed.kind, num: parsed.num, prefixId: parsed.prefixId, repo: null };
+  }
+  const match = PLAIN_ATTACHMENT_RE.exec(key);
+  if (!match) return undefined;
+  const [, owner, name, kind, num] = match;
+  return {
+    kind: kind as "pull" | "issues",
+    num: Number(num),
+    prefixId: null,
+    repo: `${owner}/${name}`.toLowerCase(),
+  };
+}

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -178,3 +178,41 @@ export async function attachmentRow(
     .first<AttachmentDbRow>();
   return row ? fromRow(row) : null;
 }
+
+/**
+ * Hides an attachment from the managed comment without deleting the object
+ * or the row (issue #709's doctrine: detach means "removed from the
+ * comment", never "deleted"). Mirrors the `gh.detached='true'` metadata
+ * stamp the adopt path already writes.
+ */
+export async function detachAttachment(
+  db: D1Queryable,
+  workspace: string,
+  objectKey: string,
+  now = new Date(),
+): Promise<void> {
+  const nowIso = now.toISOString();
+  await db
+    .prepare(
+      `UPDATE github_attachments SET detached_at = ?, updated_at = ?
+       WHERE workspace = ? AND object_key = ?`,
+    )
+    .bind(nowIso, nowIso, workspace, objectKey)
+    .run();
+}
+
+/** Inverse of `detachAttachment`: the link reappeared, so the row renders again. */
+export async function reattachAttachment(
+  db: D1Queryable,
+  workspace: string,
+  objectKey: string,
+  now = new Date(),
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE github_attachments SET detached_at = NULL, updated_at = ?
+       WHERE workspace = ? AND object_key = ?`,
+    )
+    .bind(now.toISOString(), workspace, objectKey)
+    .run();
+}

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -73,3 +73,108 @@ export function parseAttachmentKey(key: string): ParsedAttachmentKey | undefined
     repo: `${owner}/${name}`.toLowerCase(),
   };
 }
+
+export interface AttachmentIndexRow {
+  workspace: string;
+  repo: string;
+  kind: "pull" | "issues";
+  num: number;
+  objectKey: string;
+  prefixId: string | null;
+  laneId: string | null;
+  source: AttachmentSource;
+  createdAt: string;
+  updatedAt: string;
+  detachedAt: string | null;
+}
+
+interface AttachmentDbRow {
+  workspace: string;
+  repo: string;
+  kind: "pull" | "issues";
+  num: number;
+  object_key: string;
+  prefix_id: string | null;
+  lane_id: string | null;
+  source: AttachmentSource;
+  created_at: string;
+  updated_at: string;
+  detached_at: string | null;
+}
+
+const SELECT_COLUMNS =
+  "workspace, repo, kind, num, object_key, prefix_id, lane_id, source, created_at, updated_at, detached_at";
+
+function fromRow(row: AttachmentDbRow): AttachmentIndexRow {
+  return {
+    workspace: row.workspace,
+    repo: row.repo,
+    kind: row.kind,
+    num: row.num,
+    objectKey: row.object_key,
+    prefixId: row.prefix_id,
+    laneId: row.lane_id,
+    source: row.source,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    detachedAt: row.detached_at,
+  };
+}
+
+/**
+ * Upserts one attachment row. `ON CONFLICT(workspace, object_key)` makes a
+ * re-put, a re-attach, and a webhook redelivery all converge on the same
+ * row rather than duplicating; `created_at` is preserved and `detached_at`
+ * is cleared, since writing an object at a key IS a re-attachment.
+ */
+export async function recordAttachment(
+  db: D1Queryable,
+  row: Omit<AttachmentIndexRow, "createdAt" | "updatedAt" | "detachedAt">,
+  now = new Date(),
+): Promise<void> {
+  const nowIso = now.toISOString();
+  await db
+    .prepare(
+      `INSERT INTO github_attachments
+         (workspace, repo, kind, num, object_key, prefix_id, lane_id, source, created_at, updated_at, detached_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+       ON CONFLICT(workspace, object_key) DO UPDATE SET
+         repo = excluded.repo,
+         kind = excluded.kind,
+         num = excluded.num,
+         prefix_id = excluded.prefix_id,
+         lane_id = excluded.lane_id,
+         source = excluded.source,
+         updated_at = excluded.updated_at,
+         detached_at = NULL`,
+    )
+    .bind(
+      row.workspace,
+      row.repo.toLowerCase(),
+      row.kind,
+      row.num,
+      row.objectKey,
+      row.prefixId,
+      row.laneId,
+      row.source,
+      nowIso,
+      nowIso,
+    )
+    .run();
+}
+
+/** One index row, or null. Test/ops read helper — NOT the phase-3 hot read. */
+export async function attachmentRow(
+  db: D1Queryable,
+  workspace: string,
+  objectKey: string,
+): Promise<AttachmentIndexRow | null> {
+  const row = await db
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM github_attachments
+       WHERE workspace = ? AND object_key = ?`,
+    )
+    .bind(workspace, objectKey)
+    .first<AttachmentDbRow>();
+  return row ? fromRow(row) : null;
+}

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -20,14 +20,7 @@ import { type D1Queryable } from "./db-session";
 import { repoForPrefixId } from "./github-private-prefixes";
 
 /** Which server-side path wrote (or last updated) an index row. */
-export type AttachmentSource =
-  | "put"
-  | "attach"
-  | "promote"
-  | "adopt"
-  | "rotate"
-  | "backfill"
-  | "reconcile";
+export type AttachmentSource = "put" | "attach" | "promote" | "adopt" | "backfill" | "reconcile";
 
 export interface ParsedAttachmentKey {
   kind: "pull" | "issues";

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -216,3 +216,53 @@ export async function reattachAttachment(
     .bind(now.toISOString(), workspace, objectKey)
     .run();
 }
+
+/**
+ * D1's hard cap on bound parameters per query (100 — not SQLite's ~999);
+ * `test/helpers/sqlite-d1.ts` enforces the same ceiling. Same constant and
+ * same reasoning as file-metadata.ts's `D1_MAX_BOUND_PARAMS`.
+ */
+const D1_MAX_BOUND_PARAMS = 100;
+
+/** Removes an object's index row (e.g. on object delete). */
+export async function deleteAttachment(
+  db: D1Queryable,
+  workspace: string,
+  objectKey: string,
+): Promise<void> {
+  await db
+    .prepare(`DELETE FROM github_attachments WHERE workspace = ? AND object_key = ?`)
+    .bind(workspace, objectKey)
+    .run();
+}
+
+/**
+ * Removes index rows for a set of objects in one pass (the retention
+ * purge's delete batches). Chunked to stay under D1's bound-parameter
+ * limit, exactly like `deleteFileMetadataForKeys`. No-op on an empty list.
+ */
+export async function deleteAttachmentsForKeys(
+  db: D1Queryable,
+  workspace: string,
+  keys: string[],
+): Promise<void> {
+  const chunkSize = Math.max(1, D1_MAX_BOUND_PARAMS - 1); // the workspace bind
+  for (let i = 0; i < keys.length; i += chunkSize) {
+    const chunk = keys.slice(i, i + chunkSize);
+    const placeholders = chunk.map(() => "?").join(", ");
+    await db
+      .prepare(
+        `DELETE FROM github_attachments WHERE workspace = ? AND object_key IN (${placeholders})`,
+      )
+      .bind(workspace, ...chunk)
+      .run();
+  }
+}
+
+/** Removes every index row for a workspace being torn down. */
+export async function deleteAttachmentsForWorkspace(
+  db: D1Queryable,
+  workspace: string,
+): Promise<void> {
+  await db.prepare(`DELETE FROM github_attachments WHERE workspace = ?`).bind(workspace).run();
+}

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -17,7 +17,8 @@
  */
 import { GH_PRIVATE_ROOT, parseGhPrivateKey } from "@uploads/comment-render";
 import { type D1Queryable } from "./db-session";
-import { repoForPrefixId } from "./github-private-prefixes";
+import { D1_MAX_BOUND_PARAMS } from "./file-metadata";
+import { normalizeRepo, repoForPrefixId } from "./github-private-prefixes";
 
 /** Which server-side path wrote (or last updated) an index row. */
 export type AttachmentSource = "put" | "attach" | "promote" | "adopt" | "backfill" | "reconcile";
@@ -155,7 +156,7 @@ export async function recordAttachment(
     )
     .bind(
       row.workspace,
-      row.repo.toLowerCase(),
+      normalizeRepo(row.repo),
       row.kind,
       row.num,
       row.objectKey,
@@ -222,13 +223,6 @@ export async function reattachAttachment(
     .run();
 }
 
-/**
- * D1's hard cap on bound parameters per query (100 — not SQLite's ~999);
- * `test/helpers/sqlite-d1.ts` enforces the same ceiling. Same constant and
- * same reasoning as file-metadata.ts's `D1_MAX_BOUND_PARAMS`.
- */
-const D1_MAX_BOUND_PARAMS = 100;
-
 /** Removes an object's index row (e.g. on object delete). */
 export async function deleteAttachment(
   db: D1Queryable,
@@ -279,7 +273,9 @@ export async function deleteAttachmentsForWorkspace(
  * key has already inserted a row there, and a second source id in the same
  * sweep can produce the same tail — either way the OLD row is the sole
  * source of truth for the new key, and a plain UPDATE onto an occupied
- * (workspace, object_key) would throw a UNIQUE constraint violation.
+ * (workspace, object_key) would throw a UNIQUE constraint violation. Both
+ * statements go in one `db.batch`, so the delete-then-update is atomic and
+ * costs a single round trip.
  */
 export async function rekeyAttachment(
   db: D1Queryable,
@@ -290,14 +286,17 @@ export async function rekeyAttachment(
   laneId: string | null,
   now = new Date(),
 ): Promise<void> {
-  await deleteAttachment(db, workspace, toKey);
-  await db
-    .prepare(
-      `UPDATE github_attachments SET object_key = ?, prefix_id = ?, lane_id = ?, updated_at = ?
+  await db.batch([
+    db
+      .prepare(`DELETE FROM github_attachments WHERE workspace = ? AND object_key = ?`)
+      .bind(workspace, toKey),
+    db
+      .prepare(
+        `UPDATE github_attachments SET object_key = ?, prefix_id = ?, lane_id = ?, updated_at = ?
        WHERE workspace = ? AND object_key = ?`,
-    )
-    .bind(toKey, newPrefixId, laneId, now.toISOString(), workspace, fromKey)
-    .run();
+      )
+      .bind(toKey, newPrefixId, laneId, now.toISOString(), workspace, fromKey),
+  ]);
 }
 
 /**
@@ -321,82 +320,53 @@ async function safely(message: string, context: Record<string, unknown>, run: ()
   }
 }
 
-export async function recordAttachmentSafe(
-  db: D1Queryable,
-  row: Omit<AttachmentIndexRow, "createdAt" | "updatedAt" | "detachedAt">,
-  now = new Date(),
-): Promise<void> {
-  await safely(
-    "attachment index: record failed",
-    { workspace: row.workspace, objectKey: row.objectKey, source: row.source },
-    () => recordAttachment(db, row, now),
-  );
+/**
+ * Wraps one of the writers above in `safely`, logging with `message` on
+ * failure. The log's `args` context mirrors what each hand-written wrapper
+ * used to log by name — an array argument (a key list) collapses to its
+ * length rather than dumping every key.
+ */
+function safeWriter<A extends unknown[]>(
+  message: string,
+  fn: (db: D1Queryable, ...args: A) => Promise<void>,
+) {
+  return (db: D1Queryable, ...args: A): Promise<void> =>
+    safely(
+      message,
+      Object.fromEntries(args.map((a, i) => [i, Array.isArray(a) ? `${a.length} keys` : a])),
+      () => fn(db, ...args),
+    );
 }
 
-export async function detachAttachmentSafe(
-  db: D1Queryable,
-  workspace: string,
-  objectKey: string,
-  now = new Date(),
-): Promise<void> {
-  await safely("attachment index: detach failed", { workspace, objectKey }, () =>
-    detachAttachment(db, workspace, objectKey, now),
-  );
-}
+export const recordAttachmentSafe = safeWriter(
+  "attachment index: record failed",
+  (
+    db: D1Queryable,
+    row: Omit<AttachmentIndexRow, "createdAt" | "updatedAt" | "detachedAt">,
+    now?: Date,
+  ) => recordAttachment(db, row, now),
+);
 
-export async function reattachAttachmentSafe(
-  db: D1Queryable,
-  workspace: string,
-  objectKey: string,
-  now = new Date(),
-): Promise<void> {
-  await safely("attachment index: reattach failed", { workspace, objectKey }, () =>
-    reattachAttachment(db, workspace, objectKey, now),
-  );
-}
+export const detachAttachmentSafe = safeWriter("attachment index: detach failed", detachAttachment);
 
-export async function deleteAttachmentSafe(
-  db: D1Queryable,
-  workspace: string,
-  objectKey: string,
-): Promise<void> {
-  await safely("attachment index: delete failed", { workspace, objectKey }, () =>
-    deleteAttachment(db, workspace, objectKey),
-  );
-}
+export const reattachAttachmentSafe = safeWriter(
+  "attachment index: reattach failed",
+  reattachAttachment,
+);
 
-export async function deleteAttachmentsForKeysSafe(
-  db: D1Queryable,
-  workspace: string,
-  keys: string[],
-): Promise<void> {
-  await safely("attachment index: batch delete failed", { workspace, keys: keys.length }, () =>
-    deleteAttachmentsForKeys(db, workspace, keys),
-  );
-}
+export const deleteAttachmentSafe = safeWriter("attachment index: delete failed", deleteAttachment);
 
-export async function deleteAttachmentsForWorkspaceSafe(
-  db: D1Queryable,
-  workspace: string,
-): Promise<void> {
-  await safely("attachment index: workspace delete failed", { workspace }, () =>
-    deleteAttachmentsForWorkspace(db, workspace),
-  );
-}
+export const deleteAttachmentsForKeysSafe = safeWriter(
+  "attachment index: batch delete failed",
+  deleteAttachmentsForKeys,
+);
 
-export async function rekeyAttachmentSafe(
-  db: D1Queryable,
-  workspace: string,
-  fromKey: string,
-  toKey: string,
-  newPrefixId: string | null,
-  laneId: string | null,
-  now = new Date(),
-): Promise<void> {
-  await safely("attachment index: rekey failed", { workspace, fromKey, toKey }, () =>
-    rekeyAttachment(db, workspace, fromKey, toKey, newPrefixId, laneId, now),
-  );
-}
+export const deleteAttachmentsForWorkspaceSafe = safeWriter(
+  "attachment index: workspace delete failed",
+  deleteAttachmentsForWorkspace,
+);
+
+export const rekeyAttachmentSafe = safeWriter("attachment index: rekey failed", rekeyAttachment);
 
 /**
  * The one entry point every write path should use: parse the FINAL key,

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -123,8 +123,14 @@ function fromRow(row: AttachmentDbRow): AttachmentIndexRow {
 /**
  * Upserts one attachment row. `ON CONFLICT(workspace, object_key)` makes a
  * re-put, a re-attach, and a webhook redelivery all converge on the same
- * row rather than duplicating; `created_at` is preserved and `detached_at`
- * is cleared, since writing an object at a key IS a re-attachment.
+ * row rather than duplicating; `created_at` is preserved. `detached_at` is
+ * cleared for every source EXCEPT `"put"`: attaching, promoting, adopting,
+ * backfilling, or reconciling a key IS a (re-)attachment and should
+ * reappear in the comment, but `putObject`'s own best-effort index write
+ * fires on every object write — including a plain re-upload of bytes at an
+ * already-detached key (e.g. `gh.detached` metadata never round-trips
+ * through `putObject`) — so a `"put"` alone must never resurrect a row the
+ * caller deliberately detached.
  */
 export async function recordAttachment(
   db: D1Queryable,
@@ -145,7 +151,7 @@ export async function recordAttachment(
          lane_id = excluded.lane_id,
          source = excluded.source,
          updated_at = excluded.updated_at,
-         detached_at = NULL`,
+         detached_at = CASE WHEN excluded.source = 'put' THEN github_attachments.detached_at ELSE NULL END`,
     )
     .bind(
       row.workspace,

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -266,3 +266,30 @@ export async function deleteAttachmentsForWorkspace(
 ): Promise<void> {
   await db.prepare(`DELETE FROM github_attachments WHERE workspace = ?`).bind(workspace).run();
 }
+
+/**
+ * Follows an object through a private-prefix rotation. Destination-first
+ * wipe then UPDATE, mirroring how rotation re-keys `file_metadata`
+ * (github-private-prefix-service.ts): rotation's own `putObject` at the new
+ * key has already inserted a row there, and a second source id in the same
+ * sweep can produce the same tail — either way the OLD row is the sole
+ * source of truth for the new key, and a plain UPDATE onto an occupied
+ * (workspace, object_key) would throw a UNIQUE constraint violation.
+ */
+export async function rekeyAttachment(
+  db: D1Queryable,
+  workspace: string,
+  fromKey: string,
+  toKey: string,
+  newPrefixId: string | null,
+  now = new Date(),
+): Promise<void> {
+  await deleteAttachment(db, workspace, toKey);
+  await db
+    .prepare(
+      `UPDATE github_attachments SET object_key = ?, prefix_id = ?, updated_at = ?
+       WHERE workspace = ? AND object_key = ?`,
+    )
+    .bind(toKey, newPrefixId, now.toISOString(), workspace, fromKey)
+    .run();
+}

--- a/apps/api/src/github-link-adopt.test.ts
+++ b/apps/api/src/github-link-adopt.test.ts
@@ -457,3 +457,56 @@ describe("adoptLinkedFilesForWebhook", () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe("adoptLinkedFiles → attachment index (issue #934)", () => {
+  const target = { repo: REPO, kind: "pull" as const, num: NUM };
+
+  it("records an adopted copy with source 'adopt'", async () => {
+    const seeded = await seededEnv();
+    await seedSource(seeded, "f/shot.png");
+
+    const summary = await adoptLinkedFiles(
+      seeded.env,
+      WS,
+      null,
+      target,
+      "see https://storage.uploads.sh/acme/f/shot.png",
+    );
+
+    const key = summary.adopted[0]!;
+    expect(seeded.db.attachmentIndex.get(`${WS}\0${key}`)).toMatchObject({
+      repo: "acme/web",
+      kind: "pull",
+      num: NUM,
+      source: "adopt",
+      detached_at: null,
+    });
+  });
+
+  it("detaches the row when the link stops being referenced, and re-attaches when it returns", async () => {
+    const seeded = await seededEnv();
+    await seedSource(seeded, "f/shot.png");
+    const first = await adoptLinkedFiles(
+      seeded.env,
+      WS,
+      null,
+      target,
+      "see https://storage.uploads.sh/acme/f/shot.png",
+    );
+    const key = first.adopted[0]!;
+
+    const removed = await adoptLinkedFiles(seeded.env, WS, null, target, "no links now");
+    expect(removed.detached).toEqual([key]);
+    expect(seeded.db.attachmentIndex.get(`${WS}\0${key}`)?.detached_at).not.toBeNull();
+
+    const back = await adoptLinkedFiles(
+      seeded.env,
+      WS,
+      null,
+      target,
+      "back: https://storage.uploads.sh/acme/f/shot.png",
+    );
+    expect(back.reattached).toEqual([key]);
+    expect(seeded.db.attachmentIndex.get(`${WS}\0${key}`)?.detached_at).toBeNull();
+  });
+});

--- a/apps/api/src/github-link-adopt.ts
+++ b/apps/api/src/github-link-adopt.ts
@@ -55,6 +55,11 @@
  * the real `--pr` / promoted attachment, which shares that destination.
  */
 import { attachExistingObject, resolveAttachSourceKey } from "./github-attach";
+import {
+  detachAttachmentSafe,
+  reattachAttachmentSafe,
+  recordAttachmentForKeySafe,
+} from "./github-attachment-index";
 import { commentCacheKey, gatherCommentBody } from "./github-comment";
 import { GH_PRIVATE_ROOT, ghKeyPrefix, type GhTarget } from "./github-comment-render";
 import { postManagedComment } from "./github-comment-service";
@@ -274,6 +279,7 @@ export async function adoptLinkedFiles(
       // Previously detached, now referenced again — un-detach without a
       // re-copy; the object is still in storage untouched.
       await setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "false" });
+      await reattachAttachmentSafe(db, workspaceName, row.objectKey);
       await setAdoptLedgerDetached(db, repo, kind, num, key, null);
       if (row.source !== source) await setAdoptLedgerSource(db, repo, kind, num, key, source);
       summary.reattached.push(row.objectKey);
@@ -286,6 +292,16 @@ export async function adoptLinkedFiles(
         target: { repo: target.repo, kind: target.kind, num: target.num },
       });
       await setFileMetadata(db, workspaceName, result.key, { "gh.detached": "false" });
+      // Attachment index (issue #934): attachExistingObject already wrote a
+      // `source: "attach"` row; overwrite it with "adopt" so the write path
+      // is attributable. `target.repo` is the webhook-resolved repo.
+      await recordAttachmentForKeySafe(db, {
+        workspace: workspaceName,
+        objectKey: result.key,
+        source: "adopt",
+        laneId: ws.storageLaneId ?? null,
+        repo: target.repo,
+      });
       await recordAdoptedLink(db, {
         repo,
         kind,
@@ -328,6 +344,7 @@ export async function adoptLinkedFiles(
     if (referenced) {
       if (row.detachedAt !== null) {
         await setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "false" });
+        await reattachAttachmentSafe(db, workspaceName, row.objectKey);
         await setAdoptLedgerDetached(db, repo, kind, num, row.sourceKey, null);
         summary.reattached.push(row.objectKey);
       }
@@ -335,6 +352,7 @@ export async function adoptLinkedFiles(
     }
     if (row.detachedAt !== null) continue;
     await setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "true" });
+    await detachAttachmentSafe(db, workspaceName, row.objectKey);
     await setAdoptLedgerDetached(db, repo, kind, num, row.sourceKey, new Date().toISOString());
     summary.detached.push(row.objectKey);
   }

--- a/apps/api/src/github-private-prefix-rotate.test.ts
+++ b/apps/api/src/github-private-prefix-rotate.test.ts
@@ -510,7 +510,11 @@ describe("rotatePrivatePrefix", () => {
       prefixId: newId,
       num: NUM,
       source: "attach",
-      laneId: "lane-a",
+      // Not "lane-a" (the OLD row's lane): rotation re-uploads the bytes
+      // through `putObject` into whichever lane is currently active for
+      // `ws`, and `seededEnv`'s `ws` has no `storageLaneId`, so the moved
+      // row must carry `ws.storageLaneId ?? null`, not the stale lane.
+      laneId: ws.storageLaneId ?? null,
     });
   });
 });

--- a/apps/api/src/github-private-prefix-rotate.test.ts
+++ b/apps/api/src/github-private-prefix-rotate.test.ts
@@ -7,6 +7,7 @@
  * `routes/github-private-prefix-rotate.test.ts`.
  */
 import { describe, expect, it } from "vitest";
+import { attachmentRow, recordAttachment } from "./github-attachment-index";
 import { getFileMetadata } from "./file-metadata";
 import { putObject } from "./files-core";
 import {
@@ -459,5 +460,57 @@ describe("rotatePrivatePrefix", () => {
       .bind("item-ws")
       .first<{ object_key: string }>();
     expect(ownItem?.object_key).toBe(newKey);
+  });
+
+  it("issue #934: rotation re-keys the attachment index row onto the new prefix, preserving the old row's identity", async () => {
+    const { env, db, ws } = await seededEnv();
+    const oldId = await getOrMintPrefixId(db, REPO, BRANCH);
+    const pullKey = ghPrivateAttachmentKey(
+      oldId,
+      { repo: REPO, kind: "pull", num: NUM },
+      "hero.png",
+    );
+
+    await putObject(env, ws, pullKey, PNG, WS, {
+      metadata: { "gh.repo": REPO, "gh.kind": "pull", "gh.number": String(NUM) },
+    });
+    // `putObject` above already wrote a `source: "put"` row via its own
+    // best-effort index write — overwrite it here with a distinguishing
+    // `source`/`laneId` so the assertion below can tell "the OLD row
+    // survived the rename" apart from "a fresh row for the new key got
+    // created independently" (which would also happen to have `repo`/`num`
+    // right, since `putObject` resolves those from the `gh.*` metadata).
+    await recordAttachment(db, {
+      workspace: WS,
+      repo: REPO,
+      kind: "pull",
+      num: NUM,
+      objectKey: pullKey,
+      prefixId: oldId,
+      laneId: "lane-a",
+      source: "attach",
+    });
+
+    const result = await withFetch(commentFlowFetch({ bodies: [] }), () =>
+      rotatePrivatePrefix(env, ws, WS, "user-1", REPO, BRANCH),
+    );
+
+    expect(result.rotated).toBe(true);
+    if (!result.rotated) throw new Error("expected rotated: true");
+    const newId = result.prefixId;
+    const newKey = ghPrivateAttachmentKey(
+      newId,
+      { repo: REPO, kind: "pull", num: NUM },
+      "hero.png",
+    );
+
+    expect(await attachmentRow(db, WS, pullKey)).toBeNull();
+    expect(await attachmentRow(db, WS, newKey)).toMatchObject({
+      repo: REPO,
+      prefixId: newId,
+      num: NUM,
+      source: "attach",
+      laneId: "lane-a",
+    });
   });
 });

--- a/apps/api/src/github-private-prefix-rotate.test.ts
+++ b/apps/api/src/github-private-prefix-rotate.test.ts
@@ -38,6 +38,7 @@ const MIGRATIONS = [
   "migrations/20260730170533_delete_usage_claims.sql",
   "migrations/20260811120000_github_ingested_assets.sql",
   "migrations/20260811210000_github_private_prefixes.sql",
+  "migrations/20260903120000_github_attachments.sql",
 ];
 
 const WS = "acme";

--- a/apps/api/src/github-private-prefix-service.ts
+++ b/apps/api/src/github-private-prefix-service.ts
@@ -319,7 +319,19 @@ export async function rotatePrivatePrefix(
           // same tail, so the OLD row must be the sole source of truth for
           // `newKey`. The old key's own row is then removed by the
           // `deleteObject` below (which calls `deleteAttachmentSafe`).
-          await rekeyAttachmentSafe(dbFor(env), workspaceName, item.key, newKey, newId);
+          // `lane_id` is passed explicitly (not carried over from the OLD
+          // row) because `putObject` above just re-uploaded the bytes into
+          // whichever lane is CURRENTLY active for this workspace — the
+          // moved row must reflect that, not the lane the object happened
+          // to be written to originally.
+          await rekeyAttachmentSafe(
+            dbFor(env),
+            workspaceName,
+            item.key,
+            newKey,
+            newId,
+            ws.storageLaneId ?? null,
+          );
 
           // `deleteObject` (not a raw `store.delete`): it also releases the
           // old key's usage-ledger bytes/object count (and its poster, if

--- a/apps/api/src/github-private-prefix-service.ts
+++ b/apps/api/src/github-private-prefix-service.ts
@@ -19,6 +19,7 @@ import { checkRepoAuthorization, postManagedComment } from "./github-comment-ser
 import { GH_PRIVATE_ROOT, type GhTargetKind, parseGhPrivateKey } from "./github-comment-render";
 import { deleteObject, putObject, putOptsFromStoredObject } from "./files-core";
 import { deleteFileMetadata } from "./file-metadata";
+import { rekeyAttachmentSafe } from "./github-attachment-index";
 import {
   getActivePrefixId,
   getOrMintPrefixId,
@@ -310,6 +311,15 @@ export async function rotatePrivatePrefix(
             )
             .bind(newKey, item.key, workspaceName)
             .run();
+
+          // Attachment index (issue #934): the row follows the object onto
+          // the new prefix. Same destination-first-wipe guard as the
+          // file_metadata re-key above — `putObject` just inserted a row at
+          // `newKey`, and a second sourceId in this sweep can produce the
+          // same tail, so the OLD row must be the sole source of truth for
+          // `newKey`. The old key's own row is then removed by the
+          // `deleteObject` below (which calls `deleteAttachmentSafe`).
+          await rekeyAttachmentSafe(dbFor(env), workspaceName, item.key, newKey, newId);
 
           // `deleteObject` (not a raw `store.delete`): it also releases the
           // old key's usage-ledger bytes/object count (and its poster, if

--- a/apps/api/src/github-private-prefixes.ts
+++ b/apps/api/src/github-private-prefixes.ts
@@ -18,7 +18,7 @@ interface PrefixRow {
   prefix_id: string;
 }
 
-function normalizeRepo(repo: string): string {
+export function normalizeRepo(repo: string): string {
   return repo.toLowerCase();
 }
 

--- a/apps/api/src/github-private-prefixes.ts
+++ b/apps/api/src/github-private-prefixes.ts
@@ -230,3 +230,28 @@ export async function retirePrefixId(
     .bind(now.toISOString(), normalizeRepo(repo), normalizeBranch(branch), prefixId)
     .run();
 }
+
+interface PrefixRepoRow {
+  repo_full_name: string;
+}
+
+/**
+ * The repo that minted `prefixId`, or null if the id is unknown.
+ *
+ * A private-repo key (`gh/private/<id>/…`) deliberately omits the repo, and
+ * the object's `gh.repo` metadata is CLIENT-SETTABLE — so this row, minted
+ * server-side for exactly one repo, is the only authoritative answer for
+ * "which repo does this private attachment belong to?" (issue #934's
+ * attachment index derives every row's `repo` from here).
+ *
+ * Rotated (tombstoned) ids resolve too: ownership is what matters, not
+ * whether the id is still active.
+ */
+export async function repoForPrefixId(db: D1Queryable, prefixId: string): Promise<string | null> {
+  if (!PRIVATE_PREFIX_ID_RE.test(prefixId)) return null;
+  const row = await db
+    .prepare(`SELECT repo_full_name FROM github_private_prefixes WHERE prefix_id = ? LIMIT 1`)
+    .bind(prefixId)
+    .first<PrefixRepoRow>();
+  return row ? row.repo_full_name : null;
+}

--- a/apps/api/src/github-promote.test.ts
+++ b/apps/api/src/github-promote.test.ts
@@ -382,3 +382,51 @@ describe("promoteBranchAttachments — private prefixes (issue #631)", () => {
     expect(ghPrivateBranchKeyPrefix("0".repeat(32))).toBe(`gh/private/${"0".repeat(32)}/branch/`);
   });
 });
+
+describe("promoteBranchAttachments → attachment index (issue #934)", () => {
+  it("records the promoted copy with source 'promote' and no row for the staged original", async () => {
+    const seeded = await seededEnv({ isPrivate: false });
+    await seedPlainStaged(seeded, "hero.png");
+
+    const result = await promoteBranchAttachments(seeded.env, seeded.ws, WS, {
+      repo: REPO,
+      num: NUM,
+      branch: BRANCH,
+    });
+
+    expect(result.promoted).toEqual([destKey("hero.png")]);
+    expect(seeded.db.attachmentIndex.get(`${WS}\0${destKey("hero.png")}`)).toMatchObject({
+      repo: "acme/web",
+      kind: "pull",
+      num: NUM,
+      prefix_id: null,
+      source: "promote",
+    });
+    expect(seeded.db.attachmentIndex.get(`${WS}\0${stagedKey("hero.png")}`)).toBeUndefined();
+    expect(seeded.db.attachmentIndex.size).toBe(1);
+  });
+
+  it("private mode records the promoted copy under its prefix id", async () => {
+    const seeded = await seededEnv({ isPrivate: true });
+    const prefixId = await getOrMintPrefixId(seeded.db as unknown as D1Database, REPO, BRANCH);
+    await seedPrivateStaged(seeded, prefixId, "hero.png");
+
+    const result = await promoteBranchAttachments(seeded.env, seeded.ws, WS, {
+      repo: REPO,
+      num: NUM,
+      branch: BRANCH,
+    });
+
+    const dest = ghPrivateAttachmentKey(
+      prefixId,
+      { repo: REPO, kind: "pull", num: NUM },
+      "hero.png",
+    );
+    expect(result.promoted).toEqual([dest]);
+    expect(seeded.db.attachmentIndex.get(`${WS}\0${dest}`)).toMatchObject({
+      repo: "acme/web",
+      prefix_id: prefixId,
+      source: "promote",
+    });
+  });
+});

--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -19,6 +19,7 @@
 
 import { getMetadataForKeys, setFileMetadata } from "./file-metadata";
 import { putObject, putOptsFromStoredObject } from "./files-core";
+import { recordAttachmentForKeySafe } from "./github-attachment-index";
 import { resolveBranchLineageSafe } from "./github-branch-renames";
 import { ghPrivateAttachmentKey, ghPrivateBranchKeyPrefix } from "./github-comment-render";
 import { getActivePrefixId } from "./github-private-prefixes";
@@ -429,6 +430,21 @@ export async function promoteBranchAttachments(
     // below. Tagging the staged original is best-effort bookkeeping: a
     // failure here must not un-promote the file or land it in `skipped`.
     promoted.push(destKey);
+
+    // Attachment index (issue #934): re-record putObject's row as a
+    // promote, with the repo the webhook/route resolved. The STAGED
+    // ORIGINAL deliberately gets no row — it lives under the branch prefix,
+    // outside the target's attachment prefix, and is not an attachment
+    // (`parseAttachmentKey` returns undefined for branch keys, so putObject
+    // never indexed it either).
+    await recordAttachmentForKeySafe(dbFor(env), {
+      workspace: workspaceName,
+      objectKey: destKey,
+      source: "promote",
+      laneId: ws.storageLaneId ?? null,
+      repo: target.repo,
+    });
+
     try {
       // Merge (not replace) onto the staged original: mark it promoted
       // without disturbing its own gh.repo/gh.kind/gh.branch/gh.staged-at

--- a/apps/api/src/retention.ts
+++ b/apps/api/src/retention.ts
@@ -16,6 +16,7 @@
  */
 import { positiveLimit } from "./budget";
 import { deleteFileMetadataForKeys } from "./file-metadata";
+import { deleteAttachmentsForKeysSafe } from "./github-attachment-index";
 import { reconcileWorkspaceUsage, type ReconcileResult } from "./reconcile";
 import { storage } from "./storage";
 import { isUnprefixedDedicatedBucket, type WorkspaceRecord } from "./workspace";
@@ -88,6 +89,9 @@ export async function purgeExpiredObjects(
     // Bulk form: native multi-delete on R2/S3 when available.
     await store.delete(batch);
     await deleteFileMetadataForKeys(dbFor(env), workspaceName, batch);
+    // Attachment index rows follow their objects (issue #934); chunked the
+    // same way and best-effort, so a D1 hiccup never strands the sweep.
+    await deleteAttachmentsForKeysSafe(dbFor(env), workspaceName, batch);
     batch = [];
   }
 

--- a/apps/api/src/workspace-teardown.ts
+++ b/apps/api/src/workspace-teardown.ts
@@ -18,6 +18,7 @@
 import { dbFor } from "./db-session";
 import { deleteFileMetadataForWorkspace } from "./file-metadata";
 import { deleteGalleriesForWorkspace } from "./galleries";
+import { deleteAttachmentsForWorkspaceSafe } from "./github-attachment-index";
 import { deleteOrg } from "./org-workspaces";
 import { storage } from "./storage";
 import { deleteUsageForWorkspace } from "./usage";
@@ -101,6 +102,9 @@ export async function teardownWorkspace(
 
   const { galleries } = await deleteGalleriesForWorkspace(dbFor(env), name);
   await deleteFileMetadataForWorkspace(dbFor(env), name);
+  // The attachment index is workspace-scoped like file_metadata (issue
+  // #934) — a torn-down workspace must not leave rows behind.
+  await deleteAttachmentsForWorkspaceSafe(dbFor(env), name);
   await deleteUsageForWorkspace(dbFor(env), name);
 
   // Best-effort, like the self-serve rollback path in routes/workspaces.ts

--- a/apps/api/test/files-core-attachment-index.test.ts
+++ b/apps/api/test/files-core-attachment-index.test.ts
@@ -4,6 +4,8 @@
  * file_metadata + github_attachments table.
  */
 import { describe, expect, it } from "vitest";
+import { type D1Queryable } from "../src/db-session";
+import { detachAttachment } from "../src/github-attachment-index";
 import { deleteObject, putObject } from "../src/files-core";
 import { ghPrivateAttachmentKey } from "../src/github-comment-render";
 import { getOrMintPrefixId } from "../src/github-private-prefixes";
@@ -71,6 +73,28 @@ describe("putObject → attachment index", () => {
     await putObject(env, ws, key, PNG, WORKSPACE);
     await putObject(env, ws, key, PNG, WORKSPACE);
     expect(db.attachmentIndex.size).toBe(1);
+  });
+
+  it("a detached row survives a re-put of the same key (putObject writes source 'put')", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const key = "gh/acme/web/pull/12/hero.png";
+    await putObject(env, ws, key, PNG, WORKSPACE);
+    await detachAttachment(
+      db as unknown as D1Queryable,
+      WORKSPACE,
+      key,
+      new Date("2026-09-05T00:00:00.000Z"),
+    );
+    expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toMatchObject({
+      detached_at: "2026-09-05T00:00:00.000Z",
+    });
+
+    await putObject(env, ws, key, PNG, WORKSPACE);
+
+    expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toMatchObject({
+      source: "put",
+      detached_at: "2026-09-05T00:00:00.000Z",
+    });
   });
 });
 

--- a/apps/api/test/files-core-attachment-index.test.ts
+++ b/apps/api/test/files-core-attachment-index.test.ts
@@ -4,7 +4,7 @@
  * file_metadata + github_attachments table.
  */
 import { describe, expect, it } from "vitest";
-import { putObject } from "../src/files-core";
+import { deleteObject, putObject } from "../src/files-core";
 import { ghPrivateAttachmentKey } from "../src/github-comment-render";
 import { getOrMintPrefixId } from "../src/github-private-prefixes";
 import { makePosterEnv, PNG, WORKSPACE } from "./poster-fixtures";
@@ -71,5 +71,17 @@ describe("putObject → attachment index", () => {
     await putObject(env, ws, key, PNG, WORKSPACE);
     await putObject(env, ws, key, PNG, WORKSPACE);
     expect(db.attachmentIndex.size).toBe(1);
+  });
+});
+
+describe("deleteObject → attachment index", () => {
+  it("removes the index row alongside the object's metadata", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const key = "gh/acme/web/pull/12/hero.png";
+    await putObject(env, ws, key, PNG, WORKSPACE);
+    expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toBeDefined();
+
+    await deleteObject(env, ws, key, WORKSPACE);
+    expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toBeUndefined();
   });
 });

--- a/apps/api/test/files-core-attachment-index.test.ts
+++ b/apps/api/test/files-core-attachment-index.test.ts
@@ -1,0 +1,75 @@
+/**
+ * putObject/deleteObject ↔ github_attachments index wiring (issue #934,
+ * phase 1). Uses makePosterEnv's UsageFakeD1, which backs a real
+ * file_metadata + github_attachments table.
+ */
+import { describe, expect, it } from "vitest";
+import { putObject } from "../src/files-core";
+import { ghPrivateAttachmentKey } from "../src/github-comment-render";
+import { getOrMintPrefixId } from "../src/github-private-prefixes";
+import { makePosterEnv, PNG, WORKSPACE } from "./poster-fixtures";
+
+describe("putObject → attachment index", () => {
+  it("indexes a plain gh attachment key with source 'put'", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const key = "gh/acme/web/pull/12/hero.png";
+    await putObject(env, ws, key, PNG, WORKSPACE);
+    expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toMatchObject({
+      workspace: WORKSPACE,
+      repo: "acme/web",
+      kind: "pull",
+      num: 12,
+      object_key: key,
+      prefix_id: null,
+      lane_id: null,
+      source: "put",
+      detached_at: null,
+    });
+  });
+
+  it("indexes a private key, taking the repo from the prefix id's owner", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const id = await getOrMintPrefixId(env.DB, "acme/web", "feat-x");
+    const key = ghPrivateAttachmentKey(id, { repo: "acme/web", kind: "pull", num: 12 }, "hero.png");
+    await putObject(env, ws, key, PNG, WORKSPACE);
+    expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toMatchObject({
+      repo: "acme/web",
+      prefix_id: id,
+      num: 12,
+      source: "put",
+    });
+  });
+
+  it("ignores a client-supplied gh.repo/gh.ref naming another repo", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const key = "gh/acme/web/pull/12/hero.png";
+    await putObject(env, ws, key, PNG, WORKSPACE, {
+      metadata: {
+        "gh.repo": "evil/other",
+        "gh.kind": "pull",
+        "gh.number": "999",
+        "gh.ref": "evil/other#999",
+      },
+    });
+    expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toMatchObject({
+      repo: "acme/web",
+      num: 12,
+    });
+  });
+
+  it("writes no row for non-attachment keys (bare uploads, branch staging, ingest)", async () => {
+    const { env, db, ws } = makePosterEnv();
+    await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+    await putObject(env, ws, "gh/acme/web/branch/feat-x/shot.png", PNG, WORKSPACE);
+    await putObject(env, ws, "gh/acme-web/pull-12/asset-1.png", PNG, WORKSPACE);
+    expect(db.attachmentIndex.size).toBe(0);
+  });
+
+  it("re-putting the same key upserts rather than duplicating", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const key = "gh/acme/web/pull/12/hero.png";
+    await putObject(env, ws, key, PNG, WORKSPACE);
+    await putObject(env, ws, key, PNG, WORKSPACE);
+    expect(db.attachmentIndex.size).toBe(1);
+  });
+});

--- a/apps/api/test/files-core-attachment-index.test.ts
+++ b/apps/api/test/files-core-attachment-index.test.ts
@@ -109,3 +109,17 @@ describe("deleteObject → attachment index", () => {
     expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toBeUndefined();
   });
 });
+
+describe("deleteObject → attachment index on a failed lane delete", () => {
+  it("keeps the index row when the storage delete throws, since the object still exists", async () => {
+    const { env, db, ws, bucket } = makePosterEnv();
+    const key = "gh/acme/web/pull/12/hero.png";
+    await putObject(env, ws, key, PNG, WORKSPACE);
+    bucket.delete = async () => {
+      throw new Error("lane delete failed");
+    };
+
+    await expect(deleteObject(env, ws, key, WORKSPACE)).rejects.toThrow("lane delete failed");
+    expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toBeDefined();
+  });
+});

--- a/apps/api/test/github-attach-index.test.ts
+++ b/apps/api/test/github-attach-index.test.ts
@@ -1,0 +1,80 @@
+/**
+ * attachExistingObject ↔ github_attachments index wiring (issue #934).
+ */
+import { describe, expect, it } from "vitest";
+import { attachExistingObject } from "../src/github-attach";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { FakeKv } from "./fake-kv";
+import { FakeR2Bucket } from "./fake-r2";
+import { UsageFakeD1 } from "./usage-fake-d1";
+import { GITHUB_APP_CFG_ENV } from "./github-app-env";
+
+const WS = "acme";
+const PREFIX = "acme/";
+const REPO = "acme/web";
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+async function seededEnv() {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: PREFIX,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex("unused"), createdAt: new Date().toISOString() }],
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  const kv = new FakeKv();
+  kv.store.set(`ghpriv:${REPO}`, { value: "0" });
+  const env = {
+    REGISTRY: { get: async (key: string) => (key === `ws:${WS}` ? record : null) },
+    DB: db,
+    UPLOADS_DEFAULT: bucket,
+    GITHUB_CACHE: kv,
+    ...GITHUB_APP_CFG_ENV,
+  } as unknown as Env;
+  return { env, db, bucket, ws: record };
+}
+
+describe("attachExistingObject → attachment index (issue #934)", () => {
+  it("records the destination with source 'attach'", async () => {
+    const { env, db, bucket, ws } = await seededEnv();
+    await bucket.put(`${PREFIX}f/shot.png`, PNG, { httpMetadata: { contentType: "image/png" } });
+
+    const result = await attachExistingObject(env, ws, WS, {
+      source: "f/shot.png",
+      target: { repo: REPO, kind: "pull", num: 12 },
+    });
+
+    expect(db.attachmentIndex.get(`${WS}\0${result.key}`)).toMatchObject({
+      repo: "acme/web",
+      kind: "pull",
+      num: 12,
+      object_key: result.key,
+      prefix_id: null,
+      source: "attach",
+    });
+  });
+
+  it("--move deletes the source object's row when the source was itself an attachment", async () => {
+    const { env, db, bucket, ws } = await seededEnv();
+    const sourceKey = "gh/acme/web/pull/11/shot.png";
+    await bucket.put(`${PREFIX}${sourceKey}`, PNG, { httpMetadata: { contentType: "image/png" } });
+    await attachExistingObject(env, ws, WS, {
+      source: sourceKey,
+      target: { repo: REPO, kind: "pull", num: 11 },
+    });
+    expect(db.attachmentIndex.get(`${WS}\0${sourceKey}`)).toBeDefined();
+
+    const moved = await attachExistingObject(env, ws, WS, {
+      source: sourceKey,
+      target: { repo: REPO, kind: "pull", num: 12 },
+      move: true,
+    });
+
+    expect(moved.moved).toBe(true);
+    expect(db.attachmentIndex.get(`${WS}\0${sourceKey}`)).toBeUndefined();
+    expect(db.attachmentIndex.get(`${WS}\0${moved.key}`)).toMatchObject({ num: 12 });
+  });
+});

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -1,7 +1,26 @@
 /// <reference types="node" />
 
 import { describe, expect, it } from "vitest";
-import { parseAttachmentKey } from "../src/github-attachment-index";
+import {
+  attachmentRow,
+  parseAttachmentKey,
+  recordAttachment,
+} from "../src/github-attachment-index";
+import { database, SqliteD1 } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = ["migrations/20260903120000_github_attachments.sql"];
+
+const row = (over: Partial<Parameters<typeof recordAttachment>[1]> = {}) => ({
+  workspace: "acme",
+  repo: "acme/web",
+  kind: "pull" as const,
+  num: 12,
+  objectKey: "gh/acme/web/pull/12/hero.png",
+  prefixId: null,
+  laneId: null,
+  source: "put" as const,
+  ...over,
+});
 
 describe("parseAttachmentKey", () => {
   it("parses a plain gh key and recovers the sanitized repo", () => {
@@ -44,5 +63,75 @@ describe("parseAttachmentKey", () => {
     expect(parseAttachmentKey("gh/acme/web/pull/abc/hero.png")).toBeUndefined();
     expect(parseAttachmentKey("f/abc/hero.png")).toBeUndefined();
     expect(parseAttachmentKey("gh/private/short/pull/12/hero.png")).toBeUndefined();
+  });
+});
+
+describe("recordAttachment", () => {
+  it("inserts a row and reads it back", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordAttachment(db, row(), new Date("2026-09-03T00:00:00.000Z"));
+      const stored = await attachmentRow(db, "acme", "gh/acme/web/pull/12/hero.png");
+      expect(stored).toMatchObject({
+        workspace: "acme",
+        repo: "acme/web",
+        kind: "pull",
+        num: 12,
+        objectKey: "gh/acme/web/pull/12/hero.png",
+        prefixId: null,
+        laneId: null,
+        source: "put",
+        createdAt: "2026-09-03T00:00:00.000Z",
+        updatedAt: "2026-09-03T00:00:00.000Z",
+        detachedAt: null,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("upserts on (workspace, object_key): one row, fields updated, created_at kept", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordAttachment(db, row(), new Date("2026-09-03T00:00:00.000Z"));
+      await recordAttachment(
+        db,
+        row({ source: "attach", laneId: "lane-b", prefixId: "d".repeat(32) }),
+        new Date("2026-09-04T00:00:00.000Z"),
+      );
+      const stored = await attachmentRow(db, "acme", "gh/acme/web/pull/12/hero.png");
+      expect(stored).toMatchObject({
+        source: "attach",
+        laneId: "lane-b",
+        prefixId: "d".repeat(32),
+        createdAt: "2026-09-03T00:00:00.000Z",
+        updatedAt: "2026-09-04T00:00:00.000Z",
+      });
+      const all = await db
+        .prepare("SELECT COUNT(*) AS count FROM github_attachments")
+        .bind()
+        .first<{ count: number }>();
+      expect(all?.count).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("lowercases the repo and scopes by workspace", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordAttachment(db, row({ repo: "Acme/Web" }));
+      await recordAttachment(db, row({ workspace: "other" }));
+      expect((await attachmentRow(db, "acme", "gh/acme/web/pull/12/hero.png"))?.repo).toBe(
+        "acme/web",
+      );
+      expect(await attachmentRow(db, "other", "gh/acme/web/pull/12/hero.png")).not.toBeNull();
+      expect(await attachmentRow(db, "nobody", "gh/acme/web/pull/12/hero.png")).toBeNull();
+    } finally {
+      sqlite.close();
+    }
   });
 });

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -1,16 +1,23 @@
 /// <reference types="node" />
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   attachmentRow,
   deleteAttachment,
+  deleteAttachmentSafe,
   deleteAttachmentsForKeys,
+  deleteAttachmentsForKeysSafe,
   deleteAttachmentsForWorkspace,
+  deleteAttachmentsForWorkspaceSafe,
   detachAttachment,
+  detachAttachmentSafe,
   parseAttachmentKey,
   reattachAttachment,
+  reattachAttachmentSafe,
   recordAttachment,
+  recordAttachmentSafe,
   rekeyAttachment,
+  rekeyAttachmentSafe,
 } from "../src/github-attachment-index";
 import { database, SqliteD1 } from "./helpers/sqlite-d1";
 
@@ -324,6 +331,49 @@ describe("rekeyAttachment", () => {
       expect(await attachmentRow(db, "acme", "gh/acme/web/pull/12/b.png")).toBeNull();
     } finally {
       sqlite.close();
+    }
+  });
+});
+
+describe("attachment index safe writers", () => {
+  const throwingDb = {
+    prepare: () => ({
+      bind: () => ({
+        run: async () => {
+          throw new Error("D1 exploded");
+        },
+        first: async () => {
+          throw new Error("D1 exploded");
+        },
+        all: async () => {
+          throw new Error("D1 exploded");
+        },
+      }),
+    }),
+    batch: async () => [],
+  } as unknown as Parameters<typeof recordAttachment>[0];
+
+  it("swallow D1 failures and log a JSON line", async () => {
+    const errors: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((msg) => {
+      errors.push(String(msg));
+    });
+    try {
+      await recordAttachmentSafe(throwingDb, row());
+      await detachAttachmentSafe(throwingDb, "acme", row().objectKey);
+      await reattachAttachmentSafe(throwingDb, "acme", row().objectKey);
+      await deleteAttachmentSafe(throwingDb, "acme", row().objectKey);
+      await deleteAttachmentsForKeysSafe(throwingDb, "acme", [row().objectKey]);
+      await deleteAttachmentsForWorkspaceSafe(throwingDb, "acme");
+      await rekeyAttachmentSafe(throwingDb, "acme", "a", "b", null);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(errors).toHaveLength(7);
+    for (const line of errors) {
+      const parsed = JSON.parse(line) as { message: string; error: string };
+      expect(parsed.message).toContain("attachment index");
+      expect(parsed.error).toBe("D1 exploded");
     }
   });
 });

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -10,6 +10,7 @@ import {
   parseAttachmentKey,
   reattachAttachment,
   recordAttachment,
+  rekeyAttachment,
 } from "../src/github-attachment-index";
 import { database, SqliteD1 } from "./helpers/sqlite-d1";
 
@@ -245,6 +246,82 @@ describe("attachment index deletes", () => {
       await deleteAttachmentsForWorkspace(db, "acme");
       expect(await attachmentRow(db, "acme", row().objectKey)).toBeNull();
       expect(await attachmentRow(db, "other", row().objectKey)).not.toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("rekeyAttachment", () => {
+  it("moves a row to the new key and prefix id", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      const oldId = "a".repeat(32);
+      const newId = "b".repeat(32);
+      const fromKey = `gh/private/${oldId}/pull/12/hero.png`;
+      const toKey = `gh/private/${newId}/pull/12/hero.png`;
+      await recordAttachment(db, row({ objectKey: fromKey, prefixId: oldId }));
+
+      await rekeyAttachment(
+        db,
+        "acme",
+        fromKey,
+        toKey,
+        newId,
+        new Date("2026-09-07T00:00:00.000Z"),
+      );
+
+      expect(await attachmentRow(db, "acme", fromKey)).toBeNull();
+      expect(await attachmentRow(db, "acme", toKey)).toMatchObject({
+        prefixId: newId,
+        updatedAt: "2026-09-07T00:00:00.000Z",
+        source: "put",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("wipes an already-occupied destination row before the update", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      const oldId = "a".repeat(32);
+      const newId = "b".repeat(32);
+      const fromKey = `gh/private/${oldId}/pull/12/hero.png`;
+      const toKey = `gh/private/${newId}/pull/12/hero.png`;
+      // putObject already wrote a row at the destination during rotation.
+      await recordAttachment(db, row({ objectKey: toKey, prefixId: newId, source: "rotate" }));
+      await recordAttachment(db, row({ objectKey: fromKey, prefixId: oldId, laneId: "lane-a" }));
+
+      await rekeyAttachment(db, "acme", fromKey, toKey, newId);
+
+      expect(await attachmentRow(db, "acme", fromKey)).toBeNull();
+      const dest = await attachmentRow(db, "acme", toKey);
+      expect(dest).toMatchObject({ prefixId: newId, laneId: "lane-a", source: "put" });
+      const count = await db
+        .prepare("SELECT COUNT(*) AS count FROM github_attachments")
+        .bind()
+        .first<{ count: number }>();
+      expect(count?.count).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("is a no-op when the source key has no row", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await rekeyAttachment(
+        db,
+        "acme",
+        "gh/acme/web/pull/12/a.png",
+        "gh/acme/web/pull/12/b.png",
+        null,
+      );
+      expect(await attachmentRow(db, "acme", "gh/acme/web/pull/12/b.png")).toBeNull();
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -15,13 +15,20 @@ import {
   reattachAttachment,
   reattachAttachmentSafe,
   recordAttachment,
+  recordAttachmentForKeySafe,
   recordAttachmentSafe,
   rekeyAttachment,
   rekeyAttachmentSafe,
 } from "../src/github-attachment-index";
+import { getOrMintPrefixId } from "../src/github-private-prefixes";
 import { database, SqliteD1 } from "./helpers/sqlite-d1";
 
 const MIGRATIONS = ["migrations/20260903120000_github_attachments.sql"];
+
+const MIGRATIONS_WITH_PREFIXES = [
+  "migrations/20260903120000_github_attachments.sql",
+  "migrations/20260811210000_github_private_prefixes.sql",
+];
 
 const row = (over: Partial<Parameters<typeof recordAttachment>[1]> = {}) => ({
   workspace: "acme",
@@ -374,6 +381,98 @@ describe("attachment index safe writers", () => {
       const parsed = JSON.parse(line) as { message: string; error: string };
       expect(parsed.message).toContain("attachment index");
       expect(parsed.error).toBe("D1 exploded");
+    }
+  });
+});
+
+describe("recordAttachmentForKeySafe", () => {
+  it("derives repo/kind/num from a plain key", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS_WITH_PREFIXES);
+    try {
+      const db = database(sqlite);
+      await recordAttachmentForKeySafe(db, {
+        workspace: "acme",
+        objectKey: "gh/Acme/Web/pull/12/hero.png",
+        source: "put",
+        laneId: null,
+      });
+      expect(await attachmentRow(db, "acme", "gh/Acme/Web/pull/12/hero.png")).toMatchObject({
+        repo: "acme/web",
+        kind: "pull",
+        num: 12,
+        prefixId: null,
+        source: "put",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("resolves a private key's repo from the prefix id's owning row", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS_WITH_PREFIXES);
+    try {
+      const db = database(sqlite);
+      const id = await getOrMintPrefixId(db, "acme/web", "feat-x");
+      const key = `gh/private/${id}/pull/12/hero.png`;
+      await recordAttachmentForKeySafe(db, {
+        workspace: "acme",
+        objectKey: key,
+        source: "put",
+        laneId: "lane-a",
+      });
+      expect(await attachmentRow(db, "acme", key)).toMatchObject({
+        repo: "acme/web",
+        prefixId: id,
+        laneId: "lane-a",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("prefers the caller's server-resolved repo over the key's sanitized spelling", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS_WITH_PREFIXES);
+    try {
+      const db = database(sqlite);
+      await recordAttachmentForKeySafe(db, {
+        workspace: "acme",
+        objectKey: "gh/acme/we-b/pull/12/hero.png",
+        source: "attach",
+        laneId: null,
+        repo: "Acme/we.b",
+      });
+      expect((await attachmentRow(db, "acme", "gh/acme/we-b/pull/12/hero.png"))?.repo).toBe(
+        "acme/we.b",
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("writes nothing for a non-attachment key or an unresolvable private repo", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS_WITH_PREFIXES);
+    try {
+      const db = database(sqlite);
+      await recordAttachmentForKeySafe(db, {
+        workspace: "acme",
+        objectKey: "f/abc/hero.png",
+        source: "put",
+        laneId: null,
+      });
+      const orphanKey = `gh/private/${"e".repeat(32)}/pull/12/hero.png`;
+      await recordAttachmentForKeySafe(db, {
+        workspace: "acme",
+        objectKey: orphanKey,
+        source: "put",
+        laneId: null,
+      });
+      const count = await db
+        .prepare("SELECT COUNT(*) AS count FROM github_attachments")
+        .bind()
+        .first<{ count: number }>();
+      expect(count?.count).toBe(0);
+    } finally {
+      sqlite.close();
     }
   });
 });

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -3,7 +3,9 @@
 import { describe, expect, it } from "vitest";
 import {
   attachmentRow,
+  detachAttachment,
   parseAttachmentKey,
+  reattachAttachment,
   recordAttachment,
 } from "../src/github-attachment-index";
 import { database, SqliteD1 } from "./helpers/sqlite-d1";
@@ -130,6 +132,53 @@ describe("recordAttachment", () => {
       );
       expect(await attachmentRow(db, "other", "gh/acme/web/pull/12/hero.png")).not.toBeNull();
       expect(await attachmentRow(db, "nobody", "gh/acme/web/pull/12/hero.png")).toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("detachAttachment / reattachAttachment", () => {
+  it("flips detached_at and back, bumping updated_at", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordAttachment(db, row(), new Date("2026-09-03T00:00:00.000Z"));
+      await detachAttachment(db, "acme", row().objectKey, new Date("2026-09-05T00:00:00.000Z"));
+      expect(await attachmentRow(db, "acme", row().objectKey)).toMatchObject({
+        detachedAt: "2026-09-05T00:00:00.000Z",
+        updatedAt: "2026-09-05T00:00:00.000Z",
+      });
+      await reattachAttachment(db, "acme", row().objectKey, new Date("2026-09-06T00:00:00.000Z"));
+      expect(await attachmentRow(db, "acme", row().objectKey)).toMatchObject({
+        detachedAt: null,
+        updatedAt: "2026-09-06T00:00:00.000Z",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("recordAttachment clears a previously-set detached_at", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordAttachment(db, row());
+      await detachAttachment(db, "acme", row().objectKey);
+      await recordAttachment(db, row({ source: "attach" }));
+      expect((await attachmentRow(db, "acme", row().objectKey))?.detachedAt).toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("is a no-op on a key with no row", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await detachAttachment(db, "acme", "gh/acme/web/pull/12/nope.png");
+      await reattachAttachment(db, "acme", "gh/acme/web/pull/12/nope.png");
+      expect(await attachmentRow(db, "acme", "gh/acme/web/pull/12/nope.png")).toBeNull();
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -75,6 +75,23 @@ describe("parseAttachmentKey", () => {
     ).toBeUndefined();
   });
 
+  it("falls through to the plain parse for an owner literally named 'private'", () => {
+    expect(parseAttachmentKey("gh/private/web/pull/12/x.png")).toEqual({
+      kind: "pull",
+      num: 12,
+      prefixId: null,
+      repo: "private/web",
+    });
+    const id = "f".repeat(32);
+    expect(parseAttachmentKey(`gh/private/${id}/pull/12/hero.png`)).toEqual({
+      kind: "pull",
+      num: 12,
+      prefixId: id,
+      repo: null,
+    });
+    expect(parseAttachmentKey(`gh/private/${"g".repeat(32)}/branch/x.png`)).toBeUndefined();
+  });
+
   it("returns undefined for branch-staged, malformed, and non-gh keys", () => {
     expect(parseAttachmentKey("gh/acme/web/branch/feat-x/hero.png")).toBeUndefined();
     expect(parseAttachmentKey(`gh/private/${"c".repeat(32)}/branch/hero.png`)).toBeUndefined();
@@ -82,7 +99,6 @@ describe("parseAttachmentKey", () => {
     expect(parseAttachmentKey("gh/acme/web/pull/12/")).toBeUndefined();
     expect(parseAttachmentKey("gh/acme/web/pull/abc/hero.png")).toBeUndefined();
     expect(parseAttachmentKey("f/abc/hero.png")).toBeUndefined();
-    expect(parseAttachmentKey("gh/private/short/pull/12/hero.png")).toBeUndefined();
   });
 });
 

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -3,6 +3,9 @@
 import { describe, expect, it } from "vitest";
 import {
   attachmentRow,
+  deleteAttachment,
+  deleteAttachmentsForKeys,
+  deleteAttachmentsForWorkspace,
   detachAttachment,
   parseAttachmentKey,
   reattachAttachment,
@@ -179,6 +182,69 @@ describe("detachAttachment / reattachAttachment", () => {
       await detachAttachment(db, "acme", "gh/acme/web/pull/12/nope.png");
       await reattachAttachment(db, "acme", "gh/acme/web/pull/12/nope.png");
       expect(await attachmentRow(db, "acme", "gh/acme/web/pull/12/nope.png")).toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("attachment index deletes", () => {
+  it("deleteAttachment removes exactly one row", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordAttachment(db, row());
+      await recordAttachment(db, row({ objectKey: "gh/acme/web/pull/12/two.png" }));
+      await deleteAttachment(db, "acme", row().objectKey);
+      expect(await attachmentRow(db, "acme", row().objectKey)).toBeNull();
+      expect(await attachmentRow(db, "acme", "gh/acme/web/pull/12/two.png")).not.toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("deleteAttachmentsForKeys chunks past D1's 100-bound-parameter cap", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      const keys = Array.from({ length: 250 }, (_, i) => `gh/acme/web/pull/12/f${i}.png`);
+      for (const objectKey of keys) await recordAttachment(db, row({ objectKey }));
+      await recordAttachment(db, row({ objectKey: "gh/acme/web/pull/12/keep.png" }));
+
+      await deleteAttachmentsForKeys(db, "acme", keys);
+
+      const remaining = await db
+        .prepare("SELECT COUNT(*) AS count FROM github_attachments")
+        .bind()
+        .first<{ count: number }>();
+      expect(remaining?.count).toBe(1);
+      expect(await attachmentRow(db, "acme", "gh/acme/web/pull/12/keep.png")).not.toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("deleteAttachmentsForKeys is a no-op on an empty list", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordAttachment(db, row());
+      await deleteAttachmentsForKeys(db, "acme", []);
+      expect(await attachmentRow(db, "acme", row().objectKey)).not.toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("deleteAttachmentsForWorkspace clears one workspace only", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordAttachment(db, row());
+      await recordAttachment(db, row({ workspace: "other" }));
+      await deleteAttachmentsForWorkspace(db, "acme");
+      expect(await attachmentRow(db, "acme", row().objectKey)).toBeNull();
+      expect(await attachmentRow(db, "other", row().objectKey)).not.toBeNull();
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -1,0 +1,48 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { parseAttachmentKey } from "../src/github-attachment-index";
+
+describe("parseAttachmentKey", () => {
+  it("parses a plain gh key and recovers the sanitized repo", () => {
+    expect(parseAttachmentKey("gh/Acme/Web/pull/12/hero.png")).toEqual({
+      kind: "pull",
+      num: 12,
+      prefixId: null,
+      repo: "acme/web",
+    });
+    expect(parseAttachmentKey("gh/acme/web/issues/3/a.png")).toEqual({
+      kind: "issues",
+      num: 3,
+      prefixId: null,
+      repo: "acme/web",
+    });
+  });
+
+  it("parses a private key but cannot recover the repo", () => {
+    const id = "a".repeat(32);
+    expect(parseAttachmentKey(`gh/private/${id}/pull/12/hero.png`)).toEqual({
+      kind: "pull",
+      num: 12,
+      prefixId: id,
+      repo: null,
+    });
+  });
+
+  it("returns undefined for ingest keys (plain and private)", () => {
+    expect(parseAttachmentKey("gh/acme-web/pull-12/asset-1.png")).toBeUndefined();
+    expect(
+      parseAttachmentKey(`gh/private/${"b".repeat(32)}/ingest/pull-12/asset-1.png`),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for branch-staged, malformed, and non-gh keys", () => {
+    expect(parseAttachmentKey("gh/acme/web/branch/feat-x/hero.png")).toBeUndefined();
+    expect(parseAttachmentKey(`gh/private/${"c".repeat(32)}/branch/hero.png`)).toBeUndefined();
+    expect(parseAttachmentKey("gh/acme/web/pull/0/hero.png")).toBeUndefined();
+    expect(parseAttachmentKey("gh/acme/web/pull/12/")).toBeUndefined();
+    expect(parseAttachmentKey("gh/acme/web/pull/abc/hero.png")).toBeUndefined();
+    expect(parseAttachmentKey("f/abc/hero.png")).toBeUndefined();
+    expect(parseAttachmentKey("gh/private/short/pull/12/hero.png")).toBeUndefined();
+  });
+});

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -420,6 +420,38 @@ describe("attachment index safe writers", () => {
       expect(parsed.error).toBe("D1 exploded");
     }
   });
+
+  it("recordAttachmentForKeySafe swallows a throwing db for both a private and a plain key", async () => {
+    const errors: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((msg) => {
+      errors.push(String(msg));
+    });
+    try {
+      // Private key: needs a `repoForPrefixId` D1 lookup before the write,
+      // and that lookup itself throws.
+      await recordAttachmentForKeySafe(throwingDb, {
+        workspace: "acme",
+        objectKey: `gh/private/${"a".repeat(32)}/pull/12/hero.png`,
+        source: "put",
+        laneId: null,
+      });
+      // Plain key: no D1 lookup needed before the write, so only the
+      // write itself throws.
+      await recordAttachmentForKeySafe(throwingDb, {
+        workspace: "acme",
+        objectKey: "gh/acme/web/pull/12/hero.png",
+        source: "put",
+        laneId: null,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+    expect(errors).toHaveLength(2);
+    for (const line of errors) {
+      const parsed = JSON.parse(line) as { message: string; error: string };
+      expect(parsed.message).toContain("attachment index");
+    }
+  });
 });
 
 describe("recordAttachmentForKeySafe", () => {

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -193,7 +193,7 @@ describe("detachAttachment / reattachAttachment", () => {
     }
   });
 
-  it("recordAttachment clears a previously-set detached_at", async () => {
+  it("recordAttachment clears a previously-set detached_at for a non-put source", async () => {
     const sqlite = new SqliteD1(MIGRATIONS);
     try {
       const db = database(sqlite);
@@ -201,6 +201,21 @@ describe("detachAttachment / reattachAttachment", () => {
       await detachAttachment(db, "acme", row().objectKey);
       await recordAttachment(db, row({ source: "attach" }));
       expect((await attachmentRow(db, "acme", row().objectKey))?.detachedAt).toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("recordAttachment leaves detached_at untouched for a 'put' re-record", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordAttachment(db, row());
+      await detachAttachment(db, "acme", row().objectKey, new Date("2026-09-05T00:00:00.000Z"));
+      await recordAttachment(db, row({ source: "put" }));
+      expect((await attachmentRow(db, "acme", row().objectKey))?.detachedAt).toBe(
+        "2026-09-05T00:00:00.000Z",
+      );
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -394,7 +394,9 @@ describe("attachment index safe writers", () => {
         },
       }),
     }),
-    batch: async () => [],
+    batch: async () => {
+      throw new Error("D1 exploded");
+    },
   } as unknown as Parameters<typeof recordAttachment>[0];
 
   it("swallow D1 failures and log a JSON line", async () => {

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -291,7 +291,10 @@ describe("rekeyAttachment", () => {
       const newId = "b".repeat(32);
       const fromKey = `gh/private/${oldId}/pull/12/hero.png`;
       const toKey = `gh/private/${newId}/pull/12/hero.png`;
-      await recordAttachment(db, row({ objectKey: fromKey, prefixId: oldId }));
+      await recordAttachment(
+        db,
+        row({ objectKey: fromKey, prefixId: oldId, laneId: "lane-a", source: "attach" }),
+      );
 
       await rekeyAttachment(
         db,
@@ -299,14 +302,16 @@ describe("rekeyAttachment", () => {
         fromKey,
         toKey,
         newId,
+        "lane-b",
         new Date("2026-09-07T00:00:00.000Z"),
       );
 
       expect(await attachmentRow(db, "acme", fromKey)).toBeNull();
       expect(await attachmentRow(db, "acme", toKey)).toMatchObject({
         prefixId: newId,
+        laneId: "lane-b",
         updatedAt: "2026-09-07T00:00:00.000Z",
-        source: "put",
+        source: "attach",
       });
     } finally {
       sqlite.close();
@@ -322,14 +327,14 @@ describe("rekeyAttachment", () => {
       const fromKey = `gh/private/${oldId}/pull/12/hero.png`;
       const toKey = `gh/private/${newId}/pull/12/hero.png`;
       // putObject already wrote a row at the destination during rotation.
-      await recordAttachment(db, row({ objectKey: toKey, prefixId: newId, source: "rotate" }));
+      await recordAttachment(db, row({ objectKey: toKey, prefixId: newId, source: "put" }));
       await recordAttachment(db, row({ objectKey: fromKey, prefixId: oldId, laneId: "lane-a" }));
 
-      await rekeyAttachment(db, "acme", fromKey, toKey, newId);
+      await rekeyAttachment(db, "acme", fromKey, toKey, newId, "lane-b");
 
       expect(await attachmentRow(db, "acme", fromKey)).toBeNull();
       const dest = await attachmentRow(db, "acme", toKey);
-      expect(dest).toMatchObject({ prefixId: newId, laneId: "lane-a", source: "put" });
+      expect(dest).toMatchObject({ prefixId: newId, laneId: "lane-b", source: "put" });
       const count = await db
         .prepare("SELECT COUNT(*) AS count FROM github_attachments")
         .bind()
@@ -349,6 +354,7 @@ describe("rekeyAttachment", () => {
         "acme",
         "gh/acme/web/pull/12/a.png",
         "gh/acme/web/pull/12/b.png",
+        null,
         null,
       );
       expect(await attachmentRow(db, "acme", "gh/acme/web/pull/12/b.png")).toBeNull();
@@ -388,7 +394,7 @@ describe("attachment index safe writers", () => {
       await deleteAttachmentSafe(throwingDb, "acme", row().objectKey);
       await deleteAttachmentsForKeysSafe(throwingDb, "acme", [row().objectKey]);
       await deleteAttachmentsForWorkspaceSafe(throwingDb, "acme");
-      await rekeyAttachmentSafe(throwingDb, "acme", "a", "b", null);
+      await rekeyAttachmentSafe(throwingDb, "acme", "a", "b", null, null);
     } finally {
       spy.mockRestore();
     }

--- a/apps/api/test/github-ingest-e2e.test.ts
+++ b/apps/api/test/github-ingest-e2e.test.ts
@@ -190,4 +190,66 @@ describe("github ingest end-to-end (webhook → queue → real putObject)", () =
     expect(row?.detachedAt).toBeNull();
     expect(row?.objectKey).toBe(KEY);
   });
+
+  it("ingested assets get NO attachment index row (issue #934)", async () => {
+    // Reuse this file's existing happy-path ingest setup verbatim, through
+    // the call that stores at least one asset.
+    const ev = extractWebhookEvent("issue_comment", issueCommentPayload);
+    expect(ev?.ingest).toEqual({
+      repo: REPO,
+      kind: "pull",
+      num: NUM,
+      source: `comment:${COMMENT_ID}`,
+    });
+
+    const db = new UsageFakeD1();
+    const githubCache = new FakeKv();
+    githubCache.store.set("ghinst:acme/app", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "ghs_test" });
+
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "b",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      githubIngestAttachments: true,
+    };
+    const registry = {
+      get: (async (key: string) =>
+        key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+    };
+
+    const env = {
+      DB: db,
+      GITHUB_CACHE: githubCache,
+      REGISTRY: registry,
+      UPLOADS_DEFAULT: new FakeR2Bucket(),
+      ...GITHUB_APP_CFG_ENV,
+    } as unknown as Env;
+
+    await recordRepoLink(env.DB, REPO, WS, "test");
+
+    const fetchImpl = fakeFetch({
+      "/contents/": () => new Response("nf", { status: 404 }),
+      [`/issues/comments/${COMMENT_ID}`]: () =>
+        new Response(
+          JSON.stringify({ body: issueCommentPayload.comment.body, user: { login: "octocat" } }),
+          { status: 200 },
+        ),
+      [ASSET_ID]: pngRoute(PNG),
+    });
+
+    const message = msg(ev!);
+    await withGlobalFetch(fetchImpl, () => handleGithubWebhookBatch(batch([message]), env));
+
+    expect(message.acked).toBe(true);
+
+    // Ingest keys (`gh/<owner>-<name>/<kind>-<num>/…` and
+    // `gh/private/<id>/ingest/…`) deliberately live outside the comment's
+    // attachment prefix — they are an index only, never rendered — so
+    // parseAttachmentKey returns undefined and putObject writes no row.
+    expect(db.ingestLedger.size).toBeGreaterThan(0);
+    expect(db.attachmentIndex.size).toBe(0);
+  });
 });

--- a/apps/api/test/github-private-prefixes-sqlite.test.ts
+++ b/apps/api/test/github-private-prefixes-sqlite.test.ts
@@ -7,6 +7,7 @@ import {
   getOrMintPrefixId,
   listActivePrefixIds,
   PRIVATE_PREFIX_ID_RE,
+  repoForPrefixId,
   retirePrefixId,
 } from "../src/github-private-prefixes";
 import { SqliteD1, database } from "./helpers/sqlite-d1";
@@ -135,6 +136,40 @@ describe("github private prefixes persistence against SQLite", () => {
       expect(a).toBe(b);
       const ids = await listActivePrefixIds(db, "acme/web");
       expect(ids).toEqual([a]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("repoForPrefixId", () => {
+  it("returns the lowercased repo that minted the id", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      const id = await getOrMintPrefixId(db, "Acme/Web", "main");
+      expect(await repoForPrefixId(db, id)).toBe("acme/web");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("still resolves after the id is retired", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      const id = await getOrMintPrefixId(db, "acme/web", "main");
+      await retirePrefixId(db, "acme/web", "main", id);
+      expect(await repoForPrefixId(db, id)).toBe("acme/web");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns null for an unknown id", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      expect(await repoForPrefixId(database(sqlite), "f".repeat(32))).toBeNull();
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/helpers/fake-attachment-index-table.ts
+++ b/apps/api/test/helpers/fake-attachment-index-table.ts
@@ -11,6 +11,8 @@
  * ("unsupported run: …") rather than silently dropping writes.
  */
 
+import type { FakeRunResult } from "./fake-repo-links-table";
+
 export interface AttachmentIndexDbRow {
   workspace: string;
   repo: string;
@@ -23,12 +25,6 @@ export interface AttachmentIndexDbRow {
   created_at: string;
   updated_at: string;
   detached_at: string | null;
-}
-
-export interface FakeRunResult {
-  success: true;
-  meta: { changes: number };
-  results: [];
 }
 
 function key(workspace: string, objectKey: string): string {

--- a/apps/api/test/helpers/fake-attachment-index-table.ts
+++ b/apps/api/test/helpers/fake-attachment-index-table.ts
@@ -76,7 +76,10 @@ export class AttachmentIndexTable {
         source,
         created_at: existing?.created_at ?? createdAt,
         updated_at: updatedAt,
-        detached_at: null,
+        // Mirrors the module's ON CONFLICT CASE: a "put" leaves an existing
+        // detached_at untouched (does not resurrect a deliberately detached
+        // row); any other source clears it.
+        detached_at: source === "put" ? (existing?.detached_at ?? null) : null,
       });
       return { success: true, meta: { changes: 1 }, results: [] };
     }

--- a/apps/api/test/helpers/fake-attachment-index-table.ts
+++ b/apps/api/test/helpers/fake-attachment-index-table.ts
@@ -102,8 +102,9 @@ export class AttachmentIndexTable {
       return { success: true, meta: { changes: 1 }, results: [] };
     }
     if (normalizedSql.startsWith("UPDATE github_attachments SET object_key = ?")) {
-      const [toKey, newPrefixId, updatedAt, workspace, fromKey] = args as [
+      const [toKey, newPrefixId, laneId, updatedAt, workspace, fromKey] = args as [
         string,
+        string | null,
         string | null,
         string,
         string,
@@ -116,6 +117,7 @@ export class AttachmentIndexTable {
         ...row,
         object_key: toKey,
         prefix_id: newPrefixId,
+        lane_id: laneId,
         updated_at: updatedAt,
       });
       return { success: true, meta: { changes: 1 }, results: [] };

--- a/apps/api/test/helpers/fake-attachment-index-table.ts
+++ b/apps/api/test/helpers/fake-attachment-index-table.ts
@@ -1,0 +1,157 @@
+/**
+ * Shared in-memory `github_attachments` table backing for route/webhook
+ * tests (usage-fake-d1.ts) — mirrors the real D1 semantics (upsert on
+ * (workspace, object_key), detach/reattach, chunked batch delete, rotation
+ * re-key) without a full sqlite-backed D1. See
+ * github-attachment-index-sqlite.test.ts for the real-SQL coverage.
+ *
+ * The match arms below key off the EXACT statement text in
+ * src/github-attachment-index.ts, whitespace-normalized. If a statement
+ * there changes, change it here too or the suite fails loudly
+ * ("unsupported run: …") rather than silently dropping writes.
+ */
+
+export interface AttachmentIndexDbRow {
+  workspace: string;
+  repo: string;
+  kind: "pull" | "issues";
+  num: number;
+  object_key: string;
+  prefix_id: string | null;
+  lane_id: string | null;
+  source: string;
+  created_at: string;
+  updated_at: string;
+  detached_at: string | null;
+}
+
+export interface FakeRunResult {
+  success: true;
+  meta: { changes: number };
+  results: [];
+}
+
+function key(workspace: string, objectKey: string): string {
+  return `${workspace}\0${objectKey}`;
+}
+
+export class AttachmentIndexTable {
+  readonly rows = new Map<string, AttachmentIndexDbRow>();
+
+  tryRun(normalizedSql: string, args: unknown[]): FakeRunResult | undefined {
+    if (normalizedSql.startsWith("INSERT INTO github_attachments")) {
+      const [
+        workspace,
+        repo,
+        kind,
+        num,
+        objectKey,
+        prefixId,
+        laneId,
+        source,
+        createdAt,
+        updatedAt,
+      ] = args as [
+        string,
+        string,
+        "pull" | "issues",
+        number,
+        string,
+        string | null,
+        string | null,
+        string,
+        string,
+        string,
+      ];
+      const k = key(workspace, objectKey);
+      const existing = this.rows.get(k);
+      this.rows.set(k, {
+        workspace,
+        repo,
+        kind,
+        num,
+        object_key: objectKey,
+        prefix_id: prefixId,
+        lane_id: laneId,
+        source,
+        created_at: existing?.created_at ?? createdAt,
+        updated_at: updatedAt,
+        detached_at: null,
+      });
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    if (normalizedSql.startsWith("UPDATE github_attachments SET detached_at = ?")) {
+      const [detachedAt, updatedAt, workspace, objectKey] = args as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      const row = this.rows.get(key(workspace, objectKey));
+      if (!row) return { success: true, meta: { changes: 0 }, results: [] };
+      row.detached_at = detachedAt;
+      row.updated_at = updatedAt;
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    if (normalizedSql.startsWith("UPDATE github_attachments SET detached_at = NULL")) {
+      const [updatedAt, workspace, objectKey] = args as [string, string, string];
+      const row = this.rows.get(key(workspace, objectKey));
+      if (!row) return { success: true, meta: { changes: 0 }, results: [] };
+      row.detached_at = null;
+      row.updated_at = updatedAt;
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    if (normalizedSql.startsWith("UPDATE github_attachments SET object_key = ?")) {
+      const [toKey, newPrefixId, updatedAt, workspace, fromKey] = args as [
+        string,
+        string | null,
+        string,
+        string,
+        string,
+      ];
+      const row = this.rows.get(key(workspace, fromKey));
+      if (!row) return { success: true, meta: { changes: 0 }, results: [] };
+      this.rows.delete(key(workspace, fromKey));
+      this.rows.set(key(workspace, toKey), {
+        ...row,
+        object_key: toKey,
+        prefix_id: newPrefixId,
+        updated_at: updatedAt,
+      });
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    if (normalizedSql.startsWith("DELETE FROM github_attachments")) {
+      if (normalizedSql.includes("object_key IN (")) {
+        const [workspace, ...keys] = args as [string, ...string[]];
+        let changes = 0;
+        for (const objectKey of keys) {
+          if (this.rows.delete(key(workspace, objectKey))) changes++;
+        }
+        return { success: true, meta: { changes }, results: [] };
+      }
+      if (normalizedSql.includes("object_key = ?")) {
+        const [workspace, objectKey] = args as [string, string];
+        const changes = this.rows.delete(key(workspace, objectKey)) ? 1 : 0;
+        return { success: true, meta: { changes }, results: [] };
+      }
+      const [workspace] = args as [string];
+      let changes = 0;
+      for (const [k, row] of this.rows.entries()) {
+        if (row.workspace === workspace) {
+          this.rows.delete(k);
+          changes++;
+        }
+      }
+      return { success: true, meta: { changes }, results: [] };
+    }
+    return undefined;
+  }
+
+  tryFirst<T>(normalizedSql: string, args: unknown[]): T | null | undefined {
+    if (normalizedSql.includes("FROM github_attachments WHERE workspace = ? AND object_key = ?")) {
+      const [workspace, objectKey] = args as [string, string];
+      return (this.rows.get(key(workspace, objectKey)) as T) ?? null;
+    }
+    return undefined;
+  }
+}

--- a/apps/api/test/helpers/fake-private-prefixes-table.ts
+++ b/apps/api/test/helpers/fake-private-prefixes-table.ts
@@ -82,6 +82,17 @@ export class PrivatePrefixesTable {
   }
 
   tryFirst<T>(normalizedSql: string, args: unknown[]): T | null | undefined {
+    // repoForPrefixId (#934): which repo minted this id, rotated or not.
+    if (
+      normalizedSql.includes("FROM github_private_prefixes") &&
+      normalizedSql.includes("WHERE prefix_id = ?")
+    ) {
+      const [prefixId] = args as [string];
+      for (const row of this.rows.values()) {
+        if (row.prefix_id === prefixId) return { repo_full_name: row.repo_full_name } as T;
+      }
+      return null as T | null;
+    }
     if (
       normalizedSql.includes("FROM github_private_prefixes") &&
       normalizedSql.includes("branch = ?") &&

--- a/apps/api/test/retention-metadata.test.ts
+++ b/apps/api/test/retention-metadata.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { attachmentRow, recordAttachment } from "../src/github-attachment-index";
 import { purgeExpiredObjects } from "../src/retention";
 import type { WorkspaceRecord } from "../src/workspace";
 import { FakeR2Bucket } from "./fake-r2";
@@ -8,6 +9,7 @@ const MIGRATIONS = [
   "migrations/20260713210559_file_metadata.sql",
   "migrations/20260710140000_workspace_usage.sql",
   "migrations/20260822120100_workspace_usage_shared_subset.sql",
+  "migrations/20260903120000_github_attachments.sql",
 ];
 
 // Prefixed shared-bucket record — the common case (see retention-sweep.test.ts).
@@ -98,6 +100,40 @@ describe("purgeExpiredObjects — file_metadata cleanup (plan 007)", () => {
       expect(result).toMatchObject({ deleted: 0, keys: [] });
       expect(await metadataRowCount(db, "acme", "fresh.png")).toBe(1);
       expect(await metadataRowCount(db, "other-ws", "fresh.png")).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("purgeExpiredObjects — attachment index cleanup (issue #934)", () => {
+  it("deletes github_attachments rows for expired attachments it purges", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      const bucket = new FakeR2Bucket();
+      const oldKey = "gh/acme/web/pull/12/old.png";
+      const freshKey = "gh/acme/web/pull/12/fresh.png";
+      await bucket.put(`acme/${oldKey}`, new Uint8Array([1, 2, 3]));
+      bucket.setUploaded(`acme/${oldKey}`, new Date("2020-01-01T00:00:00Z"));
+      await bucket.put(`acme/${freshKey}`, new Uint8Array([1, 2, 3]));
+      for (const objectKey of [oldKey, freshKey]) {
+        await recordAttachment(db, {
+          workspace: "acme",
+          repo: "acme/web",
+          kind: "pull",
+          num: 12,
+          objectKey,
+          prefixId: null,
+          laneId: null,
+          source: "put",
+        });
+      }
+
+      await purgeExpiredObjects(makeEnv(bucket, sqlite), RECORD, "acme");
+
+      expect(await attachmentRow(db, "acme", oldKey)).toBeNull();
+      expect(await attachmentRow(db, "acme", freshKey)).not.toBeNull();
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/retention-sweep.test.ts
+++ b/apps/api/test/retention-sweep.test.ts
@@ -10,6 +10,7 @@ const MIGRATIONS = [
   "migrations/20260710140000_workspace_usage.sql",
   "migrations/20260822120100_workspace_usage_shared_subset.sql",
   "migrations/20260730170533_delete_usage_claims.sql",
+  "migrations/20260903120000_github_attachments.sql",
 ];
 
 // Prefixed shared-bucket record — the common case, and the baseline these

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -4,6 +4,7 @@
  */
 
 import { AdoptLedgerTable } from "./helpers/fake-adopt-ledger-table";
+import { AttachmentIndexTable } from "./helpers/fake-attachment-index-table";
 import { BranchRenamesTable } from "./helpers/fake-branch-renames-table";
 import { DeleteUsageClaimsTable } from "./helpers/fake-delete-usage-claims-table";
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
@@ -73,6 +74,12 @@ export class UsageFakeD1 {
   get branchRenames() {
     return this.branchRenamesTable.rows;
   }
+  // Backs `github_attachments` — the server-written attachment index that
+  // replaces the comment sync's per-prefix R2 fan-out (issue #934).
+  private attachmentIndexTable = new AttachmentIndexTable();
+  get attachmentIndex() {
+    return this.attachmentIndexTable.rows;
+  }
 
   prepare = (sql: string) => {
     const normalized = sql.replace(/\s+/g, " ").trim();
@@ -96,6 +103,8 @@ export class UsageFakeD1 {
         if (prefixFirstResult !== undefined) return prefixFirstResult;
         const adoptFirstResult = this.adoptLedgerTable.tryFirst(normalized, values);
         if (adoptFirstResult !== undefined) return adoptFirstResult;
+        const attachmentFirstResult = this.attachmentIndexTable.tryFirst(normalized, values);
+        if (attachmentFirstResult !== undefined) return attachmentFirstResult;
         throw new Error(`unsupported first: ${normalized}`);
       },
       all: async <T>() => {
@@ -139,6 +148,8 @@ export class UsageFakeD1 {
         if (renameRunResult) return renameRunResult;
         const claimResult = this.deleteUsageClaimsTable.tryRun(normalized, values);
         if (claimResult) return claimResult;
+        const attachmentRunResult = this.attachmentIndexTable.tryRun(normalized, values);
+        if (attachmentRunResult) return attachmentRunResult;
         if (normalized.startsWith("INSERT OR IGNORE INTO workspace_usage")) {
           // applyUsageDelta: (ws, period, updatedAt) with zeros
           // setUsageTotals: (ws, bytes, objects, period, updatedAt)

--- a/apps/api/test/workspace-teardown-usage.test.ts
+++ b/apps/api/test/workspace-teardown-usage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { attachmentRow, recordAttachment } from "../src/github-attachment-index";
 import { teardownWorkspace } from "../src/workspace-teardown";
 import type { WorkspaceRecord } from "../src/workspace";
 import { FakeR2Bucket } from "./fake-r2";
@@ -10,6 +11,7 @@ const MIGRATIONS = [
   "migrations/20260710140000_workspace_usage.sql",
   "migrations/20260822120100_workspace_usage_shared_subset.sql",
   "migrations/20260730170533_delete_usage_claims.sql",
+  "migrations/20260903120000_github_attachments.sql",
 ];
 
 // Prefixed shared-bucket record — mirrors retention-sweep.test.ts's RECORD.
@@ -130,6 +132,36 @@ describe("teardownWorkspace — usage ledger cleanup (#006)", () => {
 
       expect(await countRows(sqlite, "workspace_usage", "acme")).toBe(0);
       expect(await countRows(sqlite, "delete_usage_claims", "acme")).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("teardownWorkspace — attachment index cleanup (issue #934)", () => {
+  it("clears this workspace's github_attachments rows and no other's", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      const objectKey = "gh/acme/web/pull/12/hero.png";
+      for (const workspace of ["acme", "other"]) {
+        await recordAttachment(db, {
+          workspace,
+          repo: "acme/web",
+          kind: "pull",
+          num: 12,
+          objectKey,
+          prefixId: null,
+          laneId: null,
+          source: "put",
+        });
+      }
+      const { env } = makeEnv({ kvRecords: { "ws:acme": RECORD }, db: sqlite });
+
+      await teardownWorkspace(env, "acme", RECORD, { reason: "test" });
+
+      expect(await attachmentRow(db, "acme", objectKey)).toBeNull();
+      expect(await attachmentRow(db, "other", objectKey)).not.toBeNull();
     } finally {
       sqlite.close();
     }


### PR DESCRIPTION
Phase 1 of the D1 attachment index from #934. Write-only: a new `github_attachments` table is populated from every attachment write path, and nothing reads it yet. `gatherCommentBody` is untouched, so this PR changes no user-visible behavior; it exists so Phase 2 can shadow-compare the index against the R2 fan-out before switching the comment sync over.

## What's in here

**Schema.** `apps/api/migrations/20260903120000_github_attachments.sql`: one row per attachment object, PK `(workspace, object_key)`, partial index on `(workspace, repo, kind, num, object_key) WHERE detached_at IS NULL` for the eventual hot read, plus prefix-id and repo indexes for rotation and reconcile. `kind` uses the `GhTarget` spelling (`pull` | `issues`). Auto-applies on merge via the D1 migrations workflow.

**Writer module.** `apps/api/src/github-attachment-index.ts`: `parseAttachmentKey`, `recordAttachment` (upsert; keeps `created_at`; a plain `put` re-record leaves an existing `detached_at` alone so the index agrees with `gh.detached` and the adopt ledger, while attach / promote / adopt clear it), `detachAttachment` / `reattachAttachment`, single, chunked-batch and whole-workspace deletes, `rekeyAttachment` (destination-first wipe, then update), and never-throwing `*Safe` variants that log a JSON line and move on. Index writes are best-effort in the same sense as `recordUsageSafe`: a D1 failure costs a stale index row, never a failed upload.

**Trust boundary.** Every row's `repo` comes from the final object key (plain `gh/<owner>/<name>/…` keys) or from the `github_private_prefixes` row that minted the prefix id (private keys, via the new `repoForPrefixId`). It is never read from `gh.*` file_metadata, which is client-settable. A private key whose prefix id has no owning row writes no row. Tests pin that a client-supplied `gh.repo` / `gh.ref` naming another repo does not influence the recorded repo.

**Write sites.**

| Path | Effect |
| --- | --- |
| `putObject` (choke point for REST PUT, idempotent PUT, reconcile, attach, promote, rotation) | upsert, `source: "put"` |
| `attachExistingObject` | re-record with `source: "attach"` and the caller-resolved repo |
| `promoteBranchAttachments` | re-record with `source: "promote"`; the staged original gets no row |
| link adoption | `source: "adopt"`; detach / re-attach flip `detached_at` alongside `gh.detached` |
| private-prefix rotation | `rekeyAttachment` next to the existing `file_metadata` re-key |
| `deleteObject`, retention purge, workspace teardown | rows removed alongside the metadata cleanup |
| GitHub-native ingest | deliberately no rows; guard test asserts it |

**Tests.** A sqlite-backed suite for the module (parse, upsert, detach, chunked delete past the 100-parameter cap, re-key with an occupied destination, safe wrappers), a hand-rolled fake table wired into the shared test D1 so the route/webhook/adopt/ingest suites keep running, and a wiring test per write site. `apps/api`: 2611 tests; monorepo `pnpm test` green.

## Not in this PR

Phase 2 (shadow compare behind a flag), Phase 3 (read from the index), the reconcile job, and the backfill. Plan and rollout are in the #934 comment thread.

Deferred from review into the Phase 2 checklist, all performance shape rather than correctness: attach/adopt currently write the row twice (`putObject` then the caller re-records with its own `source`); the `putObject` index write is awaited serially after `recordContentHash`; rotation and retention call the index for keys that can never have a row. Also deferred: the two-statement re-key is not a `db.batch()`, and `kind` has no schema CHECK.

## Reviewer notes

- The migration is additive; no existing table or query changes.
- Per-write cost is one upsert (plus one indexed `github_private_prefixes` lookup for private keys). No new R2 calls anywhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable tracking for GitHub issue and pull request attachments.
  * Attachment records now stay synchronized when files are uploaded, copied, adopted, moved, rotated, or removed.
  * Added server-side repository resolution to improve attachment ownership accuracy.

* **Bug Fixes**
  * Prevented stale attachment records after retention cleanup or workspace deletion.
  * Improved handling when detached attachments are referenced again.

* **Tests**
  * Added comprehensive coverage for attachment tracking, lifecycle changes, cleanup, rotation, and security-related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->