### PR TITLE
fix(api): retry the active-content host KV write once on failure

### DIFF
--- a/.changeset/active-content-kv-put-retry.md
+++ b/.changeset/active-content-kv-put-retry.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+The active-content host probe now retries a failed `REGISTRY` KV write once before giving up, so a stale prior-day `ok: true` record can't survive a one-off KV hiccup and keep the SVG/XML sandboxing gate open.

--- a/apps/api/src/active-content-hosts.test.ts
+++ b/apps/api/src/active-content-hosts.test.ts
@@ -190,6 +190,73 @@ describe("probeHostActiveContent", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(registry.store.get("host-active-content:storage.uploads.sh")).toEqual(record);
   });
+
+  it("retries a failing REGISTRY.put once and writes the record on the second attempt", async () => {
+    vi.useFakeTimers();
+    try {
+      const bucket = new FakeR2Bucket();
+      const registry = fakeRegistry();
+      let calls = 0;
+      registry.put = vi.fn(async (key: string, value: string) => {
+        calls++;
+        if (calls === 1) throw new Error("kv unavailable");
+        registry.store.set(key, JSON.parse(value));
+      }) as unknown as KVNamespace["put"];
+      const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
+      const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async (url) =>
+        okProbeResponse(url),
+      );
+
+      const promise = probeHostActiveContent(e, "storage.uploads.sh", asFetch(fetchImpl));
+      await vi.advanceTimersByTimeAsync(1000);
+      const record = await promise;
+
+      expect(record.ok).toBe(true);
+      expect(registry.put).toHaveBeenCalledTimes(2);
+      expect(registry.store.get("host-active-content:storage.uploads.sh")).toEqual(record);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces an error and never claims a stale success when REGISTRY.put fails twice", async () => {
+    vi.useFakeTimers();
+    try {
+      const bucket = new FakeR2Bucket();
+      const registry = fakeRegistry({
+        "host-active-content:storage.uploads.sh": {
+          ok: true,
+          verifiedAt: "2020-01-01T00:00:00.000Z",
+        },
+      });
+      registry.put = vi.fn(async () => {
+        throw new Error("kv unavailable");
+      }) as unknown as KVNamespace["put"];
+      const e = env({ UPLOADS_DEFAULT: bucket, REGISTRY: registry });
+      const fetchImpl = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async (url) =>
+        okProbeResponse(url),
+      );
+
+      const promise = probeHostActiveContent(e, "storage.uploads.sh", asFetch(fetchImpl));
+      // Attach a rejection handler immediately so the fake-timer advance
+      // below doesn't race an unhandled rejection warning.
+      const settled = promise.catch((err: unknown) => err);
+      await vi.advanceTimersByTimeAsync(1000);
+      const err = await settled;
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toBe("kv unavailable");
+      expect(registry.put).toHaveBeenCalledTimes(2);
+      // The stale prior-day record must survive untouched — not be
+      // overwritten with a fabricated success.
+      expect(registry.store.get("host-active-content:storage.uploads.sh")).toEqual({
+        ok: true,
+        verifiedAt: "2020-01-01T00:00:00.000Z",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("runActiveContentHostSweep", () => {

--- a/apps/api/src/active-content-hosts.ts
+++ b/apps/api/src/active-content-hosts.ts
@@ -101,7 +101,26 @@ export async function probeHostActiveContent(
     verifiedAt: new Date().toISOString(),
     ...(check.hint ? { detail: check.hint } : {}),
   };
-  await env.REGISTRY.put(hostActiveContentKey(host), JSON.stringify(record));
+  const key = hostActiveContentKey(host);
+  const value = JSON.stringify(record);
+  try {
+    await env.REGISTRY.put(key, value);
+  } catch {
+    // One retry after a short backoff: a bare failure here would leave
+    // yesterday's `ok: true` record in place for up to 24h (until the next
+    // sweep), holding the gate open on stale data. If the retry also fails,
+    // surface it rather than silently keeping the stale record.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    try {
+      await env.REGISTRY.put(key, value);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(
+        JSON.stringify({ message: "active_content_host_record_write_failed", host, error: detail }),
+      );
+      throw err;
+    }
+  }
   return record;
 }
 


### PR DESCRIPTION
`probeHostActiveContent` wrote the host record to `REGISTRY` last, with no error handling around the write. If the KV `put` itself threw, the previous day's `ok: true` record survived untouched — up to 24h until the next sweep — keeping the SVG/XML sandboxing gate open on stale data.

Now the write is retried once after a short backoff; if it still fails, the failure is logged (same JSON pattern used elsewhere in the file) and rethrown, so `runActiveContentHostSweep`'s existing per-host catch synthesizes an `ok: false` result instead of the stale record surviving silently.

Refs #936

Test command: `pnpm --filter @uploads/api test` (also ran `apps/api/src/active-content-hosts.test.ts` directly — 14/14 passing) and `pnpm lint` (pre-existing unrelated tsconfig errors only, confirmed present on main too).
