### PR TITLE
docs(ops): record the applied storage-host Transform Rule ids

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -68,6 +68,15 @@ No Worker proxies image bytes — dual host is DNS + zone rules only.
 
 ## SVG and XML on the hosted hosts (issue #929)
 
+**Applied 2026-09-02** (zone ruleset `1b295145ce4a4dc685498657af8a6956`, phase `http_response_headers_transform`, via the API):
+
+| Rule id | What |
+| --- | --- |
+| `030fcb7edf324c0b9c966550c8b7d870` | `X-Content-Type-Options: nosniff` on every response from the three storage hosts |
+| `508226d5de4a4a0d8d861356b43cf912` | `Content-Security-Policy: … sandbox` + `nosniff` when the response content type is `image/svg+xml`, `application/xml`, or `text/xml` (the `eq` form; the zone is on Pro, so regex `matches` is unavailable) |
+
+The operator probe returned `ok: true` for all three hosts the same day. The `active-content-uploads` flag was still off at that point.
+
 SVG and XML (`image/svg+xml`, `application/xml`, `text/xml`) are gated
 uploads: a lane only accepts them once its public host is **verified** to
 serve them behind a sandboxing Content-Security-Policy — these are bare R2


### PR DESCRIPTION
Records the two zone Transform Rules applied on 2026-09-02 for #925/#929 (nosniff everywhere on the storage hosts; sandbox CSP on SVG/XML) and the green operator probe. No code change.