### PR TITLE
feat(api): shadow-compare the attachment index against the R2 fan-out (#934 phase 2)

### DIFF
--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -169,6 +169,30 @@ export async function recordAttachment(
     .run();
 }
 
+/**
+ * The active (non-detached) rows for one PR/issue target, sorted by key —
+ * the read the phase-3 render will switch to, served by
+ * `github_attachments_target_idx`. Phase 2 runs it in the shadow of the R2
+ * fan-out (see github-attachment-shadow.ts). `repo` is normalized the same
+ * way the writers store it.
+ */
+export async function listAttachmentsForTarget(
+  db: D1Queryable,
+  workspace: string,
+  repo: string,
+  target: { kind: "pull" | "issues"; num: number },
+): Promise<AttachmentIndexRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM github_attachments
+       WHERE workspace = ? AND repo = ? AND kind = ? AND num = ? AND detached_at IS NULL
+       ORDER BY object_key`,
+    )
+    .bind(workspace, normalizeRepo(repo), target.kind, target.num)
+    .all<AttachmentDbRow>();
+  return (results ?? []).map(fromRow);
+}
+
 /** One index row, or null. Test/ops read helper — NOT the phase-3 hot read. */
 export async function attachmentRow(
   db: D1Queryable,

--- a/apps/api/src/github-attachment-shadow.ts
+++ b/apps/api/src/github-attachment-shadow.ts
@@ -86,7 +86,7 @@ export async function startAttachmentIndexShadow(
   try {
     return await Promise.race([read, timeout]);
   } finally {
-    clearTimeout(timer);
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 

--- a/apps/api/src/github-attachment-shadow.ts
+++ b/apps/api/src/github-attachment-shadow.ts
@@ -1,0 +1,95 @@
+/**
+ * Phase 2 of the D1 attachment index (#934): read the index alongside the
+ * R2 fan-out in `gatherAttachments`, keep rendering from the fan-out, and
+ * log the symmetric difference so the index's coverage can be measured
+ * before phase 3 switches the render source to it.
+ *
+ * Behind the Flagship flag `attachment-index-shadow`. Fails closed and
+ * never fails the comment sync: a missing binding, a disabled flag, a thrown
+ * flag evaluation, or a thrown D1 read all reduce to "no shadow this sync"
+ * (the D1/flag failure is logged; a disabled flag is silent).
+ *
+ * Log line (Workers Logs, one per sync while the flag is on):
+ *   { component: "attachment-index", event: "shadow", workspace, repo, kind,
+ *     num, match, fanout, index, missingCount, extraCount, missing, extra }
+ * `missing` = rendered by the fan-out but absent from the index; `extra` =
+ * in the index but not rendered. Both are capped at `MAX_LOGGED_KEYS` keys;
+ * the counts are exact. Private prefix ids are redacted from logged keys
+ * (they are capability URLs).
+ */
+
+import { dbFor } from "./db-session";
+import { listAttachmentsForTarget } from "./github-attachment-index";
+import { normalizeRepo } from "./github-private-prefixes";
+import type { GhTarget } from "./github-comment-render";
+
+export const ATTACHMENT_INDEX_SHADOW_FLAG = "attachment-index-shadow";
+
+const MAX_LOGGED_KEYS = 5;
+
+const PRIVATE_ID_RE = /^gh\/private\/[0-9a-f]{32}\//;
+
+function redactKey(key: string): string {
+  return key.replace(PRIVATE_ID_RE, "gh/private/…/");
+}
+
+/**
+ * Starts the index read. Returns the active index keys, or `null` when the
+ * shadow is off or failed. Kick this off BEFORE the R2 fan-out so the two
+ * overlap; `await` it once the rendered key list is known.
+ */
+export async function startAttachmentIndexShadow(
+  env: Env,
+  workspace: string,
+  target: GhTarget,
+): Promise<string[] | null> {
+  if (!env.FLAGS) return null;
+  try {
+    if (!(await env.FLAGS.getBooleanValue(ATTACHMENT_INDEX_SHADOW_FLAG, false))) return null;
+    const rows = await listAttachmentsForTarget(dbFor(env), workspace, target.repo, target);
+    return rows.map((row) => row.objectKey);
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "attachment index: shadow read failed",
+        workspace,
+        repo: normalizeRepo(target.repo),
+        kind: target.kind,
+        num: target.num,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return null;
+  }
+}
+
+/** Logs the diff between what the fan-out rendered and what the index holds. No-op when the shadow was off. */
+export function reportAttachmentIndexShadow(
+  indexKeys: string[] | null,
+  workspace: string,
+  target: GhTarget,
+  renderedKeys: string[],
+): void {
+  if (indexKeys === null) return;
+  const rendered = new Set(renderedKeys);
+  const indexed = new Set(indexKeys);
+  const missing = renderedKeys.filter((key) => !indexed.has(key));
+  const extra = indexKeys.filter((key) => !rendered.has(key));
+  console.log(
+    JSON.stringify({
+      component: "attachment-index",
+      event: "shadow",
+      workspace,
+      repo: normalizeRepo(target.repo),
+      kind: target.kind,
+      num: target.num,
+      match: missing.length === 0 && extra.length === 0,
+      fanout: renderedKeys.length,
+      index: indexKeys.length,
+      missingCount: missing.length,
+      extraCount: extra.length,
+      missing: missing.slice(0, MAX_LOGGED_KEYS).map(redactKey),
+      extra: extra.slice(0, MAX_LOGGED_KEYS).map(redactKey),
+    }),
+  );
+}

--- a/apps/api/src/github-attachment-shadow.ts
+++ b/apps/api/src/github-attachment-shadow.ts
@@ -27,6 +27,14 @@ export const ATTACHMENT_INDEX_SHADOW_FLAG = "attachment-index-shadow";
 
 const MAX_LOGGED_KEYS = 5;
 
+/**
+ * The shadow's only product is a log line, so it must never hold the sync
+ * hostage to a slow D1 (see the D1 stall notes in docs/ops.md). Past this
+ * the read is abandoned (it settles in the background, unobserved) and the
+ * sync proceeds as if the shadow were off.
+ */
+export const SHADOW_TIMEOUT_MS = 1000;
+
 const PRIVATE_ID_RE = /^gh\/private\/[0-9a-f]{32}\//;
 
 function redactKey(key: string): string {
@@ -35,8 +43,10 @@ function redactKey(key: string): string {
 
 /**
  * Starts the index read. Returns the active index keys, or `null` when the
- * shadow is off or failed. Kick this off BEFORE the R2 fan-out so the two
- * overlap; `await` it once the rendered key list is known.
+ * shadow is off, failed, or timed out. Kick this off BEFORE the R2 fan-out
+ * so the two overlap (but after the sync's first real D1 query, so the
+ * shadow never becomes the query that anchors the request's D1 session);
+ * `await` it once the rendered key list is known.
  */
 export async function startAttachmentIndexShadow(
   env: Env,
@@ -44,22 +54,39 @@ export async function startAttachmentIndexShadow(
   target: GhTarget,
 ): Promise<string[] | null> {
   if (!env.FLAGS) return null;
-  try {
-    if (!(await env.FLAGS.getBooleanValue(ATTACHMENT_INDEX_SHADOW_FLAG, false))) return null;
+  const context = {
+    workspace,
+    repo: normalizeRepo(target.repo),
+    kind: target.kind,
+    num: target.num,
+  };
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    timer = setTimeout(() => {
+      console.error(
+        JSON.stringify({ message: "attachment index: shadow read timed out", ...context }),
+      );
+      resolve(null);
+    }, SHADOW_TIMEOUT_MS);
+  });
+  const read = (async () => {
+    if (!(await env.FLAGS!.getBooleanValue(ATTACHMENT_INDEX_SHADOW_FLAG, false))) return null;
     const rows = await listAttachmentsForTarget(dbFor(env), workspace, target.repo, target);
     return rows.map((row) => row.objectKey);
-  } catch (err) {
+  })().catch((err: unknown) => {
     console.error(
       JSON.stringify({
         message: "attachment index: shadow read failed",
-        workspace,
-        repo: normalizeRepo(target.repo),
-        kind: target.kind,
-        num: target.num,
+        ...context,
         error: err instanceof Error ? err.message : String(err),
       }),
     );
     return null;
+  });
+  try {
+    return await Promise.race([read, timeout]);
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { gatherCommentBody, upsertBotComment } from "./github-comment";
 import { ATTACHMENTS_MARKER, attachmentsMarker, ghPrivateKeyPrefix } from "./github-comment-render";
 import { addExternalReference, addGalleryItem, createGallery } from "./galleries";
@@ -8,6 +8,7 @@ import { replaceFileMetadata, setServerFileMetadata } from "./file-metadata";
 import { objectPublicUrls, storageConfig } from "./storage";
 import { posterKeyFor } from "./poster";
 import { getOrMintPrefixId } from "./github-private-prefixes";
+import { detachAttachment, recordAttachment } from "./github-attachment-index";
 import type { WorkspaceRecord } from "./workspace";
 import { FakeR2Bucket } from "../test/fake-r2";
 import { FakeKv } from "../test/fake-kv";
@@ -17,6 +18,7 @@ const MIGRATION = [
   "migrations/20260711180000_galleries.sql",
   "migrations/20260713210559_file_metadata.sql",
   "migrations/20260811210000_github_private_prefixes.sql",
+  "migrations/20260903120000_github_attachments.sql",
 ];
 const PRAGMAS = ["PRAGMA foreign_keys = ON"];
 const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -280,6 +282,195 @@ describe("gatherCommentBody", () => {
     expect(result.body).toContain("Launch media");
     expect(result.body).not.toContain("Not ours");
     expect(result.count).toBe(1);
+  });
+});
+
+describe("gatherCommentBody attachment index shadow compare (#934 phase 2)", () => {
+  const FLAG_ON = { getBooleanValue: async () => true };
+  const FLAG_OFF = { getBooleanValue: async (_k: string, def: boolean) => def };
+  const target = { repo: "acme/web", num: 12, kind: "pull" as const };
+  const indexRow = (objectKey: string) => ({
+    workspace: "acme",
+    repo: "acme/web",
+    kind: "pull" as const,
+    num: 12,
+    objectKey,
+    prefixId: null,
+    laneId: null,
+    source: "put" as const,
+  });
+
+  function shadowLogs(spy: { mock: { calls: unknown[][] } }): Record<string, unknown>[] {
+    return spy.mock.calls
+      .map((call) => {
+        try {
+          return JSON.parse(String(call[0])) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      })
+      .filter((line): line is Record<string, unknown> => line?.component === "attachment-index");
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs a match when the index agrees with the fan-out, and renders from the fan-out", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    (env as { FLAGS?: unknown }).FLAGS = FLAG_ON;
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await recordAttachment(env.DB, indexRow("gh/acme/web/pull/12/hero.png"));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = await gatherCommentBody(env, ws, workspaceName, target);
+    expect(result.count).toBe(1);
+    const lines = shadowLogs(log);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      event: "shadow",
+      match: true,
+      fanout: 1,
+      index: 1,
+      missing: [],
+      extra: [],
+      workspace: "acme",
+      repo: "acme/web",
+      kind: "pull",
+      num: 12,
+    });
+  });
+
+  it("logs the keys the index is missing without changing the render", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    (env as { FLAGS?: unknown }).FLAGS = FLAG_ON;
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await bucket.put("acme/gh/acme/web/pull/12/unindexed.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await recordAttachment(env.DB, indexRow("gh/acme/web/pull/12/hero.png"));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = await gatherCommentBody(env, ws, workspaceName, target);
+    expect(result.count).toBe(2);
+    expect(result.body).toContain("unindexed.png");
+    expect(shadowLogs(log)[0]).toMatchObject({
+      match: false,
+      fanout: 2,
+      index: 1,
+      missing: ["gh/acme/web/pull/12/unindexed.png"],
+      extra: [],
+    });
+  });
+
+  it("logs extra index rows (including for an empty fan-out) without rendering them", async () => {
+    const { env, ws, workspaceName } = makeTestEnv();
+    (env as { FLAGS?: unknown }).FLAGS = FLAG_ON;
+    await recordAttachment(env.DB, indexRow("gh/acme/web/pull/12/ghost.png"));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = await gatherCommentBody(env, ws, workspaceName, target);
+    expect(result.count).toBe(0);
+    expect(result.body).not.toContain("ghost.png");
+    expect(shadowLogs(log)[0]).toMatchObject({
+      match: false,
+      fanout: 0,
+      index: 0 + 1,
+      missing: [],
+      extra: ["gh/acme/web/pull/12/ghost.png"],
+    });
+  });
+
+  it("compares against the post-detach render: a detached index row matches a gh.detached object", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    (env as { FLAGS?: unknown }).FLAGS = FLAG_ON;
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await bucket.put("acme/gh/acme/web/pull/12/detached.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    await replaceFileMetadata(env.DB, workspaceName, "gh/acme/web/pull/12/detached.png", {
+      "gh.detached": "true",
+    });
+    await recordAttachment(env.DB, indexRow("gh/acme/web/pull/12/hero.png"));
+    await recordAttachment(env.DB, indexRow("gh/acme/web/pull/12/detached.png"));
+    await detachAttachment(env.DB, workspaceName, "gh/acme/web/pull/12/detached.png");
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = await gatherCommentBody(env, ws, workspaceName, target);
+    expect(result.count).toBe(1);
+    expect(shadowLogs(log)[0]).toMatchObject({ match: true, fanout: 1, index: 1 });
+  });
+
+  it("redacts private prefix ids from logged keys", async () => {
+    const { env, ws, workspaceName } = makeTestEnv();
+    (env as { FLAGS?: unknown }).FLAGS = FLAG_ON;
+    const prefixId = await getOrMintPrefixId(env.DB, "acme/web", "main");
+    const key = `${ghPrivateKeyPrefix(prefixId, target)}ghost.png`;
+    await recordAttachment(env.DB, { ...indexRow(key), prefixId });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await gatherCommentBody(env, ws, workspaceName, target);
+    const line = shadowLogs(log)[0];
+    expect(line.extra).toEqual(["gh/private/…/pull/12/ghost.png"]);
+    expect(JSON.stringify(line)).not.toContain(prefixId);
+  });
+
+  it("caps the logged key lists and reports full counts", async () => {
+    const { env, ws, workspaceName } = makeTestEnv();
+    (env as { FLAGS?: unknown }).FLAGS = FLAG_ON;
+    for (let i = 0; i < 8; i++) {
+      await recordAttachment(env.DB, indexRow(`gh/acme/web/pull/12/g${i}.png`));
+    }
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await gatherCommentBody(env, ws, workspaceName, target);
+    const line = shadowLogs(log)[0];
+    expect(line.index).toBe(8);
+    expect(line.extraCount).toBe(8);
+    expect(line.extra).toHaveLength(5);
+  });
+
+  it("does nothing when the flag is off or the FLAGS binding is absent", async () => {
+    const { env, ws, workspaceName } = makeTestEnv();
+    await recordAttachment(env.DB, indexRow("gh/acme/web/pull/12/ghost.png"));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await gatherCommentBody(env, ws, workspaceName, target);
+    (env as { FLAGS?: unknown }).FLAGS = FLAG_OFF;
+    await gatherCommentBody(env, ws, workspaceName, target);
+    expect(shadowLogs(log)).toEqual([]);
+  });
+
+  it("never fails the sync when the index read or the flag lookup throws", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    (env as { FLAGS?: unknown }).FLAGS = {
+      getBooleanValue: async () => {
+        throw new Error("flagship unreachable");
+      },
+    };
+    expect((await gatherCommentBody(env, ws, workspaceName, target)).count).toBe(1);
+
+    (env as { FLAGS?: unknown }).FLAGS = FLAG_ON;
+    const realPrepare = env.DB.prepare.bind(env.DB);
+    vi.spyOn(env.DB, "prepare").mockImplementation((sql: string) => {
+      if (sql.includes("FROM github_attachments")) throw new Error("d1 down");
+      return realPrepare(sql);
+    });
+    expect((await gatherCommentBody(env, ws, workspaceName, target)).count).toBe(1);
+    expect(shadowLogs(log)).toEqual([]);
+    expect(error.mock.calls.some((c) => String(c[0]).includes("shadow"))).toBe(true);
   });
 });
 

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -9,6 +9,7 @@ import { objectPublicUrls, storageConfig } from "./storage";
 import { posterKeyFor } from "./poster";
 import { getOrMintPrefixId } from "./github-private-prefixes";
 import { detachAttachment, recordAttachment } from "./github-attachment-index";
+import { SHADOW_TIMEOUT_MS } from "./github-attachment-shadow";
 import type { WorkspaceRecord } from "./workspace";
 import { FakeR2Bucket } from "../test/fake-r2";
 import { FakeKv } from "../test/fake-kv";
@@ -436,15 +437,62 @@ describe("gatherCommentBody attachment index shadow compare (#934 phase 2)", () 
     expect(line.extra).toHaveLength(5);
   });
 
-  it("does nothing when the flag is off or the FLAGS binding is absent", async () => {
-    const { env, ws, workspaceName } = makeTestEnv();
+  it("renders identically with the binding absent, the flag off, and the flag on", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    // An index that disagrees with the fan-out in both directions.
     await recordAttachment(env.DB, indexRow("gh/acme/web/pull/12/ghost.png"));
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    await gatherCommentBody(env, ws, workspaceName, target);
+    const absent = await gatherCommentBody(env, ws, workspaceName, target);
     (env as { FLAGS?: unknown }).FLAGS = FLAG_OFF;
-    await gatherCommentBody(env, ws, workspaceName, target);
+    const off = await gatherCommentBody(env, ws, workspaceName, target);
     expect(shadowLogs(log)).toEqual([]);
+    (env as { FLAGS?: unknown }).FLAGS = FLAG_ON;
+    const on = await gatherCommentBody(env, ws, workspaceName, target);
+    expect(shadowLogs(log)).toHaveLength(1);
+
+    expect(absent.count).toBe(1);
+    expect(off).toEqual(absent);
+    expect(on).toEqual(absent);
+  });
+
+  it("skips the shadow when the caller opts out (adoption's pre-write baseline)", async () => {
+    const { env, ws, workspaceName } = makeTestEnv();
+    (env as { FLAGS?: unknown }).FLAGS = FLAG_ON;
+    await recordAttachment(env.DB, indexRow("gh/acme/web/pull/12/ghost.png"));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await gatherCommentBody(env, ws, workspaceName, target, { shadow: false });
+    expect(shadowLogs(log)).toEqual([]);
+  });
+
+  it("abandons a slow index read at the timeout and syncs without it", async () => {
+    vi.useFakeTimers();
+    try {
+      const { env, ws, workspaceName, bucket } = makeTestEnv();
+      (env as { FLAGS?: unknown }).FLAGS = FLAG_ON;
+      await bucket.put("acme/gh/acme/web/pull/12/hero.png", PNG, {
+        httpMetadata: { contentType: "image/png" },
+      });
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+      const realPrepare = env.DB.prepare.bind(env.DB);
+      vi.spyOn(env.DB, "prepare").mockImplementation((sql: string) => {
+        if (!sql.includes("FROM github_attachments")) return realPrepare(sql);
+        return { bind: () => ({ all: () => new Promise(() => {}) }) } as never;
+      });
+
+      const pending = gatherCommentBody(env, ws, workspaceName, target);
+      await vi.advanceTimersByTimeAsync(SHADOW_TIMEOUT_MS + 1);
+      expect((await pending).count).toBe(1);
+      expect(shadowLogs(log)).toEqual([]);
+      expect(error.mock.calls.some((c) => String(c[0]).includes("timed out"))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("never fails the sync when the index read or the flag lookup throws", async () => {

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -48,13 +48,16 @@ import {
  * @param opts.headBranch The PR's head branch when the caller knows it (the
  *   webhook payload does). Lets a metadata-less private attachment under
  *   that branch's prefix be found; see `listPrefixIdsForTarget`.
+ * @param opts.shadow Set `false` for a gather that is NOT the real sync
+ *   (link adoption's pre-write baseline) so the #934 shadow compare does
+ *   not log a deliberately stale fan-out as an index mismatch.
  */
 export async function gatherCommentBody(
   env: Env,
   ws: WorkspaceRecord,
   workspaceName: string,
   target: GhTarget,
-  opts: { headBranch?: string } = {},
+  opts: { headBranch?: string; shadow?: boolean } = {},
 ): Promise<{ body: string; count: number }> {
   // Resolve repo `.uploads.yml` (if any) against the workspace's own comment
   // defaults (issue #307). Never throws — a fetch/App degradation collapses
@@ -116,7 +119,7 @@ async function gatherAttachments(
   workspaceName: string,
   target: GhTarget,
   options: ResolvedCommentOptions,
-  gatherOpts: { headBranch?: string },
+  gatherOpts: { headBranch?: string; shadow?: boolean },
 ): Promise<AttachmentItem[]> {
   // Per-workspace/repo choice (issues #304, #307): default (auto/true) links
   // the managed comment's attachments to their `/f/` file page (issue #301's
@@ -126,11 +129,6 @@ async function gatherAttachments(
   // issue #365, extended by #307: skip the metadata read entirely when
   // neither meta field would render anything.
   const showMetadata = options.metaPath || options.metaState;
-
-  // #934 phase 2: read the attachment index in the shadow of the fan-out
-  // below (flag-gated, never renders, never throws); compared once the
-  // detach filter has settled what actually renders.
-  const indexShadow = startAttachmentIndexShadow(env, workspaceName, target);
 
   // A private-repo attachment (#631) can land under a randomized prefix, not
   // just the plain `ghKeyPrefix`. Only the prefixes that can hold THIS
@@ -144,6 +142,16 @@ async function gatherAttachments(
     target,
     gatherOpts,
   );
+  // #934 phase 2: read the attachment index in the shadow of the R2 listing
+  // below (flag-gated, never renders, never throws or outlives its
+  // timeout); compared once the detach filter has settled what actually
+  // renders. Started after the prefix lookup so it is never the request's
+  // first D1 query.
+  const indexShadow =
+    gatherOpts.shadow === false
+      ? Promise.resolve(null)
+      : startAttachmentIndexShadow(env, workspaceName, target);
+
   const prefixes = [
     ghKeyPrefix(target),
     ...activePrefixIds.map((id) => ghPrivateKeyPrefix(id, target)),

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -16,6 +16,10 @@ import { parseExternalReference } from "./external-references";
 import { createLaneResolver, objectPublicUrls } from "./storage";
 import { posterKeyFor } from "./poster";
 import { listPrefixIdsForTarget } from "./github-private-prefixes";
+import {
+  reportAttachmentIndexShadow,
+  startAttachmentIndexShadow,
+} from "./github-attachment-shadow";
 import type { WorkspaceRecord } from "./workspace";
 import { githubFetch, githubHeaders, installationToken, type GithubAppConfig } from "./github-app";
 import { resolveRepoCommentOptions } from "./repo-comment-config";
@@ -123,6 +127,11 @@ async function gatherAttachments(
   // neither meta field would render anything.
   const showMetadata = options.metaPath || options.metaState;
 
+  // #934 phase 2: read the attachment index in the shadow of the fan-out
+  // below (flag-gated, never renders, never throws); compared once the
+  // detach filter has settled what actually renders.
+  const indexShadow = startAttachmentIndexShadow(env, workspaceName, target);
+
   // A private-repo attachment (#631) can land under a randomized prefix, not
   // just the plain `ghKeyPrefix`. Only the prefixes that can hold THIS
   // target's objects are listed (issue #934) — never every active prefix in
@@ -167,21 +176,28 @@ async function gatherAttachments(
   );
   let items: AttachmentItem[] = perPrefixItems.flat();
 
-  if (items.length === 0) return items;
-
   // Detach filter (issue #709) runs unconditionally — D1 rows are
   // tenant-scoped by `workspaceName` (the caller's own slug), not by
   // anything derived from `ws`, same trust boundary as gatherGalleries. The
   // path/state/video.* fetch below is skipped when the repo's meta display
   // settings are both off, but this one always runs since a detached copy
   // must never render regardless.
-  const detachByKey = await getMetadataForKeys(
-    dbFor(env),
+  if (items.length > 0) {
+    const detachByKey = await getMetadataForKeys(
+      dbFor(env),
+      workspaceName,
+      items.map((item) => item.key),
+      { metaKeys: [DETACH_META_KEY] },
+    );
+    items = items.filter((item) => detachByKey.get(item.key)?.[DETACH_META_KEY] !== "true");
+  }
+
+  reportAttachmentIndexShadow(
+    await indexShadow,
     workspaceName,
+    target,
     items.map((item) => item.key),
-    { metaKeys: [DETACH_META_KEY] },
   );
-  items = items.filter((item) => detachByKey.get(item.key)?.[DETACH_META_KEY] !== "true");
 
   if (!showMetadata || items.length === 0) return items;
 

--- a/apps/api/src/github-link-adopt.ts
+++ b/apps/api/src/github-link-adopt.ts
@@ -258,7 +258,7 @@ export async function adoptLinkedFiles(
   // isn't judged against a prefix count its own copy just inflated. Legacy
   // attachments outside the ledger (manual `attach --pr`, pre-#709 adoptions)
   // still count here; ledgered adoptions feed the guard separately below.
-  const before = await gatherCommentBody(env, ws, workspaceName, target);
+  const before = await gatherCommentBody(env, ws, workspaceName, target, { shadow: false });
 
   for (const key of keys) {
     // A URL that already points at this PR/issue's attachment prefix is the

--- a/apps/api/test/github-attachment-index-sqlite.test.ts
+++ b/apps/api/test/github-attachment-index-sqlite.test.ts
@@ -11,6 +11,7 @@ import {
   deleteAttachmentsForWorkspaceSafe,
   detachAttachment,
   detachAttachmentSafe,
+  listAttachmentsForTarget,
   parseAttachmentKey,
   reattachAttachment,
   reattachAttachmentSafe,
@@ -545,5 +546,35 @@ describe("recordAttachmentForKeySafe", () => {
     } finally {
       sqlite.close();
     }
+  });
+});
+
+describe("listAttachmentsForTarget", () => {
+  it("returns the active rows for one (workspace, repo, target), sorted by key", async () => {
+    const db = database(new SqliteD1(MIGRATIONS));
+    await recordAttachment(db, row({ objectKey: "gh/acme/web/pull/12/b.png" }));
+    await recordAttachment(db, row({ objectKey: "gh/acme/web/pull/12/a.png" }));
+    // Same workspace, other targets and repos: never returned.
+    await recordAttachment(db, row({ num: 13, objectKey: "gh/acme/web/pull/13/c.png" }));
+    await recordAttachment(db, row({ kind: "issues", objectKey: "gh/acme/web/issues/12/d.png" }));
+    await recordAttachment(db, row({ repo: "acme/api", objectKey: "gh/acme/api/pull/12/e.png" }));
+    // Other workspace, same key shape: never returned.
+    await recordAttachment(db, row({ workspace: "other" }));
+
+    const rows = await listAttachmentsForTarget(db, "acme", "Acme/Web", { kind: "pull", num: 12 });
+    expect(rows.map((r) => r.objectKey)).toEqual([
+      "gh/acme/web/pull/12/a.png",
+      "gh/acme/web/pull/12/b.png",
+    ]);
+  });
+
+  it("omits detached rows", async () => {
+    const db = database(new SqliteD1(MIGRATIONS));
+    await recordAttachment(db, row());
+    await recordAttachment(db, row({ objectKey: "gh/acme/web/pull/12/gone.png" }));
+    await detachAttachment(db, "acme", "gh/acme/web/pull/12/gone.png");
+
+    const rows = await listAttachmentsForTarget(db, "acme", "acme/web", { kind: "pull", num: 12 });
+    expect(rows.map((r) => r.objectKey)).toEqual(["gh/acme/web/pull/12/hero.png"]);
   });
 });

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1013,25 +1013,38 @@ before phase 3 switches the render to it.
 
 **Flag:** Flagship `attachment-index-shadow`, same app as
 `video-poster-generation`. Off by default; turning it on adds one D1 read per
-comment sync, overlapped with the R2 listing, and never changes what renders.
+comment sync, overlapped with the R2 listing and abandoned after one second,
+and never changes what renders. Create it once (boolean, served off), then
+flip it:
+
+```bash
+wrangler flagship flags create 8371bfe7-9767-4b4d-b75a-37b94d2724f7 \
+  attachment-index-shadow --description "#934 phase 2: log index vs R2 fan-out diff"
+```
 
 ```bash
 wrangler flagship flags update 8371bfe7-9767-4b4d-b75a-37b94d2724f7 \
   attachment-index-shadow --default on
 ```
 
-**Reading it:** one Workers Logs line per sync while the flag is on,
-`component: "attachment-index"`, `event: "shadow"`. `match: true` means the
-index and the post-detach fan-out agree. `missing` lists keys the fan-out
-rendered that the index lacks (a write path the index misses, or an object
-that predates #938 and needs the backfill); `extra` lists index rows the
-fan-out did not render (a stale row: the object was deleted or moved without
-the index hearing). Key lists are capped at five per side; `missingCount` /
-`extraCount` are exact. Private prefix ids are redacted from the keys.
+**Reading it:** one Workers Logs line per real sync while the flag is on
+(link adoption's pre-write baseline gather opts out), `component:
+"attachment-index"`, `event: "shadow"`. `match: true` means the index and the
+post-detach fan-out agree. `missing` lists keys the fan-out rendered that the
+index lacks: a write path the index misses, or an object that predates #938
+and needs the backfill. `extra` lists index rows the fan-out did not render,
+which is one of two very different things: a stale row (the object was
+deleted or moved without the index hearing), or a correct row for a private
+attachment the fan-out cannot find because its prefix has no `file_metadata`
+row and is neither the repo sentinel nor the PR head branch. The second is
+the index out-rendering the fan-out, not a defect; check the key's
+`file_metadata` presence before filing it. Key lists are capped at five per
+side; `missingCount` / `extraCount` are exact. Private prefix ids are
+redacted from the keys.
 
-A `"attachment index: shadow read failed"` error line means the flag was on
-but the D1 read (or the flag evaluation) threw; the sync still completed from
-the fan-out.
+An error line `"attachment index: shadow read failed"` means the D1 read (or
+the flag evaluation) threw; `"attachment index: shadow read timed out"` means
+it exceeded one second. Either way the sync completed from the fan-out.
 
 Fails closed like the other flags: a missing `FLAGS` binding, a disabled
 flag, or a thrown evaluation all mean no shadow.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -70,9 +70,9 @@ No Worker proxies image bytes — dual host is DNS + zone rules only.
 
 **Applied 2026-09-02** (zone ruleset `1b295145ce4a4dc685498657af8a6956`, phase `http_response_headers_transform`, via the API):
 
-| Rule id | What |
-| --- | --- |
-| `030fcb7edf324c0b9c966550c8b7d870` | `X-Content-Type-Options: nosniff` on every response from the three storage hosts |
+| Rule id                            | What                                                                                                                                                                                                        |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `030fcb7edf324c0b9c966550c8b7d870` | `X-Content-Type-Options: nosniff` on every response from the three storage hosts                                                                                                                            |
 | `508226d5de4a4a0d8d861356b43cf912` | `Content-Security-Policy: … sandbox` + `nosniff` when the response content type is `image/svg+xml`, `application/xml`, or `text/xml` (the `eq` form; the zone is on Pro, so regex `matches` is unavailable) |
 
 The operator probe returned `ok: true` for all three hosts the same day. The `active-content-uploads` flag was still off at that point.
@@ -835,7 +835,7 @@ recommend removing.
 | `ANALYTICS_API_TOKEN`                                                          | api       | Same as above — without it the breakdown panel reports `not_configured` even if `ANALYTICS` itself is bound.                                                                                                                                                                                                                                                                                            |
 | `BROWSER`                                                                      | api       | `POST /v1/render` (CLI screenshot capture) answers 503 `renderer_unavailable`. Nothing else is affected.                                                                                                                                                                                                                                                                                                |
 | `MEDIA`                                                                        | api       | Video poster-frame generation is skipped; uploads still succeed, just without a generated poster image.                                                                                                                                                                                                                                                                                                 |
-| `FLAGS`                                                                        | api       | Poster generation's runtime kill switch always evaluates to disabled (fails closed) — same effect as never enabling the feature.                                                                                                                                                                                                                                                                        |
+| `FLAGS`                                                                        | api       | Every Flagship-gated feature evaluates to off (fails closed): poster generation, active-content uploads, and the attachment index shadow — same effect as never enabling them.                                                                                                                                                                                                                          |
 | `GITHUB_WEBHOOK_QUEUE`                                                         | api       | GitHub webhook deliveries process inline (`waitUntil`) instead of through a durable queue — functionally the same, just without queue-level retry/DLQ semantics.                                                                                                                                                                                                                                        |
 | `AUTH`                                                                         | mcp       | Uploader attribution on hosted-MCP uploads degrades to the id-only `gh.uploader-id` tag (no `gh.uploader` login) — the binding backs `uploaderTags()` in `@uploads/api/uploader-identity`, called from `apps/mcp/src/tools.ts`, and every failure path there fails soft. Uploads still succeed. (Listed here because a grep of `apps/mcp/src` alone misses the usage — it lives in the shared package.) |
 | `WRITE_LIMITER`                                                                | api, mcp  | No per-workspace burst limit on uploads/deletes.                                                                                                                                                                                                                                                                                                                                                        |
@@ -1002,6 +1002,39 @@ large run:
 - Use `--limit <n>` to bound how much budget a single run spends.
 - Expect a large backfill to compete with real user uploads for the same
   budget, and to start failing with 429s if it exhausts it partway through.
+
+## Attachment index shadow (issue #934)
+
+The managed comment sync still renders from the R2 fan-out (one `ListObjects`
+per prefix that can hold the target). Phase 1 (#938) writes every attachment
+to the `github_attachments` D1 table; phase 2 reads that table alongside the
+fan-out and logs the difference, so the index's coverage can be measured
+before phase 3 switches the render to it.
+
+**Flag:** Flagship `attachment-index-shadow`, same app as
+`video-poster-generation`. Off by default; turning it on adds one D1 read per
+comment sync, overlapped with the R2 listing, and never changes what renders.
+
+```bash
+wrangler flagship flags update 8371bfe7-9767-4b4d-b75a-37b94d2724f7 \
+  attachment-index-shadow --default on
+```
+
+**Reading it:** one Workers Logs line per sync while the flag is on,
+`component: "attachment-index"`, `event: "shadow"`. `match: true` means the
+index and the post-detach fan-out agree. `missing` lists keys the fan-out
+rendered that the index lacks (a write path the index misses, or an object
+that predates #938 and needs the backfill); `extra` lists index rows the
+fan-out did not render (a stale row: the object was deleted or moved without
+the index hearing). Key lists are capped at five per side; `missingCount` /
+`extraCount` are exact. Private prefix ids are redacted from the keys.
+
+A `"attachment index: shadow read failed"` error line means the flag was on
+but the D1 read (or the flag evaluation) threw; the sync still completed from
+the fan-out.
+
+Fails closed like the other flags: a missing `FLAGS` binding, a disabled
+flag, or a thrown evaluation all mean no shadow.
 
 ## Deploys
 


### PR DESCRIPTION
Phase 2 of the D1 attachment index from #934. The comment sync still renders from the R2 fan-out; behind a Flagship flag it now also reads the `github_attachments` table written by #938 and logs how the two disagree, so the index's coverage can be measured before phase 3 switches the render source to it.

## What's in here

**Read helper.** `listAttachmentsForTarget(db, workspace, repo, target)` in `github-attachment-index.ts`: the active rows for one PR/issue target, ordered by key, served by the partial `github_attachments_target_idx` from #938. This is the query phase 3 will render from.

**Shadow.** `github-attachment-shadow.ts`, wired into `gatherAttachments`:

- `startAttachmentIndexShadow` is kicked off after the prefix lookup and before the R2 fan-out, so the flag evaluation and the D1 read overlap the listing rather than adding to it, and the shadow is never the request's first D1 query. It is abandoned after one second so a stalled D1 cannot hold the webhook.
- `reportAttachmentIndexShadow` runs after the `gh.detached` filter, so the comparison is against what actually renders. Link adoption's pre-write baseline gather passes `shadow: false` so its deliberately stale fan-out is never logged as a mismatch. It logs one JSON line per real sync: `component: "attachment-index"`, `event: "shadow"`, `match`, `fanout`, `index`, exact `missingCount` / `extraCount`, and up to five keys per side with private prefix ids redacted.
- Fails closed and never fails the sync: missing `FLAGS` binding, flag off, thrown flag evaluation, thrown D1 read, or a read past the timeout all reduce to "no shadow". The last three log an error line.

The early `items.length === 0` return in `gatherAttachments` moved below the detach filter so an empty fan-out is still compared (that is exactly the "index has rows for a target with no objects" case worth seeing). Behavior with the flag off is unchanged.

**Flag.** `attachment-index-shadow`, off by default. Runbook added to `docs/ops.md` (how to turn it on, how to read the log line, what `missing` vs `extra` means).

**Tests.** Two sqlite cases for the read helper (target/repo/workspace scoping, detached rows omitted) and ten in `github-comment.test.ts`: match, missing, extra on an empty fan-out, detached-row parity, private-id redaction, the five-key cap with exact counts, identical render output across binding-absent / flag-off / flag-on, the adoption opt-out, a throwing flag plus a throwing D1 read leaving the render intact, and a never-resolving D1 read abandoned at the timeout. `apps/api`: 2780 tests green; typecheck, lint, format clean.

## Not in this PR

The phase 2 cleanup checklist from the #938 review (collapse the double upsert per attach/adopt, fold the `putObject` index write into its `Promise.all`, skip index calls for keys that can never have rows in rotation/retention, share the SQL text with the test fake, overlap adopt's per-link writes). Those are write-shape changes with no bearing on what the shadow measures; they go in a separate PR so this one stays a pure read-side addition. Phase 3 (render from the index, lane-aware URLs), the reconcile job, and the backfill follow once the shadow shows the index agreeing.

## Rollout

1. Merge; deploy carries no behavior change.
2. Create the flag (boolean, served off) in the Flagship app with the `flags create` command in the runbook, then turn it on.
3. Watch Workers Logs for `event: "shadow"` lines over a few days of syncs. Expect `missing` on objects that predate #938 until the backfill lands. An `extra` is either a stale row or a private attachment the fan-out cannot discover (no `file_metadata` row, prefix not the sentinel or head branch); the runbook says how to tell them apart.
4. Rollback is the flag.
