### PR TITLE
feat(admin): show upgrade state, customer tenure, and storage fill bar

### DIFF
--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -965,6 +965,7 @@ describe("workspace plan editing", () => {
         maxMembers: null,
       },
       overrides: [],
+      paidSince: null,
       planSource: "none",
       subscription: null,
     });
@@ -987,6 +988,7 @@ describe("workspace plan editing", () => {
         maxMembers: 3,
       },
       overrides: [],
+      paidSince: null,
       planSource: "none",
       subscription: null,
     });
@@ -1053,6 +1055,52 @@ describe("workspace plan editing", () => {
     expect(body.available).toBe(true);
     expect(body.planApplied).toBe(true);
     expect(JSON.parse(store.get("ws:acme") ?? "{}").plan).toBe("pro");
+  });
+
+  it("PATCH stamps paidSince on the first free -> pro transition and returns it", async () => {
+    const { env, store } = planEnv(ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/plan",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ plan: "pro" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { paidSince: string | null };
+    expect(typeof body.paidSince).toBe("string");
+    const stored = JSON.parse(store.get("ws:acme") ?? "{}");
+    expect(stored.paidSince).toBe(body.paidSince);
+  });
+
+  it("PATCH never overwrites an existing paidSince", async () => {
+    const { env, store } = planEnv(ADMIN_USER, {
+      ...REC,
+      plan: "pro",
+      paidSince: "2026-01-01T00:00:00.000Z",
+    });
+    await app().request(
+      "/admin-ui/workspaces/acme/plan",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ plan: "free" }),
+      },
+      env,
+    );
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/plan",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ plan: "pro" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(JSON.parse(store.get("ws:acme") ?? "{}").paidSince).toBe("2026-01-01T00:00:00.000Z");
   });
 
   it("PATCH rejects an unknown plan id", async () => {

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -72,7 +72,7 @@ import {
 import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { LIMIT_FIELDS, validateLimitsPatch } from "../workspace-limits";
 import { planResponse, planSourceFor, validatePlanPatch } from "../workspace-plan";
-import { resolveEffectiveLimits, type WorkspacePlanLimits } from "@uploads/billing";
+import { getPlan, resolveEffectiveLimits, type WorkspacePlanLimits } from "@uploads/billing";
 import { storageStatusResponse } from "./workspace-storage";
 import { dbFor } from "../db-session";
 
@@ -800,9 +800,22 @@ export const adminUi = new Hono<SessionVars>()
       throw new ValidationError("request body must be valid JSON", { code: "invalid_plan" });
     }
     const { plan } = validatePlanPatch(body);
-    const record = await mutateWorkspaceRecord(c.env, name, (current) => ({ ...current, plan }), {
-      requireServing: true,
-    });
+    const record = await mutateWorkspaceRecord(
+      c.env,
+      name,
+      (current) => {
+        // Stamp `paidSince` on the first free -> paid transition (see
+        // workspace.ts's field doc and internal-billing.ts's Stripe-driven
+        // equivalent); never overwritten afterward.
+        const paidSince =
+          current.paidSince ??
+          (getPlan(current.plan).id === "free" && plan !== "free"
+            ? new Date().toISOString()
+            : undefined);
+        return { ...current, ...(paidSince ? { paidSince } : {}), plan };
+      },
+      { requireServing: true },
+    );
     const subscriptionInfo = await adminSubscriptionInfo(c.env, name, record);
     return c.json({ ...planResponse(name, record), ...subscriptionInfo });
   })

--- a/apps/api/src/routes/internal-billing.test.ts
+++ b/apps/api/src/routes/internal-billing.test.ts
@@ -164,6 +164,59 @@ describe("POST /internal/billing/plan", () => {
     });
   });
 
+  it("stamps paidSince on the first free -> pro transition", async () => {
+    const { env, store } = envWith({
+      secret: SECRET,
+      record: { provider: "r2", bucket: "b", prefix: "acme/" },
+    });
+    const res = await post(
+      { workspace: "acme", plan: "pro" },
+      { "x-internal-billing-key": SECRET },
+      env,
+    );
+    expect(res.status).toBe(204);
+    const stored = JSON.parse(store.get("ws:acme")!);
+    expect(typeof stored.paidSince).toBe("string");
+    expect(Number.isNaN(Date.parse(stored.paidSince))).toBe(false);
+  });
+
+  it("never overwrites an existing paidSince on a later transition", async () => {
+    const { env, store } = envWith({
+      secret: SECRET,
+      record: {
+        provider: "r2",
+        bucket: "b",
+        prefix: "acme/",
+        plan: "pro",
+        paidSince: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    // Downgrade then re-upgrade shouldn't touch the original timestamp.
+    await post({ workspace: "acme", plan: "free" }, { "x-internal-billing-key": SECRET }, env);
+    const res = await post(
+      { workspace: "acme", plan: "pro" },
+      { "x-internal-billing-key": SECRET },
+      env,
+    );
+    expect(res.status).toBe(204);
+    const stored = JSON.parse(store.get("ws:acme")!);
+    expect(stored.paidSince).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("does not stamp paidSince when the plan stays free", async () => {
+    const { env, store } = envWith({
+      secret: SECRET,
+      record: { provider: "r2", bucket: "b", prefix: "acme/" },
+    });
+    const res = await post(
+      { workspace: "acme", plan: "free" },
+      { "x-internal-billing-key": SECRET },
+      env,
+    );
+    expect(res.status).toBe(204);
+    expect(JSON.parse(store.get("ws:acme")!).paidSince).toBeUndefined();
+  });
+
   it("issue #454: clears a self-serve record's explicit overrides that exactly equal the OLD (free) plan defaults on upgrade", async () => {
     const { env, store } = envWith({
       secret: SECRET,

--- a/apps/api/src/routes/internal-billing.ts
+++ b/apps/api/src/routes/internal-billing.ts
@@ -92,7 +92,17 @@ internalBilling.post("/plan", async (c) => {
     c.env,
     workspace,
     (record) => {
-      if (!record.selfServe) return { ...record, plan };
+      // Stamp `paidSince` the first time this workspace goes free -> paid;
+      // never overwritten on a later transition (see workspace.ts's field
+      // doc for why this is the "customer since" source of truth).
+      const paidSince =
+        record.paidSince ??
+        (getPlan(record.plan).id === "free" && plan !== "free"
+          ? new Date().toISOString()
+          : undefined);
+      const stamped = paidSince ? { paidSince } : {};
+
+      if (!record.selfServe) return { ...record, ...stamped, plan };
 
       // Self-serve hardening (issue #454): pre-backfill self-serve records
       // still carry `selfServeWorkspaceRecord`'s old explicit per-limit
@@ -105,7 +115,7 @@ internalBilling.post("/plan", async (c) => {
       // (e.g. a comped higher limit) never matches the plan default and is
       // preserved untouched, same as today.
       const oldDefaults = getPlan(record.plan).defaultLimits;
-      const next: WorkspaceRecord = { ...record, plan };
+      const next: WorkspaceRecord = { ...record, ...stamped, plan };
       for (const field of LIMIT_FIELDS) {
         const current = record[field as keyof WorkspaceRecord];
         if (typeof current === "number" && current === oldDefaults[field]) {

--- a/apps/api/src/workspace-plan.test.ts
+++ b/apps/api/src/workspace-plan.test.ts
@@ -49,6 +49,7 @@ describe("planResponse", () => {
         maxMembers: null,
       },
       overrides: [],
+      paidSince: null,
     });
   });
 

--- a/apps/api/src/workspace-plan.ts
+++ b/apps/api/src/workspace-plan.ts
@@ -97,5 +97,6 @@ export function planResponse(name: string, record: WorkspaceRecord) {
     planApplied,
     limits,
     overrides,
+    paidSince: record.paidSince ?? null,
   };
 }

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -126,6 +126,20 @@ export interface WorkspaceRecord {
    */
   plan?: "free" | "pro";
   /**
+   * ISO timestamp of the first time this workspace's `plan` transitioned
+   * from free to paid (admin panel task, issue #445 follow-up). Stamped
+   * once — by the Stripe webhook bridge's plan sync
+   * (`routes/internal-billing.ts`'s `POST /internal/billing/plan`) and by
+   * the admin panel's `PATCH /admin-ui/workspaces/:name/plan` — and never
+   * cleared or overwritten on a later transition (a downgrade-then-upgrade
+   * keeps the original date, which is the honest "customer since" answer).
+   * The auth worker's `subscription` table has no equivalent durable
+   * "first paid" column (`period_start`/`period_end` roll forward on every
+   * renewal, and can reset if a subscription is recreated), so this is the
+   * one added field rather than deriving tenure from AUTH.
+   */
+  paidSince?: string;
+  /**
    * When true/undefined, bare keys (no `/`) become `f/<id>/<name>`. Set false
    * to allow root basenames (not recommended on shared buckets).
    */

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -99,11 +99,29 @@ export const prerender = false;
         { id: "pro", label: "Pro (unavailable to self-serve)" },
       ];
 
-      const PLAN_SOURCE_LABEL: Record<AdminPlanResponse["planSource"], string> = {
-        stripe: "Stripe-backed",
-        admin: "Admin-set (comped)",
-        none: "None",
+      // Badge copy/class per (plan, planSource) — the at-a-glance signal a
+      // paid workspace should be instantly distinguishable by, versus free
+      // and versus admin-comped (task 1). Free never gets a badge; there's
+      // nothing "upgraded" to call out.
+      const PLAN_BADGE: Record<
+        AdminPlanResponse["planSource"],
+        { label: string; cls: string } | null
+      > = {
+        stripe: { label: "Pro · Stripe", cls: "plan-badge plan-badge--stripe" },
+        admin: { label: "Pro · comped", cls: "plan-badge plan-badge--admin" },
+        none: null,
       };
+
+      /** Months elapsed between an ISO date and now, floored, minimum 0. */
+      function monthsSince(iso: string): number {
+        const then = new Date(iso);
+        if (Number.isNaN(then.getTime())) return 0;
+        const now = new Date();
+        let months =
+          (now.getFullYear() - then.getFullYear()) * 12 + (now.getMonth() - then.getMonth());
+        if (now.getDate() < then.getDate()) months -= 1;
+        return Math.max(0, months);
+      }
 
       function renderPlanSelector(
         host: HTMLElement,
@@ -119,24 +137,37 @@ export const prerender = false;
           ? ""
           : `<p class="muted plan-unapplied">No plan applied (legacy) — limits shown are the enforcement truth (explicit-or-unlimited), not this plan's defaults.</p>`;
 
+        const badge = PLAN_BADGE[data.planSource];
+        const badgeHtml = badge
+          ? `<span class="${badge.cls}">${escapeHtml(badge.label)}</span>`
+          : "";
+
         const sub = data.subscription;
         const stripeLink = sub?.stripeCustomerId
           ? `<a href="https://dashboard.stripe.com/customers/${encodeURIComponent(sub.stripeCustomerId)}" target="_blank" rel="noopener noreferrer">View in Stripe</a>`
           : "";
         const periodEndText = sub ? formatDate(sub.periodEnd) : null;
+        const cancelText =
+          sub?.cancelAtPeriodEnd && periodEndText
+            ? `cancels on ${escapeHtml(periodEndText)}`
+            : null;
         const subscriptionLine = sub
           ? `<p class="muted plan-subscription">
-            Subscription: ${escapeHtml(sub.status)}${sub.cancelAtPeriodEnd ? " (cancels at period end)" : ""}
-            ${periodEndText ? ` · renews/ends ${escapeHtml(periodEndText)}` : ""}
+            Subscription: ${escapeHtml(sub.status)}
+            ${cancelText ? ` · <span class="plan-cancel-notice">${cancelText}</span>` : periodEndText ? ` · renews ${escapeHtml(periodEndText)}` : ""}
             ${stripeLink ? ` · ${stripeLink}` : ""}
           </p>`
           : "";
 
+        const tenureLine = data.paidSince
+          ? `<p class="muted plan-tenure">Customer since ${escapeHtml(formatDate(data.paidSince) ?? data.paidSince)} (${monthsSince(data.paidSince)} mo)</p>`
+          : "";
+
         host.innerHTML = `
-        <h4 class="plan-heading ${ADMIN_DETAIL_HEADING}">Plan</h4>
+        <h4 class="plan-heading ${ADMIN_DETAIL_HEADING}">Plan ${badgeHtml}</h4>
         <p class="muted plan-availability">${data.available ? "Available" : "Not available for self-serve upgrade"}</p>
-        <p class="muted plan-source">Source: ${escapeHtml(PLAN_SOURCE_LABEL[data.planSource])}</p>
         ${subscriptionLine}
+        ${tenureLine}
         ${appliedNote}
         <form class="plan-form flex flex-wrap gap-2 items-center">
           <select class="plan-select ul-select ul-select--sm" style="width:auto" aria-label="Plan">${options}</select>
@@ -270,12 +301,25 @@ export const prerender = false;
           );
         }).join("");
 
-        const usageLine =
-          data.usage && data.limits.maxStorageBytes !== null
-            ? `<p class="limit-usage muted">${formatBytes(data.usage.bytes)} of ${formatBytes(data.limits.maxStorageBytes)} stored · ${data.usage.uploads} uploads this month</p>`
-            : data.usage
-              ? `<p class="limit-usage muted">${formatBytes(data.usage.bytes)} stored · ${data.usage.uploads} uploads this month</p>`
-              : "";
+        // Compact inline percent-full bar (task 3) — omitted entirely for an
+        // unlimited cap (null maxStorageBytes/maxUploadsPerPeriod), since
+        // "percent of nothing" has no meaning. ≥80% warns, ≥100% is over.
+        function storageBar(usedBytes: number, capBytes: number | null): string {
+          if (capBytes === null || capBytes <= 0) return "";
+          const pct = Math.round((usedBytes / capBytes) * 100);
+          const level = pct >= 100 ? "over" : pct >= 80 ? "warning" : "ok";
+          const fill = Math.min(100, pct);
+          return `<span class="limit-storage-bar" data-level="${level}" style="--fill:${fill}%"><span></span></span> <span class="limit-storage-pct">${pct}%</span>`;
+        }
+
+        const usageLine = data.usage
+          ? `<p class="limit-usage muted flex flex-wrap items-center gap-1.5">
+              ${formatBytes(data.usage.bytes)}${data.limits.maxStorageBytes !== null ? ` of ${formatBytes(data.limits.maxStorageBytes)}` : ""} stored
+              ${storageBar(data.usage.bytes, data.limits.maxStorageBytes)}
+              · ${data.usage.uploads}${data.limits.maxUploadsPerPeriod !== null ? ` of ${data.limits.maxUploadsPerPeriod}` : ""} uploads this month
+              ${data.limits.maxUploadsPerPeriod !== null ? storageBar(data.usage.uploads, data.limits.maxUploadsPerPeriod) : ""}
+            </p>`
+          : "";
 
         host.innerHTML = `
         <h4 class="limits-heading ${ADMIN_DETAIL_HEADING}">Limits</h4>

--- a/apps/web/src/styles/admin-workspaces.css
+++ b/apps/web/src/styles/admin-workspaces.css
@@ -17,3 +17,66 @@
 .workspace .invite-status[data-state="ready"] {
   color: var(--accent);
 }
+
+/*
+ * Plan badge (task 1, admin plan-upgrade visibility): a paid workspace
+ * should read as upgraded at a glance, distinct from admin-comped. Free
+ * gets no badge (PLAN_BADGE maps "none" to null in index.astro).
+ */
+.workspace .plan-badge {
+  display: inline-block;
+  margin-left: 0.5em;
+  padding: 0.05em 0.55em;
+  border-radius: 999px;
+  font-size: var(--text-micro);
+  font-weight: 600;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.workspace .plan-badge--stripe {
+  color: var(--green);
+  border: 1px solid color-mix(in srgb, var(--green) 45%, var(--line));
+  background: color-mix(in srgb, var(--green) 12%, transparent);
+}
+.workspace .plan-badge--admin {
+  color: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--line));
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.workspace .plan-cancel-notice {
+  color: var(--red);
+  font-weight: 600;
+}
+
+/*
+ * Storage percent-full inline bar (task 3, limits card). Plain CSS, no
+ * framework JS — the fill width is set inline per-row from JS as a style
+ * attribute (`--fill`), same astro-inline-script pattern as the rest of
+ * this file.
+ */
+.workspace .limit-storage-bar {
+  position: relative;
+  display: block;
+  width: 100%;
+  max-width: 220px;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted) 25%, transparent);
+  overflow: hidden;
+}
+.workspace .limit-storage-bar > span {
+  display: block;
+  height: 100%;
+  width: var(--fill, 0%);
+  border-radius: inherit;
+  background: var(--accent);
+}
+.workspace .limit-storage-bar[data-level="warning"] > span {
+  background: var(--orange, #d97706);
+}
+.workspace .limit-storage-bar[data-level="over"] > span {
+  background: var(--red);
+}
+.workspace .limit-storage-pct {
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## What

Improves the operator admin panel (per workspace) so an operator can see, at a glance:

1. **Upgraded state.** A Pro workspace now gets a badge: "Pro · Stripe" for a Stripe-backed subscription, "Pro · comped" for an admin-set plan with no backing subscription. Free workspaces get no badge. The existing `planSource` semantics (`stripe`/`admin`/`none`, from `workspace-plan.ts`'s `planSourceFor`) are unchanged — the badge is just a clearer rendering of the same signal, replacing the old plain "Source: …" text line. `cancelAtPeriodEnd` now renders as an explicit "cancels on `<date>`" notice (users cancel via the Stripe-hosted portal, so this is otherwise invisible to the operator).

2. **Customer tenure.** Adds a `paidSince` field to the workspace KV record, stamped once — by the Stripe webhook bridge's plan sync (`POST /internal/billing/plan`) and by the admin panel's `PATCH /admin-ui/workspaces/:name/plan` — the first time a workspace's plan transitions from free to paid. It is **never overwritten** on a later transition (a downgrade-then-re-upgrade keeps the original date). Rendered as "Customer since `<date>` (N mo)".

   **Why a new field instead of deriving it from the auth worker's subscription data:** I checked the `@better-auth/stripe` `subscription` table (`apps/auth/src/schema.ts`) and the auth worker's internal `/orgs/:slug/subscription` route. That table has no `created_at`/first-subscribed column — only `period_start`/`period_end`/`trial_start`, which roll forward every renewal and can reset if a subscription is ever recreated (e.g. a lapsed-then-resubscribed customer). None of those are a stable "first paid at" answer. `paidSince` on the workspace record (written through `mutateWorkspaceRecord`, same as every other workspace-record mutation in this repo) is the smallest addition that gives an honest, durable answer.

   One existing paid workspace in production predates this change and has no `paidSince` stamped. A backfill (set `paidSince` to the earliest known date for that workspace, or leave it null and let the UI simply omit the tenure line) is a follow-up — I did not run anything against production for this PR.

3. **Storage percent-full bar.** The limits card's "X of Y stored" line now includes a compact inline progress bar with the percent as text — plain HTML/CSS, no framework JS (same astro-inline-script pattern as the rest of the file). Warning color at ≥80%, over-cap color at ≥100%. Omitted entirely when the cap is unlimited (`null`). Did the same for uploads-per-period since it was a one-line addition on the same helper.

## Files changed

- `apps/api/src/workspace.ts` — `paidSince?: string` field + doc comment
- `apps/api/src/routes/internal-billing.ts` — stamps `paidSince` in the Stripe-driven plan-sync route
- `apps/api/src/routes/admin-ui.ts` — stamps `paidSince` in the admin `PATCH .../plan` route; imports `getPlan`
- `apps/api/src/workspace-plan.ts` — `planResponse()` now includes `paidSince: record.paidSince ?? null`
- `apps/web/src/pages/admin/index.astro` — plan badge, cancel notice, tenure line, storage/uploads percent bar
- `apps/web/src/styles/admin-workspaces.css` — badge + bar styles (design tokens only, no new colors)
- Tests: `apps/api/src/routes/internal-billing.test.ts`, `apps/api/src/routes/admin-ui.test.ts`, `apps/api/src/workspace-plan.test.ts` — coverage for the new field and the stamp-once behavior

## Constraints followed

- No `.env` edits, nothing run against production.
- Additive API changes only — `/me` responses are unaffected (this touches the admin-ui plan route and the shared `planResponse` helper, but nothing here changes the fields `/me/workspaces/:name/billing` asserts on in its tests).
- All fixtures use fictional data ("acme" workspace); no real customer name, email, workspace slug, Stripe id, or revenue/count figures appear anywhere in this diff.

## Testing

- `pnpm test:api` — 186 files / 2808 tests passed
- `pnpm test` (whole suite) — 378 files / 6001 tests passed, 1 file / 2 tests skipped (pre-existing)
- `pnpm typecheck` — 0 errors across all packages (pre-existing warnings/hints only, unrelated to this change)
- `pnpm lint` / `pnpm format` — clean; only pre-existing warnings elsewhere in the repo

No screenshot attached — reproducing the admin panel needs a signed-in prod session. Summary of the visual change: the "Plan" card heading now carries an inline pill badge when the workspace is on Pro (green for Stripe-backed, accent-colored for comped); a red "cancels on `<date>`" note appears inline in the subscription line when `cancelAtPeriodEnd` is true; a new muted line reads "Customer since `<date>` (N mo)" when `paidSince` is set; and the "Limits" card's storage line now has a small rounded progress bar next to the byte count, turning orange at 80% and red at 100%+.
