### PR TITLE
feat(api): detect SVG dimensions for image metadata

### DIFF
--- a/.changeset/active-markup-filter-precision.md
+++ b/.changeset/active-markup-filter-precision.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Sharpen the server-side reputation pre-filter for gated SVG/XML uploads (`containsActiveMarkup`): event-handler attribute matching no longer false-positives on ordinary attributes like `online=`/`once=`, and entity-encoded evasions (`&#106;avascript:`, SMIL `<set attributeName="onclick">`) are now rejected. The actual security control remains the sandboxing CSP on the serving lane; this filter is defense in depth.

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -525,12 +525,16 @@ export interface ImageDimensions {
   height: number;
 }
 
+/** Prefix of an `image/svg+xml` body decoded when looking for the root `<svg>` tag's dimensions. */
+const SVG_DIMENSION_SNIFF_BYTES = 8 * 1024;
+
 /**
  * Best-effort pixel dimensions read straight from an image's header —
  * PNG (IHDR), GIF (logical screen descriptor), JPEG (first SOF marker),
- * WebP (VP8X/VP8/VP8L chunk). Returns `undefined` for any other content
- * type or a header it can't decode; callers that gate on dimensions must
- * fail open on `undefined` rather than treating it as zero.
+ * WebP (VP8X/VP8/VP8L chunk), SVG (root `<svg>` tag's `width`/`height`, or
+ * `viewBox` as a fallback). Returns `undefined` for any other content type
+ * or a header it can't decode; callers that gate on dimensions must fail
+ * open on `undefined` rather than treating it as zero.
  */
 export function detectImageDimensions(
   bytes: Uint8Array,
@@ -590,6 +594,39 @@ export function detectImageDimensions(
       if (bytes[20] !== 0x2f) return undefined;
       const bits = view.getUint32(21, true);
       return valid((bits & 0x3fff) + 1, ((bits >> 14) & 0x3fff) + 1);
+    }
+    return undefined;
+  }
+  if (contentType === "image/svg+xml") {
+    // Declared-only, no magic bytes to sniff: decode a capped prefix as
+    // UTF-8, find the root `<svg …>` start tag, and read its `width`/
+    // `height` attributes (plain numbers or a `px` suffix only — percent,
+    // em, and other units aren't resolvable without a layout box, so they
+    // fall through to `viewBox`'s width/height, rounded to integers).
+    const head = decodeLossy(
+      bytes.subarray(0, Math.min(bytes.byteLength, SVG_DIMENSION_SNIFF_BYTES)),
+    );
+    const tag = /<svg[\s/>][\s\S]*?>/i.exec(head)?.[0];
+    if (!tag) return undefined;
+    const attr = (name: string): string | undefined =>
+      new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, "i")
+        .exec(tag)
+        ?.slice(1, 3)
+        .find((v) => v !== undefined);
+    const parseLength = (raw: string | undefined): number | undefined => {
+      if (raw === undefined) return undefined;
+      const m = /^(\d+(?:\.\d+)?)(px)?$/.exec(raw.trim());
+      return m ? Math.round(Number(m[1])) : undefined;
+    };
+    const width = parseLength(attr("width"));
+    const height = parseLength(attr("height"));
+    if (width !== undefined && height !== undefined) return valid(width, height);
+    const viewBox = attr("viewBox")
+      ?.trim()
+      .split(/[\s,]+/)
+      .map(Number);
+    if (viewBox?.length === 4 && viewBox.every(Number.isFinite)) {
+      return valid(Math.round(viewBox[2]!), Math.round(viewBox[3]!));
     }
     return undefined;
   }

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -112,6 +112,33 @@ describe("detectImageDimensions", () => {
     expect(detectImageDimensions(new Uint8Array(30), "video/webm")).toBeUndefined();
     expect(detectImageDimensions(new Uint8Array(0), "image/jpeg")).toBeUndefined();
   });
+
+  it("reads SVG dimensions from plain numeric width/height", () => {
+    const svg = new TextEncoder().encode('<svg width="120" height="80"><rect/></svg>');
+    expect(detectImageDimensions(svg, "image/svg+xml")).toEqual({ width: 120, height: 80 });
+  });
+
+  it("reads SVG dimensions from width/height with a px suffix", () => {
+    const svg = new TextEncoder().encode(
+      '<?xml version="1.0"?><svg width="240px" height="160px" xmlns="http://www.w3.org/2000/svg"></svg>',
+    );
+    expect(detectImageDimensions(svg, "image/svg+xml")).toEqual({ width: 240, height: 160 });
+  });
+
+  it("falls back to viewBox when width/height are absent", () => {
+    const svg = new TextEncoder().encode('<svg viewBox="0 0 300 150"></svg>');
+    expect(detectImageDimensions(svg, "image/svg+xml")).toEqual({ width: 300, height: 150 });
+  });
+
+  it("returns undefined for percent (or other non-px) width/height units", () => {
+    const svg = new TextEncoder().encode('<svg width="100%" height="50%"></svg>');
+    expect(detectImageDimensions(svg, "image/svg+xml")).toBeUndefined();
+  });
+
+  it("returns undefined when there is no <svg root tag", () => {
+    const notSvg = new TextEncoder().encode("<xml><foo/></xml>");
+    expect(detectImageDimensions(notSvg, "image/svg+xml")).toBeUndefined();
+  });
 });
 
 describe("checkDeclaredLength", () => {


### PR DESCRIPTION
## Summary

Adds an `image/svg+xml` branch to `detectImageDimensions` (`apps/api/src/guards.ts`) so SVG uploads get `image.width`/`image.height` server metadata like the other image types, letting the managed GitHub comment size them.

- Decodes at most the first 8 KiB as UTF-8 and finds the root `<svg …>` start tag.
- Reads `width`/`height` when both are plain numbers or have a `px` suffix.
- Falls back to `viewBox`'s third/fourth values (rounded) when `width`/`height` aren't usable.
- Percent, em, or other units, or no parseable `<svg` tag → `undefined` (fail-open, matching the existing contract).

Callers verified:
- `apps/api/src/files-core.ts`'s `uploadKind(contentType) !== "image"` gate already passes SVG through — `image/svg+xml`'s row in `GATED_UPLOAD_TYPES` has `kind: "image"`.
- `apps/api/src/github-ingest.ts` never reaches `detectImageDimensions` for SVG today: it calls with `activeContent: false`, and `detectContentType` (magic-byte sniff) returns `null` for SVG since it's a declared-only type, so the `!sniffed` check skips it before the allowlist/dimension step. No change needed there; noting it as a known gap outside this issue's scope.
- `packages/comment-render`: `naturalMediaWidth`/`isSmallAsset` already work generically off `dims.width`/`dims.height` — no changes needed.

## Tests

Added cases to `apps/api/test/guards.test.ts`'s `detectImageDimensions` describe block: numeric width/height, `px`-suffixed width/height, `viewBox` fallback, percent units → `undefined`, no `<svg` root → `undefined`.

```
pnpm --filter @uploads/api test
```
2773 tests passed (183 files).

Refs #936

