### PR TITLE
ci: run Lint & Format on every PR, fix docs/ops.md formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
-      - "LICENSE"
   push:
     branches: [main]
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -70,9 +70,9 @@ No Worker proxies image bytes — dual host is DNS + zone rules only.
 
 **Applied 2026-09-02** (zone ruleset `1b295145ce4a4dc685498657af8a6956`, phase `http_response_headers_transform`, via the API):
 
-| Rule id | What |
-| --- | --- |
-| `030fcb7edf324c0b9c966550c8b7d870` | `X-Content-Type-Options: nosniff` on every response from the three storage hosts |
+| Rule id                            | What                                                                                                                                                                                                        |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `030fcb7edf324c0b9c966550c8b7d870` | `X-Content-Type-Options: nosniff` on every response from the three storage hosts                                                                                                                            |
 | `508226d5de4a4a0d8d861356b43cf912` | `Content-Security-Policy: … sandbox` + `nosniff` when the response content type is `image/svg+xml`, `application/xml`, or `text/xml` (the `eq` form; the zone is on Pro, so regex `matches` is unavailable) |
 
 The operator probe returned `ok: true` for all three hosts the same day. The `active-content-uploads` flag was still off at that point.


### PR DESCRIPTION
Fixes the `pnpm format:check` failure on main that surfaced on the unrelated
changesets release PR #930 ([run](https://github.com/buildinternet/uploads/actions/runs/33662407763)).

## What broke

PR #939 (docs-only) landed unformatted markdown because `.github/workflows/ci.yml`
has a workflow-level `paths-ignore` for `docs/**`, `*.md`, and `LICENSE` on
`pull_request` — so no lint ran on that PR. `oxfmt` does format `.md` files
(only `**/*.mdx` is excluded in `.oxfmtrc.json`), so the drift went straight
to main and only showed up when an unrelated push-triggered run hit
`format:check`.

## Changes

1. **`docs/ops.md`** — ran `pnpm format` and committed the resulting table
   reflow. `pnpm format:check` now passes clean.
2. **`.github/workflows/ci.yml`** — removed the `pull_request`-trigger
   `paths-ignore` block so **Lint & Format** runs on every PR, docs-only
   included. The block has been in the workflow unchanged since its first
   commit (#9) with no comment indicating a deliberate cost tradeoff, so
   removing it (rather than adding a job-level skip) is the safer fix. Job
   names (`Lint & Format`, `Test`) are unchanged for branch protection.

No local hook change needed: the Husky pre-commit hook already runs
`oxfmt`/`prettier` via `lint-staged` on staged `*.md` files (see
`.lintstagedrc.mjs`), so this was purely a CI trigger gap, not a missing
local check.

No changeset — `.changeset/config.json` only tracks
`@buildinternet/uploads`, and this is a docs/CI-only change.

Once this merges to main, the open changesets release PR (#930) will pick up
a green run automatically on its next push.
