### PR TITLE
fix(admin): tidy the crowded workspace detail drawer

### DIFF
--- a/apps/web/src/components/admin/LimitsEditor.tsx
+++ b/apps/web/src/components/admin/LimitsEditor.tsx
@@ -15,6 +15,7 @@ import { Button } from "@uploads/ui/components/ui/button";
 import { errMessage, type AdminApi, type AdminLimitsResponse } from "../../lib/admin-api";
 import {
   formatBytes,
+  formatUsedBytes,
   LIMIT_FIELDS,
   LIMIT_UNITS,
   multForUnit,
@@ -50,26 +51,40 @@ function seedFields(data: AdminLimitsResponse): Record<LimitKey, FieldState> {
 }
 
 /**
- * Compact inline percent-full bar; renders nothing for an unlimited/zero cap.
- * Self-contained (Tailwind + inline fill) so the drawer needs no page CSS:
- * ≥80% is orange, ≥100% red, else accent — the same thresholds the imperative
- * `.limit-storage-bar` used.
+ * One usage meter: a "used of cap" label with a right-aligned percent on the
+ * same baseline, and a full-width fill bar beneath. Renders label-only (no
+ * bar, no percent) for an unlimited/zero cap. Self-contained (Tailwind +
+ * inline fill) so the drawer needs no page CSS: ≥80% is orange, ≥100% red,
+ * else accent — the same thresholds the imperative `.limit-storage-bar` used.
+ *
+ * Split from the old single-line flex-wrap layout, where the full-width bar
+ * forced the percent onto its own line, floated to the right edge.
  */
-function StorageBar({ used, cap }: { used: number; cap: number | null }) {
-  if (cap === null || cap <= 0) return null;
-  const pct = Math.round((used / cap) * 100);
-  const fill = Math.min(100, pct);
-  const color = pct >= 100 ? "var(--red)" : pct >= 80 ? "var(--orange, #d97706)" : "var(--accent)";
+function UsageMeter({ label, used, cap }: { label: string; used: number; cap: number | null }) {
+  const pct = cap !== null && cap > 0 ? Math.round((used / cap) * 100) : null;
+  const color =
+    pct === null
+      ? ""
+      : pct >= 100
+        ? "var(--red)"
+        : pct >= 80
+          ? "var(--orange, #d97706)"
+          : "var(--accent)";
   return (
-    <>
-      <span className="relative block h-1.5 w-full max-w-[220px] overflow-hidden rounded-full bg-muted/25">
-        <span
-          className="block h-full rounded-full"
-          style={{ width: `${fill}%`, background: color }}
-        />
-      </span>{" "}
-      <span className="tabular-nums">{pct}%</span>
-    </>
+    <div className="grid gap-1">
+      <div className="flex items-baseline justify-between gap-2 text-(length:--text-micro) text-muted-foreground">
+        <span>{label}</span>
+        {pct !== null && <span className="tabular-nums">{pct}%</span>}
+      </div>
+      {pct !== null && (
+        <span className="relative block h-1.5 w-full overflow-hidden rounded-full bg-muted/25">
+          <span
+            className="block h-full rounded-full"
+            style={{ width: `${Math.min(100, pct)}%`, background: color }}
+          />
+        </span>
+      )}
+    </div>
   );
 }
 
@@ -157,21 +172,26 @@ export function LimitsEditor({ api, workspace }: { api: AdminApi; workspace: str
     <div>
       <SectionHeading>Limits</SectionHeading>
       {usage && (
-        <p className="m-0 flex flex-wrap items-center gap-1.5 text-(length:--text-micro) text-muted-foreground">
-          {formatBytes(usage.bytes)}
-          {data.limits.maxStorageBytes !== null
-            ? ` of ${formatBytes(data.limits.maxStorageBytes)}`
-            : ""}{" "}
-          stored
-          <StorageBar used={usage.bytes} cap={data.limits.maxStorageBytes} />· {usage.uploads}
-          {data.limits.maxUploadsPerPeriod !== null
-            ? ` of ${data.limits.maxUploadsPerPeriod}`
-            : ""}{" "}
-          uploads this month
-          {data.limits.maxUploadsPerPeriod !== null && (
-            <StorageBar used={usage.uploads} cap={data.limits.maxUploadsPerPeriod} />
-          )}
-        </p>
+        <div className="mt-1 grid gap-2.5">
+          <UsageMeter
+            label={`${formatUsedBytes(usage.bytes)}${
+              data.limits.maxStorageBytes !== null
+                ? ` of ${formatBytes(data.limits.maxStorageBytes)}`
+                : ""
+            } stored`}
+            used={usage.bytes}
+            cap={data.limits.maxStorageBytes}
+          />
+          <UsageMeter
+            label={`${usage.uploads}${
+              data.limits.maxUploadsPerPeriod !== null
+                ? ` of ${data.limits.maxUploadsPerPeriod}`
+                : ""
+            } uploads this month`}
+            used={usage.uploads}
+            cap={data.limits.maxUploadsPerPeriod}
+          />
+        </div>
       )}
       <form onSubmit={save} className="mt-2 flex flex-col gap-2">
         {LIMIT_FIELDS.map((f) => {

--- a/apps/web/src/components/admin/PeopleSection.tsx
+++ b/apps/web/src/components/admin/PeopleSection.tsx
@@ -33,7 +33,7 @@ export function PeopleSection({
   // load dep and refetches — a plain parent-owned signal, no global events.
   const [membersReload, setMembersReload] = useState(0);
   return (
-    <div className="grid gap-3.5">
+    <div className="grid gap-4">
       {hasOrg ? <MembersInvites api={api} workspace={workspace} reloadKey={membersReload} /> : null}
       {hasOrg ? (
         <InviteForm
@@ -44,7 +44,12 @@ export function PeopleSection({
       ) : (
         <Muted>No organization provisioned for this workspace yet — run the org backfill.</Muted>
       )}
-      <InviteLinks api={api} workspace={workspace} />
+      {/* Invite links are a separate concern (share-by-link enrollment) from the
+          member invite above — divide them so the two forms don't read as one
+          crowded block. */}
+      <div className="border-t border-border pt-4">
+        <InviteLinks api={api} workspace={workspace} />
+      </div>
     </div>
   );
 }
@@ -142,6 +147,7 @@ function InviteForm({
 
   return (
     <form onSubmit={submit} className="grid gap-2">
+      <SectionHeading>Invite a member</SectionHeading>
       <div className="flex flex-wrap items-end gap-2">
         <label className={FIELD_LABEL}>
           Email
@@ -235,6 +241,7 @@ function InviteLinks({ api, workspace }: { api: AdminApi; workspace: string }) {
 
   return (
     <div className="grid gap-2">
+      <SectionHeading>Invite link</SectionHeading>
       <div className="flex flex-wrap items-end gap-2">
         <label className={FIELD_LABEL}>
           Label (optional)
@@ -284,8 +291,8 @@ function InviteLinks({ api, workspace }: { api: AdminApi; workspace: string }) {
       {loadError ? (
         <Muted>Failed to load invite links.</Muted>
       ) : links && links.length > 0 ? (
-        <div>
-          <SectionHeading>Invite links</SectionHeading>
+        <div className="mt-1">
+          <SectionHeading>Active links</SectionHeading>
           <ul className="grid list-none gap-1.5 p-0">
             {links.map((link) => {
               const expiry = link.expiresAt

--- a/apps/web/src/lib/admin-limits.ts
+++ b/apps/web/src/lib/admin-limits.ts
@@ -38,6 +38,20 @@ export function formatBytes(n: number): string {
   return `${value} ${unit}`;
 }
 
+/**
+ * Human display for an arbitrary (usually non-round) byte count, e.g. live
+ * usage: GB once past 1 GB, otherwise MB, rounded to one decimal and with a
+ * trailing ".0" trimmed. `formatBytes` above stays exact for the round plan
+ * caps; this is only for the "X of Y stored" left side, so `8550413` reads as
+ * "8.6 MB", not "8.550413 MB".
+ */
+export function formatUsedBytes(n: number): string {
+  const unit =
+    n >= 1_000_000_000 ? { label: "GB", mult: 1_000_000_000 } : { label: "MB", mult: 1_000_000 };
+  const value = Math.round((n / unit.mult) * 10) / 10;
+  return `${value} ${unit.label}`;
+}
+
 export function multForUnit(unit: string): number {
   return LIMIT_UNITS.find((u) => u.label === unit)?.mult ?? 1_000_000;
 }


### PR DESCRIPTION
## What

Light UX tidy of the operator workspace **detail drawer** (from #961) — it was crowded and a couple of things rendered awkwardly.

- **Usage meters.** Storage and uploads each render as a clean line — `8.6 MB of 10 GB stored` with a right-aligned `56%` on the same baseline and a full-width fill bar beneath. Before, everything sat in one `flex-wrap` row, so the full-width bar pushed the percent onto its own line floated to the right edge (the stray `0%` in the screenshot).
- **Rounded usage.** Live storage use shows as `8.6 MB`, not `8.550413 MB`. Plan caps stay exact.
- **Grouping.** The member-invite form and the invite-link generator now sit under their own headings ("Invite a member" / "Invite link"), split by a divider, so the two forms stop reading as one dense block. The existing-links list is retitled "Active links" to not echo the generator heading.

No behavior or wire changes — presentation only.

## Verification

- `@uploads/web` typecheck: 0 errors; oxlint clean; full web suite (959) passes.
- No live screenshot: capturing the drawer needs an admin-authed local stack (demo user is `role: user`, and the dev ports were held). Happy to grab a before/after once a stack is free.
