### PR TITLE
feat(admin): expose paidSince on the bearer workspace GET

### DIFF
--- a/apps/api/src/routes/admin-workspace-delete.test.ts
+++ b/apps/api/src/routes/admin-workspace-delete.test.ts
@@ -426,10 +426,21 @@ describe("GET /admin/workspaces/:name", () => {
       purgeAt: null,
       selfServe: false,
       plan: null,
+      paidSince: null,
       hasHttpCredentials: false,
     });
     // Unset key policy reads as the permissive default, not as absent.
     expect(body.keyPolicy).toMatchObject({ autoPrefixBareKeys: true, allowedKeyPrefixes: null });
+  });
+
+  it("exposes paidSince for a paid workspace", async () => {
+    const { app, env } = appWith({
+      kvRecords: { "ws:acme": { ...RECORD, plan: "pro", paidSince: "2026-01-02T03:04:05.000Z" } },
+    });
+    const res = await app.request(getRequest("acme"), {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { plan: string; paidSince: string | null };
+    expect(body).toMatchObject({ plan: "pro", paidSince: "2026-01-02T03:04:05.000Z" });
   });
 
   it("reports a soft-deleted workspace with its grace window instead of 404ing", async () => {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -558,6 +558,10 @@ export const admin = new Hono<{ Bindings: Env }>()
       prefix: raw.prefix ?? null,
       publicBaseUrl: raw.publicBaseUrl ?? null,
       plan: raw.plan ?? null,
+      // Billing lifecycle, mirrored from the cookie-authed admin panel's plan
+      // view so bearer-token operators (ops scripts, CI) see the same
+      // "customer since" answer.
+      paidSince: raw.paidSince ?? null,
       selfServe: raw.selfServe === true,
       createdAt: raw.createdAt ?? null,
       createdByUserId: raw.createdByUserId ?? null,


### PR DESCRIPTION
## Summary
- \`GET /admin/workspaces/:name\` (bearer/operator token) now returns \`paidSince\` next to \`plan\`, mirroring the cookie-authed admin panel plan view added in #958.
- Additive only; the route stays an explicit allowlist (no secrets, no feature-config dump).

## Why
Ops scripts and CI use the bearer route and saw \`null\` for a field the panel renders, which reads as drift.

## Tests
- Extended \`admin-workspace-delete.test.ts\`: default record returns \`paidSince: null\`; a paid record returns the stored timestamp. 21/21 pass.
- Fixtures are fictional.