### PR TITLE
perf(api): trim the attachment-index dual-write (#934 cleanup)

### DIFF
--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -31,7 +31,11 @@ import {
   inheritableMetaForHash,
   recordContentHash,
 } from "./content-hash";
-import { deleteAttachmentSafe, recordAttachmentForKeySafe } from "./github-attachment-index";
+import {
+  type AttachmentSource,
+  deleteAttachmentSafe,
+  recordAttachmentForKeySafe,
+} from "./github-attachment-index";
 import { recordPrActivityFromMetadata } from "./github-pr-activity";
 import { noteStorageFailure, noteStorageSuccess } from "./storage-health";
 import {
@@ -510,6 +514,22 @@ export async function putObject(
      * question instead — see `serverCopy` above).
      */
     activeContent?: boolean;
+    /**
+     * Attribution for this put's attachment-index row (issue #934), for the
+     * server-side copy paths that already know what they are doing: attach,
+     * promote, adopt. Absent (every other caller — the REST PUT, the
+     * idempotent PUT, rotation) means `source: "put"` with the repo derived
+     * from the key, which is the historical behavior.
+     *
+     * `repo` must be a SERVER-RESOLVED repo (the request/webhook target),
+     * never `gh.*` file_metadata — see github-attachment-index.ts's trust
+     * boundary. Supplying it also avoids the plain key's lossy sanitized
+     * owner/name segments.
+     *
+     * A non-`"put"` source clears `detached_at`, exactly as the follow-up
+     * `recordAttachmentForKeySafe` these callers used to make did.
+     */
+    attachment?: { source: AttachmentSource; repo?: string };
   },
 ): Promise<{
   key: string;
@@ -803,8 +823,9 @@ export async function putObject(
     await recordAttachmentForKeySafe(dbFor(env), {
       workspace: workspaceName,
       objectKey: finalKey,
-      source: "put",
+      source: opts?.attachment?.source ?? "put",
       laneId: ws.storageLaneId ?? null,
+      repo: opts?.attachment?.repo,
     });
   }
 

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -1366,6 +1366,16 @@ export async function deleteObject(
   ws: WorkspaceRecord,
   key: string,
   workspaceName: string,
+  opts?: {
+    /**
+     * Server-internal (issue #934): the caller has already moved this key's
+     * attachment-index row elsewhere, so the DELETE below could only ever
+     * match nothing. Private-prefix rotation sets it — it calls
+     * `rekeyAttachment` for the old key immediately before deleting it.
+     * Never set from a request: an ordinary delete must still clear the row.
+     */
+    skipAttachmentIndex?: boolean;
+  },
 ): Promise<{ key: string; deleted: true }> {
   if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
 
@@ -1406,7 +1416,7 @@ export async function deleteObject(
   // surviving attachment silently drops out of the managed comment.
   // Best-effort past that point: a stale row costs a broken image until
   // reconcile, never a failed delete.
-  await deleteAttachmentSafe(dbFor(env), workspaceName, key);
+  if (!opts?.skipAttachmentIndex) await deleteAttachmentSafe(dbFor(env), workspaceName, key);
 
   // Derived poster (issue #299), best-effort: a missing one is the norm for
   // every non-video object. Guarded so a transient poster-cleanup failure

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -773,6 +773,24 @@ export async function putObject(
         repo: opts?.metadata?.["gh.repo"],
       },
     }),
+    // Attachment index (issue #934): the single choke point covering every
+    // putObject caller — REST PUT, the idempotent PUT and its reconcile,
+    // attach, promote, and rotation. See github-attachment-index.ts's header
+    // doc comment for the trust-boundary rationale. `lane_id` is the active
+    // lane this write went to (`storage(env, ws)` above). Best-effort and
+    // never-throwing like its neighbours here, and the object is durably
+    // stored by the time this block runs — so it rides along with the rest
+    // of the post-write bookkeeping rather than costing its own serial round
+    // trip on every attachment upload.
+    isManagedGithubKey(finalKey)
+      ? recordAttachmentForKeySafe(dbFor(env), {
+          workspace: workspaceName,
+          objectKey: finalKey,
+          source: opts?.attachment?.source ?? "put",
+          laneId: ws.storageLaneId ?? null,
+          repo: opts?.attachment?.repo,
+        })
+      : Promise.resolve(),
   ]);
 
   // Derived metadata from a content-identical earlier upload in this workspace
@@ -812,22 +830,6 @@ export async function putObject(
   // the object is durably stored by now, so a failed index write costs a later
   // inheritance rather than this upload.
   await recordContentHash(dbFor(env), workspaceName, finalKey, contentSha256);
-
-  // Attachment index (issue #934): the single choke point covering every
-  // putObject caller — REST PUT, the idempotent PUT and its reconcile,
-  // attach, promote, and rotation. See github-attachment-index.ts's header
-  // doc comment for the trust-boundary rationale. `lane_id` is the active
-  // lane this write went to (`storage(env, ws)` above). Best-effort and
-  // last, like recordContentHash: the object is durably stored by now.
-  if (isManagedGithubKey(finalKey)) {
-    await recordAttachmentForKeySafe(dbFor(env), {
-      workspace: workspaceName,
-      objectKey: finalKey,
-      source: opts?.attachment?.source ?? "put",
-      laneId: ws.storageLaneId ?? null,
-      repo: opts?.attachment?.repo,
-    });
-  }
 
   // After the metadata replace, never before: replaceFileMetadata is
   // delete-then-insert and would wipe the server-owned video.*/image.* rows.

--- a/apps/api/src/github-attach.ts
+++ b/apps/api/src/github-attach.ts
@@ -36,7 +36,7 @@ import {
   sanitizeKeyBasename,
 } from "./files-core";
 import { getFileMetadata, setFileMetadata } from "./file-metadata";
-import { recordAttachmentForKeySafe } from "./github-attachment-index";
+import { type AttachmentSource } from "./github-attachment-index";
 import { resolveGhKeyContextSafe } from "./github-private-prefix-service";
 import { storage, storageConfig } from "./storage";
 import { webOrigin } from "./web-url";
@@ -171,6 +171,13 @@ export async function attachExistingObject(
   ws: WorkspaceRecord,
   workspaceName: string,
   req: AttachExistingRequest,
+  /**
+   * Server-internal, never routed from a request body: which source the
+   * attachment-index row is attributed to. Link adoption (#709) passes
+   * `"adopt"` for the copy it makes through this function; everything else
+   * is a plain attach.
+   */
+  opts?: { indexSource?: AttachmentSource },
 ): Promise<AttachExistingResult> {
   const cfg = await storageConfig(env, ws);
   const sourceKey = await resolveAttachSourceKey(env, cfg, workspaceName, req.source);
@@ -207,9 +214,15 @@ export async function attachExistingObject(
   const ref = `${owner}/${name}#${req.target.num}`.toLowerCase();
   const nowIso = new Date().toISOString();
 
+  // Attachment index (issue #934): `putObject` writes the row itself, with
+  // the repo the CALLER resolved (req.target.repo) — authoritative, and not
+  // lossy the way a plain key's sanitized owner/name segments are. Never
+  // derived from the gh.* metadata stamped below: that bag is
+  // client-influenced on the source object.
   const put = await putObject(env, ws, destKey, bytes, workspaceName, {
     ...putOptsFromStoredObject(source),
     surface: "attach",
+    attachment: { source: opts?.indexSource ?? "attach", repo: req.target.repo },
   });
 
   // Additive merge (PR #157 preserve mode): the source's existing metadata
@@ -221,20 +234,6 @@ export async function attachExistingObject(
     "gh.number": String(req.target.num),
     "gh.ref": ref,
     "gh.attached-at": nowIso,
-  });
-
-  // Attachment index (issue #934): putObject above already wrote a
-  // `source: "put"` row for destKey; re-record it as an attach with the
-  // repo the CALLER resolved (req.target.repo), which is authoritative and
-  // not lossy the way a plain key's sanitized owner/name segments are.
-  // Never derived from the gh.* metadata stamped just above — that bag is
-  // client-influenced on the source object.
-  await recordAttachmentForKeySafe(dbFor(env), {
-    workspace: workspaceName,
-    objectKey: destKey,
-    source: "attach",
-    laneId: ws.storageLaneId ?? null,
-    repo: req.target.repo,
   });
 
   if (req.move) {

--- a/apps/api/src/github-attachment-index.ts
+++ b/apps/api/src/github-attachment-index.ts
@@ -105,6 +105,46 @@ interface AttachmentDbRow {
 const SELECT_COLUMNS =
   "workspace, repo, kind, num, object_key, prefix_id, lane_id, source, created_at, updated_at, detached_at";
 
+/**
+ * Every `github_attachments` statement this module issues, in one place.
+ * The route/webhook tests' in-memory stand-in
+ * (test/helpers/fake-attachment-index-table.ts) matches on these exact
+ * strings rather than on re-typed copies, so a reworded statement can never
+ * silently desync the fake into dropping writes.
+ */
+export const ATTACHMENT_INDEX_SQL = {
+  upsert: `INSERT INTO github_attachments
+         (workspace, repo, kind, num, object_key, prefix_id, lane_id, source, created_at, updated_at, detached_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+       ON CONFLICT(workspace, object_key) DO UPDATE SET
+         repo = excluded.repo,
+         kind = excluded.kind,
+         num = excluded.num,
+         prefix_id = excluded.prefix_id,
+         lane_id = excluded.lane_id,
+         source = excluded.source,
+         updated_at = excluded.updated_at,
+         detached_at = CASE WHEN excluded.source = 'put' THEN github_attachments.detached_at ELSE NULL END`,
+  listForTarget: `SELECT ${SELECT_COLUMNS} FROM github_attachments
+       WHERE workspace = ? AND repo = ? AND kind = ? AND num = ? AND detached_at IS NULL
+       ORDER BY object_key`,
+  selectOne: `SELECT ${SELECT_COLUMNS} FROM github_attachments
+       WHERE workspace = ? AND object_key = ?`,
+  detach: `UPDATE github_attachments SET detached_at = ?, updated_at = ?
+       WHERE workspace = ? AND object_key = ?`,
+  reattach: `UPDATE github_attachments SET detached_at = NULL, updated_at = ?
+       WHERE workspace = ? AND object_key = ?`,
+  rekey: `UPDATE github_attachments SET object_key = ?, prefix_id = ?, lane_id = ?, updated_at = ?
+       WHERE workspace = ? AND object_key = ?`,
+  deleteOne: `DELETE FROM github_attachments WHERE workspace = ? AND object_key = ?`,
+  /** `placeholders` is the comma-joined `?` list for one chunk of keys. */
+  deleteForKeys: (placeholders: string) =>
+    `${ATTACHMENT_INDEX_SQL.deleteForKeysPrefix}${placeholders})`,
+  /** The invariant head of `deleteForKeys`, for matchers that can't know the chunk size. */
+  deleteForKeysPrefix: `DELETE FROM github_attachments WHERE workspace = ? AND object_key IN (`,
+  deleteForWorkspace: `DELETE FROM github_attachments WHERE workspace = ?`,
+} as const;
+
 function fromRow(row: AttachmentDbRow): AttachmentIndexRow {
   return {
     workspace: row.workspace,
@@ -140,20 +180,7 @@ export async function recordAttachment(
 ): Promise<void> {
   const nowIso = now.toISOString();
   await db
-    .prepare(
-      `INSERT INTO github_attachments
-         (workspace, repo, kind, num, object_key, prefix_id, lane_id, source, created_at, updated_at, detached_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
-       ON CONFLICT(workspace, object_key) DO UPDATE SET
-         repo = excluded.repo,
-         kind = excluded.kind,
-         num = excluded.num,
-         prefix_id = excluded.prefix_id,
-         lane_id = excluded.lane_id,
-         source = excluded.source,
-         updated_at = excluded.updated_at,
-         detached_at = CASE WHEN excluded.source = 'put' THEN github_attachments.detached_at ELSE NULL END`,
-    )
+    .prepare(ATTACHMENT_INDEX_SQL.upsert)
     .bind(
       row.workspace,
       normalizeRepo(row.repo),
@@ -183,11 +210,7 @@ export async function listAttachmentsForTarget(
   target: { kind: "pull" | "issues"; num: number },
 ): Promise<AttachmentIndexRow[]> {
   const { results } = await db
-    .prepare(
-      `SELECT ${SELECT_COLUMNS} FROM github_attachments
-       WHERE workspace = ? AND repo = ? AND kind = ? AND num = ? AND detached_at IS NULL
-       ORDER BY object_key`,
-    )
+    .prepare(ATTACHMENT_INDEX_SQL.listForTarget)
     .bind(workspace, normalizeRepo(repo), target.kind, target.num)
     .all<AttachmentDbRow>();
   return (results ?? []).map(fromRow);
@@ -200,10 +223,7 @@ export async function attachmentRow(
   objectKey: string,
 ): Promise<AttachmentIndexRow | null> {
   const row = await db
-    .prepare(
-      `SELECT ${SELECT_COLUMNS} FROM github_attachments
-       WHERE workspace = ? AND object_key = ?`,
-    )
+    .prepare(ATTACHMENT_INDEX_SQL.selectOne)
     .bind(workspace, objectKey)
     .first<AttachmentDbRow>();
   return row ? fromRow(row) : null;
@@ -222,13 +242,7 @@ export async function detachAttachment(
   now = new Date(),
 ): Promise<void> {
   const nowIso = now.toISOString();
-  await db
-    .prepare(
-      `UPDATE github_attachments SET detached_at = ?, updated_at = ?
-       WHERE workspace = ? AND object_key = ?`,
-    )
-    .bind(nowIso, nowIso, workspace, objectKey)
-    .run();
+  await db.prepare(ATTACHMENT_INDEX_SQL.detach).bind(nowIso, nowIso, workspace, objectKey).run();
 }
 
 /** Inverse of `detachAttachment`: the link reappeared, so the row renders again. */
@@ -239,10 +253,7 @@ export async function reattachAttachment(
   now = new Date(),
 ): Promise<void> {
   await db
-    .prepare(
-      `UPDATE github_attachments SET detached_at = NULL, updated_at = ?
-       WHERE workspace = ? AND object_key = ?`,
-    )
+    .prepare(ATTACHMENT_INDEX_SQL.reattach)
     .bind(now.toISOString(), workspace, objectKey)
     .run();
 }
@@ -253,10 +264,7 @@ export async function deleteAttachment(
   workspace: string,
   objectKey: string,
 ): Promise<void> {
-  await db
-    .prepare(`DELETE FROM github_attachments WHERE workspace = ? AND object_key = ?`)
-    .bind(workspace, objectKey)
-    .run();
+  await db.prepare(ATTACHMENT_INDEX_SQL.deleteOne).bind(workspace, objectKey).run();
 }
 
 /**
@@ -274,9 +282,7 @@ export async function deleteAttachmentsForKeys(
     const chunk = keys.slice(i, i + chunkSize);
     const placeholders = chunk.map(() => "?").join(", ");
     await db
-      .prepare(
-        `DELETE FROM github_attachments WHERE workspace = ? AND object_key IN (${placeholders})`,
-      )
+      .prepare(ATTACHMENT_INDEX_SQL.deleteForKeys(placeholders))
       .bind(workspace, ...chunk)
       .run();
   }
@@ -287,7 +293,7 @@ export async function deleteAttachmentsForWorkspace(
   db: D1Queryable,
   workspace: string,
 ): Promise<void> {
-  await db.prepare(`DELETE FROM github_attachments WHERE workspace = ?`).bind(workspace).run();
+  await db.prepare(ATTACHMENT_INDEX_SQL.deleteForWorkspace).bind(workspace).run();
 }
 
 /**
@@ -311,14 +317,9 @@ export async function rekeyAttachment(
   now = new Date(),
 ): Promise<void> {
   await db.batch([
+    db.prepare(ATTACHMENT_INDEX_SQL.deleteOne).bind(workspace, toKey),
     db
-      .prepare(`DELETE FROM github_attachments WHERE workspace = ? AND object_key = ?`)
-      .bind(workspace, toKey),
-    db
-      .prepare(
-        `UPDATE github_attachments SET object_key = ?, prefix_id = ?, lane_id = ?, updated_at = ?
-       WHERE workspace = ? AND object_key = ?`,
-      )
+      .prepare(ATTACHMENT_INDEX_SQL.rekey)
       .bind(toKey, newPrefixId, laneId, now.toISOString(), workspace, fromKey),
   ]);
 }

--- a/apps/api/src/github-link-adopt.test.ts
+++ b/apps/api/src/github-link-adopt.test.ts
@@ -481,6 +481,9 @@ describe("adoptLinkedFiles → attachment index (issue #934)", () => {
       source: "adopt",
       detached_at: null,
     });
+    // One upsert for the adopted copy, not a "put" row re-recorded as
+    // "adopt" straight after (issue #934 cleanup).
+    expect(seeded.db.attachmentIndexUpserts).toBe(1);
   });
 
   it("detaches the row when the link stops being referenced, and re-attaches when it returns", async () => {

--- a/apps/api/src/github-link-adopt.test.ts
+++ b/apps/api/src/github-link-adopt.test.ts
@@ -512,4 +512,50 @@ describe("adoptLinkedFiles → attachment index (issue #934)", () => {
     expect(back.reattached).toEqual([key]);
     expect(seeded.db.attachmentIndex.get(`${WS}\0${key}`)?.detached_at).toBeNull();
   });
+
+  it("issues a detach's independent per-link writes concurrently, not one round trip at a time", async () => {
+    const seeded = await seededEnv();
+    await seedSource(seeded, "f/shot.png");
+    const first = await adoptLinkedFiles(
+      seeded.env,
+      WS,
+      null,
+      target,
+      "see https://storage.uploads.sh/acme/f/shot.png",
+    );
+    const key = first.adopted[0]!;
+
+    // Hold the metadata stamp (a `db.batch`) open, then check the index and
+    // ledger writes were already issued while it was still in flight —
+    // impossible if they ran serially behind it.
+    const statements: string[] = [];
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const db = seeded.db as unknown as {
+      prepare: (sql: string) => unknown;
+      batch: (statements: unknown[]) => Promise<unknown>;
+    };
+    const realPrepare = db.prepare.bind(db);
+    const realBatch = db.batch.bind(db);
+    db.prepare = (sql: string) => {
+      statements.push(sql.replace(/\s+/g, " ").trim());
+      return realPrepare(sql);
+    };
+    db.batch = async (stmts: unknown[]) => {
+      await gate;
+      return realBatch(stmts);
+    };
+
+    const pending = adoptLinkedFiles(seeded.env, WS, null, target, "no links now");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(statements.some((sql) => sql.startsWith("UPDATE github_attachments"))).toBe(true);
+    expect(statements.some((sql) => sql.startsWith("UPDATE github_adopted_links"))).toBe(true);
+
+    release();
+    const removed = await pending;
+    expect(removed.detached).toEqual([key]);
+    expect(seeded.db.attachmentIndex.get(`${WS}\0${key}`)?.detached_at).not.toBeNull();
+  });
 });

--- a/apps/api/src/github-link-adopt.ts
+++ b/apps/api/src/github-link-adopt.ts
@@ -55,11 +55,7 @@
  * the real `--pr` / promoted attachment, which shares that destination.
  */
 import { attachExistingObject, resolveAttachSourceKey } from "./github-attach";
-import {
-  detachAttachmentSafe,
-  reattachAttachmentSafe,
-  recordAttachmentForKeySafe,
-} from "./github-attachment-index";
+import { detachAttachmentSafe, reattachAttachmentSafe } from "./github-attachment-index";
 import { commentCacheKey, gatherCommentBody } from "./github-comment";
 import { GH_PRIVATE_ROOT, ghKeyPrefix, type GhTarget } from "./github-comment-render";
 import { postManagedComment } from "./github-comment-service";
@@ -287,21 +283,21 @@ export async function adoptLinkedFiles(
     }
 
     try {
-      const result = await attachExistingObject(env, ws, workspaceName, {
-        source: key,
-        target: { repo: target.repo, kind: target.kind, num: target.num },
-      });
+      // Attachment index (issue #934): `indexSource` makes the copy's own
+      // (single) row say "adopt" rather than "attach", so the write path
+      // stays attributable. The repo it records is `target.repo`, the
+      // webhook-resolved one, passed on by attachExistingObject.
+      const result = await attachExistingObject(
+        env,
+        ws,
+        workspaceName,
+        {
+          source: key,
+          target: { repo: target.repo, kind: target.kind, num: target.num },
+        },
+        { indexSource: "adopt" },
+      );
       await setFileMetadata(db, workspaceName, result.key, { "gh.detached": "false" });
-      // Attachment index (issue #934): attachExistingObject already wrote a
-      // `source: "attach"` row; overwrite it with "adopt" so the write path
-      // is attributable. `target.repo` is the webhook-resolved repo.
-      await recordAttachmentForKeySafe(db, {
-        workspace: workspaceName,
-        objectKey: result.key,
-        source: "adopt",
-        laneId: ws.storageLaneId ?? null,
-        repo: target.repo,
-      });
       await recordAdoptedLink(db, {
         repo,
         kind,

--- a/apps/api/src/github-link-adopt.ts
+++ b/apps/api/src/github-link-adopt.ts
@@ -274,10 +274,19 @@ export async function adoptLinkedFiles(
       }
       // Previously detached, now referenced again — un-detach without a
       // re-copy; the object is still in storage untouched.
-      await setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "false" });
-      await reattachAttachmentSafe(db, workspaceName, row.objectKey);
-      await setAdoptLedgerDetached(db, repo, kind, num, key, null);
-      if (row.source !== source) await setAdoptLedgerSource(db, repo, kind, num, key, source);
+      //
+      // The four writes land in three different tables (and, for the two
+      // ledger updates, disjoint columns of one row); none reads what
+      // another wrote, so they go out together rather than as serial D1
+      // round trips per re-referenced link.
+      await Promise.all([
+        setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "false" }),
+        reattachAttachmentSafe(db, workspaceName, row.objectKey),
+        setAdoptLedgerDetached(db, repo, kind, num, key, null),
+        row.source !== source
+          ? setAdoptLedgerSource(db, repo, kind, num, key, source)
+          : Promise.resolve(),
+      ]);
       summary.reattached.push(row.objectKey);
       continue;
     }
@@ -297,17 +306,21 @@ export async function adoptLinkedFiles(
         },
         { indexSource: "adopt" },
       );
-      await setFileMetadata(db, workspaceName, result.key, { "gh.detached": "false" });
-      await recordAdoptedLink(db, {
-        repo,
-        kind,
-        num,
-        sourceKey: key,
-        workspace: workspaceName,
-        objectKey: result.key,
-        source,
-        createdAt: new Date().toISOString(),
-      });
+      // Independent of each other (file_metadata vs the adopt ledger) and
+      // both only need `result.key`, so they overlap.
+      await Promise.all([
+        setFileMetadata(db, workspaceName, result.key, { "gh.detached": "false" }),
+        recordAdoptedLink(db, {
+          repo,
+          kind,
+          num,
+          sourceKey: key,
+          workspace: workspaceName,
+          objectKey: result.key,
+          source,
+          createdAt: new Date().toISOString(),
+        }),
+      ]);
       summary.adopted.push(result.key);
     } catch (err) {
       // Source vanished between resolve and copy (deleted concurrently), or a
@@ -339,17 +352,23 @@ export async function adoptLinkedFiles(
     const referenced = foundKeys.has(row.sourceKey) || foundKeys.has(row.objectKey);
     if (referenced) {
       if (row.detachedAt !== null) {
-        await setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "false" });
-        await reattachAttachmentSafe(db, workspaceName, row.objectKey);
-        await setAdoptLedgerDetached(db, repo, kind, num, row.sourceKey, null);
+        // Three tables, no read-after-write between them — issued together.
+        await Promise.all([
+          setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "false" }),
+          reattachAttachmentSafe(db, workspaceName, row.objectKey),
+          setAdoptLedgerDetached(db, repo, kind, num, row.sourceKey, null),
+        ]);
         summary.reattached.push(row.objectKey);
       }
       continue;
     }
     if (row.detachedAt !== null) continue;
-    await setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "true" });
-    await detachAttachmentSafe(db, workspaceName, row.objectKey);
-    await setAdoptLedgerDetached(db, repo, kind, num, row.sourceKey, new Date().toISOString());
+    // Same three independent tables as the re-attach above, mirrored.
+    await Promise.all([
+      setFileMetadata(db, workspaceName, row.objectKey, { "gh.detached": "true" }),
+      detachAttachmentSafe(db, workspaceName, row.objectKey),
+      setAdoptLedgerDetached(db, repo, kind, num, row.sourceKey, new Date().toISOString()),
+    ]);
     summary.detached.push(row.objectKey);
   }
 

--- a/apps/api/src/github-private-prefix-rotate.test.ts
+++ b/apps/api/src/github-private-prefix-rotate.test.ts
@@ -593,4 +593,54 @@ describe("rotatePrivatePrefix", () => {
     expect(bucket.store.has(`${PREFIX}${branchKey}`)).toBe(false);
     expect(statements.some((sql) => sql.startsWith("UPDATE github_attachments"))).toBe(false);
   });
+
+  it("issue #934: rotation's old-key delete skips its no-op index DELETE", async () => {
+    const seeded = await seededEnv();
+    const { db, ws } = seeded;
+    const oldId = await getOrMintPrefixId(db, REPO, BRANCH);
+    const pullKey = ghPrivateAttachmentKey(
+      oldId,
+      { repo: REPO, kind: "pull", num: NUM },
+      "hero.png",
+    );
+
+    const statements: string[] = [];
+    const spyDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "prepare") {
+          return (sql: string) => {
+            statements.push(sql.replace(/\s+/g, " ").trim());
+            return target.prepare(sql);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    const env = { ...(seeded.env as unknown as Record<string, unknown>), DB: spyDb } as Env;
+
+    await putObject(env, ws, pullKey, PNG, WS);
+    statements.length = 0;
+
+    const result = await withFetch(commentFlowFetch({ bodies: [] }), () =>
+      rotatePrivatePrefix(env, ws, WS, "user-1", REPO, BRANCH),
+    );
+
+    expect(result.rotated).toBe(true);
+    if (!result.rotated) throw new Error("expected rotated: true");
+    // Exactly one index DELETE: `rekeyAttachment`'s destination-first wipe,
+    // inside its batch. The row already moved with that re-key, so
+    // `deleteObject`'s own DELETE for the old key could only ever match
+    // nothing — rotation skips it.
+    const indexDeletes = statements.filter((sql) =>
+      sql.startsWith("DELETE FROM github_attachments"),
+    );
+    expect(indexDeletes).toHaveLength(1);
+    const newKey = ghPrivateAttachmentKey(
+      result.prefixId,
+      { repo: REPO, kind: "pull", num: NUM },
+      "hero.png",
+    );
+    expect(await attachmentRow(db, WS, pullKey)).toBeNull();
+    expect(await attachmentRow(db, WS, newKey)).not.toBeNull();
+  });
 });

--- a/apps/api/src/github-private-prefix-rotate.test.ts
+++ b/apps/api/src/github-private-prefix-rotate.test.ts
@@ -559,4 +559,38 @@ describe("rotatePrivatePrefix", () => {
       laneId: ws.storageLaneId ?? null,
     });
   });
+
+  it("issue #934: skips the index re-key entirely for keys that can never have a row", async () => {
+    const seeded = await seededEnv();
+    const { db, bucket, ws } = seeded;
+    const oldId = await getOrMintPrefixId(db, REPO, BRANCH);
+    // Branch-staged: not an attachment until promoted, so no index row can
+    // exist for it and the re-key would be a guaranteed no-op UPDATE.
+    const branchKey = ghPrivateBranchAttachmentKey(oldId, "b.png");
+
+    const statements: string[] = [];
+    const spyDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "prepare") {
+          return (sql: string) => {
+            statements.push(sql.replace(/\s+/g, " ").trim());
+            return target.prepare(sql);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    const env = { ...(seeded.env as unknown as Record<string, unknown>), DB: spyDb } as Env;
+
+    await putObject(env, ws, branchKey, PNG, WS);
+    statements.length = 0;
+
+    const result = await withFetch(commentFlowFetch({ bodies: [] }), () =>
+      rotatePrivatePrefix(env, ws, WS, "user-1", REPO, BRANCH),
+    );
+
+    expect(result.rotated).toBe(true);
+    expect(bucket.store.has(`${PREFIX}${branchKey}`)).toBe(false);
+    expect(statements.some((sql) => sql.startsWith("UPDATE github_attachments"))).toBe(false);
+  });
 });

--- a/apps/api/src/github-private-prefix-service.ts
+++ b/apps/api/src/github-private-prefix-service.ts
@@ -19,7 +19,7 @@ import { checkRepoAuthorization, postManagedComment } from "./github-comment-ser
 import { GH_PRIVATE_ROOT, type GhTargetKind, parseGhPrivateKey } from "./github-comment-render";
 import { deleteObject, putObject, putOptsFromStoredObject } from "./files-core";
 import { deleteFileMetadata } from "./file-metadata";
-import { rekeyAttachmentSafe } from "./github-attachment-index";
+import { parseAttachmentKey, rekeyAttachmentSafe } from "./github-attachment-index";
 import {
   getActivePrefixId,
   getOrMintPrefixId,
@@ -361,14 +361,20 @@ export async function rotatePrivatePrefix(
           // whichever lane is CURRENTLY active for this workspace — the
           // moved row must reflect that, not the lane the object happened
           // to be written to originally.
-          await rekeyAttachmentSafe(
-            dbFor(env),
-            workspaceName,
-            item.key,
-            newKey,
-            newId,
-            ws.storageLaneId ?? null,
-          );
+          // Only for keys that CAN hold a row: a branch-staged or ingest
+          // key never has one, so the batch would be a guaranteed no-op
+          // DELETE + UPDATE per object — most of a rotation's objects, on
+          // the sweep that already re-uploads every one of them.
+          if (parseAttachmentKey(item.key)) {
+            await rekeyAttachmentSafe(
+              dbFor(env),
+              workspaceName,
+              item.key,
+              newKey,
+              newId,
+              ws.storageLaneId ?? null,
+            );
+          }
 
           // `deleteObject` (not a raw `store.delete`): it also releases the
           // old key's usage-ledger bytes/object count (and its poster, if

--- a/apps/api/src/github-private-prefix-service.ts
+++ b/apps/api/src/github-private-prefix-service.ts
@@ -381,7 +381,11 @@ export async function rotatePrivatePrefix(
           // any — `putObject` above already regenerated one for the new key
           // when applicable), so a rotation doesn't inflate the workspace's
           // storage usage or orphan a video's poster frame.
-          await deleteObject(env, ws, item.key, workspaceName);
+          // `skipAttachmentIndex` (issue #934): whatever index row this key
+          // had was just moved onto `newKey` by `rekeyAttachmentSafe` above
+          // (and a key that can't have one never had a row), so the delete's
+          // own index DELETE is a guaranteed no-op round trip per object.
+          await deleteObject(env, ws, item.key, workspaceName, { skipAttachmentIndex: true });
           moved++;
 
           const parsed = parseGhPrivateKey(newKey);

--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -20,7 +20,6 @@
 import { UnsupportedMediaTypeError } from "@uploads/errors";
 import { getMetadataForKeys, setFileMetadata } from "./file-metadata";
 import { putObject, putOptsFromStoredObject } from "./files-core";
-import { recordAttachmentForKeySafe } from "./github-attachment-index";
 import { resolveBranchLineageSafe } from "./github-branch-renames";
 import { ghPrivateAttachmentKey, ghPrivateBranchKeyPrefix } from "./github-comment-render";
 import { getActivePrefixId } from "./github-private-prefixes";
@@ -410,6 +409,13 @@ export async function promoteBranchAttachments(
           "gh.promoted-at": nowIso,
         },
         surface: "promote",
+        // Attachment index (issue #934): the copy is indexed by `putObject`
+        // itself, as a promote with the repo the webhook/route resolved.
+        // The STAGED ORIGINAL deliberately gets no row — it lives under the
+        // branch prefix, outside the target's attachment prefix, and is not
+        // an attachment (`parseAttachmentKey` returns undefined for branch
+        // keys, so putObject never indexed it either).
+        attachment: { source: "promote", repo: target.repo },
       });
     } catch (err) {
       // A 415 is this one object's problem, not the batch's (issue #929
@@ -449,20 +455,6 @@ export async function promoteBranchAttachments(
     // below. Tagging the staged original is best-effort bookkeeping: a
     // failure here must not un-promote the file or land it in `skipped`.
     promoted.push(destKey);
-
-    // Attachment index (issue #934): re-record putObject's row as a
-    // promote, with the repo the webhook/route resolved. The STAGED
-    // ORIGINAL deliberately gets no row — it lives under the branch prefix,
-    // outside the target's attachment prefix, and is not an attachment
-    // (`parseAttachmentKey` returns undefined for branch keys, so putObject
-    // never indexed it either).
-    await recordAttachmentForKeySafe(dbFor(env), {
-      workspace: workspaceName,
-      objectKey: destKey,
-      source: "promote",
-      laneId: ws.storageLaneId ?? null,
-      repo: target.repo,
-    });
 
     try {
       // Merge (not replace) onto the staged original: mark it promoted

--- a/apps/api/src/retention.ts
+++ b/apps/api/src/retention.ts
@@ -16,7 +16,7 @@
  */
 import { positiveLimit } from "./budget";
 import { deleteFileMetadataForKeys } from "./file-metadata";
-import { deleteAttachmentsForKeysSafe } from "./github-attachment-index";
+import { deleteAttachmentsForKeysSafe, parseAttachmentKey } from "./github-attachment-index";
 import { reconcileWorkspaceUsage, type ReconcileResult } from "./reconcile";
 import { storage } from "./storage";
 import { isUnprefixedDedicatedBucket, type WorkspaceRecord } from "./workspace";
@@ -91,7 +91,13 @@ export async function purgeExpiredObjects(
     await deleteFileMetadataForKeys(dbFor(env), workspaceName, batch);
     // Attachment index rows follow their objects (issue #934); chunked the
     // same way and best-effort, so a D1 hiccup never strands the sweep.
-    await deleteAttachmentsForKeysSafe(dbFor(env), workspaceName, batch);
+    // Filtered to keys that can actually hold a row — a retention sweep is
+    // mostly ordinary uploads, and an all-non-attachment batch (the common
+    // case) should cost no D1 round trip at all.
+    const attachmentKeys = batch.filter((key) => parseAttachmentKey(key));
+    if (attachmentKeys.length > 0) {
+      await deleteAttachmentsForKeysSafe(dbFor(env), workspaceName, attachmentKeys);
+    }
     batch = [];
   }
 

--- a/apps/api/test/fake-attachment-index-sql.test.ts
+++ b/apps/api/test/fake-attachment-index-sql.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The in-memory `github_attachments` fake (helpers/fake-attachment-index-table.ts)
+ * must recognize every statement github-attachment-index.ts actually issues.
+ * Both sides read the SQL from one exported source (`ATTACHMENT_INDEX_SQL`),
+ * so this test fails the moment a statement is reworded on one side only —
+ * rather than the fake silently dropping writes.
+ */
+import { describe, expect, it } from "vitest";
+import { ATTACHMENT_INDEX_SQL } from "../src/github-attachment-index";
+import { AttachmentIndexTable } from "./helpers/fake-attachment-index-table";
+
+const normalize = (sql: string) => sql.replace(/\s+/g, " ").trim();
+
+const NOW = "2026-09-02T00:00:00.000Z";
+const UPSERT_ARGS = ["acme", "acme/web", "pull", 12, "k.png", null, null, "put", NOW, NOW];
+
+describe("fake github_attachments table ↔ ATTACHMENT_INDEX_SQL", () => {
+  it("matches every write statement the module issues", () => {
+    const table = new AttachmentIndexTable();
+    const cases: [string, unknown[]][] = [
+      [ATTACHMENT_INDEX_SQL.upsert, UPSERT_ARGS],
+      [ATTACHMENT_INDEX_SQL.detach, [NOW, NOW, "acme", "k.png"]],
+      [ATTACHMENT_INDEX_SQL.reattach, [NOW, "acme", "k.png"]],
+      [ATTACHMENT_INDEX_SQL.rekey, ["k2.png", null, null, NOW, "acme", "k.png"]],
+      [ATTACHMENT_INDEX_SQL.deleteOne, ["acme", "k.png"]],
+      [ATTACHMENT_INDEX_SQL.deleteForKeys("?"), ["acme", "k.png"]],
+      [ATTACHMENT_INDEX_SQL.deleteForWorkspace, ["acme"]],
+    ];
+    for (const [sql, args] of cases) {
+      expect(table.tryRun(normalize(sql), args), sql).toBeDefined();
+    }
+  });
+
+  it("matches the single-row read the module issues", () => {
+    const table = new AttachmentIndexTable();
+    table.tryRun(normalize(ATTACHMENT_INDEX_SQL.upsert), UPSERT_ARGS);
+    expect(
+      table.tryFirst(normalize(ATTACHMENT_INDEX_SQL.selectOne), ["acme", "k.png"]),
+    ).toMatchObject({ object_key: "k.png" });
+  });
+});

--- a/apps/api/test/files-core-attachment-index.test.ts
+++ b/apps/api/test/files-core-attachment-index.test.ts
@@ -75,6 +75,41 @@ describe("putObject → attachment index", () => {
     expect(db.attachmentIndex.size).toBe(1);
   });
 
+  it("attributes the row to opts.attachment's source and repo when the caller supplies one", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const key = "gh/acme/web/pull/12/hero.png";
+    await putObject(env, ws, key, PNG, WORKSPACE, {
+      attachment: { source: "attach", repo: "Acme/Web-Site" },
+    });
+    expect(db.attachmentIndexUpserts).toBe(1);
+    expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toMatchObject({
+      source: "attach",
+      repo: "acme/web-site",
+      num: 12,
+    });
+  });
+
+  it("a caller-supplied non-put source clears detached_at, exactly like a re-record would", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const key = "gh/acme/web/pull/12/hero.png";
+    await putObject(env, ws, key, PNG, WORKSPACE);
+    await detachAttachment(
+      db as unknown as D1Queryable,
+      WORKSPACE,
+      key,
+      new Date("2026-09-05T00:00:00.000Z"),
+    );
+
+    await putObject(env, ws, key, PNG, WORKSPACE, {
+      attachment: { source: "adopt", repo: "acme/web" },
+    });
+
+    expect(db.attachmentIndex.get(`${WORKSPACE}\0${key}`)).toMatchObject({
+      source: "adopt",
+      detached_at: null,
+    });
+  });
+
   it("a detached row survives a re-put of the same key (putObject writes source 'put')", async () => {
     const { env, db, ws } = makePosterEnv();
     const key = "gh/acme/web/pull/12/hero.png";

--- a/apps/api/test/files-core-attachment-index.test.ts
+++ b/apps/api/test/files-core-attachment-index.test.ts
@@ -133,6 +133,30 @@ describe("putObject → attachment index", () => {
   });
 });
 
+describe("putObject → attachment index scheduling", () => {
+  it("issues the index write with the other post-write D1 bookkeeping, not serially after it", async () => {
+    const { env, ws } = makePosterEnv();
+    const statements: string[] = [];
+    const db = env.DB as unknown as { prepare: (sql: string) => unknown };
+    const realPrepare = db.prepare.bind(db);
+    db.prepare = (sql: string) => {
+      statements.push(sql.replace(/\s+/g, " ").trim());
+      return realPrepare(sql);
+    };
+
+    await putObject(env, ws, "gh/acme/web/pull/12/hero.png", PNG, WORKSPACE);
+
+    const indexAt = statements.findIndex((sql) => sql.startsWith("INSERT INTO github_attachments"));
+    const hashAt = statements.findIndex((sql) => sql.includes("INSERT INTO file_content_hash"));
+    expect(indexAt).toBeGreaterThanOrEqual(0);
+    expect(hashAt).toBeGreaterThanOrEqual(0);
+    // The index write now rides in putObject's post-write `Promise.all`,
+    // which runs before the metadata/content-hash tail — so it overlaps
+    // those round trips instead of adding its own after them.
+    expect(indexAt).toBeLessThan(hashAt);
+  });
+});
+
 describe("deleteObject → attachment index", () => {
   it("removes the index row alongside the object's metadata", async () => {
     const { env, db, ws } = makePosterEnv();

--- a/apps/api/test/github-attach-index.test.ts
+++ b/apps/api/test/github-attach-index.test.ts
@@ -55,6 +55,9 @@ describe("attachExistingObject → attachment index (issue #934)", () => {
       prefix_id: null,
       source: "attach",
     });
+    // One upsert, not putObject's "put" row followed by an attach
+    // re-record (issue #934 cleanup).
+    expect(db.attachmentIndexUpserts).toBe(1);
   });
 
   it("--move deletes the source object's row when the source was itself an attachment", async () => {

--- a/apps/api/test/github-promote-index.test.ts
+++ b/apps/api/test/github-promote-index.test.ts
@@ -1,0 +1,69 @@
+/**
+ * promoteBranchAttachments ↔ github_attachments index wiring (issue #934).
+ * The promoted COPY is indexed once, with the caller-resolved repo; the
+ * staged original stays unindexed (branch keys are not attachments).
+ */
+import { describe, expect, it } from "vitest";
+import { promoteBranchAttachments } from "../src/github-promote";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { FakeKv } from "./fake-kv";
+import { FakeR2Bucket } from "./fake-r2";
+import { UsageFakeD1 } from "./usage-fake-d1";
+import { GITHUB_APP_CFG_ENV } from "./github-app-env";
+
+const WS = "acme";
+const PREFIX = "acme/";
+const REPO = "acme/web";
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+async function seededEnv() {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: PREFIX,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex("unused"), createdAt: new Date().toISOString() }],
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  const kv = new FakeKv();
+  kv.store.set(`ghpriv:${REPO}`, { value: "0" });
+  const env = {
+    REGISTRY: { get: async (key: string) => (key === `ws:${WS}` ? record : null) },
+    DB: db,
+    UPLOADS_DEFAULT: bucket,
+    GITHUB_CACHE: kv,
+    ...GITHUB_APP_CFG_ENV,
+  } as unknown as Env;
+  return { env, db, bucket, ws: record };
+}
+
+describe("promoteBranchAttachments → attachment index (issue #934)", () => {
+  it("indexes the promoted copy once, with source 'promote'", async () => {
+    const { env, db, bucket, ws } = await seededEnv();
+    const stagedKey = "gh/acme/web/branch/feat-x/shot.png";
+    await bucket.put(`${PREFIX}${stagedKey}`, PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+
+    const result = await promoteBranchAttachments(env, ws, WS, {
+      repo: REPO,
+      num: 12,
+      branch: "feat-x",
+    });
+
+    expect(result.promoted).toEqual(["gh/acme/web/pull/12/shot.png"]);
+    expect(db.attachmentIndex.get(`${WS}\0gh/acme/web/pull/12/shot.png`)).toMatchObject({
+      repo: "acme/web",
+      kind: "pull",
+      num: 12,
+      source: "promote",
+      detached_at: null,
+    });
+    // The staged original is not an attachment and gets no row.
+    expect(db.attachmentIndex.get(`${WS}\0${stagedKey}`)).toBeUndefined();
+    // One upsert, not a "put" row re-recorded as "promote" (issue #934 cleanup).
+    expect(db.attachmentIndexUpserts).toBe(1);
+  });
+});

--- a/apps/api/test/helpers/fake-attachment-index-table.ts
+++ b/apps/api/test/helpers/fake-attachment-index-table.ts
@@ -5,13 +5,29 @@
  * re-key) without a full sqlite-backed D1. See
  * github-attachment-index-sqlite.test.ts for the real-SQL coverage.
  *
- * The match arms below key off the EXACT statement text in
- * src/github-attachment-index.ts, whitespace-normalized. If a statement
- * there changes, change it here too or the suite fails loudly
- * ("unsupported run: …") rather than silently dropping writes.
+ * The match arms below key off `ATTACHMENT_INDEX_SQL` — the statement text
+ * exported by src/github-attachment-index.ts itself, whitespace-normalized
+ * here the same way usage-fake-d1.ts normalizes incoming SQL. Matching the
+ * module's own strings (rather than re-typed copies) means a reworded
+ * statement cannot silently desync this fake; it fails loudly instead
+ * ("unsupported run: …"). See fake-attachment-index-sql.test.ts.
  */
 
+import { ATTACHMENT_INDEX_SQL } from "../../src/github-attachment-index";
 import type { FakeRunResult } from "./fake-repo-links-table";
+
+const normalize = (sql: string) => sql.replace(/\s+/g, " ").trim();
+
+const SQL = {
+  upsert: normalize(ATTACHMENT_INDEX_SQL.upsert),
+  detach: normalize(ATTACHMENT_INDEX_SQL.detach),
+  reattach: normalize(ATTACHMENT_INDEX_SQL.reattach),
+  rekey: normalize(ATTACHMENT_INDEX_SQL.rekey),
+  deleteOne: normalize(ATTACHMENT_INDEX_SQL.deleteOne),
+  deleteForKeysPrefix: normalize(ATTACHMENT_INDEX_SQL.deleteForKeysPrefix),
+  deleteForWorkspace: normalize(ATTACHMENT_INDEX_SQL.deleteForWorkspace),
+  selectOne: normalize(ATTACHMENT_INDEX_SQL.selectOne),
+};
 
 export interface AttachmentIndexDbRow {
   workspace: string;
@@ -41,7 +57,7 @@ export class AttachmentIndexTable {
   upserts = 0;
 
   tryRun(normalizedSql: string, args: unknown[]): FakeRunResult | undefined {
-    if (normalizedSql.startsWith("INSERT INTO github_attachments")) {
+    if (normalizedSql === SQL.upsert) {
       const [
         workspace,
         repo,
@@ -86,7 +102,7 @@ export class AttachmentIndexTable {
       });
       return { success: true, meta: { changes: 1 }, results: [] };
     }
-    if (normalizedSql.startsWith("UPDATE github_attachments SET detached_at = ?")) {
+    if (normalizedSql === SQL.detach) {
       const [detachedAt, updatedAt, workspace, objectKey] = args as [
         string,
         string,
@@ -99,7 +115,7 @@ export class AttachmentIndexTable {
       row.updated_at = updatedAt;
       return { success: true, meta: { changes: 1 }, results: [] };
     }
-    if (normalizedSql.startsWith("UPDATE github_attachments SET detached_at = NULL")) {
+    if (normalizedSql === SQL.reattach) {
       const [updatedAt, workspace, objectKey] = args as [string, string, string];
       const row = this.rows.get(key(workspace, objectKey));
       if (!row) return { success: true, meta: { changes: 0 }, results: [] };
@@ -107,7 +123,7 @@ export class AttachmentIndexTable {
       row.updated_at = updatedAt;
       return { success: true, meta: { changes: 1 }, results: [] };
     }
-    if (normalizedSql.startsWith("UPDATE github_attachments SET object_key = ?")) {
+    if (normalizedSql === SQL.rekey) {
       const [toKey, newPrefixId, laneId, updatedAt, workspace, fromKey] = args as [
         string,
         string | null,
@@ -129,7 +145,7 @@ export class AttachmentIndexTable {
       return { success: true, meta: { changes: 1 }, results: [] };
     }
     if (normalizedSql.startsWith("DELETE FROM github_attachments")) {
-      if (normalizedSql.includes("object_key IN (")) {
+      if (normalizedSql.startsWith(SQL.deleteForKeysPrefix)) {
         const [workspace, ...keys] = args as [string, ...string[]];
         let changes = 0;
         for (const objectKey of keys) {
@@ -137,11 +153,12 @@ export class AttachmentIndexTable {
         }
         return { success: true, meta: { changes }, results: [] };
       }
-      if (normalizedSql.includes("object_key = ?")) {
+      if (normalizedSql === SQL.deleteOne) {
         const [workspace, objectKey] = args as [string, string];
         const changes = this.rows.delete(key(workspace, objectKey)) ? 1 : 0;
         return { success: true, meta: { changes }, results: [] };
       }
+      if (normalizedSql !== SQL.deleteForWorkspace) return undefined;
       const [workspace] = args as [string];
       let changes = 0;
       for (const [k, row] of this.rows.entries()) {
@@ -156,7 +173,7 @@ export class AttachmentIndexTable {
   }
 
   tryFirst<T>(normalizedSql: string, args: unknown[]): T | null | undefined {
-    if (normalizedSql.includes("FROM github_attachments WHERE workspace = ? AND object_key = ?")) {
+    if (normalizedSql === SQL.selectOne) {
       const [workspace, objectKey] = args as [string, string];
       return (this.rows.get(key(workspace, objectKey)) as T) ?? null;
     }

--- a/apps/api/test/helpers/fake-attachment-index-table.ts
+++ b/apps/api/test/helpers/fake-attachment-index-table.ts
@@ -33,6 +33,12 @@ function key(workspace: string, objectKey: string): string {
 
 export class AttachmentIndexTable {
   readonly rows = new Map<string, AttachmentIndexDbRow>();
+  /**
+   * How many upsert statements have run. Lets a wiring test assert that a
+   * path writes the row ONCE (issue #934 cleanup: attach/promote/adopt used
+   * to write `put` and then immediately re-record their own source).
+   */
+  upserts = 0;
 
   tryRun(normalizedSql: string, args: unknown[]): FakeRunResult | undefined {
     if (normalizedSql.startsWith("INSERT INTO github_attachments")) {
@@ -61,6 +67,7 @@ export class AttachmentIndexTable {
       ];
       const k = key(workspace, objectKey);
       const existing = this.rows.get(k);
+      this.upserts++;
       this.rows.set(k, {
         workspace,
         repo,

--- a/apps/api/test/retention-metadata.test.ts
+++ b/apps/api/test/retention-metadata.test.ts
@@ -138,4 +138,42 @@ describe("purgeExpiredObjects — attachment index cleanup (issue #934)", () => 
       sqlite.close();
     }
   });
+
+  it("issues no index DELETE for a batch that holds no attachment keys", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      // Neither key can ever have an index row: a bare upload, and a
+      // branch-staged key (not an attachment until promoted).
+      for (const key of ["shots/old.png", "gh/acme/web/branch/feat-x/old.png"]) {
+        await bucket.put(`acme/${key}`, new Uint8Array([1, 2, 3]));
+        bucket.setUploaded(`acme/${key}`, new Date("2020-01-01T00:00:00Z"));
+      }
+
+      const statements: string[] = [];
+      const db = database(sqlite);
+      const spyDb = new Proxy(db, {
+        get(target, prop, receiver) {
+          if (prop === "prepare") {
+            return (sql: string) => {
+              statements.push(sql.replace(/\s+/g, " ").trim());
+              return target.prepare(sql);
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+
+      const result = await purgeExpiredObjects(
+        { BUCKET: bucket, DB: spyDb } as unknown as Env,
+        RECORD,
+        "acme",
+      );
+
+      expect(result).toMatchObject({ deleted: 2 });
+      expect(statements.some((sql) => sql.includes("DELETE FROM github_attachments"))).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
 });

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -80,6 +80,10 @@ export class UsageFakeD1 {
   get attachmentIndex() {
     return this.attachmentIndexTable.rows;
   }
+  /** Upsert statements run against `github_attachments` (see the table fake). */
+  get attachmentIndexUpserts() {
+    return this.attachmentIndexTable.upserts;
+  }
 
   prepare = (sql: string) => {
     const normalized = sql.replace(/\s+/g, " ").trim();


### PR DESCRIPTION
The write-shape cleanup deferred from the #938 review, split out of #940 so that PR stayed a pure read-side change. No user-visible behavior changes; every item is fewer or overlapped D1 round trips on the attachment-index dual-write from #934.

## Items

1. **One index upsert per attach / promote / adopt, not two.** `putObject` gains an optional `attachment: { source, repo }` option that the three server-side copy paths pass; their follow-up `recordAttachmentForKeySafe` calls are gone. `repo` is always the server-resolved target, never `gh.*` metadata. Adopt passes its source through a server-internal parameter on `attachExistingObject`, not a request-body field.
2. **The `putObject` index write rides in the existing post-write `Promise.all`** instead of a serial await after `recordContentHash`. Still gated on `isManagedGithubKey` and still after the object is durable.
3. **Rotation and retention skip index calls for keys that can never have a row** (branch-staged, ingest): `parseAttachmentKey` gates the rekey per object, and the retention batch is filtered before the chunked DELETE.
4. **Rotation's `deleteObject` on the old key skips the index DELETE** via a server-internal `skipAttachmentIndex` option; the rekey immediately before it already moved the row. An ordinary delete still clears the row.
5. **Link adoption overlaps its independent per-link D1 writes** (metadata stamp, ledger row, index record) with `Promise.all`. All are best-effort and never throw, so the failure-path outcome is unchanged.
6. **The test fake imports the index module's statement text** (`ATTACHMENT_INDEX_SQL`) instead of re-typing prefixes, so a wording change cannot silently desync it. Bind order is still positional in the fake.

**Skipped: a CHECK on `kind`.** It needs a full table-rebuild migration (three indexes recreated) that would auto-apply to prod on merge, for a column that only ever comes from a closed union in the writers. Fold it in if a rebuild happens for another reason.

## Tests

Ten new tests, each written failing first, covering: a single row per attach/promote/adopt with the right source and `detached_at` cleared on adopt; the index write no longer serial in `putObject`; rotation and retention skipping non-attachment keys; rotation skipping the old-key index DELETE while an ordinary delete still clears it; adoption's overlapped writes landing; the fake reading the shared SQL. `apps/api`: 2801 tests green; typecheck clean in `apps/api` and `apps/mcp`.
