### PR TITLE
fix(api): stop copying server-owned metadata keys on attach

### DIFF
--- a/apps/api/src/github-attach.ts
+++ b/apps/api/src/github-attach.ts
@@ -35,7 +35,7 @@ import {
   putOptsFromStoredObject,
   sanitizeKeyBasename,
 } from "./files-core";
-import { getFileMetadata, setFileMetadata } from "./file-metadata";
+import { getFileMetadata, isServerMetaKey, setFileMetadata } from "./file-metadata";
 import { type AttachmentSource } from "./github-attachment-index";
 import { resolveGhKeyContextSafe } from "./github-private-prefix-service";
 import { storage, storageConfig } from "./storage";
@@ -225,10 +225,18 @@ export async function attachExistingObject(
     attachment: { source: opts?.indexSource ?? "attach", repo: req.target.repo },
   });
 
-  // Additive merge (PR #157 preserve mode): the source's existing metadata
-  // rides along unchanged, gh.* is stamped fresh on top and always wins.
+  // Additive merge (PR #157 preserve mode): the source's existing CLIENT
+  // metadata rides along unchanged, gh.* is stamped fresh on top and always
+  // wins. Server-owned keys (`image.*`, `video.*`) are dropped: putObject
+  // above derives the copy's own, and this write validates as a client
+  // write, so re-submitting them threw `reserved metadata key` for every
+  // source uploaded with dimensions (issue #870 onward) — which broke link
+  // adoption of branch-staged images.
+  const clientSourceMeta = Object.fromEntries(
+    Object.entries(sourceMeta).filter(([key]) => !isServerMetaKey(key)),
+  );
   await setFileMetadata(dbFor(env), workspaceName, destKey, {
-    ...sourceMeta,
+    ...clientSourceMeta,
     "gh.repo": `${owner}/${name}`.toLowerCase(),
     "gh.kind": req.target.kind,
     "gh.number": String(req.target.num),

--- a/apps/api/test/github-attach-server-meta.test.ts
+++ b/apps/api/test/github-attach-server-meta.test.ts
@@ -1,0 +1,67 @@
+/**
+ * attachExistingObject must not re-submit the source's SERVER-owned
+ * metadata (`image.*`, `video.*`) through the client-validated metadata
+ * write: those keys are reserved there, so a source that was uploaded with
+ * derived dimensions made every attach — and every link adoption of a
+ * branch-staged image — throw `reserved metadata key: image.height`.
+ */
+import { describe, expect, it } from "vitest";
+import { attachExistingObject } from "../src/github-attach";
+import { getFileMetadata, setFileMetadata, setServerFileMetadata } from "../src/file-metadata";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { FakeKv } from "./fake-kv";
+import { FakeR2Bucket } from "./fake-r2";
+import { UsageFakeD1 } from "./usage-fake-d1";
+import { GITHUB_APP_CFG_ENV } from "./github-app-env";
+
+const WS = "acme";
+const PREFIX = "acme/";
+const REPO = "acme/web";
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+async function seededEnv() {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: PREFIX,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex("unused"), createdAt: new Date().toISOString() }],
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  const kv = new FakeKv();
+  kv.store.set(`ghpriv:${REPO}`, { value: "0" });
+  const env = {
+    REGISTRY: { get: async (key: string) => (key === `ws:${WS}` ? record : null) },
+    DB: db,
+    UPLOADS_DEFAULT: bucket,
+    GITHUB_CACHE: kv,
+    ...GITHUB_APP_CFG_ENV,
+  } as unknown as Env;
+  return { env, db, bucket, ws: record };
+}
+
+describe("attachExistingObject with server-owned source metadata", () => {
+  it("attaches a source that carries image.* dimensions, keeping its client tags", async () => {
+    const { env, bucket, ws } = await seededEnv();
+    await bucket.put(`${PREFIX}f/shot.png`, PNG, { httpMetadata: { contentType: "image/png" } });
+    await setFileMetadata(env.DB, WS, "f/shot.png", { path: "src/app.tsx" });
+    await setServerFileMetadata(env.DB, WS, "f/shot.png", {
+      "image.width": "640",
+      "image.height": "480",
+      "video.poster": "1",
+    });
+
+    const result = await attachExistingObject(env, ws, WS, {
+      source: "f/shot.png",
+      target: { repo: REPO, kind: "pull", num: 12 },
+    });
+
+    const meta = await getFileMetadata(env.DB, WS, result.key);
+    expect(meta).toMatchObject({ path: "src/app.tsx", "gh.repo": "acme/web", "gh.number": "12" });
+    // Server-owned keys are derived for the copy by putObject itself (or
+    // not at all); never copied through the client-validated merge.
+    expect(meta["video.poster"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
`attachExistingObject` merges the source object's D1 metadata onto the copy through `setFileMetadata`, which validates as a client write and rejects server-owned keys. Any source uploaded with derived dimensions (`image.width` / `image.height`, stamped since #870) therefore threw `reserved metadata key: image.width` on attach. The path that hits this in practice is link adoption (#701): a PR body pasting a branch-staged image URL runs the adoption copy through `attachExistingObject`, so those images silently never reached the managed comment, and the webhook consumer logged `link adoption: attach failed for resolved key` on every retry.

Found today in Workers Logs while verifying the #934 shadow: the error line appeared for the first time this morning and repeated across the afternoon on one workspace's PR traffic. The code path is unchanged since Aug 27, so this is a latent bug that new traffic exposed, not a regression from today's attachment-index PRs.

## Fix

Filter server-owned keys (`isServerMetaKey`: `image.*`, `video.*`) out of the source metadata before the merge. `putObject` derives the copy's own dimensions; client tags such as `path` still ride along and `gh.*` is still stamped on top. Promote was already copying only named keys and is unaffected.

## Test

`apps/api/test/github-attach-server-meta.test.ts`: a source carrying `image.width` / `image.height` / `video.poster` server metadata plus a client `path` tag attaches successfully, the copy keeps `path` and the fresh `gh.*` set, and the server keys are not copied through. Reproduced the exact production error before the fix. `apps/api`: 2802 tests green; typecheck clean.
