### PR TITLE
fix(web): label the file card link "Download" when it forces a download

### DIFF
--- a/.changeset/file-card-download-label.md
+++ b/.changeset/file-card-download-label.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+The public file page's card for non-media files now labels its link "Download <name>" when it points at the forced-download URL.

--- a/apps/web/src/components/MediaFallback.astro
+++ b/apps/web/src/components/MediaFallback.astro
@@ -9,13 +9,15 @@ interface Props {
   body?: string;
   href?: string | null;
   filename?: string;
+  /** Link text override; defaults to `Open <filename>` / `Open original`. */
+  label?: string;
   /** Start hidden until `applyMediaFailure` unhides it. */
   pending?: boolean;
   /** Tighter padding for gallery-grid tiles. */
   compact?: boolean;
 }
 
-const { title, body, href = null, filename, pending = false, compact = false } = Astro.props;
+const { title, body, href = null, filename, label, pending = false, compact = false } = Astro.props;
 ---
 
 <div
@@ -29,7 +31,7 @@ const { title, body, href = null, filename, pending = false, compact = false } =
   {
     href ? (
       <a href={href} rel="noopener noreferrer">
-        {filename ? `Open ${filename}` : "Open original"}
+        {label ?? (filename ? `Open ${filename}` : "Open original")}
       </a>
     ) : null
   }

--- a/apps/web/src/components/MediaStage.astro
+++ b/apps/web/src/components/MediaStage.astro
@@ -128,6 +128,7 @@ const fileCardBody = `${fileTypeLabel(filename, contentType ?? "")} · ${
               body={fileCardBody}
               href={fileHref}
               filename={filename}
+              label={downloadUrl ? `Download ${filename}` : undefined}
             />
           ))}
         {kind === "missing" && (


### PR DESCRIPTION
The file card on /f/ (from #949) links to the `?download=1` URL but its label said "Open <name>". MediaFallback gains an optional `label` prop; the file card passes "Download <name>" when a download URL is present.

Refs #946.
